### PR TITLE
Add back the finalizer for resources in agent

### DIFF
--- a/agent/pkg/status/controller/generic/generic_status_sync_controller.go
+++ b/agent/pkg/status/controller/generic/generic_status_sync_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/bundle"
@@ -88,9 +90,13 @@ func (c *genericStatusSyncController) Reconcile(ctx context.Context, request ctr
 	}
 
 	if c.isObjectBeingDeleted(object) {
-		c.deleteObject(ctx, object, reqLogger)
+		if err := c.deleteObjectAndFinalizer(ctx, object, reqLogger); err != nil {
+			return ctrl.Result{Requeue: true, RequeueAfter: REQUEUE_PERIOD}, err
+		}
 	} else { // otherwise, the object was not deleted and no error occurred
-		c.updateObject(ctx, object, reqLogger)
+		if err := c.updateObjectAndFinalizer(ctx, object, reqLogger); err != nil {
+			return ctrl.Result{Requeue: true, RequeueAfter: REQUEUE_PERIOD}, err
+		}
 	}
 
 	reqLogger.Info("Reconciliation complete.")
@@ -102,9 +108,13 @@ func (c *genericStatusSyncController) isObjectBeingDeleted(object bundle.Object)
 	return !object.GetDeletionTimestamp().IsZero()
 }
 
-func (c *genericStatusSyncController) updateObject(ctx context.Context, object bundle.Object,
+func (c *genericStatusSyncController) updateObjectAndFinalizer(ctx context.Context, object bundle.Object,
 	log logr.Logger,
-) {
+) error {
+	if err := c.addFinalizer(ctx, object, log); err != nil {
+		return fmt.Errorf("failed to add finalizer - %w", err)
+	}
+
 	cleanObject(object)
 
 	c.lock.Lock() // make sure bundles are not updated if we're during bundles sync
@@ -113,11 +123,13 @@ func (c *genericStatusSyncController) updateObject(ctx context.Context, object b
 	for _, entry := range c.orderedBundleCollection {
 		entry.bundle.UpdateObject(object) // update in each bundle from the collection according to their order.
 	}
+
+	return nil
 }
 
-func (c *genericStatusSyncController) deleteObject(ctx context.Context, object bundle.Object,
+func (c *genericStatusSyncController) deleteObjectAndFinalizer(ctx context.Context, object bundle.Object,
 	log logr.Logger,
-) {
+) error {
 	c.lock.Lock() // make sure bundles are not updated if we're during bundles sync
 
 	for _, entry := range c.orderedBundleCollection {
@@ -125,6 +137,8 @@ func (c *genericStatusSyncController) deleteObject(ctx context.Context, object b
 	}
 
 	c.lock.Unlock() // not using defer since remove finalizer may get delayed. release lock as soon as possible.
+
+	return c.removeFinalizer(ctx, object, log)
 }
 
 func (c *genericStatusSyncController) periodicSync() {
@@ -184,6 +198,39 @@ func (c *genericStatusSyncController) syncBundles() {
 			entry.lastSentBundleVersion = *bundleVersion
 		}
 	}
+}
+
+func (c *genericStatusSyncController) addFinalizer(ctx context.Context, object bundle.Object, log logr.Logger) error {
+	if controllerutil.ContainsFinalizer(object, c.finalizerName) {
+		return nil
+	}
+
+	log.Info("adding finalizer")
+	controllerutil.AddFinalizer(object, c.finalizerName)
+
+	if err := c.client.Update(ctx, object); err != nil &&
+		!strings.Contains(err.Error(), "the object has been modified") {
+		return fmt.Errorf("failed to add finalizer %s - %w", c.finalizerName, err)
+	}
+
+	return nil
+}
+
+func (c *genericStatusSyncController) removeFinalizer(ctx context.Context, object bundle.Object,
+	log logr.Logger,
+) error {
+	if !controllerutil.ContainsFinalizer(object, c.finalizerName) {
+		return nil // if finalizer is not there, do nothing.
+	}
+
+	log.Info("removing finalizer")
+	controllerutil.RemoveFinalizer(object, c.finalizerName)
+
+	if err := c.client.Update(ctx, object); err != nil {
+		return fmt.Errorf("failed to remove finalizer %s - %w", c.finalizerName, err)
+	}
+
+	return nil
 }
 
 func cleanObject(object bundle.Object) {

--- a/agent/pkg/status/controller/generic/generic_status_sync_controller_test.go
+++ b/agent/pkg/status/controller/generic/generic_status_sync_controller_test.go
@@ -1,0 +1,70 @@
+package generic
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+)
+
+func TestAddRemoveFinalizer(t *testing.T) {
+	namespacedName := types.NamespacedName{
+		Name:      "test",
+		Namespace: "default",
+	}
+	policy := &policiesv1.Policy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      namespacedName.Name,
+			Namespace: namespacedName.Namespace,
+		},
+		Spec: policiesv1.PolicySpec{},
+	}
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypes(policiesv1.GroupVersion, policy)
+	c := fake.NewFakeClientWithScheme(scheme, policy)
+
+	controller := &genericStatusSyncController{
+		client:        c,
+		log:           ctrl.Log.WithName("test-controller"),
+		finalizerName: constants.GlobalHubCleanupFinalizer,
+		lock:          sync.Mutex{},
+	}
+
+	if err := controller.removeFinalizer(context.TODO(), policy, controller.log); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := controller.updateObjectAndFinalizer(context.TODO(), policy, controller.log); err != nil {
+		t.Fatal(err)
+	}
+
+	runtimePolicy := &policiesv1.Policy{}
+	if err := c.Get(context.TODO(), namespacedName, runtimePolicy); err != nil {
+		t.Fatal(err)
+	}
+
+	if !controllerutil.ContainsFinalizer(runtimePolicy, constants.GlobalHubCleanupFinalizer) {
+		t.Fatalf("Expect to have the finalizer %s", constants.GlobalHubCleanupFinalizer)
+	}
+
+	if err := controller.deleteObjectAndFinalizer(context.TODO(), policy, controller.log); err != nil {
+		t.Fatal(err)
+	}
+
+	runtimePolicy = &policiesv1.Policy{}
+	if err := c.Get(context.TODO(), namespacedName, runtimePolicy); err != nil {
+		t.Fatal(err)
+	}
+	if !controllerutil.ContainsFinalizer(runtimePolicy, constants.GlobalHubCleanupFinalizer) {
+		t.Fatalf("Expect no finalizer %s", constants.GlobalHubCleanupFinalizer)
+	}
+}


### PR DESCRIPTION
revert: https://github.com/stolostron/multicluster-global-hub/pull/172
fix: https://github.com/stolostron/backlog/issues/26311

the finalizer is useful to clean the records in the database before deleting the resources in the regional hub cluster.

Signed-off-by: clyang82 <chuyang@redhat.com>