### PR TITLE
fix e2e-arch img link

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -1,4 +1,4 @@
 # multicluster-global-hub-e2e
 
 ## E2E Tests
-![E2E Architecture](doc/architecture/multicluster-global-hub-e2e-arch.png)
+![E2E Architecture](../doc/architecture/multicluster-global-hub-e2e-arch.png)


### PR DESCRIPTION
edit image link from "doc/architecture/multicluster-global-hub-e2e-arch.png" to "../doc/architecture/multicluster-global-hub-e2e-arch.png"