### PR TITLE
add multiclusterhub crd for e2e test

### DIFF
--- a/test/setup/hoh/hoh_setup.sh
+++ b/test/setup/hoh/hoh_setup.sh
@@ -59,6 +59,9 @@ rootDir="$(cd "$(dirname "$0")/../.." ; pwd -P)"
 kubectl apply -f ${currentDir}/components/leader-election-configmap.yaml -n "$namespace"
 
 cd ${rootDir}
+# install crds
+kubectl --context kind-$LEAF_HUB_NAME apply -f ./pkg/testdata/crds/0000_01_operator.open-cluster-management.io_multiclusterhubs.crd.yaml
+
 export IMG=$MULTICLUSTER_GLOBAL_HUB_OPERATOR_IMAGE_REF
 make deploy-operator 
 kubectl wait deployment -n "$namespace" multicluster-global-hub-operator --for condition=Available=True --timeout=600s


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>
We need to add multiclusterhub crd for the global hub agent. Otherwise it will occur the following error message:
```
$ oc logs -f -l name=multicluster-global-hub-agent -n open-cluster-management-agent-addon
...
{"level":"error","ts":1667288012.9255772,"logger":"controller-runtime.source","msg":"if kind is a CRD, it should be installed before calling Start","kind":"MultiClusterHub.operator.open-cluster-management.io","error":"no matches for kind \"MultiClusterHub\" in version \"operator.open-cluster-management.io/v1\"","stacktrace":"sigs.k8s.io/controller-runtime/pkg/source.(*Kind).Start.func1.1\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.3/pkg/source/source.go:139\nk8s.io/apimachinery/pkg/util/wait.runConditionWithCrashProtectionWithContext\n\t/go/pkg/mod/k8s.io/apimachinery@v0.25.0/pkg/util/wait/wait.go:235\nk8s.io/apimachinery/pkg/util/wait.WaitForWithContext\n\t/go/pkg/mod/k8s.io/apimachinery@v0.25.0/pkg/util/wait/wait.go:662\nk8s.io/apimachinery/pkg/util/wait.poll\n\t/go/pkg/mod/k8s.io/apimachinery@v0.25.0/pkg/util/wait/wait.go:596\nk8s.io/apimachinery/pkg/util/wait.PollImmediateUntilWithContext\n\t/go/pkg/mod/k8s.io/apimachinery@v0.25.0/pkg/util/wait/wait.go:547\nsigs.k8s.io/controller-runtime/pkg/source.(*Kind).Start.func1\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.3/pkg/source/source.go:132"}
```