### PR TITLE
upgrade confluent-kafka-go to v2.0.2 to be compatible with linux/aarch64

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Shopify/sarama v1.38.1
 	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/cloudevents/sdk-go/v2 v2.13.0
-	github.com/confluentinc/confluent-kafka-go v1.9.2
+	github.com/confluentinc/confluent-kafka-go/v2 v2.0.2
 	github.com/deckarep/golang-set v1.8.0
 	github.com/fergusstrange/embedded-postgres v1.17.0
 	github.com/gin-gonic/gin v1.7.7

--- a/go.sum
+++ b/go.sum
@@ -281,8 +281,8 @@ github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/confluentinc/confluent-kafka-go v1.9.2 h1:gV/GxhMBUb03tFWkN+7kdhg+zf+QUM+wVkI9zwh770Q=
-github.com/confluentinc/confluent-kafka-go v1.9.2/go.mod h1:ptXNqsuDfYbAE/LBW6pnwWZElUoWxHoV8E43DCrliyo=
+github.com/confluentinc/confluent-kafka-go/v2 v2.0.2 h1:YmUjjRp1mSTqTxtHQYMQKBLa2hfgIZz9PSqoSRDkwf4=
+github.com/confluentinc/confluent-kafka-go/v2 v2.0.2/go.mod h1:qWGwym8EpAsIP5lZsTKhYTnYSGqkbxEfRB4A489Jo64=
 github.com/containerd/aufs v0.0.0-20200908144142-dab0cbea06f4/go.mod h1:nukgQABAEopAHvB6j7cnP5zJ+/3aVcE7hCYqvIwAHyE=
 github.com/containerd/aufs v0.0.0-20201003224125-76a6863f2989/go.mod h1:AkGGQs9NM2vtYHaUen+NljV0/baGCAPELGm2q9ZXpWU=
 github.com/containerd/aufs v0.0.0-20210316121734-20793ff83c97/go.mod h1:kL5kd6KM5TzQjR79jljyi4olc1Vrx6XBlcyj3gNv2PU=

--- a/manager/cmd/manager/main_test.go
+++ b/manager/cmd/manager/main_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/manager/pkg/statussyncer/transport2db/syncer/syncers_test.go
+++ b/manager/pkg/statussyncer/transport2db/syncer/syncers_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"

--- a/pkg/compressor/compressor_test.go
+++ b/pkg/compressor/compressor_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 
 	statusbundle "github.com/stolostron/multicluster-global-hub/pkg/bundle/status"
 	"github.com/stolostron/multicluster-global-hub/pkg/compressor"

--- a/pkg/transport/consumer/bundle_metadata.go
+++ b/pkg/transport/consumer/bundle_metadata.go
@@ -1,7 +1,7 @@
 package consumer
 
 import (
-	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 
 	"github.com/stolostron/multicluster-global-hub/pkg/bundle"
 )

--- a/pkg/transport/consumer/committer.go
+++ b/pkg/transport/consumer/committer.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	"github.com/go-logr/logr"
 
 	"github.com/stolostron/multicluster-global-hub/pkg/bundle"
@@ -53,8 +53,7 @@ func (c *committer) periodicCommit(ctx context.Context) {
 			bundlesMetadata := c.getBundlesMetadataFunc()
 			// extract the lowest per partition in the pending bundles, the highest per partition in the
 			// processed bundles
-			pendingOffsetsToCommit, processedOffsetsToCommit :=
-				c.filterMetadataPerPartition(bundlesMetadata)
+			pendingOffsetsToCommit, processedOffsetsToCommit := c.filterMetadataPerPartition(bundlesMetadata)
 			// patch the processed offsets map with that of the pending ones, so that if a partition
 			// has both types, the pending bundle gains priority (overwrites).
 			for partition, offset := range pendingOffsetsToCommit {

--- a/pkg/transport/consumer/kafka_consumer.go
+++ b/pkg/transport/consumer/kafka_consumer.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	"github.com/go-logr/logr"
 
 	"github.com/stolostron/multicluster-global-hub/pkg/bundle"

--- a/pkg/transport/consumer/kafka_message_assembler.go
+++ b/pkg/transport/consumer/kafka_message_assembler.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"strings"
 
-	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 )
 
 func newKafkaMessageAssembler() *kafkaMessageAssembler {

--- a/pkg/transport/consumer/message_fragement.go
+++ b/pkg/transport/consumer/message_fragement.go
@@ -3,7 +3,7 @@ package consumer
 import (
 	"time"
 
-	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 )
 
 // messageFragment represents one fragment of a kafka message.

--- a/pkg/transport/consumer/message_fragment_collection.go
+++ b/pkg/transport/consumer/message_fragment_collection.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 )
 
 var errFragmentsAreIncomplete = fmt.Errorf("some fragments are missing")

--- a/pkg/transport/helpers/helpers.go
+++ b/pkg/transport/helpers/helpers.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 )
 
 func LoadCACertToConfigMap(kafkaCAPath string, kafkaConfigMap *kafka.ConfigMap) error {

--- a/pkg/transport/helpers/helpers_test.go
+++ b/pkg/transport/helpers/helpers_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 )
 
 func TestLoadCACertcoConfigMap(t *testing.T) {

--- a/pkg/transport/producer/kafka_producer.go
+++ b/pkg/transport/producer/kafka_producer.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	"github.com/go-logr/logr"
 
 	"github.com/stolostron/multicluster-global-hub/pkg/compressor"

--- a/pkg/transport/producer/message_builder.go
+++ b/pkg/transport/producer/message_builder.go
@@ -1,7 +1,7 @@
 package producer
 
 import (
-	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 )
 
 // NewMessageBuilder creates a new instance of MessageBuilder.

--- a/pkg/transport/transport_suite_test.go
+++ b/pkg/transport/transport_suite_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>

Ref: https://github.com/confluentinc/confluent-kafka-go/releases/tag/v2.0.2, https://github.com/confluentinc/confluent-kafka-go/issues/805

CI-Ref: https://github.com/openshift/release/pull/35168, https://github.com/openshift/release/blob/3c84e31c12059a9baa4b8e4df6feea0519fdc76e/ci-operator/jobs/stolostron/multicluster-global-hub/stolostron-multicluster-global-hub-main-postsubmits.yaml#L122