### PR TITLE
fixed the issue "AccumulateTarget: containers path is not of type []interface{} but map[string]interface" when installing postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The agent is running in the regional hub clusters. It is responsible to sync-up 
 kubectl create secret generic storage-secret -n "open-cluster-management" \
     --from-literal=database_uri=<postgresql-uri> 
 ```
-> You can run this sample script `./operator/config/samples/storage/deploy_postgres.sh` to install postgres in `hoh-postgres` namespace and create the secret `storage-secret` in namespace `open-cluster-management` automatically. To override the secret namespace, set `TARGET_NAMESPACE` environment variable to the ACM installation namespace before executing the script.
+> You can run this sample script `./operator/config/samples/storage/deploy_postgres.sh`(Note: the client version of kubectl must be v1.21+) to install postgres in `hoh-postgres` namespace and create the secret `storage-secret` in namespace `open-cluster-management` automatically. To override the secret namespace, set `TARGET_NAMESPACE` environment variable to the ACM installation namespace before executing the script.
 
 4. Kafka is installed and two topics `spec` and `status` are created, also a secret with name `transport-secret` that contains the kafka access information should be created in `open-cluster-management` namespace:
 

--- a/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -55,15 +55,16 @@ spec:
     that contains the database access credential in `open-cluster-management` namespace.
     You can run the following command to create the secret: \n\n```\nkubectl create
     secret generic storage-secret -n open-cluster-management \\\n  --from-literal=database_uri=<postgresql-uri>
-    \n```\n>_Note:_ There is a sample script available [here](https://github.com/stolostron/multicluster-global-hub/tree/main/operator/config/samples/storage)
-    to install postgres in `hoh-postgres` namespace and create the secret `storage-secret`
-    in namespace `open-cluster-management` automatically. To override the secret namespace,
-    set `TARGET_NAMESPACE` environment variable to the RHACM installation namespace
-    before executing the script.\n\n- Kafka needs to be installed, and you must create
-    two sections, `spec` and `status`. You need to create a secret named kafka-secret
-    that contains the kafka access information should be created in `open-cluster-management`
-    namespace. You can run the following command to create the secret: \n\n```\nkubectl
-    create secret generic transport-secret -n open-cluster-management \\\n  --from-literal=bootstrap_server=<kafka-bootstrap-server-address>
+    \n```\n>_Note:_ There is a sample script available [here](https://github.com/stolostron/multicluster-global-hub/tree/main/operator/config/samples/storage)(Note:
+    the client version of kubectl must be v1.21+) to install postgres in `hoh-postgres`
+    namespace and create the secret `storage-secret` in namespace `open-cluster-management`
+    automatically. To override the secret namespace, set `TARGET_NAMESPACE` environment
+    variable to the RHACM installation namespace before executing the script.\n\n-
+    Kafka needs to be installed, and you must create two sections, `spec` and `status`.
+    You need to create a secret named kafka-secret that contains the kafka access
+    information should be created in `open-cluster-management` namespace. You can
+    run the following command to create the secret: \n\n```\nkubectl create secret
+    generic transport-secret -n open-cluster-management \\\n  --from-literal=bootstrap_server=<kafka-bootstrap-server-address>
     \\\n  --from-literal=CA=<CA-for-kafka-server>\n```\n >_Note:_ There is a sample
     script available [here](https://github.com/stolostron/multicluster-global-hub/tree/main/operator/config/samples/transport)
     to install kafka in `kafka` namespace and create the secret `transport-secret`

--- a/operator/config/manifests/bases/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -33,15 +33,16 @@ spec:
     that contains the database access credential in `open-cluster-management` namespace.
     You can run the following command to create the secret: \n\n```\nkubectl create
     secret generic storage-secret -n open-cluster-management \\\n  --from-literal=database_uri=<postgresql-uri>
-    \n```\n>_Note:_ There is a sample script available [here](https://github.com/stolostron/multicluster-global-hub/tree/main/operator/config/samples/storage)
-    to install postgres in `hoh-postgres` namespace and create the secret `storage-secret`
-    in namespace `open-cluster-management` automatically. To override the secret namespace,
-    set `TARGET_NAMESPACE` environment variable to the RHACM installation namespace
-    before executing the script.\n\n- Kafka needs to be installed, and you must create
-    two sections, `spec` and `status`. You need to create a secret named kafka-secret
-    that contains the kafka access information should be created in `open-cluster-management`
-    namespace. You can run the following command to create the secret: \n\n```\nkubectl
-    create secret generic transport-secret -n open-cluster-management \\\n  --from-literal=bootstrap_server=<kafka-bootstrap-server-address>
+    \n```\n>_Note:_ There is a sample script available [here](https://github.com/stolostron/multicluster-global-hub/tree/main/operator/config/samples/storage)(Note:
+    the client version of kubectl must be v1.21+) to install postgres in `hoh-postgres`
+    namespace and create the secret `storage-secret` in namespace `open-cluster-management`
+    automatically. To override the secret namespace, set `TARGET_NAMESPACE` environment
+    variable to the RHACM installation namespace before executing the script.\n\n-
+    Kafka needs to be installed, and you must create two sections, `spec` and `status`.
+    You need to create a secret named kafka-secret that contains the kafka access
+    information should be created in `open-cluster-management` namespace. You can
+    run the following command to create the secret: \n\n```\nkubectl create secret
+    generic transport-secret -n open-cluster-management \\\n  --from-literal=bootstrap_server=<kafka-bootstrap-server-address>
     \\\n  --from-literal=CA=<CA-for-kafka-server>\n```\n >_Note:_ There is a sample
     script available [here](https://github.com/stolostron/multicluster-global-hub/tree/main/operator/config/samples/transport)
     to install kafka in `kafka` namespace and create the secret `transport-secret`

--- a/test/setup/e2e_dependencies.sh
+++ b/test/setup/e2e_dependencies.sh
@@ -56,9 +56,9 @@ function checkKubectl() {
   if ! command -v kubectl >/dev/null 2>&1; then 
     echo "This script will install kubectl (https://kubernetes.io/docs/tasks/tools/install-kubectl/) on your machine"
     if [[ "$(uname)" == "Linux" ]]; then
-        curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
+        curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.21.0/bin/linux/amd64/kubectl
     elif [[ "$(uname)" == "Darwin" ]]; then
-        curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/darwin/amd64/kubectl
+        curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.21.0/bin/darwin/amd64/kubectl
     fi
     chmod +x ./kubectl
     sudo mv ./kubectl ${binDir}/kubectl


### PR DESCRIPTION
Signed-off-by: myan [myan@redhat.com](mailto:myan@redhat.com)

When the installed kubectl version is lower than v0.21, the following error may occur when installing postgres
```
error: AccumulateTarget: containers path is not of type []interface{} but map[string]interface {}
```