### PR TITLE
fix conflict in configmap deletion.

### DIFF
--- a/operator/pkg/controllers/hubofhubs/finalizer.go
+++ b/operator/pkg/controllers/hubofhubs/finalizer.go
@@ -116,24 +116,22 @@ func (r *MulticlusterGlobalHubReconciler) pruneNamespacedResources(ctx context.C
 	// the multicluster-global-hub-config configmap is created by operator and finalized by manager
 	log.Info(fmt.Sprintf("clean up the namespace %s configmap %s", constants.HOHSystemNamespace, constants.HOHConfigName))
 	existingMghConfigMap := &corev1.ConfigMap{}
-	if err := r.Client.Get(ctx,
+	err := r.Client.Get(ctx,
 		types.NamespacedName{
 			Namespace: constants.HOHSystemNamespace,
 			Name:      constants.HOHConfigName,
-		}, existingMghConfigMap); err != nil && !errors.IsNotFound(err) {
+		}, existingMghConfigMap)
+	if err != nil && !errors.IsNotFound(err) {
 		return err
-	}
-	if err := r.Client.Delete(ctx, existingMghConfigMap); err != nil && !errors.IsNotFound(err) {
-		return err
-	}
-
-	// clean the finalizers added by multicluster-global-hub-manager
-	existingMghConfigMap.SetFinalizers([]string{})
-	if err := r.Client.Update(ctx, existingMghConfigMap); err != nil {
-		return err
-	}
-	if err := r.Client.Delete(ctx, existingMghConfigMap); err != nil && !errors.IsNotFound(err) {
-		return err
+	} else if err == nil {
+		// clean the finalizers added by multicluster-global-hub-manager
+		existingMghConfigMap.SetFinalizers([]string{})
+		if err := r.Client.Update(ctx, existingMghConfigMap); err != nil {
+			return err
+		}
+		if err := r.Client.Delete(ctx, existingMghConfigMap); err != nil && !errors.IsNotFound(err) {
+			return err
+		}
 	}
 
 	log.Info(fmt.Sprintf("clean up the namespace %s", constants.HOHSystemNamespace))


### PR DESCRIPTION
fix:

```
1.6620269077928638e+09	ERROR	Reconciler error	{"controller": "managedcluster", "controllerGroup": "cluster.open-cluster-management.io", "controllerKind": "ManagedCluster", "managedCluster": {"name":"hub1"}, "namespace": "", "name": "hub1", "reconcileID": "f23dbe90-f331-4b73-9984-e4a9aed7254e", "error": "failed to set condition(True): failed to update status condition: Operation cannot be fulfilled on multiclusterglobalhubs.operator.open-cluster-management.io \"multiclusterglobalhub\": the object has been modified; please apply your changes to the latest version and try again"}
1.6620270477579641e+09	ERROR	failed to remove namespaced resources	{"controller": "multiclusterglobalhub", "controllerGroup": "operator.open-cluster-management.io", "controllerKind": "MulticlusterGlobalHub", "multiclusterGlobalHub": {"name":"multiclusterglobalhub","namespace":"open-cluster-management"}, "namespace": "open-cluster-management", "name": "multiclusterglobalhub", "reconcileID": "fc79307c-c28d-4aa1-a4e6-882dfc2ec56f", "error": "Operation cannot be fulfilled on configmaps \"multicluster-global-hub-config\": the object has been modified; please apply your changes to the latest version and try again"}
1.6620270477580087e+09	ERROR	Reconciler error	{"controller": "multiclusterglobalhub", "controllerGroup": "operator.open-cluster-management.io", "controllerKind": "MulticlusterGlobalHub", "multiclusterGlobalHub": {"name":"multiclusterglobalhub","namespace":"open-cluster-management"}, "namespace": "open-cluster-management", "name": "multiclusterglobalhub", "reconcileID": "fc79307c-c28d-4aa1-a4e6-882dfc2ec56f", "error": "Operation cannot be fulfilled on configmaps \"multicluster-global-hub-config\": the object has been modified; please apply your changes to the latest version and try again"}
root@mcdev:~/workspace/multicluster-global-hub/operator# oc logs  multicluster-global-hub-operator-7c57798465-cd9st | grep -i fail
1.6620269077928638e+09	ERROR	Reconciler error	{"controller": "managedcluster", "controllerGroup": "cluster.open-cluster-management.io", "controllerKind": "ManagedCluster", "managedCluster": {"name":"hub1"}, "namespace": "", "name": "hub1", "reconcileID": "f23dbe90-f331-4b73-9984-e4a9aed7254e", "error": "failed to set condition(True): failed to update status condition: Operation cannot be fulfilled on multiclusterglobalhubs.operator.open-cluster-management.io \"multiclusterglobalhub\": the object has been modified; please apply your changes to the latest version and try again"}
1.6620270477579641e+09	ERROR	failed to remove namespaced resources	{"controller": "multiclusterglobalhub", "controllerGroup": "operator.open-cluster-management.io", "controllerKind": "MulticlusterGlobalHub", "multiclusterGlobalHub": {"name":"multiclusterglobalhub","namespace":"open-cluster-management"}, "namespace": "open-cluster-management", "name": "multiclusterglobalhub", "reconcileID": "fc79307c-c28d-4aa1-a4e6-882dfc2ec56f", "error": "Operation cannot be fulfilled on configmaps \"multicluster-global-hub-config\": the object has been modified; please apply your changes to the latest version and try again"}
```

Signed-off-by: morvencao <lcao@redhat.com>