### PR TITLE
fix oauth-proxy permission issue.

### DIFF
--- a/operator/pkg/controllers/hubofhubs/manifests/manager/deployment.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/manager/deployment.yaml
@@ -72,8 +72,8 @@ spec:
             # - '--client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token'
             - '--pass-user-bearer-token=true'
             - '--pass-access-token=true'
-            - --openshift-sar={"resource":"namespaces","verb":"get"}
-            - --openshift-delegate-urls={"/":{"resource":"namespaces","verb":"get"}}
+            - --openshift-sar={"resource":"projects","verb":"list"}
+            - --openshift-delegate-urls={"/":{"resource":"projects","verb":"list"}}
             - --tls-cert=/etc/tls/private/tls.crt
             - --tls-key=/etc/tls/private/tls.key
             - --openshift-service-account=multicluster-global-hub-manager


### PR DESCRIPTION
See: https://github.com/openshift/oauth-proxy#limiting-access-to-users for `--openshift-sar` usage
End user or service account must have permission list in `--openshift-sar` to access backend service.

Newly created user doesn't have permission to get  or list `namespaces`:

```bash
# oc get ns
Error from server (Forbidden): namespaces is forbidden: User "acm-user1" cannot list resource "namespaces" in API group "" at the cluster scope
```

But newly created user has permission to list `projects` in openshift, but can't see any project:

```
# oc get projects
No resources found
```

Signed-off-by: morvencao <lcao@redhat.com>