### PR TITLE
fix e2e setup log redirect.

### DIFF
--- a/test/setup/leafhub_setup.sh
+++ b/test/setup/leafhub_setup.sh
@@ -28,22 +28,22 @@ hover $! "  Leaf Hub: export KUBECONFIG=${KUBECONFIG}"
 
 # initCluster
 for i in $(seq 1 "${HUB_CLUSTER_NUM}"); do
-  initKinDCluster "hub${i}" >> $LEAF_HUB_LOG 2>&1 & 
+  initKinDCluster "hub${i}" >> "$LEAF_HUB_LOG" 2>&1 & 
   hover $! "  Create KinD Cluster hub${i}" 
-  enableRouter "kind-hub${i}" 2>&1 >> $LEAF_HUB_LOG
+  enableRouter "kind-hub${i}" 2>&1 >> "$LEAF_HUB_LOG"
   for j in $(seq 1 "${MANAGED_CLUSTER_NUM}"); do
-    initKinDCluster "hub${i}-cluster${j}" >> $LEAF_HUB_LOG 2>&1 & 
+    initKinDCluster "hub${i}-cluster${j}" >> "$LEAF_HUB_LOG" 2>&1 & 
     hover $! "  Create KinD Cluster hub${i}-cluster${j}" 
-    enableRouter "kind-hub${i}-cluster${j}" 2>&1 >> $LEAF_HUB_LOG
+    enableRouter "kind-hub${i}-cluster${j}" 2>&1 >> "$LEAF_HUB_LOG"
   done
 done
 
 # init ocm
 for i in $(seq 1 "${HUB_CLUSTER_NUM}"); do
-  initHub "kind-hub${i}" "${CONFIG_DIR}/kind-hub${i}" 2>&1 >> $LEAF_HUB_LOG &
+  initHub "kind-hub${i}" "${CONFIG_DIR}/kind-hub${i}" 2>&1 >> "$LEAF_HUB_LOG" &
   hover $! "  OCM init hub kind-hub${i}" 
   for j in $(seq 1 "${MANAGED_CLUSTER_NUM}"); do
-    initManaged "kind-hub${i}" "kind-hub${i}-cluster${j}" 2>&1 >> $LEAF_HUB_LOG &
+    initManaged "kind-hub${i}" "kind-hub${i}-cluster${j}" 2>&1 >> "$LEAF_HUB_LOG" &
     hover $! "  OCM join managed kind-hub${i}-cluster${j}" 
   done
 done
@@ -51,7 +51,7 @@ done
 # init app
 for i in $(seq 1 "${HUB_CLUSTER_NUM}"); do
   for j in $(seq 1 "${MANAGED_CLUSTER_NUM}"); do
-    initApp "kind-hub${i}" "kind-hub${i}-cluster${j}" 2>&1 >> $LEAF_HUB_LOG &
+    initApp "kind-hub${i}" "kind-hub${i}-cluster${j}" 2>&1 >> "$LEAF_HUB_LOG" &
     hover $! "  Application hub${i}-cluster${j}" 
   done
 done
@@ -61,7 +61,7 @@ for i in $(seq 1 "${HUB_CLUSTER_NUM}"); do
   HUB_KUBECONFIG=${CONFIG_DIR}/kubeconfig-hub-hub${i}
   kind get kubeconfig --name "hub${i}" --internal > "$HUB_KUBECONFIG"
   for j in $(seq 1 "${MANAGED_CLUSTER_NUM}"); do
-    initPolicy "kind-hub${i}" "kind-hub${i}-cluster${j}" "$HUB_KUBECONFIG" 2>&1 >> $LEAF_HUB_LOG &
+    initPolicy "kind-hub${i}" "kind-hub${i}-cluster${j}" "$HUB_KUBECONFIG" 2>&1 >> "$LEAF_HUB_LOG" &
     hover $! "  Policy hub${i}-cluster${j}" 
   done
 done


### PR DESCRIPTION
fix e2e setup log redirect errors:

```bash
./test/setup/e2e_setup.sh
[06:33:52]  ✅  KUBECONFIG=/root/workspace/multicluster-global-hub/test/setup/config/kubeconfig ...
[06:35:02]  ✅  1 Prepare top hub cluster hub-of-hubs ...
[06:36:00]  ✅    Enable OLM for microshift ...
[06:36:01]  ✅  2 Prepare leaf hub cluster hub1 ...
[06:36:02]  ✅    Leaf Hub: export KUBECONFIG=/root/workspace/multicluster-global-hub/test/setup/config/kubeconfig ...
/root/workspace/multicluster-global-hub/test/setup/leafhub_setup.sh: line 31: $LEAF_HUB_LOG: ambiguous redirect
[06:36:02]  ✅    Create KinD Cluster hub1
/root/workspace/multicluster-global-hub/test/setup/leafhub_setup.sh: line 33: $LEAF_HUB_LOG: ambiguous redirect
Makefile:69: recipe for target 'e2e-setup-start' failed
make: *** [e2e-setup-start] Error 1
```

Signed-off-by: morvencao <lcao@redhat.com>