### PR TITLE
fixed the security hotspots from the sunar postsubmit

### DIFF
--- a/operator/bundle.Dockerfile
+++ b/operator/bundle.Dockerfile
@@ -1,5 +1,9 @@
 FROM scratch
 
+RUN groupadd -g 999 appuser && \
+    useradd -r -u 999 -g appuser appuser
+USER appuser
+
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>
Risk message: Scratch images run as root by default. Make sure it is safe here.
