### PR TITLE
upgrade managedclusterset and managedclustersetbinding api version.

### DIFF
--- a/agent/pkg/scheme/scheme.go
+++ b/agent/pkg/scheme/scheme.go
@@ -11,6 +11,7 @@ import (
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	clusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
 	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
+	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
 	operatorv1 "open-cluster-management.io/api/operator/v1"
 	policyv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 	channelv1 "open-cluster-management.io/multicloud-operators-channel/pkg/apis/apps/v1"
@@ -27,6 +28,7 @@ func AddToScheme(runtimeScheme *runtime.Scheme) error {
 		clusterv1.Install,
 		clusterv1alpha1.Install,
 		clusterv1beta1.Install,
+		clusterv1beta2.Install,
 		operatorv1.Install,
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -32,8 +32,8 @@ require (
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/klog v1.0.0
 	open-cluster-management.io/addon-framework v0.5.1-0.20221207035227-64204bec3525
-	open-cluster-management.io/api v0.8.1-0.20220922101757-abd2ec6ed64f
-	open-cluster-management.io/governance-policy-propagator v0.8.0
+	open-cluster-management.io/api v0.9.0
+	open-cluster-management.io/governance-policy-propagator v0.9.0
 	open-cluster-management.io/multicloud-operators-channel v0.8.0
 	open-cluster-management.io/multicloud-operators-subscription v0.8.0
 	sigs.k8s.io/application v0.8.3

--- a/go.sum
+++ b/go.sum
@@ -2455,10 +2455,10 @@ modernc.org/strutil v1.0.0/go.mod h1:lstksw84oURvj9y3tn8lGvRxyRC1S2+g5uuIzNfIOBs
 modernc.org/xc v1.0.0/go.mod h1:mRNCo0bvLjGhHO9WsyuKVU4q0ceiDDDoEeWDJHrNx8I=
 open-cluster-management.io/addon-framework v0.5.1-0.20221207035227-64204bec3525 h1:n8TqX08l2yVevOoHwXuYtoqi7dXzMB18prA3jUkJZCo=
 open-cluster-management.io/addon-framework v0.5.1-0.20221207035227-64204bec3525/go.mod h1:Fymctw1tnmCTXnmAMgc0zdHetAw6UaiAsj1S6w5VW6s=
-open-cluster-management.io/api v0.8.1-0.20220922101757-abd2ec6ed64f h1:jICP+I2K3n5wPxeV22aT2mSRC31EE6RNINKnDZfDJ5Q=
-open-cluster-management.io/api v0.8.1-0.20220922101757-abd2ec6ed64f/go.mod h1:+OEARSAl2jIhuLItUcS30UgLA3khmA9ihygLVxzEn+U=
-open-cluster-management.io/governance-policy-propagator v0.8.0 h1:rWDHz4JglAq3/5cLHtN6mSYmOuvPo0fq5DDCzJW73zQ=
-open-cluster-management.io/governance-policy-propagator v0.8.0/go.mod h1:cHcn2tv8bUUFDIY0KcZmx5MskEFn2RoAm90oQAIPFMA=
+open-cluster-management.io/api v0.9.0 h1:JQidCTMY3RdS0m3UDP24j6ykNpxWJ20LEdNtbxJApxo=
+open-cluster-management.io/api v0.9.0/go.mod h1:+OEARSAl2jIhuLItUcS30UgLA3khmA9ihygLVxzEn+U=
+open-cluster-management.io/governance-policy-propagator v0.9.0 h1:85JxyaUaZb39ZAVBoWQil5nKyIOycqVnQhrZ8gvwaZo=
+open-cluster-management.io/governance-policy-propagator v0.9.0/go.mod h1:qANM1Ww0i7fN90ZDsN9CmPWyRq5kL5ZhuFpBG4MzzDY=
 open-cluster-management.io/multicloud-operators-channel v0.8.0 h1:2Cr7AiIWc4maVnhBI2MagNc1YF3UU/VHHCrlSpG3Yr8=
 open-cluster-management.io/multicloud-operators-channel v0.8.0/go.mod h1:E2Y3/mDp+U6glXp+LMn27ViRJ4BsHwJ6QzDLeENEJmc=
 open-cluster-management.io/multicloud-operators-subscription v0.8.0 h1:0YRrUErVU6K6xwExGNaCMF//FOfJT6XyeHAvSbZNEiY=

--- a/manager/pkg/scheme/scheme.go
+++ b/manager/pkg/scheme/scheme.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
 	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
+	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
 	policyv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 	channelv1 "open-cluster-management.io/multicloud-operators-channel/pkg/apis/apps/v1"
 	placementrulev1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/placementrule/v1"
@@ -23,6 +24,7 @@ func AddToScheme(runtimeScheme *runtime.Scheme) error {
 	schemeInstallFuncs := []func(scheme *runtime.Scheme) error{
 		clusterv1alpha1.Install,
 		clusterv1beta1.Install,
+		clusterv1beta2.Install,
 	}
 
 	schemeBuilders := []*scheme.Builder{

--- a/manager/pkg/specsyncer/db2transport/syncer/dbsyncer/managed_cluster_set_bindings_db_to_transport_syncer.go
+++ b/manager/pkg/specsyncer/db2transport/syncer/dbsyncer/managed_cluster_set_bindings_db_to_transport_syncer.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
+	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/specsyncer/db2transport/bundle"
@@ -26,7 +26,7 @@ func AddManagedClusterSetBindingsDBToTransportSyncer(mgr ctrl.Manager, specDB db
 	transportObj producer.Producer, specSyncInterval time.Duration,
 ) error {
 	createObjFunc := func() metav1.Object {
-		return &clusterv1beta1.ManagedClusterSetBinding{}
+		return &clusterv1beta2.ManagedClusterSetBinding{}
 	}
 	lastSyncTimestampPtr := &time.Time{}
 

--- a/manager/pkg/specsyncer/db2transport/syncer/dbsyncer/managed_cluster_sets_db_to_transport_syncer.go
+++ b/manager/pkg/specsyncer/db2transport/syncer/dbsyncer/managed_cluster_sets_db_to_transport_syncer.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
+	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/specsyncer/db2transport/bundle"
@@ -24,7 +24,7 @@ const (
 func AddManagedClusterSetsDBToTransportSyncer(mgr ctrl.Manager, specDB db.SpecDB, transportObj producer.Producer,
 	specSyncInterval time.Duration,
 ) error {
-	createObjFunc := func() metav1.Object { return &clusterv1beta1.ManagedClusterSet{} }
+	createObjFunc := func() metav1.Object { return &clusterv1beta2.ManagedClusterSet{} }
 	lastSyncTimestampPtr := &time.Time{}
 
 	if err := mgr.Add(&genericDBToTransportSyncer{

--- a/manager/pkg/specsyncer/db2transport/syncer/dbsyncer/placements_db_to_transport_syncer.go
+++ b/manager/pkg/specsyncer/db2transport/syncer/dbsyncer/placements_db_to_transport_syncer.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
+	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/specsyncer/db2transport/bundle"
@@ -24,7 +24,7 @@ const (
 func AddPlacementsDBToTransportSyncer(mgr ctrl.Manager, specDB db.SpecDB, transportObj producer.Producer,
 	specSyncInterval time.Duration,
 ) error {
-	createObjFunc := func() metav1.Object { return &clusterv1alpha1.Placement{} }
+	createObjFunc := func() metav1.Object { return &clusterv1beta1.Placement{} }
 	lastSyncTimestampPtr := &time.Time{}
 
 	if err := mgr.Add(&genericDBToTransportSyncer{

--- a/manager/pkg/specsyncer/spec2db/controller/managedclusterset_spec_sync.go
+++ b/manager/pkg/specsyncer/spec2db/controller/managedclusterset_spec_sync.go
@@ -8,7 +8,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
+	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -27,7 +27,7 @@ func AddManagedClusterSetController(mgr ctrl.Manager, specDB db.SpecDB) error {
 		},
 	})
 	if err := ctrl.NewControllerManagedBy(mgr).
-		For(&clusterv1beta1.ManagedClusterSet{}).
+		For(&clusterv1beta2.ManagedClusterSet{}).
 		WithEventFilter(managedclustersetPredicate).
 		Complete(&genericSpecToDBReconciler{
 			client:         mgr.GetClient(),
@@ -35,7 +35,7 @@ func AddManagedClusterSetController(mgr ctrl.Manager, specDB db.SpecDB) error {
 			log:            ctrl.Log.WithName("managedclustersets-spec-syncer"),
 			tableName:      "managedclustersets",
 			finalizerName:  constants.GlobalHubCleanupFinalizer,
-			createInstance: func() client.Object { return &clusterv1beta1.ManagedClusterSet{} },
+			createInstance: func() client.Object { return &clusterv1beta2.ManagedClusterSet{} },
 			cleanObject:    cleanManagedClusterSetStatus,
 			areEqual:       areManagedClusterSetsEqual,
 		}); err != nil {
@@ -46,18 +46,18 @@ func AddManagedClusterSetController(mgr ctrl.Manager, specDB db.SpecDB) error {
 }
 
 func cleanManagedClusterSetStatus(instance client.Object) {
-	managedClusterSet, ok := instance.(*clusterv1beta1.ManagedClusterSet)
+	managedClusterSet, ok := instance.(*clusterv1beta2.ManagedClusterSet)
 
 	if !ok {
 		panic("wrong instance passed to cleanManagedClusterSetStatus: not a ManagedClusterSet")
 	}
 
-	managedClusterSet.Status = clusterv1beta1.ManagedClusterSetStatus{}
+	managedClusterSet.Status = clusterv1beta2.ManagedClusterSetStatus{}
 }
 
 func areManagedClusterSetsEqual(instance1, instance2 client.Object) bool {
-	managedClusterSet1, ok1 := instance1.(*clusterv1beta1.ManagedClusterSet)
-	managedClusterSet2, ok2 := instance2.(*clusterv1beta1.ManagedClusterSet)
+	managedClusterSet1, ok1 := instance1.(*clusterv1beta2.ManagedClusterSet)
+	managedClusterSet2, ok2 := instance2.(*clusterv1beta2.ManagedClusterSet)
 
 	if !ok1 || !ok2 {
 		return false

--- a/manager/pkg/specsyncer/spec2db/controller/managedclusterset_spec_sync_test.go
+++ b/manager/pkg/specsyncer/spec2db/controller/managedclusterset_spec_sync_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2020 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package controller_test
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+)
+
+var _ = Describe("managedclusterset controller", Ordered, func() {
+	It("create the spec.managedclusterset table in database", func() {
+		_, err := postgresSQL.GetConn().Exec(ctx, `
+			CREATE SCHEMA IF NOT EXISTS spec;
+			CREATE TABLE IF NOT EXISTS spec.managedclustersets (
+				id uuid NOT NULL,
+				payload jsonb NOT NULL,
+				created_at timestamp without time zone DEFAULT now() NOT NULL,
+				updated_at timestamp without time zone DEFAULT now() NOT NULL,
+				deleted boolean DEFAULT false NOT NULL
+			);
+		`)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("create the managedclusterset in kubernetes", func() {
+		testManagedClusterSet := &clusterv1beta2.ManagedClusterSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-managedclusterset-1",
+				Namespace: config.GetDefaultNamespace(),
+			},
+			Spec: clusterv1beta2.ManagedClusterSetSpec{
+				ClusterSelector: clusterv1beta2.ManagedClusterSelector{
+					SelectorType: clusterv1beta2.ExclusiveClusterSetLabel,
+				},
+			},
+		}
+		Expect(kubeClient.Create(ctx, testManagedClusterSet, &client.CreateOptions{})).ToNot(HaveOccurred())
+	})
+
+	It("get the managedclusterset from postgres", func() {
+		Eventually(func() error {
+			rows, err := postgresSQL.GetConn().Query(ctx,
+				"SELECT payload FROM spec.managedclustersets")
+			if err != nil {
+				return err
+			}
+			defer rows.Close()
+			for rows.Next() {
+				gotManagedClusterSet := &clusterv1beta2.ManagedClusterSet{}
+				if err := rows.Scan(gotManagedClusterSet); err != nil {
+					return err
+				}
+				if gotManagedClusterSet.Name == "test-managedclusterset-1" &&
+					string(gotManagedClusterSet.Spec.ClusterSelector.SelectorType) == string(clusterv1beta2.ExclusiveClusterSetLabel) {
+					return nil
+				}
+			}
+			return fmt.Errorf("not find managedclusterset in database")
+		}, 1*time.Second).ShouldNot(HaveOccurred())
+	})
+})

--- a/manager/pkg/specsyncer/spec2db/controller/managedclustersetbinding_spec_sync.go
+++ b/manager/pkg/specsyncer/spec2db/controller/managedclustersetbinding_spec_sync.go
@@ -8,7 +8,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
+	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -27,7 +27,7 @@ func AddManagedClusterSetBindingController(mgr ctrl.Manager, specDB db.SpecDB) e
 		},
 	})
 	if err := ctrl.NewControllerManagedBy(mgr).
-		For(&clusterv1beta1.ManagedClusterSetBinding{}).
+		For(&clusterv1beta2.ManagedClusterSetBinding{}).
 		WithEventFilter(managedclustersetbindingPredicate).
 		Complete(&genericSpecToDBReconciler{
 			client:        mgr.GetClient(),
@@ -36,7 +36,7 @@ func AddManagedClusterSetBindingController(mgr ctrl.Manager, specDB db.SpecDB) e
 			tableName:     "managedclustersetbindings",
 			finalizerName: constants.GlobalHubCleanupFinalizer,
 			createInstance: func() client.Object {
-				return &clusterv1beta1.ManagedClusterSetBinding{}
+				return &clusterv1beta2.ManagedClusterSetBinding{}
 			},
 			cleanObject: cleanManagedClusterSetBindingsStatus,
 			areEqual:    areManagedClusterSetBindingsEqual,
@@ -48,7 +48,7 @@ func AddManagedClusterSetBindingController(mgr ctrl.Manager, specDB db.SpecDB) e
 }
 
 func cleanManagedClusterSetBindingsStatus(instance client.Object) {
-	_, ok := instance.(*clusterv1beta1.ManagedClusterSetBinding)
+	_, ok := instance.(*clusterv1beta2.ManagedClusterSetBinding)
 	// ManagedClusterSetBinding has no status
 	if !ok {
 		panic("wrong instance passed to cleanManagedClusterSetBindingsStatus: not a ManagedClusterSetBinding")
@@ -56,8 +56,8 @@ func cleanManagedClusterSetBindingsStatus(instance client.Object) {
 }
 
 func areManagedClusterSetBindingsEqual(instance1, instance2 client.Object) bool {
-	managedClusterSetBinding1, ok1 := instance1.(*clusterv1beta1.ManagedClusterSetBinding)
-	managedClusterSetBinding2, ok2 := instance2.(*clusterv1beta1.ManagedClusterSetBinding)
+	managedClusterSetBinding1, ok1 := instance1.(*clusterv1beta2.ManagedClusterSetBinding)
+	managedClusterSetBinding2, ok2 := instance2.(*clusterv1beta2.ManagedClusterSetBinding)
 
 	if !ok1 || !ok2 {
 		return false

--- a/manager/pkg/specsyncer/spec2db/controller/managedclustersetbinding_spec_sync_test.go
+++ b/manager/pkg/specsyncer/spec2db/controller/managedclustersetbinding_spec_sync_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2020 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package controller_test
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+)
+
+var _ = Describe("managedclustersetbinding controller", Ordered, func() {
+	It("create the spec.managedclustersetbinding table in database", func() {
+		_, err := postgresSQL.GetConn().Exec(ctx, `
+			CREATE SCHEMA IF NOT EXISTS spec;
+			CREATE TABLE IF NOT EXISTS  spec.managedclustersetbindings (
+				id uuid NOT NULL,
+				payload jsonb NOT NULL,
+				created_at timestamp without time zone DEFAULT now() NOT NULL,
+				updated_at timestamp without time zone DEFAULT now() NOT NULL,
+				deleted boolean DEFAULT false NOT NULL
+			);
+		`)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("create the managedclustersetbinding in kubernetes", func() {
+		testManagedClusterSetBinding := &clusterv1beta2.ManagedClusterSetBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-managedclustersetbinding-1",
+				Namespace: config.GetDefaultNamespace(),
+			},
+			Spec: clusterv1beta2.ManagedClusterSetBindingSpec{
+				ClusterSet: "testing",
+			},
+		}
+		Expect(kubeClient.Create(ctx, testManagedClusterSetBinding, &client.CreateOptions{})).ToNot(HaveOccurred())
+	})
+
+	It("get the managedclustersetbinding from postgres", func() {
+		Eventually(func() error {
+			rows, err := postgresSQL.GetConn().Query(ctx,
+				"SELECT payload FROM spec.managedclustersetbindings")
+			if err != nil {
+				return err
+			}
+			defer rows.Close()
+			for rows.Next() {
+				gotManagedClusterSetBinding := &clusterv1beta2.ManagedClusterSetBinding{}
+				if err := rows.Scan(gotManagedClusterSetBinding); err != nil {
+					return err
+				}
+				if gotManagedClusterSetBinding.Name == "test-managedclustersetbinding-1" &&
+					gotManagedClusterSetBinding.Spec.ClusterSet == "testing" {
+					return nil
+				}
+			}
+			return fmt.Errorf("not find managedclustersetbinding in database")
+		}, 1*time.Second).ShouldNot(HaveOccurred())
+	})
+})

--- a/manager/pkg/statussyncer/transport2db/syncer/syncers.go
+++ b/manager/pkg/statussyncer/transport2db/syncer/syncers.go
@@ -17,7 +17,8 @@ import (
 
 // AddTransport2DBSyncers performs the initial setup required before starting the runtime manager.
 // adds controllers and/or runnables to the manager, registers handler functions within the dispatcher
-//  and create bundle functions within the bundle.
+//
+//	and create bundle functions within the bundle.
 func AddTransport2DBSyncers(mgr ctrl.Manager, dbWorkerPool *workerpool.DBWorkerPool,
 	conflationManager *conflator.ConflationManager, conflationReadyQueue *conflator.ConflationReadyQueue,
 	transport consumer.Consumer, statistics manager.Runnable,

--- a/operator/main.go
+++ b/operator/main.go
@@ -45,6 +45,7 @@ import (
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
+	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
 	workv1 "open-cluster-management.io/api/work/v1"
 	policyv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 	chnv1 "open-cluster-management.io/multicloud-operators-channel/pkg/apis/apps/v1"
@@ -82,6 +83,7 @@ func init() {
 	utilruntime.Must(operatorsv1.AddToScheme(scheme))
 	utilruntime.Must(clusterv1.AddToScheme(scheme))
 	utilruntime.Must(clusterv1beta1.AddToScheme(scheme))
+	utilruntime.Must(clusterv1beta2.AddToScheme(scheme))
 	utilruntime.Must(workv1.AddToScheme(scheme))
 	utilruntime.Must(addonv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(hypershiftdeploymentv1alpha1.AddToScheme(scheme))

--- a/operator/pkg/controllers/addon/addon_suite_test.go
+++ b/operator/pkg/controllers/addon/addon_suite_test.go
@@ -35,6 +35,7 @@ import (
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
+	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
 	workv1 "open-cluster-management.io/api/work/v1"
 	chnv1 "open-cluster-management.io/multicloud-operators-channel/pkg/apis/apps/v1"
 	placementrulesv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/placementrule/v1"
@@ -52,7 +53,6 @@ import (
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/addon"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	commonobjects "github.com/stolostron/multicluster-global-hub/pkg/objects"
-	// +kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -98,6 +98,8 @@ var _ = BeforeSuite(func() {
 	err = clusterv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 	err = clusterv1beta1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+	err = clusterv1beta2.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 	err = workv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())

--- a/operator/pkg/controllers/hubofhubs/controllers_suite_test.go
+++ b/operator/pkg/controllers/hubofhubs/controllers_suite_test.go
@@ -31,6 +31,7 @@ import (
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
+	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
 	workv1 "open-cluster-management.io/api/work/v1"
 	policyv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 	chnv1 "open-cluster-management.io/multicloud-operators-channel/pkg/apis/apps/v1"
@@ -47,7 +48,6 @@ import (
 	operatorv1alpha2 "github.com/stolostron/multicluster-global-hub/operator/apis/v1alpha2"
 	hubofhubscontroller "github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/hubofhubs"
 	commonobjects "github.com/stolostron/multicluster-global-hub/pkg/objects"
-	//+kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -99,6 +99,8 @@ var _ = BeforeSuite(func() {
 	err = clusterv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 	err = clusterv1beta1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+	err = clusterv1beta2.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 	err = workv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())

--- a/operator/pkg/controllers/hubofhubs/multiclusterglobalhub_controller_test.go
+++ b/operator/pkg/controllers/hubofhubs/multiclusterglobalhub_controller_test.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
+	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
 	policyv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 	chnv1 "open-cluster-management.io/multicloud-operators-channel/pkg/apis/apps/v1"
 	placementrulesv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/placementrule/v1"
@@ -682,13 +683,13 @@ var _ = Describe("MulticlusterGlobalHub controller", Ordered, func() {
 			Expect(k8sClient.Create(ctx, testPlacementrule, &client.CreateOptions{})).Should(Succeed())
 
 			By("By creating a finalizer managedclustersetbinding")
-			testManagedClusterSetBinding := &clusterv1beta1.ManagedClusterSetBinding{
+			testManagedClusterSetBinding := &clusterv1beta2.ManagedClusterSetBinding{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "test-managedclustersetbinding-1",
 					Namespace:  config.GetDefaultNamespace(),
 					Finalizers: []string{constants.GlobalHubCleanupFinalizer},
 				},
-				Spec: clusterv1beta1.ManagedClusterSetBindingSpec{
+				Spec: clusterv1beta2.ManagedClusterSetBindingSpec{
 					ClusterSet: "test-clusterset",
 				},
 			}
@@ -804,7 +805,7 @@ var _ = Describe("MulticlusterGlobalHub controller", Ordered, func() {
 
 			By("By checking the managedclustersetbinding finalizer is deleted")
 			Eventually(func() error {
-				managedclustersetbindings := &clusterv1beta1.ManagedClusterSetBindingList{}
+				managedclustersetbindings := &clusterv1beta2.ManagedClusterSetBindingList{}
 				if err := k8sClient.List(ctx, managedclustersetbindings, &client.ListOptions{}); err != nil {
 					return err
 				}

--- a/pkg/jobs/jobs_suite_test.go
+++ b/pkg/jobs/jobs_suite_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	mchv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
-	apiRuntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 	"open-cluster-management.io/api/client/cluster/clientset/versioned/scheme"
@@ -62,7 +62,7 @@ var _ = AfterSuite(func() {
 	Expect(testenv.Stop()).To(Succeed())
 })
 
-func addToScheme(runtimeScheme *apiRuntime.Scheme) error {
+func addToScheme(runtimeScheme *runtime.Scheme) error {
 	schemeBuilders := []*runtimescheme.Builder{
 		policyv1.SchemeBuilder,
 		placementrulev1.SchemeBuilder,

--- a/pkg/jobs/prune_finalizer.go
+++ b/pkg/jobs/prune_finalizer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-logr/logr"
 	"k8s.io/client-go/util/retry"
 	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
+	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
 	policyv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 	chnv1 "open-cluster-management.io/multicloud-operators-channel/pkg/apis/apps/v1"
 	placementrulesv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/placementrule/v1"
@@ -82,7 +83,7 @@ func (p *PruneFinalizer) prunePlacementResources() error {
 	}
 
 	p.log.Info("clean up the managedclusterset finalizer")
-	managedclustersets := &clusterv1beta1.ManagedClusterSetList{}
+	managedclustersets := &clusterv1beta2.ManagedClusterSetList{}
 	if err := p.client.List(p.ctx, managedclustersets, &client.ListOptions{}); err != nil {
 		return err
 	}
@@ -93,7 +94,7 @@ func (p *PruneFinalizer) prunePlacementResources() error {
 	}
 
 	p.log.Info("clean up the managedclustersetbinding finalizer")
-	managedclustersetbindings := &clusterv1beta1.ManagedClusterSetBindingList{}
+	managedclustersetbindings := &clusterv1beta2.ManagedClusterSetBindingList{}
 	if err := p.client.List(p.ctx, managedclustersetbindings, &client.ListOptions{}); err != nil {
 		return err
 	}

--- a/pkg/jobs/prune_finalizer_test.go
+++ b/pkg/jobs/prune_finalizer_test.go
@@ -8,6 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
+	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
 	policyv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 	chnv1 "open-cluster-management.io/multicloud-operators-channel/pkg/apis/apps/v1"
 	placementrulesv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/placementrule/v1"
@@ -28,8 +29,8 @@ var _ = Describe("Prune Resource Finalizer", func() {
 	var placement *clusterv1beta1.Placement
 	var placementbinding *policyv1.PlacementBinding
 	var policy *policyv1.Policy
-	var managedClusterSetBinding *clusterv1beta1.ManagedClusterSetBinding
-	var managedClusterSet *clusterv1beta1.ManagedClusterSet
+	var managedClusterSetBinding *clusterv1beta2.ManagedClusterSetBinding
+	var managedClusterSet *clusterv1beta2.ManagedClusterSet
 
 	BeforeEach(func() {
 		By("Create application instance with global hub finalizer")
@@ -124,13 +125,13 @@ var _ = Describe("Prune Resource Finalizer", func() {
 		}, 1*time.Second, 100*time.Millisecond).Should(BeTrue())
 
 		By("Create managedclustersetbinding instance with global hub finalizer")
-		managedClusterSetBinding = &clusterv1beta1.ManagedClusterSetBinding{
+		managedClusterSetBinding = &clusterv1beta2.ManagedClusterSetBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       "test-managedclustersetbinding-1",
 				Namespace:  "default",
 				Finalizers: []string{constants.GlobalHubCleanupFinalizer},
 			},
-			Spec: clusterv1beta1.ManagedClusterSetBindingSpec{
+			Spec: clusterv1beta2.ManagedClusterSetBindingSpec{
 				ClusterSet: "test-clusterset",
 			},
 		}
@@ -140,7 +141,7 @@ var _ = Describe("Prune Resource Finalizer", func() {
 		}, 1*time.Second, 100*time.Millisecond).Should(BeTrue())
 
 		By("Create managedclusterset instance with global hub finalizer")
-		managedClusterSet = &clusterv1beta1.ManagedClusterSet{
+		managedClusterSet = &clusterv1beta2.ManagedClusterSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       "test-managedclusterset-1",
 				Namespace:  "default",

--- a/pkg/testdata/crds/0000_00_cluster.open-cluster-management.io_managedclustersetbindings.crd.yaml
+++ b/pkg/testdata/crds/0000_00_cluster.open-cluster-management.io_managedclustersetbindings.crd.yaml
@@ -9,88 +9,162 @@ spec:
     listKind: ManagedClusterSetBindingList
     plural: managedclustersetbindings
     shortNames:
-    - mclsetbinding
-    - mclsetbindings
+      - mclsetbinding
+      - mclsetbindings
     singular: managedclustersetbinding
   scope: Namespaced
+  preserveUnknownFields: false
   versions:
-  - deprecated: true
-    deprecationWarning: cluster.open-cluster-management.io/v1alpha1 ManagedClusterSetBinding
-      is deprecated; use cluster.open-cluster-management.io/v1beta1 ManagedClusterSetBinding
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: ManagedClusterSetBinding projects a ManagedClusterSet into a
-          certain namespace. User is able to create a ManagedClusterSetBinding in
-          a namespace and bind it to a ManagedClusterSet if they have an RBAC rule
-          to CREATE on the virtual subresource of managedclustersets/bind. Workloads
-          created in the same namespace can only be distributed to ManagedClusters
-          in ManagedClusterSets bound in this namespace by higher level controllers.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: Spec defines the attributes of ManagedClusterSetBinding.
-            properties:
-              clusterSet:
-                description: ClusterSet is the name of the ManagedClusterSet to bind.
-                  It must match the instance name of the ManagedClusterSetBinding
-                  and cannot change once created. User is allowed to set this field
-                  if they have an RBAC rule to CREATE on the virtual subresource of
-                  managedclustersets/bind.
-                minLength: 1
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: false
-  - name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: ManagedClusterSetBinding projects a ManagedClusterSet into a
-          certain namespace. User is able to create a ManagedClusterSetBinding in
-          a namespace and bind it to a ManagedClusterSet if they have an RBAC rule
-          to CREATE on the virtual subresource of managedclustersets/bind. Workloads
-          created in the same namespace can only be distributed to ManagedClusters
-          in ManagedClusterSets bound in this namespace by higher level controllers.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: Spec defines the attributes of ManagedClusterSetBinding.
-            properties:
-              clusterSet:
-                description: ClusterSet is the name of the ManagedClusterSet to bind.
-                  It must match the instance name of the ManagedClusterSetBinding
-                  and cannot change once created. User is allowed to set this field
-                  if they have an RBAC rule to CREATE on the virtual subresource of
-                  managedclustersets/bind.
-                minLength: 1
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
+    - name: v1beta1
+      deprecated: true
+      deprecationWarning: "cluster.open-cluster-management.io/v1beta1 ManagedClusterSetBinding is deprecated; use cluster.open-cluster-management.io/v1beta2 ManagedClusterSetBinding"
+      schema:
+        openAPIV3Schema:
+          description: ManagedClusterSetBinding projects a ManagedClusterSet into a certain namespace. User is able to create a ManagedClusterSetBinding in a namespace and bind it to a ManagedClusterSet if they have an RBAC rule to CREATE on the virtual subresource of managedclustersets/bind. Workloads created in the same namespace can only be distributed to ManagedClusters in ManagedClusterSets bound in this namespace by higher level controllers.
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec defines the attributes of ManagedClusterSetBinding.
+              type: object
+              properties:
+                clusterSet:
+                  description: ClusterSet is the name of the ManagedClusterSet to bind. It must match the instance name of the ManagedClusterSetBinding and cannot change once created. User is allowed to set this field if they have an RBAC rule to CREATE on the virtual subresource of managedclustersets/bind.
+                  type: string
+                  minLength: 1
+            status:
+              description: Status represents the current status of the ManagedClusterSetBinding
+              type: object
+              properties:
+                conditions:
+                  description: Conditions contains the different condition statuses for this ManagedClusterSetBinding.
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - name: v1beta2
+      schema:
+        openAPIV3Schema:
+          description: ManagedClusterSetBinding projects a ManagedClusterSet into a certain namespace. User is able to create a ManagedClusterSetBinding in a namespace and bind it to a ManagedClusterSet if they have an RBAC rule to CREATE on the virtual subresource of managedclustersets/bind. Workloads created in the same namespace can only be distributed to ManagedClusters in ManagedClusterSets bound in this namespace by higher level controllers.
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec defines the attributes of ManagedClusterSetBinding.
+              type: object
+              properties:
+                clusterSet:
+                  description: ClusterSet is the name of the ManagedClusterSet to bind. It must match the instance name of the ManagedClusterSetBinding and cannot change once created. User is allowed to set this field if they have an RBAC rule to CREATE on the virtual subresource of managedclustersets/bind.
+                  type: string
+                  minLength: 1
+            status:
+              description: Status represents the current status of the ManagedClusterSetBinding
+              type: object
+              properties:
+                conditions:
+                  description: Conditions contains the different condition statuses for this ManagedClusterSetBinding.
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+      served: true
+      storage: false
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/pkg/testdata/crds/0000_00_cluster.open-cluster-management.io_managedclustersets.crd.yaml
+++ b/pkg/testdata/crds/0000_00_cluster.open-cluster-management.io_managedclustersets.crd.yaml
@@ -9,262 +9,260 @@ spec:
     listKind: ManagedClusterSetList
     plural: managedclustersets
     shortNames:
-    - mclset
-    - mclsets
+      - mclset
+      - mclsets
     singular: managedclusterset
   scope: Cluster
+  preserveUnknownFields: false
   versions:
-  - deprecated: true
-    deprecationWarning: cluster.open-cluster-management.io/v1alpha1 ManagedClusterSet
-      is deprecated; use cluster.open-cluster-management.io/v1beta1 ManagedClusterSet
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: "ManagedClusterSet defines a group of ManagedClusters that user's
-          workload can run on. A workload can be defined to deployed on a ManagedClusterSet,
-          which mean:   1. The workload can run on any ManagedCluster in the ManagedClusterSet
-          \  2. The workload cannot run on any ManagedCluster outside the ManagedClusterSet
-          \  3. The service exposed by the workload can be shared in any ManagedCluster
-          in the ManagedClusterSet \n In order to assign a ManagedCluster to a certian
-          ManagedClusterSet, add a label with name `cluster.open-cluster-management.io/clusterset`
-          on the ManagedCluster to refers to the ManagedClusterSet. User is not allow
-          to add/remove this label on a ManagedCluster unless they have a RBAC rule
-          to CREATE on a virtual subresource of managedclustersets/join. In order
-          to update this label, user must have the permission on both the old and
-          new ManagedClusterSet."
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: Spec defines the attributes of the ManagedClusterSet
-            type: object
-          status:
-            description: Status represents the current status of the ManagedClusterSet
-            properties:
-              conditions:
-                description: Conditions contains the different condition statuses
-                  for this ManagedClusterSet.
-                items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
-                  properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                type: array
-            type: object
-        type: object
-    served: true
-    storage: false
-    subresources:
-      status: {}
-  - additionalPrinterColumns:
-    - jsonPath: .status.conditions[?(@.type=="ClusterSetEmpty")].status
-      name: Empty
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: "ManagedClusterSet defines a group of ManagedClusters that user's
-          workload can run on. A workload can be defined to deployed on a ManagedClusterSet,
-          which mean:   1. The workload can run on any ManagedCluster in the ManagedClusterSet
-          \  2. The workload cannot run on any ManagedCluster outside the ManagedClusterSet
-          \  3. The service exposed by the workload can be shared in any ManagedCluster
-          in the ManagedClusterSet \n In order to assign a ManagedCluster to a certian
-          ManagedClusterSet, add a label with name `cluster.open-cluster-management.io/clusterset`
-          on the ManagedCluster to refers to the ManagedClusterSet. User is not allow
-          to add/remove this label on a ManagedCluster unless they have a RBAC rule
-          to CREATE on a virtual subresource of managedclustersets/join. In order
-          to update this label, user must have the permission on both the old and
-          new ManagedClusterSet."
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            default:
-              clusterSelector:
-                selectorType: LegacyClusterSetLabel
-            description: Spec defines the attributes of the ManagedClusterSet
-            properties:
-              clusterSelector:
-                default:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="ClusterSetEmpty")].status
+          name: Empty
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      deprecated: true
+      deprecationWarning: "cluster.open-cluster-management.io/v1beta1 ManagedClusterSet is deprecated; use cluster.open-cluster-management.io/v1beta2 ManagedClusterSet"
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      "schema":
+        "openAPIV3Schema":
+          description: "ManagedClusterSet defines a group of ManagedClusters that user's workload can run on. A workload can be defined to deployed on a ManagedClusterSet, which mean:   1. The workload can run on any ManagedCluster in the ManagedClusterSet   2. The workload cannot run on any ManagedCluster outside the ManagedClusterSet   3. The service exposed by the workload can be shared in any ManagedCluster in the ManagedClusterSet \n In order to assign a ManagedCluster to a certian ManagedClusterSet, add a label with name `cluster.open-cluster-management.io/clusterset` on the ManagedCluster to refers to the ManagedClusterSet. User is not allow to add/remove this label on a ManagedCluster unless they have a RBAC rule to CREATE on a virtual subresource of managedclustersets/join. In order to update this label, user must have the permission on both the old and new ManagedClusterSet."
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec defines the attributes of the ManagedClusterSet
+              type: object
+              default:
+                clusterSelector:
                   selectorType: LegacyClusterSetLabel
-                description: ClusterSelector represents a selector of ManagedClusters
-                properties:
-                  selectorType:
-                    default: LegacyClusterSetLabel
-                    description: SelectorType could only be "LegacyClusterSetLabel"
-                      now, will support more SelectorType later "LegacyClusterSetLabel"
-                      means to use label "cluster.open-cluster-management.io/clusterset:<ManagedClusterSet
-                      Name>"" to select target clusters.
-                    enum:
-                    - LegacyClusterSetLabel
-                    type: string
-                type: object
-            type: object
-          status:
-            description: Status represents the current status of the ManagedClusterSet
-            properties:
-              conditions:
-                description: Conditions contains the different condition statuses
-                  for this ManagedClusterSet.
-                items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
-                  properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
+              properties:
+                clusterSelector:
+                  description: ClusterSelector represents a selector of ManagedClusters
                   type: object
-                type: array
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                  default:
+                    selectorType: LegacyClusterSetLabel
+                  properties:
+                    labelSelector:
+                      description: LabelSelector define the general labelSelector which clusterset will use to select target managedClusters
+                      type: object
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                          type: array
+                          items:
+                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            type: object
+                            required:
+                              - key
+                              - operator
+                            properties:
+                              key:
+                                description: key is the label key that the selector applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                type: array
+                                items:
+                                  type: string
+                        matchLabels:
+                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                          additionalProperties:
+                            type: string
+                    selectorType:
+                      description: SelectorType could only be "LegacyClusterSetLabel" or "LabelSelector" "LegacyClusterSetLabel" means to use label "cluster.open-cluster-management.io/clusterset:<ManagedClusterSet Name>"" to select target clusters. "LabelSelector" means use labelSelector to select target managedClusters
+                      type: string
+                      default: LegacyClusterSetLabel
+                      enum:
+                        - LegacyClusterSetLabel
+                        - LabelSelector
+            status:
+              description: Status represents the current status of the ManagedClusterSet
+              type: object
+              properties:
+                conditions:
+                  description: Conditions contains the different condition statuses for this ManagedClusterSet.
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="ClusterSetEmpty")].status
+          name: Empty
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta2
+      served: true
+      storage: false
+      subresources:
+        status: {}
+      "schema":
+        "openAPIV3Schema":
+          description: "ManagedClusterSet defines a group of ManagedClusters that user's workload can run on. A workload can be defined to deployed on a ManagedClusterSet, which mean:   1. The workload can run on any ManagedCluster in the ManagedClusterSet   2. The workload cannot run on any ManagedCluster outside the ManagedClusterSet   3. The service exposed by the workload can be shared in any ManagedCluster in the ManagedClusterSet \n In order to assign a ManagedCluster to a certian ManagedClusterSet, add a label with name `cluster.open-cluster-management.io/clusterset` on the ManagedCluster to refers to the ManagedClusterSet. User is not allow to add/remove this label on a ManagedCluster unless they have a RBAC rule to CREATE on a virtual subresource of managedclustersets/join. In order to update this label, user must have the permission on both the old and new ManagedClusterSet."
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec defines the attributes of the ManagedClusterSet
+              type: object
+              default:
+                clusterSelector:
+                  selectorType: ExclusiveClusterSetLabel
+              properties:
+                clusterSelector:
+                  description: ClusterSelector represents a selector of ManagedClusters
+                  type: object
+                  default:
+                    selectorType: ExclusiveClusterSetLabel
+                  properties:
+                    labelSelector:
+                      description: LabelSelector define the general labelSelector which clusterset will use to select target managedClusters
+                      type: object
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                          type: array
+                          items:
+                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            type: object
+                            required:
+                              - key
+                              - operator
+                            properties:
+                              key:
+                                description: key is the label key that the selector applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                type: array
+                                items:
+                                  type: string
+                        matchLabels:
+                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                          additionalProperties:
+                            type: string
+                    selectorType:
+                      description: SelectorType could only be "ExclusiveClusterSetLabel" or "LabelSelector" "ExclusiveClusterSetLabel" means to use label "cluster.open-cluster-management.io/clusterset:<ManagedClusterSet Name>"" to select target clusters. "LabelSelector" means use labelSelector to select target managedClusters
+                      type: string
+                      default: ExclusiveClusterSetLabel
+                      enum:
+                        - ExclusiveClusterSetLabel
+                        - LabelSelector
+            status:
+              description: Status represents the current status of the ManagedClusterSet
+              type: object
+              properties:
+                conditions:
+                  description: Conditions contains the different condition statuses for this ManagedClusterSet.
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
 status:
   acceptedNames:
     kind: ""

--- a/test/pkg/e2e/hoh-prune_test.go
+++ b/test/pkg/e2e/hoh-prune_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
+	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 	chnv1 "open-cluster-management.io/multicloud-operators-channel/pkg/apis/apps/v1"
 	placementrulesv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/placementrule/v1"
@@ -64,6 +65,7 @@ var _ = Describe("Delete the multiclusterglobalhub and prune resources", Label("
 		appsv1alpha1.AddToScheme(scheme)
 		rbacv1.AddToScheme(scheme)
 		clusterv1beta1.AddToScheme(scheme)
+		clusterv1beta2.AddToScheme(scheme)
 		policiesv1.AddToScheme(scheme)
 		clusterv1.AddToScheme(scheme)
 		corev1.AddToScheme(scheme)
@@ -240,7 +242,7 @@ var _ = Describe("Delete the multiclusterglobalhub and prune resources", Label("
 
 		By("Delete managedclusterset finalizer")
 		Eventually(func() error {
-			managedclustersets := &clusterv1beta1.ManagedClusterSetList{}
+			managedclustersets := &clusterv1beta2.ManagedClusterSetList{}
 			if err := runtimeClient.List(ctx, managedclustersets, &client.ListOptions{}); err != nil {
 				return err
 			}
@@ -256,7 +258,7 @@ var _ = Describe("Delete the multiclusterglobalhub and prune resources", Label("
 
 		By("Delete managedclustersetbinding finalizer")
 		Eventually(func() error {
-			managedclustersetbindings := &clusterv1beta1.ManagedClusterSetBindingList{}
+			managedclustersetbindings := &clusterv1beta2.ManagedClusterSetBindingList{}
 			if err := runtimeClient.List(ctx, managedclustersetbindings, &client.ListOptions{}); err != nil &&
 				!errors.IsNotFound(err) {
 				return err


### PR DESCRIPTION
We have many warnings about managedclusterset and managedclustersetbinding api version in global hub components:

```
W0104 10:52:45.471745       1 warnings.go:70] cluster.open-cluster-management.io/v1beta1 ManagedClusterSet is deprecated; use cluster.open-cluster-management.io/v1beta2 ManagedClusterSet
W0104 10:54:16.472666       1 warnings.go:70] cluster.open-cluster-management.io/v1beta1 ManagedClusterSetBinding is deprecated; use cluster.open-cluster-management.io/v1beta2 ManagedClusterSetBinding
...
```

Signed-off-by: morvencao <lcao@redhat.com>