### PR TITLE
Init resources

### DIFF
--- a/agent/pkg/controllers/clusterrole_controller.go
+++ b/agent/pkg/controllers/clusterrole_controller.go
@@ -11,6 +11,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	clustersv1 "open-cluster-management.io/api/cluster/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -118,10 +119,12 @@ func AddClusterRoleController(mgr ctrl.Manager) error {
 	return nil
 }
 
-func InitClusterRole(mgr ctrl.Manager) error {
-	err := mgr.GetClient().Get(context.TODO(), client.ObjectKey{Name: HubOfHubsClusterRoleName}, &rbacv1.ClusterRole{})
+func InitClusterRole(ctx context.Context, kubeClient *kubernetes.Clientset) error {
+	_, err := kubeClient.RbacV1().ClusterRoles().Get(
+		ctx, HubOfHubsClusterRoleName, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
-		if err := mgr.GetClient().Create(context.Background(), createClusterRole()); err != nil {
+		if _, err := kubeClient.RbacV1().ClusterRoles().Create(
+			ctx, createClusterRole(), metav1.CreateOptions{}); err != nil {
 			return err
 		}
 		return nil

--- a/agent/pkg/controllers/clusterrolebinding_controller.go
+++ b/agent/pkg/controllers/clusterrolebinding_controller.go
@@ -11,6 +11,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -88,11 +89,12 @@ func AddClusterRoleBindingController(mgr ctrl.Manager) error {
 	return nil
 }
 
-func InitClusterRoleBinding(mgr ctrl.Manager) error {
-	err := mgr.GetClient().Get(context.TODO(),
-		client.ObjectKey{Name: HubOfHubsClusterRoleName}, &rbacv1.ClusterRoleBinding{})
+func InitClusterRoleBinding(ctx context.Context, kubeClient *kubernetes.Clientset) error {
+	_, err := kubeClient.RbacV1().ClusterRoleBindings().Get(
+		ctx, HubOfHubsClusterRoleName, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
-		if err := mgr.GetClient().Create(context.Background(), createClusterRoleBinding()); err != nil {
+		if _, err := kubeClient.RbacV1().ClusterRoleBindings().Create(
+			ctx, createClusterRoleBinding(), metav1.CreateOptions{}); err != nil {
 			return err
 		}
 		return nil

--- a/agent/pkg/controllers/controllers.go
+++ b/agent/pkg/controllers/controllers.go
@@ -4,8 +4,10 @@
 package controllers
 
 import (
+	"context"
 	"fmt"
 
+	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -25,15 +27,15 @@ func AddControllers(mgr ctrl.Manager) error {
 	return nil
 }
 
-func InitResources(mgr ctrl.Manager) error {
-	initControllerFunctions := []func(ctrl.Manager) error{
+func InitResources(ctx context.Context, kubeClient *kubernetes.Clientset) error {
+	initControllerFunctions := []func(context.Context, *kubernetes.Clientset) error{
 		InitClusterRole,
 		InitClusterRoleBinding,
 	}
 
 	for _, initControllerFunction := range initControllerFunctions {
-		if err := initControllerFunction(mgr); err != nil {
-			return fmt.Errorf("failed to init controller: %w", err)
+		if err := initControllerFunction(ctx, kubeClient); err != nil {
+			return fmt.Errorf("failed to execute init function: %w", err)
 		}
 	}
 

--- a/agent/pkg/controllers/controllers.go
+++ b/agent/pkg/controllers/controllers.go
@@ -25,7 +25,7 @@ func AddControllers(mgr ctrl.Manager) error {
 	return nil
 }
 
-func PostStart(mgr ctrl.Manager) error {
+func InitResources(mgr ctrl.Manager) error {
 	initControllerFunctions := []func(ctrl.Manager) error{
 		InitClusterRole,
 		InitClusterRoleBinding,

--- a/operator/pkg/controllers/hubofhubs/manifests/placement/placement.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/placement/placement.yaml
@@ -18,3 +18,11 @@ spec:
         type: BuiltIn
       weight: 3
     mode: Exact
+  predicates:
+  - requiredClusterSelector:
+      labelSelector:
+        matchExpressions:
+        - key: local-cluster
+          operator: NotIn
+          values:
+          - "true"


### PR DESCRIPTION
ref: https://github.com/stolostron/backlog/issues/25232

2 fixes:
1. filter out the `local-cluster` to be selected as a regional hub cluster
2. init `clusterrole` and `clusterrolebinding` by agent. the previous way cannot be executed. use kubeclient to create such resources.