### PR TITLE
fix duplicated kafka consumer ID in global hub agent.

### DIFF
--- a/agent/cmd/agent/main_test.go
+++ b/agent/cmd/agent/main_test.go
@@ -116,6 +116,8 @@ func TestAgent(t *testing.T) {
 			"default",
 			"--leaf-hub-name",
 			"hub1",
+			"--kakfa-consumer-id",
+			"hub1",
 			"--lease-duration",
 			"15",
 			"--renew-deadline",

--- a/operator/pkg/controllers/addon/manifests/templates/agent/multicluster-global-hub-agent-deployment.yaml
+++ b/operator/pkg/controllers/addon/manifests/templates/agent/multicluster-global-hub-agent-deployment.yaml
@@ -24,6 +24,7 @@ spec:
             - '--zap-devel=true'
             - --pod-namespace=$(POD_NAMESPACE)
             - --leaf-hub-name={{ .LeafHubID }}
+            - --kakfa-consumer-id={{ .LeafHubID }}
             - --enforce-hoh-rbac=false
             - --transport-type=kafka
             - --kafka-bootstrap-server={{ .KafkaBootstrapServer }}

--- a/operator/pkg/controllers/addon/manifests/templates/hostedagent/multicluster-global-hub-hosting-agent-deployment.yaml
+++ b/operator/pkg/controllers/addon/manifests/templates/hostedagent/multicluster-global-hub-hosting-agent-deployment.yaml
@@ -25,6 +25,7 @@ spec:
             - '--zap-devel=true'
             - --pod-namespace=$(POD_NAMESPACE)
             - --leaf-hub-name={{ .LeafHubID }}
+            - --kakfa-consumer-id={{ .LeafHubID }}
             - --enforce-hoh-rbac=false
             - --transport-type=kafka
             - --kafka-bootstrap-server={{ .KafkaBootstrapServer }}


### PR DESCRIPTION
fix: https://github.com/stolostron/backlog/issues/27083
which is introduced in https://github.com/stolostron/multicluster-global-hub/pull/259/

Signed-off-by: morvencao <lcao@redhat.com>