### PR TITLE
support installation in any namespace.

### DIFF
--- a/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -802,6 +802,7 @@ spec:
           verbs:
           - create
           - delete
+          - deletecollection
           - get
           - list
           - patch
@@ -831,6 +832,10 @@ spec:
                 command:
                 - multicluster-global-hub-operator
                 env:
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
                 - name: OPERAND_IMAGE_MULTICLUSTER_GLOBAL_HUB_MANAGER
                   value: quay.io/stolostron/multicluster-global-hub-manager:latest
                 - name: OPERAND_IMAGE_MULTICLUSTER_GLOBAL_HUB_AGENT

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -34,6 +34,10 @@ spec:
         image: quay.io/stolostron/multicluster-global-hub-operator:latest
         name: multicluster-global-hub-operator
         env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: OPERAND_IMAGE_MULTICLUSTER_GLOBAL_HUB_MANAGER
           value: quay.io/stolostron/multicluster-global-hub-manager:latest
         - name: OPERAND_IMAGE_MULTICLUSTER_GLOBAL_HUB_AGENT

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -254,6 +254,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch

--- a/operator/config/samples/storage/deploy_postgres.sh
+++ b/operator/config/samples/storage/deploy_postgres.sh
@@ -2,10 +2,11 @@
 KUBECONFIG=${1:-$KUBECONFIG}
 currentDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+TARGET_NAMESPACE=${TARGET_NAMESPACE:-"open-cluster-management"}
 storageSecret=${STORAGE_SECRET_NAME:-"storage-secret"}
-ready=$(kubectl get secret $storageSecret -n open-cluster-management --ignore-not-found=true)
+ready=$(kubectl get secret $storageSecret -n $TARGET_NAMESPACE --ignore-not-found=true)
 if [ ! -z "$ready" ]; then
-  echo "storageSecret $storageSecret already exists in open-cluster-management namespace"
+  echo "storageSecret $storageSecret already exists in $TARGET_NAMESPACE namespace"
   exit 0
 fi
 
@@ -43,6 +44,6 @@ databasePassword=$(printf %s "$databasePassword" |jq -sRr @uri)
 
 databaseUri="postgres://${databaseUser}:${databasePassword}@${databaseHost}:${pgAdminPort}/hoh"
 
-kubectl create secret generic $storageSecret -n "open-cluster-management" \
+kubectl create secret generic $storageSecret -n $TARGET_NAMESPACE \
     --from-literal=database_uri=$databaseUri
-echo "storage secret is ready!"
+echo "storage secret is ready in $TARGET_NAMESPACE namespace!"

--- a/operator/config/samples/transport/deploy_kafka.sh
+++ b/operator/config/samples/transport/deploy_kafka.sh
@@ -3,10 +3,11 @@
 KUBECONFIG=${1:-$KUBECONFIG}
 currentDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+TARGET_NAMESPACE=${TARGET_NAMESPACE:-"open-cluster-management"}
 transportSecret=${TRANSPORT_SECRET_NAME:-"transport-secret"}
-ready=$(kubectl get secret $transportSecret -n open-cluster-management --ignore-not-found=true)
+ready=$(kubectl get secret $transportSecret -n $TARGET_NAMESPACE --ignore-not-found=true)
 if [ ! -z "$ready" ]; then
-  echo "transportSecret $transportSecret already exists in open-cluster-management namespace"
+  echo "transportSecret $transportSecret already exists in $TARGET_NAMESPACE namespace"
   exit 0
 fi
 
@@ -63,9 +64,9 @@ echo "Kafka topics spec and status are ready!"
 
 bootstrapServers=$(kubectl get kafka kafka-brokers-cluster -n kafka -o jsonpath='{.status.listeners[1].bootstrapServers}')
 kubectl get kafka kafka-brokers-cluster -n kafka -o jsonpath='{.status.listeners[1].certificates[0]}' > $currentDir/kafka-cert.pem
-kubectl create secret generic ${transportSecret} -n "open-cluster-management" \
+kubectl create secret generic ${transportSecret} -n $TARGET_NAMESPACE \
     --from-literal=bootstrap_server=$bootstrapServers \
     --from-file=CA=$currentDir/kafka-cert.pem
 
 rm $currentDir/kafka-cert.pem
-echo "transport secret is ready!"
+echo "transport secret is ready in $TARGET_NAMESPACE namespace!"

--- a/operator/pkg/condition/condition.go
+++ b/operator/pkg/condition/condition.go
@@ -38,13 +38,6 @@ const (
 	CONDITION_STATUS_UNKNOWN = "Unknown"
 )
 
