### PR TITLE
fixed the agent compile issue

### DIFF
--- a/agent/pkg/status/controller/generic/generic_status_sync_controller_test.go
+++ b/agent/pkg/status/controller/generic/generic_status_sync_controller_test.go
@@ -31,7 +31,7 @@ func TestAddRemoveFinalizer(t *testing.T) {
 	}
 	scheme := runtime.NewScheme()
 	scheme.AddKnownTypes(policiesv1.GroupVersion, policy)
-	c := fake.NewFakeClientWithScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 	controller := &genericStatusSyncController{
 		client:        c,
@@ -48,7 +48,7 @@ func TestAddRemoveFinalizer(t *testing.T) {
 		t.Fatal("Expect to report error")
 	}
 
-	//create the object
+	// create the object
 	if err := c.Create(context.TODO(), policy, &client.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
@@ -57,7 +57,7 @@ func TestAddRemoveFinalizer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	//do nothing
+	// do nothing
 	if err := controller.addFinalizer(context.TODO(), policy, controller.log); err != nil {
 		t.Fatal(err)
 	}
@@ -75,7 +75,7 @@ func TestAddRemoveFinalizer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	//do nothing
+	// do nothing
 	if err := controller.removeFinalizer(context.TODO(), policy, controller.log); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>

Error message: 
```bash
$ make uint-tests-agent
...
golangci-lint run ./cmd/... ./pkg/...
pkg/status/controller/generic/generic_status_sync_controller_test.go:34:7: SA1019: fake.NewFakeClientWithScheme is deprecated: Please use NewClientBuilder instead. (staticcheck)
        c := fake.NewFakeClientWithScheme(scheme)
 ...
```