### PR TITLE
fix data path conflict of testing embed postgres.

### DIFF
--- a/manager/pkg/specsyncer/spec2db/controller/hoh_config_spec_sync_test.go
+++ b/manager/pkg/specsyncer/spec2db/controller/hoh_config_spec_sync_test.go
@@ -53,7 +53,8 @@ var _ = Describe("spec to database controller", Ordered, func() {
 		Expect(postgresSQL).NotTo(BeNil())
 
 		By("Adding the controllers to the manager")
-		controller.AddHubOfHubsConfigController(mgr, postgresSQL)
+		err = controller.AddHubOfHubsConfigController(mgr, postgresSQL)
+		Expect(err).NotTo(HaveOccurred())
 		go func() {
 			defer GinkgoRecover()
 			err = mgr.Start(ctx)

--- a/test/pkg/testpostgres/testpostgres.go
+++ b/test/pkg/testpostgres/testpostgres.go
@@ -8,8 +8,10 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"os"
 	"os/exec"
 	"os/user"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"syscall"
@@ -48,10 +50,22 @@ func NewTestPostgres() (*TestPostgres, error) {
 			return pg, err
 		}
 	} else {
+		postgresDataPath, err := os.UserHomeDir()
+		if err != nil || postgresDataPath == "" {
+			postgresDataPath = os.TempDir()
+		}
+		postgresDataPath = filepath.Join(postgresDataPath,
+			fmt.Sprintf(".embedded-postgres-go-%d", postgresPort),
+			"extracted")
 		pg.rootUser = false
 		pg.username = currentUser.Username
+		postgresConfig := embeddedpostgres.DefaultConfig()
+		postgresConfig = postgresConfig.Port(postgresPort)
+		postgresConfig = postgresConfig.RuntimePath(postgresDataPath)
+		postgresConfig = postgresConfig.BinariesPath(postgresDataPath)
+		postgresConfig = postgresConfig.DataPath(filepath.Join(postgresDataPath, "data"))
 		pg.embedded = embeddedpostgres.NewDatabase(
-			embeddedpostgres.DefaultConfig().Port(postgresPort).Database("hoh"))
+			postgresConfig.Database("hoh"))
 		if err = pg.embedded.Start(); err != nil {
 			fmt.Printf("failed to get embeddedPostgres: %s", err.Error())
 			return pg, err


### PR DESCRIPTION
When running multiple testing embeded postgresql instances in the same host,
the data path must be different, otherwise there will be conflict.

Signed-off-by: morvencao <lcao@redhat.com>