### PR TITLE
Fixed TestManager error in operator

### DIFF
--- a/operator/main.go
+++ b/operator/main.go
@@ -172,7 +172,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	mgr, err := getManager(operatorConfig, electionConfig, newCacheFunc, ctrl.GetConfigOrDie())
+	mgr, err := getManager(ctrl.GetConfigOrDie(), electionConfig, newCacheFunc, operatorConfig)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
@@ -243,8 +243,8 @@ func parseFlags() *operatorConfig {
 	return config
 }
 
-func getManager(operatorConfig *operatorConfig, electionConfig *commonobjects.LeaderElectionConfig,
-	newCacheFunc cache.NewCacheFunc, restConfig *rest.Config,
+func getManager(restConfig *rest.Config, electionConfig *commonobjects.LeaderElectionConfig,
+	newCacheFunc cache.NewCacheFunc, operatorConfig *operatorConfig,
 ) (ctrl.Manager, error) {
 	leaseDuration := time.Duration(electionConfig.LeaseDuration) * time.Second
 	renewDeadline := time.Duration(electionConfig.RenewDeadline) * time.Second

--- a/operator/main.go
+++ b/operator/main.go
@@ -38,6 +38,8 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -170,7 +172,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	mgr, err := getManager(operatorConfig, electionConfig, newCacheFunc)
+	mgr, err := getManager(operatorConfig, electionConfig, newCacheFunc, ctrl.GetConfigOrDie())
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
@@ -242,13 +244,13 @@ func parseFlags() *operatorConfig {
 }
 
 func getManager(operatorConfig *operatorConfig, electionConfig *commonobjects.LeaderElectionConfig,
-	newCacheFunc cache.NewCacheFunc,
+	newCacheFunc cache.NewCacheFunc, restConfig *rest.Config,
 ) (ctrl.Manager, error) {
 	leaseDuration := time.Duration(electionConfig.LeaseDuration) * time.Second
 	renewDeadline := time.Duration(electionConfig.RenewDeadline) * time.Second
 	retryPeriod := time.Duration(electionConfig.RetryPeriod) * time.Second
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme:                  scheme,
 		MetricsBindAddress:      operatorConfig.MetricsAddress,
 		Port:                    9443,

--- a/operator/main_test.go
+++ b/operator/main_test.go
@@ -114,7 +114,7 @@ func TestManager(t *testing.T) {
 			},
 		},
 	})
-	_, err := getManager(operatorConfig, electionConfig, newCacheFunc, cfg)
+	_, err := getManager(cfg, electionConfig, newCacheFunc, operatorConfig)
 	if err != nil {
 		t.Fatalf("failed to create manager %v", err)
 	}

--- a/operator/main_test.go
+++ b/operator/main_test.go
@@ -114,7 +114,7 @@ func TestManager(t *testing.T) {
 			},
 		},
 	})
-	_, err := getManager(operatorConfig, electionConfig, newCacheFunc)
+	_, err := getManager(operatorConfig, electionConfig, newCacheFunc, cfg)
 	if err != nil {
 		t.Fatalf("failed to create manager %v", err)
 	}


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>
Error message:
```bash
$ make unit-tests-operator
...
=== RUN   TestManager
1.6662492562370045e+09  ERROR   Failed to get API Group-Resources       {"error": "Unauthorized"}
sigs.k8s.io/controller-runtime/pkg/cluster.New
        /root/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.3/pkg/cluster/cluster.go:160
sigs.k8s.io/controller-runtime/pkg/manager.New
        /root/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.3/pkg/manager/manager.go:322
github.com/stolostron/multicluster-global-hub/operator.getManager
        /root/workspace/hub-of-hubs/operator/main.go:251
github.com/stolostron/multicluster-global-hub/operator.TestManager
        /root/workspace/hub-of-hubs/operator/main_test.go:117
testing.tRunner
        /usr/local/go/src/testing/testing.go:1439
    main_test.go:119: failed to create manager Unauthorized
--- FAIL: TestManager (0.85s)
FAIL
FAIL    github.com/stolostron/multicluster-global-hub/operator  6.046s
...
```