### PR TITLE
use the default control-runtime default values

### DIFF
--- a/agent/cmd/agent/main.go
+++ b/agent/cmd/agent/main.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"runtime"
 	"strconv"
-	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
@@ -168,17 +167,17 @@ func getProducer(environmentManager *helper.ConfigManager) (producer.Producer, e
 func createManager(consumer consumer.Consumer, producer producer.Producer,
 	environmentManager *helper.ConfigManager,
 ) (ctrl.Manager, error) {
-	leaseDuration := 137 * time.Second
-	renewDeadline := 107 * time.Second
-	retryPeriod := 26 * time.Second
+	// leaseDuration := 137 * time.Second
+	// renewDeadline := 107 * time.Second
+	// retryPeriod := 26 * time.Second
 	options := ctrl.Options{
 		MetricsBindAddress:      fmt.Sprintf("%s:%d", METRICS_HOST, METRICS_PORT),
 		LeaderElection:          true,
 		LeaderElectionID:        LEADER_ELECTION_ID,
 		LeaderElectionNamespace: environmentManager.PodNameSpace,
-		LeaseDuration:           &leaseDuration,
-		RenewDeadline:           &renewDeadline,
-		RetryPeriod:             &retryPeriod,
+		// LeaseDuration:           &leaseDuration,
+		// RenewDeadline:           &renewDeadline,
+		// RetryPeriod:             &retryPeriod,
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)


### PR DESCRIPTION
resolve: https://github.com/stolostron/backlog/issues/24752

the root cause is if there is an existing lease in your environment, it needs spend 137s to acquire lease.
if that is brand new environment, there is no such problem.
we have not decided to use OpenShift default values yet, because it impact on the high available https://github.com/openshift/enhancements/blob/master/CONVENTIONS.md#high-availability

so for our case, let me use the default value in this release.
we may expose those values in mgh CRD and pass them into each operator.

I am not sure if it impacts on this issue or not - https://github.com/stolostron/backlog/issues/23768. Let me observe it.

Signed-off-by: clyang82 <chuyang@redhat.com>