-// NOTE: the status of ResourceFound can only be True; otherwise there is no condition
-const (
-	CONDITION_TYPE_RESOURCE_FOUND    = "ResourceFound"
-	CONDITION_REASON_RESOURCE_FOUND  = "ResourceFound"
-	CONDITION_MESSAGE_RESOURCE_FOUND = "Resource found"
-)
-
 // NOTE: the status of DatabaseInitialized can be True or False
 const (
 	CONDITION_TYPE_DATABASE_INIT    = "DatabaseInitialized"
@@ -93,11 +86,6 @@ const (
 type SetConditionFunc func(ctx context.Context, c client.Client,
 	mgh *operatorv1alpha1.MulticlusterGlobalHub,
 	status metav1.ConditionStatus) error
-
-func SetConditionResourceFound(ctx context.Context, c client.Client, mgh *operatorv1alpha1.MulticlusterGlobalHub) error {
-	return SetCondition(ctx, c, mgh, CONDITION_TYPE_RESOURCE_FOUND, CONDITION_STATUS_TRUE,
-		CONDITION_REASON_RESOURCE_FOUND, CONDITION_MESSAGE_RESOURCE_FOUND)
-}
 
 func SetConditionDatabaseInit(ctx context.Context, c client.Client, mgh *operatorv1alpha1.MulticlusterGlobalHub,
 	status metav1.ConditionStatus,

--- a/operator/pkg/config/multiclusterglobalhub_config.go
+++ b/operator/pkg/config/multiclusterglobalhub_config.go
@@ -52,6 +52,16 @@ var (
 	}
 )
 
+// GetDefaultNamespace returns default installation namespace
+func GetDefaultNamespace() string {
+	defaultNamespace, _ := os.LookupEnv("POD_NAMESPACE")
+	if defaultNamespace == "" {
+		defaultNamespace = constants.HOHDefaultNamespace
+	}
+
+	return defaultNamespace
+}
+
 func SetHoHMGHNamespacedName(namespacedName types.NamespacedName) {
 	hohMGHNamespacedName = namespacedName
 }

--- a/operator/pkg/constants/constants.go
+++ b/operator/pkg/constants/constants.go
@@ -17,10 +17,11 @@ limitations under the License.
 package constants
 
 const (
-	HOHDefaultNamespace = "open-cluster-management"
-	HOHSystemNamespace  = "hoh-system"
-	HOHConfigName       = "multicluster-global-hub-config"
-	LocalClusterName    = "local-cluster"
+	HOHDefaultNamespace        = "open-cluster-management"
+	HOHSystemNamespace         = "hoh-system"
+	HOHConfigName              = "multicluster-global-hub-config"
+	LocalClusterName           = "local-cluster"
+	DefaultImagePullSecretName = "multiclusterhub-operator-pull-secret"
 )
 
 const (
@@ -32,7 +33,6 @@ const (
 	HoHManagedClusterAddonDisplayName = "Multicluster Global Hub Controller"
 	HoHManagedClusterAddonDescription = "Multicluster Global Hub Controller " +
 		"manages multicluster-global-hub components."
-	HoHManagedClusterAddonInstallationNamespace = "open-cluster-management"
 )
 
 const (

--- a/operator/pkg/controllers/hubofhubs/manifests/console-cleanup/hoh-console-cleanup.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/console-cleanup/hoh-console-cleanup.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: multicluster-global-hub-console-cleanup
-  namespace: open-cluster-management
+  namespace: {{.Namespace}}
   labels:
     name: multicluster-global-hub-console
 spec:

--- a/operator/pkg/controllers/hubofhubs/manifests/console-setup/hoh-console-script.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/console-setup/hoh-console-script.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name:  multicluster-global-hub-console-script
-  namespace: open-cluster-management
+  namespace: {{.Namespace}}
   labels:
     name: multicluster-global-hub-console
 data:
@@ -16,31 +16,31 @@ data:
       | jq 'del(.metadata.managedFields, .metadata.resourceVersion, .metadata.generation, .metadata.creationTimestamp)' \
       | kubectl apply -f -
 
-    kubectl annotate mch multiclusterhub mch-pause=true -n open-cluster-management --overwrite
+    kubectl annotate mch multiclusterhub mch-pause=true -n {{.Namespace}} --overwrite
 
-    helm get values -a -n open-cluster-management $(helm ls -n open-cluster-management | cut -d' ' -f1 | grep console-chart) -o yaml > /tmp/values.yaml
-    kubectl delete appsub console-chart-sub -n open-cluster-management --ignore-not-found
+    helm get values -a -n {{.Namespace}} $(helm ls -n {{.Namespace}} | cut -d' ' -f1 | grep console-chart) -o yaml > /tmp/values.yaml
+    kubectl delete appsub console-chart-sub -n {{.Namespace}} --ignore-not-found
     cat /tmp/values.yaml |
       yq e ".global.imageOverrides.console = \"quay.io/open-cluster-management-hub-of-hubs/console:v0.5.0\"" - |
       yq e '.global.pullPolicy = "Always"' - |
-      helm upgrade console-chart charts/console-chart -n open-cluster-management --install -f -
+      helm upgrade console-chart charts/console-chart -n {{.Namespace}} --install -f -
 
-    helm get values -a -n open-cluster-management $(helm ls -n open-cluster-management | cut -d' ' -f1 | grep grc) -o yaml > /tmp/values.yaml
-    kubectl delete appsub grc-sub -n open-cluster-management --ignore-not-found
+    helm get values -a -n {{.Namespace}} $(helm ls -n {{.Namespace}} | cut -d' ' -f1 | grep grc) -o yaml > /tmp/values.yaml
+    kubectl delete appsub grc-sub -n {{.Namespace}} --ignore-not-found
     cat /tmp/values.yaml |
       yq e ".global.imageOverrides.governance_policy_propagator = \"quay.io/open-cluster-management-hub-of-hubs/governance-policy-propagator:hub-of-hubs\"" - |
       yq e ".global.imageOverrides.grc_ui = \"quay.io/open-cluster-management-hub-of-hubs/grc-ui:v0.5.0\"" - |
       yq e ".global.imageOverrides.grc_ui_api = \"quay.io/stolostron/grc-ui-api:2.4.3-SNAPSHOT-2022-03-21-21-19-21\"" - |
       yq e '.global.pullPolicy = "Always"' - |
-      helm upgrade grc charts/grc -n open-cluster-management --install -f -
+      helm upgrade grc charts/grc -n {{.Namespace}} --install -f -
 
     echo "" |
       yq e ".global.imageOverrides.application_ui = \"quay.io/open-cluster-management-hub-of-hubs/application-ui:v0.5.0\"" - |
       yq e ".global.imageOverrides.console_api = \"quay.io/stolostron/console-api:2.4.3-SNAPSHOT-2022-04-07-03-58-40\"" - |
       yq e '.global.pullPolicy = "Always"' - |
-      helm upgrade application-chart charts/application-chart -n open-cluster-management --install -f -
+      helm upgrade application-chart charts/application-chart -n {{.Namespace}} --install -f -
 
-    kubectl -n open-cluster-management patch $(kubectl get csv -oname -l operators.coreos.com/advanced-cluster-management.open-cluster-management -n open-cluster-management) --type=json -p='[{"op": "replace", "path": "/spec/install/spec/deployments/3/spec/template/spec/containers/0/image", "value":"quay.io/open-cluster-management-hub-of-hubs/multicloud-operators-subscription:hub-of-hubs"}]'
+    kubectl -n {{.Namespace}} patch $(kubectl get csv -oname -l operators.coreos.com/advanced-cluster-management.{{.Namespace}} -n {{.Namespace}}) --type=json -p='[{"op": "replace", "path": "/spec/install/spec/deployments/3/spec/template/spec/containers/0/image", "value":"quay.io/open-cluster-management-hub-of-hubs/multicloud-operators-subscription:hub-of-hubs"}]'
 
     cat <<EOF | kubectl apply -n multicluster-engine -f -
     apiVersion: v1
@@ -65,14 +65,14 @@ data:
     set -e
     set -o pipefail
 
-    helm uninstall console-chart -n open-cluster-management
-    helm uninstall grc -n open-cluster-management
-    helm uninstall application-chart -n open-cluster-management
+    helm uninstall console-chart -n {{.Namespace}}
+    helm uninstall grc -n {{.Namespace}}
+    helm uninstall application-chart -n {{.Namespace}}
 
     sub_image=$(kubectl get deploy multiclusterhub-operator -ojsonpath='{.spec.template.spec.containers[0].env[?(@.name=="OPERAND_IMAGE_MULTICLUSTER_OPERATORS_SUBSCRIPTION")].value}')
-    kubectl -n open-cluster-management patch $(kubectl get csv -oname -l operators.coreos.com/advanced-cluster-management.open-cluster-management -n open-cluster-management) --type=json -p='[{"op": "replace", "path": "/spec/install/spec/deployments/3/spec/template/spec/containers/0/image", "value":'"${sub_image}"'}]'
+    kubectl -n {{.Namespace}} patch $(kubectl get csv -oname -l operators.coreos.com/advanced-cluster-management.{{.Namespace}} -n {{.Namespace}}) --type=json -p='[{"op": "replace", "path": "/spec/install/spec/deployments/3/spec/template/spec/containers/0/image", "value":'"${sub_image}"'}]'
 
-    kubectl annotate mch multiclusterhub mch-pause=false -n open-cluster-management --overwrite
+    kubectl annotate mch multiclusterhub mch-pause=false -n {{.Namespace}} --overwrite
     kubectl get mutatingwebhookconfiguration ocm-mutating-webhook -o json \
       | jq 'del(.webhooks[0].rules[] | select(.apiGroups == ["policy.open-cluster-management.io"]) )' \
       | jq 'del(.metadata.managedFields, .metadata.resourceVersion, .metadata.generation, .metadata.creationTimestamp)' \

--- a/operator/pkg/controllers/hubofhubs/manifests/console-setup/hoh-console-setup.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/console-setup/hoh-console-setup.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: multicluster-global-hub-console-setup
-  namespace: open-cluster-management
+  namespace: {{.Namespace}}
   labels:
     name: multicluster-global-hub-console
 spec:

--- a/operator/pkg/controllers/hubofhubs/manifests/manager/clusterrolebinding.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/manager/clusterrolebinding.yaml
@@ -7,7 +7,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: multicluster-global-hub-manager
-  namespace: open-cluster-management
+  namespace: {{.Namespace}}
 roleRef:
   kind: ClusterRole
   name: multicluster-global-hub-manager

--- a/operator/pkg/controllers/hubofhubs/manifests/manager/configmap-ca-bundle.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/manager/configmap-ca-bundle.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: multicluster-global-hub-rbac-ca-bundle
-  namespace: open-cluster-management
+  namespace: {{.Namespace}}
   annotations:
     service.beta.openshift.io/inject-cabundle: "true"
   labels:

--- a/operator/pkg/controllers/hubofhubs/manifests/manager/deployment.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/manager/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: multicluster-global-hub-manager
-  namespace: open-cluster-management
+  namespace: {{.Namespace}}
   labels:
     name: multicluster-global-hub-manager
 spec:

--- a/operator/pkg/controllers/hubofhubs/manifests/manager/ingress.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/manager/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
     ingress.open-cluster-management.io/secure-backends: "true"
     kubernetes.io/ingress.class: ingress-open-cluster-management
   name: multicluster-global-hub-manager
-  namespace: open-cluster-management
+  namespace: {{.Namespace}}
   labels:
     name: multicluster-global-hub-manager
 spec:

--- a/operator/pkg/controllers/hubofhubs/manifests/manager/role.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/manager/role.yaml
@@ -3,7 +3,7 @@ kind: Role
 metadata:
   creationTimestamp: null
   name: multicluster-global-hub-manager
-  namespace: open-cluster-management
+  namespace: {{.Namespace}}
   labels:
     name: multicluster-global-hub-manager
 rules:

--- a/operator/pkg/controllers/hubofhubs/manifests/manager/rolebinding.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/manager/rolebinding.yaml
@@ -2,7 +2,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: multicluster-global-hub-manager
-  namespace: open-cluster-management
+  namespace: {{.Namespace}}
   labels:
     name: multicluster-global-hub-manager
 subjects:

--- a/operator/pkg/controllers/hubofhubs/manifests/manager/service.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/manager/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: multicluster-global-hub-manager
-  namespace: open-cluster-management
+  namespace: {{.Namespace}}
   labels:
     name: multicluster-global-hub-manager
     service: multicluster-global-hub-manager

--- a/operator/pkg/controllers/hubofhubs/manifests/manager/serviceaccount.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/manager/serviceaccount.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: multicluster-global-hub-manager
-  namespace: open-cluster-management
+  namespace: {{.Namespace}}
   labels:
     name: multicluster-global-hub-manager

--- a/operator/pkg/controllers/hubofhubs/manifests/placement/managedclustersetbinding.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/placement/managedclustersetbinding.yaml
@@ -2,6 +2,6 @@ apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: ManagedClusterSetBinding
 metadata:
   name: default
-  namespace: open-cluster-management
+  namespace: {{.Namespace}}
 spec:
   clusterSet: default

--- a/operator/pkg/controllers/hubofhubs/manifests/placement/placement.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/placement/placement.yaml
@@ -2,9 +2,7 @@ apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
   name: default
-  namespace: open-cluster-management
-  labels:
-    global-hub.open-cluster-management.io/managed-by: multicluster-global-hub-operator
+  namespace: {{.Namespace}}
 spec:
   numberOfClusters: 1
   prioritizerPolicy:

--- a/operator/pkg/controllers/hubofhubs/manifests/rbac/deployment.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/rbac/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: multicluster-global-hub-rbac
-  namespace: open-cluster-management
+  namespace: {{.Namespace}}
   labels:
     name: multicluster-global-hub-rbac
 spec:

--- a/operator/pkg/controllers/hubofhubs/manifests/rbac/networkpolicy.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/rbac/networkpolicy.yaml
@@ -3,7 +3,7 @@ kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   name: allow-within-namespace-for-opa
-  namespace: open-cluster-management
+  namespace: {{.Namespace}}
   labels:
     name: multicluster-global-hub-rbac
 spec:

--- a/operator/pkg/controllers/hubofhubs/manifests/rbac/secret-opa-data.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/rbac/secret-opa-data.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: opa-data
-  namespace: open-cluster-management
+  namespace: {{.Namespace}}
   labels:
     name: multicluster-global-hub-rbac
 type: Opaque
@@ -20,7 +20,7 @@ stringData:
     }
   role_bindings.yaml: |
     roleBindings:
-      "system:serviceaccount:open-cluster-management:console-chart":
+      "system:serviceaccount:{{.Namespace}}:console-chart":
         roles:
           - admin
       "kube:admin":

--- a/operator/pkg/controllers/hubofhubs/manifests/rbac/service.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/rbac/service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: multicluster-global-hub-rbac
-  namespace: open-cluster-management
+  namespace: {{.Namespace}}
   labels:
     name: multicluster-global-hub-rbac
     service: multicluster-global-hub-rbac

--- a/operator/pkg/controllers/hubofhubs/manifests/rbac/serviceaccount.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/rbac/serviceaccount.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: multicluster-global-hub-rbac
-  namespace: open-cluster-management
+  namespace: {{.Namespace}}
   labels:
     name: multicluster-global-hub-rbac

--- a/operator/pkg/controllers/leafhub/addon.go
+++ b/operator/pkg/controllers/leafhub/addon.go
@@ -166,7 +166,7 @@ func buildManagedClusterAddon(managedClusterName string) *addonv1alpha1.ManagedC
 		},
 		Spec: addonv1alpha1.ManagedClusterAddOnSpec{
 			// addon lease namespace, should be the namespace of multicluster-global-hub-agent
-			InstallNamespace: constants.HoHManagedClusterAddonInstallationNamespace,
+			InstallNamespace: constants.HOHDefaultNamespace,
 		},
 	}
 }

