### PR TITLE
exclude yaml file to code coverage

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@ sonar.projectKey=open-cluster-management_hub-of-hubs
 sonar.projectName=hub-of-hubs
 
 sonar.sources=.
-sonar.exclusions=test/**,**/*.sql,**/*_test.go,**/*_generated*.go,**/*_generated/**,**/vendor/**
+sonar.exclusions=test/**,**/*.sql,**/*.yaml,**/*_test.go,**/*_generated*.go,**/*_generated/**,**/vendor/**
 
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go


### PR DESCRIPTION
`.yaml` is for test purpose. we should not analysis it in code coverage.

Signed-off-by: clyang82 <chuyang@redhat.com>