### PR TITLE
make the postgres-operator compatible with k8s v1.25

### DIFF
--- a/operator/config/samples/storage/postgres-operator/bases/manager/manager.yaml
+++ b/operator/config/samples/storage/postgres-operator/bases/manager/manager.yaml
@@ -10,7 +10,9 @@ spec:
     spec:
       containers:
       - name: operator
-        image: postgres-operator
+        # since the k8s v1.25 compatible fix has not been released yet, this image is used for now.
+        # https://github.com/CrunchyData/postgres-operator/issues/3365
+        image: quay.io/myan/postgres-operator:ubi8-k8s.1.25       
         env:
         - name: CRUNCHY_DEBUG
           value: "true"

--- a/operator/config/samples/storage/postgres-operator/bases/rbac/cluster/role.yaml
+++ b/operator/config/samples/storage/postgres-operator/bases/rbac/cluster/role.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: postgres-operator
+  labels:
+    postgres-operator.crunchydata.com/control-plane: postgres-operator
 rules:
 - apiGroups:
   - ''
@@ -81,6 +83,17 @@ rules:
   resources:
   - cronjobs
   - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
   verbs:
   - create
   - delete

--- a/operator/config/samples/storage/postgres-operator/bases/rbac/namespace/role.yaml
+++ b/operator/config/samples/storage/postgres-operator/bases/rbac/namespace/role.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: postgres-operator
+  labels:
+    postgres-operator.crunchydata.com/control-plane: postgres-operator
 rules:
 - apiGroups:
   - ''
@@ -81,6 +83,17 @@ rules:
   resources:
   - cronjobs
   - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
   verbs:
   - create
   - delete


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>
Fixed: https://issues.redhat.com/browse/ACM-1950, https://github.com/stolostron/backlog/issues/26694

Since the [k8s v1.25 compatible fix](https://github.com/CrunchyData/postgres-operator/pull/3370) has not been released yet, the image `quay.io/myan/postgres-operator:ubi8-k8s.1.25` is used for now.