### PR TITLE
Add transport to database unit tests for policies (UT for statussyncer)

### DIFF
--- a/manager/pkg/statussyncer/transport2db/syncer/dbsyncer/dbsyncer_suite_test.go
+++ b/manager/pkg/statussyncer/transport2db/syncer/dbsyncer/dbsyncer_suite_test.go
@@ -1,0 +1,150 @@
+package dbsyncer_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/confluentinc/confluent-kafka-go/kafka"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	managerscheme "github.com/stolostron/multicluster-global-hub/manager/pkg/scheme"
+	"github.com/stolostron/multicluster-global-hub/manager/pkg/specsyncer/db2transport/db/postgresql"
+	"github.com/stolostron/multicluster-global-hub/manager/pkg/statistics"
+	"github.com/stolostron/multicluster-global-hub/manager/pkg/statussyncer/transport2db/conflator"
+	"github.com/stolostron/multicluster-global-hub/manager/pkg/statussyncer/transport2db/db/workerpool"
+	statussyncer "github.com/stolostron/multicluster-global-hub/manager/pkg/statussyncer/transport2db/syncer"
+	"github.com/stolostron/multicluster-global-hub/manager/pkg/statussyncer/transport2db/transport"
+	teststatuskafka "github.com/stolostron/multicluster-global-hub/manager/pkg/statussyncer/transport2db/transport/test"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/test/pkg/testpostgres"
+)
+
+var (
+	testenv             *envtest.Environment
+	cfg                 *rest.Config
+	ctx                 context.Context
+	cancel              context.CancelFunc
+	mgr                 ctrl.Manager
+	kubeClient          client.Client
+	testPostgres        *testpostgres.TestPostgres
+	transportPostgreSQL *postgresql.PostgreSQL
+	dbWorkerPool        *workerpool.DBWorkerPool
+	statusTransport     transport.Transport
+	kafkaMessageChan    chan *kafka.Message
+)
+
+func TestDbsyncer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Database syncer Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	Expect(os.Setenv("POD_NAMESPACE", "default")).To(Succeed())
+
+	ctx, cancel = context.WithCancel(context.Background())
+
+	By("Prepare envtest environment")
+	var err error
+	testenv = &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "..", "..", "..", "..", "pkg", "testdata", "crds"),
+		},
+		ErrorIfCRDPathMissing: true,
+	}
+	cfg, err = testenv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	By("Create test postgres")
+	testPostgres, err = testpostgres.NewTestPostgres()
+	Expect(err).NotTo(HaveOccurred())
+	transportPostgreSQL, err = postgresql.NewPostgreSQL(testPostgres.URI)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Create database work pool")
+	stats, err := statistics.NewStatistics(ctrl.Log.WithName("statistics"), &statistics.StatisticsConfig{})
+	Expect(err).NotTo(HaveOccurred())
+	dbWorkerPool, err = workerpool.NewDBWorkerPool(ctrl.Log.WithName("db-worker-pool"), testPostgres.URI, stats)
+	Expect(dbWorkerPool.Start()).Should(Succeed())
+
+	By("Create conflationReadyQueue")
+	conflationReadyQueue := conflator.NewConflationReadyQueue(stats)
+	conflationManager := conflator.NewConflationManager(ctrl.Log.WithName("conflation"), conflationReadyQueue,
+		false, stats) // manage all Conflation Units
+
+	kafkaMessageChan = make(chan *kafka.Message)
+	statusTransport, err = teststatuskafka.NewKafkaTestConsumer(kafkaMessageChan, conflationManager, stats,
+		ctrl.Log.WithName("kafka-consumer"))
+	Expect(err).NotTo(HaveOccurred())
+	statusTransport.Start()
+
+	mgr, err = ctrl.NewManager(cfg, ctrl.Options{
+		MetricsBindAddress: "0",
+		Scheme:             scheme.Scheme,
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Get kubeClient")
+	kubeClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(kubeClient).NotTo(BeNil())
+
+	mghSystemNamespace := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: constants.HohSystemNamespace}}
+	Expect(kubeClient.Create(ctx, mghSystemNamespace)).Should(Succeed())
+	mghSystemConfigMap := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.HoHConfigName,
+			Namespace: constants.HohSystemNamespace,
+		},
+		Data: map[string]string{"aggregationLevel": "full", "enableLocalPolicies": "true"},
+	}
+	Expect(kubeClient.Create(ctx, mghSystemConfigMap)).Should(Succeed())
+
+	By("Add to Scheme")
+	Expect(managerscheme.AddToScheme(mgr.GetScheme())).NotTo(HaveOccurred())
+
+	By("Add transport to database controller")
+	err = statussyncer.AddTransport2DBSyncers(mgr, dbWorkerPool, conflationManager,
+		conflationReadyQueue, statusTransport, stats)
+	Expect(err).NotTo(HaveOccurred())
+	go func() {
+		defer GinkgoRecover()
+		err = mgr.Start(ctx)
+		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
+	}()
+
+	By("Waiting for the manager to be ready")
+	Expect(mgr.GetCache().WaitForCacheSync(ctx)).To(BeTrue())
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+
+	cancel()
+	statusTransport.Stop()
+	transportPostgreSQL.Stop()
+	dbWorkerPool.Stop()
+	Expect(testPostgres.Stop()).NotTo(HaveOccurred())
+
+	err := testenv.Stop()
+	// https://github.com/kubernetes-sigs/controller-runtime/issues/1571
+	// Set 4 with random
+	if err != nil {
+		time.Sleep(4 * time.Second)
+	}
+	Expect(testenv.Stop()).NotTo(HaveOccurred())
+})

