### PR TITLE
wait Kclusterlet until is installed in agent to avoid E2E setup error

### DIFF
--- a/test/setup/common.sh
+++ b/test/setup/common.sh
@@ -110,14 +110,11 @@ function initManaged() {
     kubectl config use-context "${managed}"
     clusteradm get token --context "${hub}" | grep "clusteradm" > "$joinCommand"
     if [[ $hub =~ "kind" ]]; then
-      sed -e "s;<cluster_name>;${managed} --force-internal-endpoint-lookup;" "$joinCommand" > "${joinCommand}-named"
-      sed -e "s;<cluster_name>;${managed} --force-internal-endpoint-lookup;" "$joinCommand" | bash
-      if [ $? -ne 0 ]; then
-        sed -e "s;<cluster_name>;${managed} --force-internal-endpoint-lookup;" "$joinCommand" | bash
-      fi
+      sed -e "s;<cluster_name>;${managed} --force-internal-endpoint-lookup --wait;" "$joinCommand" > "${joinCommand}-named"
+      sed -e "s;<cluster_name>;${managed} --force-internal-endpoint-lookup --wait;" "$joinCommand" | bash
     else
-      sed -e "s;<cluster_name>;${managed};" "$joinCommand" > "${joinCommand}-named"
-      sed -e "s;<cluster_name>;${managed};" "$joinCommand" | bash
+      sed -e "s;<cluster_name>;${managed} --wait;" "$joinCommand" > "${joinCommand}-named"
+      sed -e "s;<cluster_name>;${managed} --wait;" "$joinCommand" | bash
     fi
     sleep 2
     kubectl scale deployment klusterlet -n open-cluster-management --replicas=1


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>

E2E setup error:
```
$ make e2e-setup-start
...
Switched to context "kind-hub1-cluster2".
E1019 04:13:37.753132   46697 memcache.go:196] couldn't get resource list for operator.open-cluster-management.io/v1: the server could not find the requested resource
Error: no matches for kind "Klusterlet" in version "operator.open-cluster-management.io/v1"
[04:13:37]  ✅    OCM join managed kind-hub1-cluster2
...
```