### PR TITLE
format code with same rule.

### DIFF
--- a/agent/Makefile
+++ b/agent/Makefile
@@ -15,9 +15,9 @@ all: fmt lint build
 
 .PHONY: fmt				##formats the code
 fmt:
-	@gci -w ./cmd/ ./pkg/
+	@gci write -s standard -s default -s "prefix(github.com/stolostron/multicluster-global-hub)" ./cmd/ ./pkg/
 	@go fmt ./cmd/... ./pkg/...
-	@gofumpt -w ./cmd/ ./pkg/
+	GOFUMPT_SPLIT_LONG_LINES=on gofumpt -w ./cmd/ ./pkg/
 
 CONTROLLER_GEN = controller-gen
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"

--- a/manager/Makefile
+++ b/manager/Makefile
@@ -15,9 +15,9 @@ all: fmt lint build
 
 .PHONY: fmt				##formats the code
 fmt:
-	@gci -w ./cmd/ ./pkg/
+	@gci write -s standard -s default -s "prefix(github.com/stolostron/multicluster-global-hub)" ./cmd/ ./pkg/
 	@go fmt ./cmd/... ./pkg/...
-	@gofumpt -w ./cmd/ ./pkg/
+	GOFUMPT_SPLIT_LONG_LINES=on gofumpt -w ./cmd/ ./pkg/
 
 CONTROLLER_GEN = controller-gen
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -98,7 +98,9 @@ generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and
 
 .PHONY: fmt
 fmt: ## Run go fmt against code.
-	go fmt ./...
+	@gci write -s standard -s default -s "prefix(github.com/stolostron/multicluster-global-hub)" ./main.go ./apis/ ./pkg/
+	@go fmt ./...
+	GOFUMPT_SPLIT_LONG_LINES=on gofumpt -w ./main.go ./apis/ ./pkg/
 
 .PHONY: vet
 vet: ## Run go vet against code.


### PR DESCRIPTION
format code with same rule in the root Makefile:

https://github.com/stolostron/multicluster-global-hub/blob/ba2f9d21f7fab6259d4c22f77625176aaacdcccf/Makefile#L83-L87

to avoid unnecessary changes after build images.

Signed-off-by: morvencao <lcao@redhat.com>