### PR TITLE
fixed the permission issue when build the operator bundle image

### DIFF
--- a/operator/bundle.Dockerfile
+++ b/operator/bundle.Dockerfile
@@ -1,9 +1,5 @@
 FROM scratch
 
-RUN groupadd -g 999 appuser && \
-    useradd -r -u 999 -g appuser appuser
-USER appuser
-
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>

Building the operator bundle image should run with the enough permission, otherwise, it will echo the following error message:
```bash
docker build -f bundle.Dockerfile -t quay.io/myan/multicluster-global-hub-operator-bundle:v0.0.1 .
Sending build context to Docker daemon  135.6MB
Step 1/17 : FROM scratch
 ---> 
Step 2/17 : RUN groupadd -g 999 appuser &&     useradd -r -u 999 -g appuser appuser
 ---> Running in a5f2b09b7fc4
failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "/bin/sh": stat /bin/sh: no such file or directory: unknown
make: *** [Makefile:203: bundle-build] Error 1
```