--- a/operator/pkg/controllers/leafhub/leafhub_controller.go
+++ b/operator/pkg/controllers/leafhub/leafhub_controller.go
@@ -86,7 +86,7 @@ type LeafHubReconciler struct {
 
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;watch
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=hypershiftdeployments,verbs=get;list;watch
-//+kubebuilder:rbac:groups=work.open-cluster-management.io,resources=manifestworks,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=work.open-cluster-management.io,resources=manifestworks,verbs=get;list;watch;create;update;patch;delete;deletecollection
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=clustermanagementaddons,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=packages.operators.coreos.com,resources=packagemanifests,verbs=get;list;watch
@@ -615,7 +615,7 @@ func (r *LeafHubReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				return []reconcile.Request{
 					{NamespacedName: types.NamespacedName{
 						// add fake namespace to trigger MGH reconcile when clustermanagementaddon updated/deleted
-						Namespace: constants.HOHDefaultNamespace,
+						Namespace: config.GetDefaultNamespace(),
 						Name:      obj.GetName(),
 					}},
 				}


### PR DESCRIPTION
ref: https://github.com/stolostron/backlog/issues/25234

Add support to install multicluster-global-hub-operator and operands in any namespace that ACM is installed within.

To create the storage secret and transport secret for customized namespace, need to expose env `export TARGET_NAMESPACE=<the operator installation namespace>` before executing https://github.com/stolostron/multicluster-global-hub/blob/main/operator/config/samples/transport/deploy_kafka.sh and https://github.com/stolostron/multicluster-global-hub/blob/main/operator/config/samples/storage/deploy_postgres.sh

To deploy operator locally, change the `namespace` in https://github.com/stolostron/multicluster-global-hub/blob/main/operator/config/default/kustomization.yaml and then execute `make deploy`



Signed-off-by: morvencao <lcao@redhat.com>