### PR TITLE
fix webhook lint issues.

### DIFF
--- a/manager/pkg/webhook/admission_handler_test.go
+++ b/manager/pkg/webhook/admission_handler_test.go
@@ -66,9 +66,13 @@ var _ = Describe("Multicluster hub manager webhook", func() {
 			}
 
 			Eventually(func() bool {
-				c.Create(ctx, testPlacement, &client.CreateOptions{})
+				if err := c.Create(ctx, testPlacement, &client.CreateOptions{}); err != nil {
+					return false
+				}
 				placement := &clusterv1beta1.Placement{}
-				c.Get(ctx, client.ObjectKeyFromObject(testPlacement), placement)
+				if err := c.Get(ctx, client.ObjectKeyFromObject(testPlacement), placement); err != nil {
+					return false
+				}
 				return placement.Annotations[clusterv1beta1.PlacementDisableAnnotation] == "true"
 			}, 1*time.Second, 5*time.Second).Should(BeTrue())
 		})
@@ -86,9 +90,13 @@ var _ = Describe("Multicluster hub manager webhook", func() {
 			}
 
 			Eventually(func() bool {
-				c.Create(ctx, testPlacement, &client.CreateOptions{})
+				if err := c.Create(ctx, testPlacement, &client.CreateOptions{}); err != nil {
+					return false
+				}
 				placement := &clusterv1beta1.Placement{}
-				c.Get(ctx, client.ObjectKeyFromObject(testPlacement), placement)
+				if err := c.Get(ctx, client.ObjectKeyFromObject(testPlacement), placement); err != nil {
+					return false
+				}
 				return placement.Annotations == nil
 			}, 1*time.Second, 5*time.Second).Should(BeTrue())
 		})
@@ -103,9 +111,13 @@ var _ = Describe("Multicluster hub manager webhook", func() {
 			}
 
 			Eventually(func() bool {
-				c.Create(ctx, testPlacementRule, &client.CreateOptions{})
+				if err := c.Create(ctx, testPlacementRule, &client.CreateOptions{}); err != nil {
+					return false
+				}
 				placementrule := &placementrulesv1.PlacementRule{}
-				c.Get(ctx, client.ObjectKeyFromObject(testPlacementRule), placementrule)
+				if err := c.Get(ctx, client.ObjectKeyFromObject(testPlacementRule), placementrule); err != nil {
+					return false
+				}
 				return placementrule.Spec.SchedulerName == constants.GlobalHubSchedulerName
 			}, 1*time.Second, 5*time.Second).Should(BeTrue())
 		})
@@ -123,9 +135,13 @@ var _ = Describe("Multicluster hub manager webhook", func() {
 			}
 
 			Eventually(func() bool {
-				c.Create(ctx, testPlacementRule, &client.CreateOptions{})
+				if err := c.Create(ctx, testPlacementRule, &client.CreateOptions{}); err != nil {
+					return false
+				}
 				placementrule := &placementrulesv1.PlacementRule{}
-				c.Get(ctx, client.ObjectKeyFromObject(testPlacementRule), placementrule)
+				if err := c.Get(ctx, client.ObjectKeyFromObject(testPlacementRule), placementrule); err != nil {
+					return false
+				}
 				return placementrule.Spec.SchedulerName != constants.GlobalHubSchedulerName
 			}, 1*time.Second, 5*time.Second).Should(BeTrue())
 		})

--- a/manager/pkg/webhook/admission_suite_test.go
+++ b/manager/pkg/webhook/admission_suite_test.go
@@ -23,9 +23,7 @@ import (
 	. "github.com/onsi/gomega"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -37,12 +35,10 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	cfg        *rest.Config
-	k8sClient  client.Client // You'll be using this client in your tests.
-	kubeClient *kubernetes.Clientset
-	testEnv    *envtest.Environment
-	ctx        context.Context
-	cancel     context.CancelFunc
+	cfg     *rest.Config
+	testEnv *envtest.Environment
+	ctx     context.Context
+	cancel  context.CancelFunc
 )
 
 func TestControllers(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: morvencao <lcao@redhat.com>

fix lint issues when build manager image:
```
pkg/webhook/admission_suite_test.go:41:2: `k8sClient` is unused (deadcode)
	k8sClient  client.Client // You'll be using this client in your tests.
	^
pkg/webhook/admission_suite_test.go:42:2: `kubeClient` is unused (deadcode)
	kubeClient *kubernetes.Clientset
	^
pkg/webhook/admission_handler_test.go:69:13: Error return value of `c.Create` is not checked (errcheck)
				c.Create(ctx, testPlacement, &client.CreateOptions{})
				        ^
pkg/webhook/admission_handler_test.go:71:10: Error return value of `c.Get` is not checked (errcheck)
				c.Get(ctx, client.ObjectKeyFromObject(testPlacement), placement)
				     ^
pkg/webhook/admission_handler_test.go:89:13: Error return value of `c.Create` is not checked (errcheck)
				c.Create(ctx, testPlacement, &client.CreateOptions{})
				        ^
pkg/webhook/admission_handler_test.go:91:10: Error return value of `c.Get` is not checked (errcheck)
				c.Get(ctx, client.ObjectKeyFromObject(testPlacement), placement)
				     ^
pkg/webhook/admission_handler_test.go:106:13: Error return value of `c.Create` is not checked (errcheck)
				c.Create(ctx, testPlacementRule, &client.CreateOptions{})
				        ^
pkg/webhook/admission_handler_test.go:108:10: Error return value of `c.Get` is not checked (errcheck)
				c.Get(ctx, client.ObjectKeyFromObject(testPlacementRule), placementrule)
				     ^
Makefile:50: recipe for target 'lint' failed
make[1]: *** [lint] Error 1
make[1]: Leaving directory '/root/workspace/multicluster-global-hub/manager'
```