### PR TITLE
Fixed the golangci-lint error

### DIFF
--- a/manager/pkg/nonk8sapi/non_k8s_api_test.go
+++ b/manager/pkg/nonk8sapi/non_k8s_api_test.go
@@ -45,6 +45,7 @@ var _ = Describe("Nonk8s API Server", Ordered, func() {
 	var postgresSQL *postgresql.PostgreSQL
 	var router *gin.Engine
 	var plc1ID string
+	var w4 *TestResponseRecorder
 
 	BeforeAll(func() {
 		var err error
@@ -334,7 +335,7 @@ var _ = Describe("Nonk8s API Server", Ordered, func() {
 		Expect(w3.Body.String()).Should(MatchJSON(mclTable))
 
 		By("Check the managedcclusters can be listed with watch")
-		w4 := CreateTestResponseRecorder()
+		w4 = CreateTestResponseRecorder()
 		timeoutCtx, cancelFunc := context.WithTimeout(ctx, 5*time.Second)
 		defer cancelFunc()
 		req4, err := http.NewRequestWithContext(timeoutCtx, "GET",
@@ -860,7 +861,7 @@ var _ = Describe("Nonk8s API Server", Ordered, func() {
 		Expect(err).ToNot(HaveOccurred())
 		router.ServeHTTP(w1, req1)
 		Expect(w1.Code).To(Equal(200))
-		Expect(w1.Body.String()).Should(MatchJSON(fmt.Sprintf("%s", expectedPolicyStatus1)))
+		Expect(w1.Body.String()).Should(MatchJSON(expectedPolicyStatus1))
 
 		By("Check the policy status can be retrieved with policy ID as table reponse")
 		plcTable := `
@@ -970,6 +971,7 @@ var _ = Describe("Nonk8s API Server", Ordered, func() {
 	})
 
 	AfterAll(func() {
+		w4.closeClient()
 		cancel()
 		postgresSQL.Stop()
 	})

--- a/manager/pkg/nonk8sapi/non_k8s_api_test.go
+++ b/manager/pkg/nonk8sapi/non_k8s_api_test.go
@@ -45,7 +45,6 @@ var _ = Describe("Nonk8s API Server", Ordered, func() {
 	var postgresSQL *postgresql.PostgreSQL
 	var router *gin.Engine
 	var plc1ID string
-	var w4 *TestResponseRecorder
 
 	BeforeAll(func() {
 		var err error
@@ -335,7 +334,7 @@ var _ = Describe("Nonk8s API Server", Ordered, func() {
 		Expect(w3.Body.String()).Should(MatchJSON(mclTable))
 
 		By("Check the managedcclusters can be listed with watch")
-		w4 = CreateTestResponseRecorder()
+		w4 := CreateTestResponseRecorder()
 		timeoutCtx, cancelFunc := context.WithTimeout(ctx, 5*time.Second)
 		defer cancelFunc()
 		req4, err := http.NewRequestWithContext(timeoutCtx, "GET",
@@ -348,6 +347,7 @@ var _ = Describe("Nonk8s API Server", Ordered, func() {
 		for {
 			select {
 			case <-timeoutCtx.Done():
+				w4.closeClient()
 				return
 			default:
 				time.Sleep(4 * time.Second)
@@ -971,7 +971,6 @@ var _ = Describe("Nonk8s API Server", Ordered, func() {
 	})
 
 	AfterAll(func() {
-		w4.closeClient()
 		cancel()
 		postgresSQL.Stop()
 	})


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>
Error message:
```bash
$ make build-manager-image
...
golangci-lint run ./cmd/... ./pkg/...
pkg/nonk8sapi/non_k8s_api_test.go:33:32: func `(*TestResponseRecorder).closeClient` is unused (unused)
func (r *TestResponseRecorder) closeClient() {
                               ^
pkg/nonk8sapi/non_k8s_api_test.go:863:45: S1025: the argument is already a string, there's no need to use fmt.Sprintf (gosimple)
                Expect(w1.Body.String()).Should(MatchJSON(fmt.Sprintf("%s", expectedPolicyStatus1)))
```