### PR TITLE
failed to remove the finalizer from resource when delete the mgh cr

### DIFF
--- a/agent/pkg/status/controller/generic/generic_status_sync_controller.go
+++ b/agent/pkg/status/controller/generic/generic_status_sync_controller.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/bundle"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/controller/syncintervals"
-	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	commonconstants "github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport/producer"
@@ -51,7 +50,7 @@ func NewGenericStatusSyncController(mgr ctrl.Manager, logName string, producer p
 		log:                     ctrl.Log.WithName(logName),
 		transport:               producer,
 		orderedBundleCollection: orderedBundleCollection,
-		finalizerName:           constants.GlobalHubCleanupFinalizer,
+		finalizerName:           commonconstants.GlobalHubCleanupFinalizer,
 		createBundleObjFunc:     createObjFunc,
 		resolveSyncIntervalFunc: resolveSyncIntervalFunc,
 		lock:                    sync.Mutex{},
@@ -180,7 +179,7 @@ func (c *genericStatusSyncController) syncBundles() {
 			if err != nil {
 				c.log.Error(
 					fmt.Errorf("sync object from type %s with id %s - %w",
-						constants.StatusBundle, entry.transportBundleKey, err),
+						commonconstants.StatusBundle, entry.transportBundleKey, err),
 					"failed to sync bundle")
 			}
 
@@ -192,7 +191,7 @@ func (c *genericStatusSyncController) syncBundles() {
 			c.transport.SendAsync(&transport.Message{
 				Key:     transportMessageKey,
 				ID:      entry.transportBundleKey,
-				MsgType: constants.StatusBundle,
+				MsgType: commonconstants.StatusBundle,
 				Version: entry.bundle.GetBundleVersion().String(),
 				Payload: payloadBytes,
 			})

--- a/agent/pkg/status/controller/generic/generic_status_sync_controller.go
+++ b/agent/pkg/status/controller/generic/generic_status_sync_controller.go
@@ -213,7 +213,7 @@ func cleanObject(object bundle.Object) {
 
 func (c *genericStatusSyncController) addFinalizer(ctx context.Context, object bundle.Object, log logr.Logger) error {
 	// if the removing finalizer label hasn't expired, then skip the adding finalizer action
-	if val, found := object.GetLabels()[commonconstants.GlobalHubRemovingFinalizer]; found {
+	if val, found := object.GetLabels()[commonconstants.GlobalHubFinalizerRemovingDeadline]; found {
 		deadline, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
 			return err
@@ -221,7 +221,7 @@ func (c *genericStatusSyncController) addFinalizer(ctx context.Context, object b
 		if time.Now().Unix() < deadline {
 			return nil
 		} else {
-			delete(object.GetLabels(), commonconstants.GlobalHubRemovingFinalizer)
+			delete(object.GetLabels(), commonconstants.GlobalHubFinalizerRemovingDeadline)
 		}
 	}
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -81,7 +81,7 @@ const (
 
 	// indicate the removing the global hub finalizer, shouldn't add it back to the resource
 	// the value is a timestamp which is the expiration time of this label
-	GlobalHubRemovingFinalizer = "global-hub.open-cluster-management.io/finalizer-removing"
+	GlobalHubFinalizerRemovingDeadline = "global-hub.open-cluster-management.io/finalizer-removing-deadline"
 )
 
 // store all the annotations

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -78,6 +78,10 @@ const (
 
 	// identify the resource is a local-resource
 	GlobalHubLocalResource = "global-hub.open-cluster-management.io/local-resource"
+
+	// indicate the removing the global hub finalizer, shouldn't add it back to the resource
+	// the value is a timestamp which is the expiration time of this label
+	GlobalHubRemovingFinalizer = "global-hub.open-cluster-management.io/finalizer-removing"
 )
 
 // store all the annotations

--- a/pkg/jobs/prune_finalizer.go
+++ b/pkg/jobs/prune_finalizer.go
@@ -2,6 +2,8 @@ package jobs
 
 import (
 	"context"
+	"strconv"
+	"time"
 
 	"github.com/go-logr/logr"
 	"k8s.io/client-go/util/retry"
@@ -49,6 +51,13 @@ func (p *PruneFinalizer) Run() error {
 
 func (p *PruneFinalizer) pruneFinalizer(object client.Object) error {
 	if controllerutil.RemoveFinalizer(object, p.finalizer) {
+		labels := object.GetLabels()
+		if labels == nil {
+			labels = map[string]string{}
+		}
+		// set the removing finalizer ttl with 60 seconds
+		labels[commonconstants.GlobalHubRemovingFinalizer] = strconv.FormatInt(time.Now().Unix()+60, 10)
+		object.SetLabels(labels)
 		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			return p.client.Update(p.ctx, object, &client.UpdateOptions{})
 		})

--- a/pkg/jobs/prune_finalizer.go
+++ b/pkg/jobs/prune_finalizer.go
@@ -56,7 +56,7 @@ func (p *PruneFinalizer) pruneFinalizer(object client.Object) error {
 			labels = map[string]string{}
 		}
 		// set the removing finalizer ttl with 60 seconds
-		labels[commonconstants.GlobalHubRemovingFinalizer] = strconv.FormatInt(time.Now().Unix()+60, 10)
+		labels[commonconstants.GlobalHubFinalizerRemovingDeadline] = strconv.FormatInt(time.Now().Unix()+60, 10)
 		object.SetLabels(labels)
 		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			return p.client.Update(p.ctx, object, &client.UpdateOptions{})


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>
Fixed: https://github.com/stolostron/multicluster-global-hub/issues/258, https://github.com/stolostron/backlog/issues/26691


The process is updated to:
1. The addon pre-delete job adds a removing-finalizer label(with ttl=60s) to the resource and remove the finalizer from it
2. Global hub agent detected the removing-finalizer label in the resource and stop adding the finalizer back to it.
3. Then the finalizer is removed from resources on the regional hub.