### PR TITLE
Create synchronized regional hub resources without status

### DIFF
--- a/agent/pkg/controllers/testdata/crd/0000_03_clusters.open-cluster-management.io_clustersetrolebinding.crd.yaml
+++ b/agent/pkg/controllers/testdata/crd/0000_03_clusters.open-cluster-management.io_clustersetrolebinding.crd.yaml
@@ -1,0 +1,99 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: managedclustersetbindings.cluster.open-cluster-management.io
+spec:
+  group: cluster.open-cluster-management.io
+  names:
+    kind: ManagedClusterSetBinding
+    listKind: ManagedClusterSetBindingList
+    plural: managedclustersetbindings
+    shortNames:
+    - mclsetbinding
+    - mclsetbindings
+    singular: managedclustersetbinding
+  scope: Namespaced
+  versions:
+  - deprecated: true
+    deprecationWarning: cluster.open-cluster-management.io/v1alpha1 ManagedClusterSetBinding
+      is deprecated; use cluster.open-cluster-management.io/v1beta1 ManagedClusterSetBinding
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ManagedClusterSetBinding projects a ManagedClusterSet into a
+          certain namespace. User is able to create a ManagedClusterSetBinding in
+          a namespace and bind it to a ManagedClusterSet if they have an RBAC rule
+          to CREATE on the virtual subresource of managedclustersets/bind. Workloads
+          created in the same namespace can only be distributed to ManagedClusters
+          in ManagedClusterSets bound in this namespace by higher level controllers.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the attributes of ManagedClusterSetBinding.
+            properties:
+              clusterSet:
+                description: ClusterSet is the name of the ManagedClusterSet to bind.
+                  It must match the instance name of the ManagedClusterSetBinding
+                  and cannot change once created. User is allowed to set this field
+                  if they have an RBAC rule to CREATE on the virtual subresource of
+                  managedclustersets/bind.
+                minLength: 1
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ManagedClusterSetBinding projects a ManagedClusterSet into a
+          certain namespace. User is able to create a ManagedClusterSetBinding in
+          a namespace and bind it to a ManagedClusterSet if they have an RBAC rule
+          to CREATE on the virtual subresource of managedclustersets/bind. Workloads
+          created in the same namespace can only be distributed to ManagedClusters
+          in ManagedClusterSets bound in this namespace by higher level controllers.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the attributes of ManagedClusterSetBinding.
+            properties:
+              clusterSet:
+                description: ClusterSet is the name of the ManagedClusterSet to bind.
+                  It must match the instance name of the ManagedClusterSetBinding
+                  and cannot change once created. User is allowed to set this field
+                  if they have an RBAC rule to CREATE on the virtual subresource of
+                  managedclustersets/bind.
+                minLength: 1
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/agent/pkg/helper/object.go
+++ b/agent/pkg/helper/object.go
@@ -17,6 +17,7 @@ const (
 
 // UpdateObject function updates a given k8s object.
 func UpdateObject(ctx context.Context, k8sClient client.Client, obj *unstructured.Unstructured) error {
+	delete(obj.Object, "status")
 	objectBytes, err := obj.MarshalJSON()
 	if err != nil {
 		return fmt.Errorf("failed to update object - %w", err)

--- a/agent/pkg/helper/object_test.go
+++ b/agent/pkg/helper/object_test.go
@@ -1,0 +1,58 @@
+package helper
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	clustersV1beta1 "open-cluster-management.io/api/cluster/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+var (
+	config        *rest.Config
+	runtimeClient client.Client
+)
+
+func TestMain(m *testing.M) {
+	t := &envtest.Environment{
+		ErrorIfCRDPathMissing: true,
+		CRDDirectoryPaths:     []string{filepath.Join("..", "controllers", "testdata", "crd")},
+	}
+
+	var err error
+	config, err = t.Start()
+	if err != nil {
+		panic(err)
+	}
+
+	if err := clustersV1beta1.AddToScheme(scheme.Scheme); err != nil {
+		panic(err)
+	}
+	runtimeClient, err = client.New(config, client.Options{})
+	if err != nil {
+		panic(err)
+	}
+
+	code := m.Run()
+	t.Stop()
+	os.Exit(code)
+}
+
+func TestUpdateObject(t *testing.T) {
+	mclSetBindingJson := "{\"apiVersion\":\"cluster.open-cluster-management.io/v1beta1\",\"kind\":\"ManagedClusterSetBinding\",\"metadata\":{\"annotations\":{\"global-hub.open-cluster-management.io/origin-ownerreference-uid\":\"bd957348-d27a-49a4-9218-89d9016338f6\"},\"creationTimestamp\":\"2022-09-19T02:39:42Z\",\"name\":\"default\",\"namespace\":\"default\",\"selfLink\":\"/apis/cluster.open-cluster-management.io/v1beta1/namespaces/default/managedclustersetbindings/default\"},\"spec\":{\"clusterSet\":\"default\"},\"status\":{\"conditions\":null}}\n"
+
+	obj := &unstructured.Unstructured{}
+	if err := json.Unmarshal([]byte(mclSetBindingJson), obj); err != nil {
+		panic(err)
+	}
+	if err := UpdateObject(context.Background(), runtimeClient, obj); err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>
Fixed `multicluster-global-hub-agent` issue:
```bash
{"level":"error","ts":1663554121.5829706,"logger":"generic-bundle-syncer","msg":"failed to update object","name":"default","namespace":"default","kind":"ManagedClusterSetBinding","error":"failed to update object - failed to create typed patch object (default/default; cluster.open-cluster-management.io/v1beta1, Kind=ManagedClusterSetBinding): .status: field not declared in schema","stacktrace":"github.com/stolostron/multicluster-global-hub/agent/pkg/spec/controller/workers.(*Worker).start.func1\n\t/workspace/agent/pkg/spec/controller/workers/worker.go:45"}
```