### PR TITLE
add missing permission for operator.

### DIFF
--- a/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -668,6 +668,7 @@ spec:
           verbs:
           - get
           - list
+          - update
           - watch
         - apiGroups:
           - cluster.open-cluster-management.io

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -120,6 +120,7 @@ rules:
   verbs:
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - cluster.open-cluster-management.io

--- a/operator/pkg/controllers/leafhub/leafhub_controller.go
+++ b/operator/pkg/controllers/leafhub/leafhub_controller.go
@@ -84,7 +84,7 @@ type LeafHubReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;watch
+//+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;update;watch
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=hypershiftdeployments,verbs=get;list;watch
 //+kubebuilder:rbac:groups=work.open-cluster-management.io,resources=manifestworks,verbs=get;list;watch;create;update;patch;delete;deletecollection
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=clustermanagementaddons,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
multicluster-global-hub-operator need this permission to add annotation to (hypershift hosted) managedcluster so that it can be a regional hub. 

Signed-off-by: morvencao <lcao@redhat.com>