--- a/manager/pkg/statussyncer/transport2db/syncer/dbsyncer/dbsyncer_suite_test.go
+++ b/manager/pkg/statussyncer/transport2db/syncer/dbsyncer/dbsyncer_suite_test.go
@@ -2,6 +2,7 @@ package dbsyncer_test
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -20,6 +21,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	producer "github.com/stolostron/multicluster-global-hub/agent/pkg/transport/producer"
 	managerscheme "github.com/stolostron/multicluster-global-hub/manager/pkg/scheme"
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/specsyncer/db2transport/db/postgresql"
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/statistics"
@@ -27,7 +29,9 @@ import (
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/statussyncer/transport2db/db/workerpool"
 	statussyncer "github.com/stolostron/multicluster-global-hub/manager/pkg/statussyncer/transport2db/syncer"
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/statussyncer/transport2db/transport"
+	"github.com/stolostron/multicluster-global-hub/pkg/compressor"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/kafka/headers"
 	"github.com/stolostron/multicluster-global-hub/test/pkg/testkafka"
 	"github.com/stolostron/multicluster-global-hub/test/pkg/testpostgres"
 )
@@ -79,12 +83,12 @@ var _ = BeforeSuite(func() {
 	stats, err := statistics.NewStatistics(ctrl.Log.WithName("statistics"), &statistics.StatisticsConfig{})
 	Expect(err).NotTo(HaveOccurred())
 	dbWorkerPool, err = workerpool.NewDBWorkerPool(ctrl.Log.WithName("db-worker-pool"), testPostgres.URI, stats)
+	Expect(err).NotTo(HaveOccurred())
 	Expect(dbWorkerPool.Start()).Should(Succeed())
 
 	By("Create conflationReadyQueue")
 	conflationReadyQueue := conflator.NewConflationReadyQueue(stats)
-	conflationManager := conflator.NewConflationManager(ctrl.Log.WithName("conflation"), conflationReadyQueue,
-		false, stats) // manage all Conflation Units
+	conflationManager := conflator.NewConflationManager(ctrl.Log.WithName("conflation"), conflationReadyQueue, false, stats) // manage all Conflation Units
 
 	kafkaMessageChan = make(chan *kafka.Message)
 	statusTransport, err = testkafka.NewKafkaTestConsumer(kafkaMessageChan, conflationManager, stats,
@@ -103,6 +107,10 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(kubeClient).NotTo(BeNil())
 
+	By("Add to Scheme")
+	Expect(managerscheme.AddToScheme(mgr.GetScheme())).NotTo(HaveOccurred())
+
+	By("Create the global hub ConfigMap with aggregationLevel=full and enableLocalPolicies=true")
 	mghSystemNamespace := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: constants.HohSystemNamespace}}
 	Expect(kubeClient.Create(ctx, mghSystemNamespace)).Should(Succeed())
 	mghSystemConfigMap := &v1.ConfigMap{
@@ -114,17 +122,14 @@ var _ = BeforeSuite(func() {
 	}
 	Expect(kubeClient.Create(ctx, mghSystemConfigMap)).Should(Succeed())
 
-	By("Add to Scheme")
-	Expect(managerscheme.AddToScheme(mgr.GetScheme())).NotTo(HaveOccurred())
+	By("Add controllers to manager")
+	err = statussyncer.AddTransport2DBSyncers(mgr, dbWorkerPool, conflationManager, conflationReadyQueue, statusTransport, stats)
+	Expect(err).ToNot(HaveOccurred())
 
-	By("Add transport to database controller")
-	err = statussyncer.AddTransport2DBSyncers(mgr, dbWorkerPool, conflationManager,
-		conflationReadyQueue, statusTransport, stats)
-	Expect(err).NotTo(HaveOccurred())
+	By("Start the manager")
 	go func() {
 		defer GinkgoRecover()
-		err = mgr.Start(ctx)
-		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
+		Expect(mgr.Start(ctx)).ToNot(HaveOccurred(), "failed to run manager")
 	}()
 
 	By("Waiting for the manager to be ready")
@@ -132,14 +137,13 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	By("tearing down the test environment")
-
 	cancel()
 	statusTransport.Stop()
 	transportPostgreSQL.Stop()
 	dbWorkerPool.Stop()
 	Expect(testPostgres.Stop()).NotTo(HaveOccurred())
 
+	By("Tearing down the test environment")
 	err := testenv.Stop()
 	// https://github.com/kubernetes-sigs/controller-runtime/issues/1571
 	// Set 4 with random
@@ -148,3 +152,42 @@ var _ = AfterSuite(func() {
 	}
 	Expect(testenv.Stop()).NotTo(HaveOccurred())
 })
+
+func buildKafkaMessage(key, id string, payload []byte) (*kafka.Message, error) {
+	transportMessage := &producer.Message{
+		Key:     key,
+		ID:      id, // entry.transportBundleKey
+		MsgType: constants.StatusBundle,
+		Version: "0.2", // entry.bundle.GetBundleVersion().String()
+		Payload: payload,
+	}
+	transportMessageBytes, err := json.Marshal(transportMessage)
+	if err != nil {
+		return nil, err
+	}
+
+	compressor, err := compressor.NewCompressor(compressor.GZip)
+	if err != nil {
+		return nil, err
+	}
+	compressedTransportBytes, err := compressor.Compress(transportMessageBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	topic := "status"
+	kafkaMessage := &kafka.Message{
+		Key: []byte(transportMessage.Key),
+		TopicPartition: kafka.TopicPartition{
+			Topic:     &topic,
+			Partition: 0,
+		},
+		Headers: []kafka.Header{
+			{Key: headers.CompressionType, Value: []byte(compressor.GetType())},
+		},
+		Value:         compressedTransportBytes,
+		TimestampType: 1,
+		Timestamp:     time.Now(),
+	}
+	return kafkaMessage, nil
+}

--- a/manager/pkg/statussyncer/transport2db/syncer/dbsyncer/dbsyncer_suite_test.go
+++ b/manager/pkg/statussyncer/transport2db/syncer/dbsyncer/dbsyncer_suite_test.go
@@ -27,8 +27,8 @@ import (
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/statussyncer/transport2db/db/workerpool"
 	statussyncer "github.com/stolostron/multicluster-global-hub/manager/pkg/statussyncer/transport2db/syncer"
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/statussyncer/transport2db/transport"
-	teststatuskafka "github.com/stolostron/multicluster-global-hub/manager/pkg/statussyncer/transport2db/transport/test"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/test/pkg/testkafka"
 	"github.com/stolostron/multicluster-global-hub/test/pkg/testpostgres"
 )
 
@@ -87,7 +87,7 @@ var _ = BeforeSuite(func() {
 		false, stats) // manage all Conflation Units
 
 	kafkaMessageChan = make(chan *kafka.Message)
-	statusTransport, err = teststatuskafka.NewKafkaTestConsumer(kafkaMessageChan, conflationManager, stats,
+	statusTransport, err = testkafka.NewKafkaTestConsumer(kafkaMessageChan, conflationManager, stats,
 		ctrl.Log.WithName("kafka-consumer"))
 	Expect(err).NotTo(HaveOccurred())
 	statusTransport.Start()

--- a/manager/pkg/statussyncer/transport2db/syncer/dbsyncer/policies_db_syncer_test.go
+++ b/manager/pkg/statussyncer/transport2db/syncer/dbsyncer/policies_db_syncer_test.go
@@ -22,7 +22,8 @@ var _ = Describe("Policies", Ordered, func() {
 	const testTable = "compliance"
 	const leafHubName = "hub1"
 
-	It("create status policy database table", func() {
+	BeforeAll(func() {
+		By("Create status compliance table in database")
 		_, err := transportPostgreSQL.GetConn().Exec(ctx, `
 			CREATE SCHEMA IF NOT EXISTS status;
 			DO $$ BEGIN
@@ -71,7 +72,7 @@ var _ = Describe("Policies", Ordered, func() {
 		}, 10*time.Second, 2*time.Second).ShouldNot(HaveOccurred())
 	})
 
-	It("delete policy from database", func() {
+	It("delete the expired policy from database", func() {
 		deletedPolicyId := "b8b3e164-477e-4be1-a870-992265f31f7d"
 		createdPolicyId := "d9347b09-bb46-4e2b-91ea-513e83ab9ea7"
 		By("Add an expired policy to the database")

--- a/manager/pkg/statussyncer/transport2db/syncer/dbsyncer/policies_db_syncer_test.go
+++ b/manager/pkg/statussyncer/transport2db/syncer/dbsyncer/policies_db_syncer_test.go
@@ -5,22 +5,25 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/confluentinc/confluent-kafka-go/kafka"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	policyv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 
-	producer "github.com/stolostron/multicluster-global-hub/agent/pkg/transport/producer"
+	"github.com/stolostron/multicluster-global-hub/manager/pkg/statussyncer/transport2db/bundle"
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/statussyncer/transport2db/db"
+	"github.com/stolostron/multicluster-global-hub/manager/pkg/statussyncer/transport2db/transport"
 	statusbundle "github.com/stolostron/multicluster-global-hub/pkg/bundle/status"
-	"github.com/stolostron/multicluster-global-hub/pkg/compressor"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
-	"github.com/stolostron/multicluster-global-hub/pkg/kafka/headers"
 )
 
 var _ = Describe("Policies", Ordered, func() {
-	const testSchema = "status"
-	const testTable = "compliance"
-	const leafHubName = "hub1"
+	const (
+		testSchema                = "status"
+		complianceTable           = "compliance"
+		aggregatedComplianceTable = "aggregated_compliance"
+		leafHubName               = "hub1"
+		createdPolicyId           = "d9347b09-bb46-4e2b-91ea-513e83ab9ea7"
+	)
 
 	BeforeAll(func() {
 		By("Create status compliance table in database")
@@ -50,38 +53,51 @@ var _ = Describe("Policies", Ordered, func() {
 				error status.error_type NOT NULL,
 				compliance status.compliance_type NOT NULL
 			);
+			CREATE TABLE IF NOT EXISTS  status.aggregated_compliance (
+				id uuid NOT NULL,
+				leaf_hub_name character varying(63) NOT NULL,
+				applied_clusters integer NOT NULL,
+				non_compliant_clusters integer NOT NULL
+			);
 		`)
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Check whether the table is created")
+		By("Check whether the tables are created")
 		Eventually(func() error {
 			rows, err := transportPostgreSQL.GetConn().Query(ctx, "SELECT * FROM pg_tables")
 			if err != nil {
 				return err
 			}
 			defer rows.Close()
+			complianceReady := false
+			aggregatedComplianceReady := false
 			for rows.Next() {
 				columnValues, _ := rows.Values()
 				schema := columnValues[0]
 				table := columnValues[1]
-				if schema == testSchema && table == testTable {
-					return nil
+				if schema == testSchema && table == complianceTable {
+					complianceReady = true
+				}
+				if schema == testSchema && table == aggregatedComplianceTable {
+					aggregatedComplianceReady = true
 				}
 			}
-			return fmt.Errorf("failed to create test table %s.%s", testSchema, testTable)
+			if complianceReady && aggregatedComplianceReady {
+				return nil
+			}
+			return fmt.Errorf("failed to create test table %s: %s and %s", testSchema, complianceTable, aggregatedComplianceTable)
 		}, 10*time.Second, 2*time.Second).ShouldNot(HaveOccurred())
 	})
 
-	It("delete the expired policy from database", func() {
-		deletedPolicyId := "b8b3e164-477e-4be1-a870-992265f31f7d"
-		createdPolicyId := "d9347b09-bb46-4e2b-91ea-513e83ab9ea7"
+	It("delete and insert policy with ClustersPerPolicy Bundle where aggregationLevel = full", func() {
 		By("Add an expired policy to the database")
-		_, err := transportPostgreSQL.GetConn().Exec(ctx, fmt.Sprintf(`
-			INSERT INTO %s.%s (id,cluster_name,leaf_hub_name,error,compliance) VALUES($1, $2, $3, $4, $5)`,
-			testSchema, testTable), deletedPolicyId, "cluster1", leafHubName, "none", "unknown")
+		deletedPolicyId := "b8b3e164-477e-4be1-a870-992265f31f7d"
+		_, err := transportPostgreSQL.GetConn().Exec(ctx, fmt.Sprintf(`INSERT INTO %s.%s (id,cluster_name,leaf_hub_name,error,compliance) VALUES($1, $2, $3, $4, $5)`, testSchema, complianceTable), deletedPolicyId, "cluster1", leafHubName, "none", "unknown")
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Check the expired policy is added in database")
 		Eventually(func() error {
-			rows, err := transportPostgreSQL.GetConn().Query(ctx, fmt.Sprintf("SELECT id FROM %s.%s", testSchema, testTable))
+			rows, err := transportPostgreSQL.GetConn().Query(ctx, fmt.Sprintf("SELECT id FROM %s.%s", testSchema, complianceTable))
 			if err != nil {
 				return err
 			}
@@ -92,11 +108,11 @@ var _ = Describe("Policies", Ordered, func() {
 				if err != nil {
 					return err
 				}
-				if policyId == "b8b3e164-477e-4be1-a870-992265f31f7d" {
+				if policyId == deletedPolicyId {
 					return nil
 				}
 			}
-			return fmt.Errorf("failed to load content of table %s.%s", testSchema, testTable)
+			return fmt.Errorf("failed to load content of table %s.%s", testSchema, complianceTable)
 		}, 10*time.Second, 2*time.Second).ShouldNot(HaveOccurred())
 
 		By("Build a new policy bundle in the regional hub")
@@ -106,27 +122,25 @@ var _ = Describe("Policies", Ordered, func() {
 			LeafHubName:   leafHubName,
 			BundleVersion: statusbundle.NewBundleVersion(1, 0),
 		}
-
 		transportPayload.Objects = append(transportPayload.Objects, &statusbundle.PolicyGenericComplianceStatus{
 			PolicyID:                  createdPolicyId,
-			CompliantClusters:         []string{"cluster1"},
-			NonCompliantClusters:      []string{"cluster2"},
+			CompliantClusters:         []string{"cluster1"}, // generate record: createdPolicyId hub1-cluster1 compliant
+			NonCompliantClusters:      []string{"cluster2"}, // generate record: createdPolicyId hub1-cluster2 non_compliant
 			UnknownComplianceClusters: make([]string, 0),
 		})
-
 		// transport bundle
 		clustersPerPolicyTransportKey := fmt.Sprintf("%s.%s", leafHubName, constants.ClustersPerPolicyMsgKey)
 		payloadBytes, err := json.Marshal(transportPayload)
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Synchronize the latest policy bundle with transport")
+		By("Synchronize the latest ClustersPerPolicy bundle with transport")
 		kafkaMessage, err := buildKafkaMessage(clustersPerPolicyTransportKey, clustersPerPolicyTransportKey, payloadBytes)
 		Expect(err).ToNot(HaveOccurred())
 		kafkaMessageChan <- kafkaMessage
 
-		By("Check the latest policy is created and expired policy is deleted from database")
+		By("Check the ClustersPerPolicy policy is created and expired policy is deleted from database")
 		Eventually(func() error {
-			querySql := fmt.Sprintf("SELECT id,cluster_name,leaf_hub_name,compliance FROM %s.%s", testSchema, testTable)
+			querySql := fmt.Sprintf("SELECT id,cluster_name,leaf_hub_name,compliance FROM %s.%s", testSchema, complianceTable)
 			rows, err := transportPostgreSQL.GetConn().Query(ctx, querySql)
 			if err != nil {
 				return err
@@ -153,46 +167,134 @@ var _ = Describe("Policies", Ordered, func() {
 			if deletedPolicyCount == 0 && createdPolicyCount > 0 {
 				return nil
 			}
-			return fmt.Errorf("failed to sync content of table %s.%s", testSchema, testTable)
+			return fmt.Errorf("failed to sync content of table %s.%s", testSchema, complianceTable)
+		}, 30*time.Second, 2*time.Second).ShouldNot(HaveOccurred())
+	})
+
+	It("update the policy status with PolicyDeltaCompliance bundle where aggregationLevel = full", func() {
+		By("Create the delta policy bundle")
+		transportPayload := statusbundle.BaseDeltaComplianceStatusBundle{
+			Objects:       make([]*statusbundle.PolicyGenericComplianceStatus, 0),
+			LeafHubName:   leafHubName,
+			BundleVersion: statusbundle.NewBundleVersion(1, 0),
+		}
+		// the delta policy bundle tries to do the following action:
+		// 1. delete record: createdPolicyId hub1-cluster1 compliant
+		// 2. update record: createdPolicyId hub1-cluster2 non_compliant => createdPolicyId hub1-cluster2 compliant
+		// 3. insert record: createdPolicyId hub1-cluster3 non_compliant
+		transportPayload.Objects = append(transportPayload.Objects, &statusbundle.PolicyGenericComplianceStatus{
+			PolicyID:                  createdPolicyId,
+			CompliantClusters:         []string{"cluster2"},
+			NonCompliantClusters:      []string{"cluster3"},
+			UnknownComplianceClusters: make([]string, 0),
+		})
+		// transport bundle
+		policyDeltaComplianceTransportKey := fmt.Sprintf("%s.%s", leafHubName, constants.PolicyDeltaComplianceMsgKey)
+		payloadBytes, err := json.Marshal(transportPayload)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Synchronize the delta policy bundle with transport")
+		kafkaMessage, err := buildKafkaMessage(policyDeltaComplianceTransportKey, policyDeltaComplianceTransportKey, payloadBytes)
+		Expect(err).ToNot(HaveOccurred())
+		kafkaMessageChan <- kafkaMessage
+
+		By("Check the delta policy bundle is only update compliance status of the existing record in database")
+		Eventually(func() error {
+			querySql := fmt.Sprintf("SELECT id,cluster_name,leaf_hub_name,compliance FROM %s.%s", testSchema, complianceTable)
+			rows, err := transportPostgreSQL.GetConn().Query(ctx, querySql)
+			if err != nil {
+				return err
+			}
+			defer rows.Close()
+			isDeleted := true
+			isUpdated := false
+			isInserted := false
+			for rows.Next() {
+				var (
+					policyId, clusterName, hubName string
+					complianceStatus               db.ComplianceStatus
+				)
+				if err := rows.Scan(&policyId, &clusterName, &hubName, &complianceStatus); err != nil {
+					return err
+				}
+				fmt.Printf("id(%s) %s-%s: %s \n", policyId, leafHubName, clusterName, complianceStatus)
+				if policyId == createdPolicyId && hubName == leafHubName {
+					// delete record: createdPolicyId hub1 cluster1 compliant
+					if clusterName == "cluster1" && complianceStatus == "compliant" {
+						isDeleted = false
+					}
+					// update record: createdPolicyId hub1-cluster2 non_compliant => createdPolicyId hub1-cluster2 compliant
+					if clusterName == "cluster2" && complianceStatus == "compliant" {
+						isUpdated = true
+					}
+					// insert record: createdPolicyId hub1-cluster3 non_compliant
+					if clusterName == "cluster3" && complianceStatus == "non_compliant" {
+						isInserted = true
+					}
+				}
+			}
+			// check deletion and creation do not take effect
+			if !isDeleted && !isInserted && isUpdated {
+				return nil
+			}
+			return fmt.Errorf("failed to sync content of table %s.%s", testSchema, complianceTable)
+		}, 30*time.Second, 2*time.Second).ShouldNot(HaveOccurred())
+	})
+
+	It("sync the aggregated policy with MinimalPolicyCompliance bundle where aggregationLevel = minimal", func() {
+		By("Overwrite the MinimalComplianceStatusBundle Predicate function, so that the minimal bundle cloud be processed")
+		statusTransport.Register(&transport.BundleRegistration{
+			MsgID:            constants.MinimalPolicyComplianceMsgKey,
+			CreateBundleFunc: bundle.NewMinimalComplianceStatusBundle,
+			Predicate: func() bool {
+				return true // syncer.config.Data["aggregationLevel"] == "minimal"
+			},
+		})
+
+		By("Create the minimal policy bundle")
+		transportPayload := statusbundle.BaseMinimalComplianceStatusBundle{
+			Objects:       make([]*statusbundle.MinimalPolicyComplianceStatus, 0),
+			LeafHubName:   leafHubName,
+			BundleVersion: statusbundle.NewBundleVersion(1, 0),
+		}
+		transportPayload.Objects = append(transportPayload.Objects, &statusbundle.MinimalPolicyComplianceStatus{
+			PolicyID:             createdPolicyId,
+			RemediationAction:    policyv1.Inform,
+			NonCompliantClusters: 2,
+			AppliedClusters:      3,
+		})
+		// transport bundle
+		minimalPolicyComplianceTransportKey := fmt.Sprintf("%s.%s", leafHubName, constants.MinimalPolicyComplianceMsgKey)
+		payloadBytes, err := json.Marshal(transportPayload)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Synchronize the policy bundle with transport")
+		kafkaMessage, err := buildKafkaMessage(minimalPolicyComplianceTransportKey, minimalPolicyComplianceTransportKey, payloadBytes)
+		Expect(err).ToNot(HaveOccurred())
+		kafkaMessageChan <- kafkaMessage
+
+		By("Check the minimal policy is synchronized to database")
+		Eventually(func() error {
+			querySql := fmt.Sprintf("SELECT id,leaf_hub_name,applied_clusters,non_compliant_clusters FROM %s.%s", testSchema, aggregatedComplianceTable)
+			rows, err := transportPostgreSQL.GetConn().Query(ctx, querySql)
+			if err != nil {
+				return err
+			}
+			defer rows.Close()
+			for rows.Next() {
+				var (
+					policyId, hubName                     string
+					appliedClusters, nonCompliantClusters int
+				)
+				if err := rows.Scan(&policyId, &hubName, &appliedClusters, &nonCompliantClusters); err != nil {
+					return err
+				}
+				fmt.Printf("%s %s %d %d \n", policyId, hubName, appliedClusters, nonCompliantClusters)
+				if policyId == createdPolicyId && hubName == leafHubName && appliedClusters == 3 && nonCompliantClusters == 2 {
+					return nil
+				}
+			}
+			return fmt.Errorf("failed to sync content of table %s.%s", testSchema, aggregatedComplianceTable)
 		}, 30*time.Second, 2*time.Second).ShouldNot(HaveOccurred())
 	})
 })
-
-func buildKafkaMessage(key, id string, payload []byte) (*kafka.Message, error) {
-	transportMessage := &producer.Message{
-		Key:     key,
-		ID:      id, // entry.transportBundleKey
-		MsgType: constants.StatusBundle,
-		Version: "0.2", // entry.bundle.GetBundleVersion().String()
-		Payload: payload,
-	}
-	transportMessageBytes, err := json.Marshal(transportMessage)
-	if err != nil {
-		return nil, err
-	}
-
-	compressor, err := compressor.NewCompressor(compressor.GZip)
-	if err != nil {
-		return nil, err
-	}
-	compressedTransportBytes, err := compressor.Compress(transportMessageBytes)
-	if err != nil {
-		return nil, err
-	}
-
-	topic := "status"
-	kafkaMessage := &kafka.Message{
-		Key: []byte(transportMessage.Key),
-		TopicPartition: kafka.TopicPartition{
-			Topic:     &topic,
-			Partition: 0,
-		},
-		Headers: []kafka.Header{
-			{Key: headers.CompressionType, Value: []byte(compressor.GetType())},
-		},
-		Value:         compressedTransportBytes,
-		TimestampType: 1,
-		Timestamp:     time.Now(),
-	}
-	return kafkaMessage, nil
-}

--- a/manager/pkg/statussyncer/transport2db/syncer/dbsyncer/policies_db_syncer_test.go
+++ b/manager/pkg/statussyncer/transport2db/syncer/dbsyncer/policies_db_syncer_test.go
@@ -1,0 +1,197 @@
+package dbsyncer_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/confluentinc/confluent-kafka-go/kafka"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	producer "github.com/stolostron/multicluster-global-hub/agent/pkg/transport/producer"
+	"github.com/stolostron/multicluster-global-hub/manager/pkg/statussyncer/transport2db/db"
+	statusbundle "github.com/stolostron/multicluster-global-hub/pkg/bundle/status"
+	"github.com/stolostron/multicluster-global-hub/pkg/compressor"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/kafka/headers"
+)
+
+var _ = Describe("Policies", Ordered, func() {
+	const testSchema = "status"
+	const testTable = "compliance"
+	const leafHubName = "hub1"
+
+	It("create status policy database table", func() {
+		_, err := transportPostgreSQL.GetConn().Exec(ctx, `
+			CREATE SCHEMA IF NOT EXISTS status;
+			DO $$ BEGIN
+				CREATE TYPE status.compliance_type AS ENUM (
+					'compliant',
+					'non_compliant',
+					'unknown'
+				);
+			EXCEPTION
+				WHEN duplicate_object THEN null;
+			END $$;
+			DO $$ BEGIN
+				CREATE TYPE status.error_type AS ENUM (
+					'disconnected',
+					'none'
+				);
+			EXCEPTION
+				WHEN duplicate_object THEN null;
+			END $$;
+			CREATE TABLE IF NOT EXISTS  status.compliance (
+				id uuid NOT NULL,
+				cluster_name character varying(63) NOT NULL,
+				leaf_hub_name character varying(63) NOT NULL,
+				error status.error_type NOT NULL,
+				compliance status.compliance_type NOT NULL
+			);
+		`)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Check whether the table is created")
+		Eventually(func() error {
+			rows, err := transportPostgreSQL.GetConn().Query(ctx, "SELECT * FROM pg_tables")
+			if err != nil {
+				return err
+			}
+			defer rows.Close()
+			for rows.Next() {
+				columnValues, _ := rows.Values()
+				schema := columnValues[0]
+				table := columnValues[1]
+				if schema == testSchema && table == testTable {
+					return nil
+				}
+			}
+			return fmt.Errorf("failed to create test table %s.%s", testSchema, testTable)
+		}, 10*time.Second, 2*time.Second).ShouldNot(HaveOccurred())
+	})
+
+	It("delete policy from database", func() {
+		deletedPolicyId := "b8b3e164-477e-4be1-a870-992265f31f7d"
+		createdPolicyId := "d9347b09-bb46-4e2b-91ea-513e83ab9ea7"
+		By("Add an expired policy to the database")
+		_, err := transportPostgreSQL.GetConn().Exec(ctx, fmt.Sprintf(`
+			INSERT INTO %s.%s (id,cluster_name,leaf_hub_name,error,compliance) VALUES($1, $2, $3, $4, $5)`,
+			testSchema, testTable), deletedPolicyId, "cluster1", leafHubName, "none", "unknown")
+		Expect(err).ToNot(HaveOccurred())
+		Eventually(func() error {
+			rows, err := transportPostgreSQL.GetConn().Query(ctx, fmt.Sprintf("SELECT id FROM %s.%s", testSchema, testTable))
+			if err != nil {
+				return err
+			}
+			defer rows.Close()
+			for rows.Next() {
+				var policyId string
+				err = rows.Scan(&policyId)
+				if err != nil {
+					return err
+				}
+				if policyId == "b8b3e164-477e-4be1-a870-992265f31f7d" {
+					return nil
+				}
+			}
+			return fmt.Errorf("failed to load content of table %s.%s", testSchema, testTable)
+		}, 10*time.Second, 2*time.Second).ShouldNot(HaveOccurred())
+
+		By("Build a new policy bundle in the regional hub")
+		// policy bundle
+		transportPayload := statusbundle.BaseClustersPerPolicyBundle{
+			Objects:       make([]*statusbundle.PolicyGenericComplianceStatus, 0),
+			LeafHubName:   leafHubName,
+			BundleVersion: statusbundle.NewBundleVersion(1, 0),
+		}
+
+		transportPayload.Objects = append(transportPayload.Objects, &statusbundle.PolicyGenericComplianceStatus{
+			PolicyID:                  createdPolicyId,
+			CompliantClusters:         []string{"cluster1"},
+			NonCompliantClusters:      []string{"cluster2"},
+			UnknownComplianceClusters: make([]string, 0),
+		})
+
+		// transport bundle
+		clustersPerPolicyTransportKey := fmt.Sprintf("%s.%s", leafHubName, constants.ClustersPerPolicyMsgKey)
+		payloadBytes, err := json.Marshal(transportPayload)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Synchronize the latest policy bundle with transport")
+		kafkaMessage, err := buildKafkaMessage(clustersPerPolicyTransportKey, clustersPerPolicyTransportKey, payloadBytes)
+		Expect(err).ToNot(HaveOccurred())
+		kafkaMessageChan <- kafkaMessage
+
+		By("Check the latest policy is created and expired policy is deleted from database")
+		Eventually(func() error {
+			querySql := fmt.Sprintf("SELECT id,cluster_name,leaf_hub_name,compliance FROM %s.%s", testSchema, testTable)
+			rows, err := transportPostgreSQL.GetConn().Query(ctx, querySql)
+			if err != nil {
+				return err
+			}
+			defer rows.Close()
+			deletedPolicyCount := 0
+			createdPolicyCount := 0
+			for rows.Next() {
+				var (
+					policyId, clusterName, leafHubName string
+					complianceStatus                   db.ComplianceStatus
+				)
+				if err := rows.Scan(&policyId, &clusterName, &leafHubName, &complianceStatus); err != nil {
+					return err
+				}
+				fmt.Printf("id(%s) %s-%s: %s \n", policyId, leafHubName, clusterName, complianceStatus)
+				if policyId == createdPolicyId {
+					createdPolicyCount++
+				}
+				if policyId == deletedPolicyId {
+					deletedPolicyCount++
+				}
+			}
+			if deletedPolicyCount == 0 && createdPolicyCount > 0 {
+				return nil
+			}
+			return fmt.Errorf("failed to sync content of table %s.%s", testSchema, testTable)
+		}, 30*time.Second, 2*time.Second).ShouldNot(HaveOccurred())
+	})
+})
+
+func buildKafkaMessage(key, id string, payload []byte) (*kafka.Message, error) {
+	transportMessage := &producer.Message{
+		Key:     key,
+		ID:      id, // entry.transportBundleKey
+		MsgType: constants.StatusBundle,
+		Version: "0.2", // entry.bundle.GetBundleVersion().String()
+		Payload: payload,
+	}
+	transportMessageBytes, err := json.Marshal(transportMessage)
+	if err != nil {
+		return nil, err
+	}
+
+	compressor, err := compressor.NewCompressor(compressor.GZip)
+	if err != nil {
+		return nil, err
+	}
+	compressedTransportBytes, err := compressor.Compress(transportMessageBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	topic := "status"
+	kafkaMessage := &kafka.Message{
+		Key: []byte(transportMessage.Key),
+		TopicPartition: kafka.TopicPartition{
+			Topic:     &topic,
+			Partition: 0,
+		},
+		Headers: []kafka.Header{
+			{Key: headers.CompressionType, Value: []byte(compressor.GetType())},
+		},
+		Value:         compressedTransportBytes,
+		TimestampType: 1,
+		Timestamp:     time.Now(),
+	}
+	return kafkaMessage, nil
+}

--- a/manager/pkg/statussyncer/transport2db/transport/test/kafka.go
+++ b/manager/pkg/statussyncer/transport2db/transport/test/kafka.go
@@ -1,0 +1,196 @@
+package test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"github.com/go-logr/logr"
+
+	"github.com/stolostron/multicluster-global-hub/manager/pkg/statistics"
+	"github.com/stolostron/multicluster-global-hub/manager/pkg/statussyncer/transport2db/conflator"
+	"github.com/stolostron/multicluster-global-hub/manager/pkg/statussyncer/transport2db/transport"
+	statuskafka "github.com/stolostron/multicluster-global-hub/manager/pkg/statussyncer/transport2db/transport/kafka"
+	"github.com/stolostron/multicluster-global-hub/pkg/compressor"
+	"github.com/stolostron/multicluster-global-hub/pkg/kafka/headers"
+)
+
+const (
+	msgIDTokensLength      = 2
+	defaultCompressionType = compressor.NoOp
+)
+
+var errMessageIDWrongFormat = errors.New("message ID format is bad")
+
+type KafkaTestConsumer struct {
+	log               logr.Logger
+	compressorsMap    map[compressor.CompressionType]compressor.Compressor
+	conflationManager *conflator.ConflationManager
+	statistics        *statistics.Statistics
+
+	msgChan                chan *kafka.Message
+	msgIDToRegistrationMap map[string]*transport.BundleRegistration
+
+	ctx        context.Context
+	cancelFunc context.CancelFunc
+	startOnce  sync.Once
+	stopOnce   sync.Once
+}
+
+// NewKafkaTestConsumer creates a new instance of TestConsumer.
+func NewKafkaTestConsumer(messageChan chan *kafka.Message,
+	conflationManager *conflator.ConflationManager,
+	statistics *statistics.Statistics, log logr.Logger,
+) (*KafkaTestConsumer, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+
+	return &KafkaTestConsumer{
+		log:                    log,
+		compressorsMap:         make(map[compressor.CompressionType]compressor.Compressor),
+		conflationManager:      conflationManager,
+		statistics:             statistics,
+		msgChan:                messageChan,
+		msgIDToRegistrationMap: make(map[string]*transport.BundleRegistration),
+		ctx:                    ctx,
+		cancelFunc:             cancelFunc,
+	}, nil
+}
+
+// Start function starts the consumer.
+func (c *KafkaTestConsumer) Start() {
+	c.startOnce.Do(func() {
+		go c.handleKafkaMessages(c.ctx)
+	})
+}
+
+// Stop stops the consumer.
+func (c *KafkaTestConsumer) Stop() {
+	c.stopOnce.Do(func() {
+		c.cancelFunc()
+		close(c.msgChan)
+	})
+}
+
+// Register function registers a msgID to the bundle updates channel.
+func (c *KafkaTestConsumer) Register(registration *transport.BundleRegistration) {
+	c.msgIDToRegistrationMap[registration.MsgID] = registration
+}
+
+func (c *KafkaTestConsumer) handleKafkaMessages(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case msg := <-c.msgChan:
+			c.processMessage(msg)
+		}
+	}
+}
+
+func (c *KafkaTestConsumer) processMessage(msg *kafka.Message) {
+	compressionType := defaultCompressionType
+
+	if compressionTypeBytes, found := c.lookupHeaderValue(msg, headers.CompressionType); found {
+		compressionType = compressor.CompressionType(compressionTypeBytes)
+	}
+
+	decompressedPayload, err := c.decompressPayload(msg.Value, compressionType)
+	if err != nil {
+		c.logError(err, "failed to decompress bundle bytes", msg)
+		return
+	}
+
+	transportMsg := &statuskafka.Message{}
+	if err := json.Unmarshal(decompressedPayload, transportMsg); err != nil {
+		c.logError(err, "failed to parse transport message", msg)
+		return
+	}
+
+	// get msgID
+	msgIDTokens := strings.Split(transportMsg.ID, ".") // object id is LH_ID.MSG_ID
+	if len(msgIDTokens) != msgIDTokensLength {
+		c.logError(errMessageIDWrongFormat, "expecting MessageID of format LH_ID.MSG_ID", msg)
+		return
+	}
+
+	msgID := msgIDTokens[1]
+	if _, found := c.msgIDToRegistrationMap[msgID]; !found {
+		c.log.Info("no bundle-registration available, not sending bundle", "messageId", transportMsg.ID,
+			"messageType", transportMsg.MsgType, "version", transportMsg.Version)
+		// no one registered for this msg id
+		return
+	}
+
+	if !c.msgIDToRegistrationMap[msgID].Predicate() {
+		c.log.Info("predicate is false, not sending bundle", "messageId", transportMsg.ID,
+			"messageType", transportMsg.MsgType, "version", transportMsg.Version)
+
+		return // bundle-registration predicate is false, do not send the update in the channel
+	}
+
+	receivedBundle := c.msgIDToRegistrationMap[msgID].CreateBundleFunc()
+	if err := json.Unmarshal(transportMsg.Payload, receivedBundle); err != nil {
+		c.logError(err, "failed to parse bundle", msg)
+		return
+	}
+
+	c.statistics.IncrementNumberOfReceivedBundles(receivedBundle)
+
+	c.conflationManager.Insert(receivedBundle, newBundleMetadata(msg.TopicPartition.Partition,
+		msg.TopicPartition.Offset))
+}
+
+func (c *KafkaTestConsumer) logError(err error, errMessage string, msg *kafka.Message) {
+	c.log.Error(err, errMessage, "MessageKey", string(msg.Key), "TopicPartition", msg.TopicPartition)
+}
+
+func (c *KafkaTestConsumer) lookupHeaderValue(msg *kafka.Message, headerKey string) ([]byte, bool) {
+	for _, header := range msg.Headers {
+		if header.Key == headerKey {
+			return header.Value, true
+		}
+	}
+
+	return nil, false
+}
+
+func (c *KafkaTestConsumer) decompressPayload(payload []byte, msgCompressorType compressor.CompressionType) ([]byte, error) {
+	msgCompressor, found := c.compressorsMap[msgCompressorType]
+	if !found {
+		newCompressor, err := compressor.NewCompressor(msgCompressorType)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create compressor: %w", err)
+		}
+
+		msgCompressor = newCompressor
+		c.compressorsMap[msgCompressorType] = msgCompressor
+	}
+
+	decompressedBytes, err := msgCompressor.Decompress(payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decompress message: %w", err)
+	}
+
+	return decompressedBytes, nil
+}
+
+// newBundleMetadata returns a new instance of BundleMetadata.
+func newBundleMetadata(partition int32, offset kafka.Offset) *bundleMetadata {
+	return &bundleMetadata{
+		BaseBundleMetadata: transport.NewBaseBundleMetadata(),
+		partition:          partition,
+		offset:             offset,
+	}
+}
+
+// bundleMetadata wraps the info required for the associated bundle to be used for committing purposes.
+type bundleMetadata struct {
+	*transport.BaseBundleMetadata
+	partition int32
+	offset    kafka.Offset
+}

--- a/test/pkg/testkafka/transportConsumer.go
+++ b/test/pkg/testkafka/transportConsumer.go
@@ -1,4 +1,4 @@
-package test
+package testkafka
 
 import (
 	"context"
@@ -159,16 +159,16 @@ func (c *KafkaTestConsumer) lookupHeaderValue(msg *kafka.Message, headerKey stri
 	return nil, false
 }
 
-func (c *KafkaTestConsumer) decompressPayload(payload []byte, msgCompressorType compressor.CompressionType) ([]byte, error) {
-	msgCompressor, found := c.compressorsMap[msgCompressorType]
+func (c *KafkaTestConsumer) decompressPayload(payload []byte, compressType compressor.CompressionType) ([]byte, error) {
+	msgCompressor, found := c.compressorsMap[compressType]
 	if !found {
-		newCompressor, err := compressor.NewCompressor(msgCompressorType)
+		newCompressor, err := compressor.NewCompressor(compressType)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create compressor: %w", err)
 		}
 
 		msgCompressor = newCompressor
-		c.compressorsMap[msgCompressorType] = msgCompressor
+		c.compressorsMap[compressType] = msgCompressor
 	}
 
 	decompressedBytes, err := msgCompressor.Decompress(payload)


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>

This PR focuses on the following points of the policy syncer:
- Mock the Kafka consumer client for transport to the database UT
- Verify that expired policies are deleted from the database.
- Verify the delta policy bundle is used only for policy compliance status updates.
- Test the difference of bundle in two scenarios with `aggragationLevel` being `full` and `minimal`.

Ref: https://github.com/stolostron/backlog/issues/25859, https://github.com/stolostron/backlog/issues/26233