### PR TITLE
Init compliance history table

### DIFF
--- a/manager/pkg/statussyncer/transport2db/db/postgresql/batch/base_batch_builder.go
+++ b/manager/pkg/statussyncer/transport2db/db/postgresql/batch/base_batch_builder.go
@@ -151,7 +151,8 @@ func (builder *baseBatchBuilder) generateInsertStatement() string {
 	if builder.tableColumns == "" {
 		stringBuilder.WriteString(fmt.Sprintf("INSERT into %s.%s values ", builder.schema, builder.tableName))
 	} else {
-		stringBuilder.WriteString(fmt.Sprintf("INSERT into %s.%s (%s) values ", builder.schema, builder.tableName, builder.tableColumns))
+		stringBuilder.WriteString(fmt.Sprintf("INSERT into %s.%s (%s) values ",
+			builder.schema, builder.tableName, builder.tableColumns))
 	}
 	columnsCount := len(builder.insertArgs) / builder.insertRowsCount // total num of args divided by num of rows
 	stringBuilder.WriteString(builder.generateInsertOrUpdateArgs(builder.insertRowsCount, columnsCount,

--- a/manager/pkg/statussyncer/transport2db/db/postgresql/batch/base_batch_builder.go
+++ b/manager/pkg/statussyncer/transport2db/db/postgresql/batch/base_batch_builder.go
@@ -21,7 +21,7 @@ type batchItem struct {
 	arguments []interface{}
 }
 
-func newBaseBatchBuilder(schema string, tableName string, tableSpecialColumns map[int]string, leafHubName string,
+func newBaseBatchBuilder(schema, tableName, tableColumns string, tableSpecialColumns map[int]string, leafHubName string,
 	deleteRowKey string,
 ) *baseBatchBuilder {
 	return &baseBatchBuilder{
@@ -30,6 +30,7 @@ func newBaseBatchBuilder(schema string, tableName string, tableSpecialColumns ma
 		updateBatchItems:    make([]*batchItem, 0),
 		schema:              schema,
 		tableName:           tableName,
+		tableColumns:        tableColumns,
 		tableSpecialColumns: tableSpecialColumns,
 		leafHubName:         leafHubName,
 		insertArgs:          make([]interface{}, 0),
@@ -48,6 +49,7 @@ type baseBatchBuilder struct {
 	updateBatchItems        []*batchItem
 	schema                  string
 	tableName               string
+	tableColumns            string
 	tableSpecialColumns     map[int]string
 	leafHubName             string
 	insertArgs              []interface{}
@@ -146,8 +148,11 @@ func (builder *baseBatchBuilder) setUpdateStatementFunc(generateUpdateStatementF
 func (builder *baseBatchBuilder) generateInsertStatement() string {
 	var stringBuilder strings.Builder
 
-	stringBuilder.WriteString(fmt.Sprintf("INSERT into %s.%s values ", builder.schema, builder.tableName))
-
+	if builder.tableColumns == "" {
+		stringBuilder.WriteString(fmt.Sprintf("INSERT into %s.%s values ", builder.schema, builder.tableName))
+	} else {
+		stringBuilder.WriteString(fmt.Sprintf("INSERT into %s.%s (%s) values ", builder.schema, builder.tableName, builder.tableColumns))
+	}
 	columnsCount := len(builder.insertArgs) / builder.insertRowsCount // total num of args divided by num of rows
 	stringBuilder.WriteString(builder.generateInsertOrUpdateArgs(builder.insertRowsCount, columnsCount,
 		builder.tableSpecialColumns))

--- a/manager/pkg/statussyncer/transport2db/db/postgresql/batch/generic_batch_builder.go
+++ b/manager/pkg/statussyncer/transport2db/db/postgresql/batch/generic_batch_builder.go
@@ -19,7 +19,7 @@ func NewGenericBatchBuilder(schema string, tableName string, leafHubName string)
 	tableSpecialColumns[genericUUIDColumnIndex] = database.UUID
 	tableSpecialColumns[genericJsonbColumnIndex] = database.Jsonb
 	builder := &GenericBatchBuilder{
-		baseBatchBuilder: newBaseBatchBuilder(schema, tableName, tableSpecialColumns, leafHubName,
+		baseBatchBuilder: newBaseBatchBuilder(schema, tableName, "", tableSpecialColumns, leafHubName,
 			genericDeleteRowKey),
 	}
 

--- a/manager/pkg/statussyncer/transport2db/db/postgresql/batch/generic_local_batch_builder.go
+++ b/manager/pkg/statussyncer/transport2db/db/postgresql/batch/generic_local_batch_builder.go
@@ -10,6 +10,7 @@ import (
 const (
 	genericLocalJsonbColumnIndex = 2
 	genericLocalDeleteRowKey     = "payload->'metadata'->>'uid'"
+	genericLocalTableColumns     = "leaf_hub_name, payload"
 )
 
 // NewGenericLocalBatchBuilder creates a new instance of PostgreSQL GenericLocalBatchBuilder.
@@ -17,7 +18,7 @@ func NewGenericLocalBatchBuilder(schema string, tableName string, leafHubName st
 	tableSpecialColumns := make(map[int]string)
 	tableSpecialColumns[genericLocalJsonbColumnIndex] = database.Jsonb
 	builder := &GenericLocalBatchBuilder{
-		baseBatchBuilder: newBaseBatchBuilder(schema, tableName, tableSpecialColumns, leafHubName,
+		baseBatchBuilder: newBaseBatchBuilder(schema, tableName, genericLocalTableColumns, tableSpecialColumns, leafHubName,
 			genericLocalDeleteRowKey),
 	}
 

--- a/manager/pkg/statussyncer/transport2db/db/postgresql/batch/managed_clusters_batch_builder.go
+++ b/manager/pkg/statussyncer/transport2db/db/postgresql/batch/managed_clusters_batch_builder.go
@@ -10,6 +10,7 @@ import (
 const (
 	managedClustersJsonbColumnIndex = 2
 	managedClustersDeleteRowKey     = "payload->'metadata'->>'name'"
+	managedClustersTableColumns     = "leaf_hub_name, payload, error"
 )
 
 // NewManagedClustersBatchBuilder creates a new instance of PostgreSQL ManagedClustersBatchBuilder.
@@ -18,8 +19,8 @@ func NewManagedClustersBatchBuilder(schema string, tableName string, leafHubName
 	tableSpecialColumns[managedClustersJsonbColumnIndex] = database.Jsonb
 
 	builder := &ManagedClustersBatchBuilder{
-		baseBatchBuilder: newBaseBatchBuilder(schema, tableName, tableSpecialColumns, leafHubName,
-			managedClustersDeleteRowKey),
+		baseBatchBuilder: newBaseBatchBuilder(schema, tableName, managedClustersTableColumns,
+			tableSpecialColumns, leafHubName, managedClustersDeleteRowKey),
 	}
 
 	builder.setUpdateStatementFunc(builder.generateUpdateStatement)

--- a/manager/pkg/statussyncer/transport2db/db/postgresql/batch/policies_batch_builder.go
+++ b/manager/pkg/statussyncer/transport2db/db/postgresql/batch/policies_batch_builder.go
@@ -22,7 +22,7 @@ func NewPoliciesBatchBuilder(schema string, tableName string, leafHubName string
 	tableSpecialColumns[policyUUIDColumnIndex] = database.UUID
 
 	builder := &PoliciesBatchBuilder{
-		baseBatchBuilder: newBaseBatchBuilder(schema, tableName, tableSpecialColumns, leafHubName,
+		baseBatchBuilder: newBaseBatchBuilder(schema, tableName, "", tableSpecialColumns, leafHubName,
 			policyDeleteRowKey),
 		updateClusterComplianceArgs:      make([]interface{}, 0),
 		updateClusterComplianceRowsCount: 0,

--- a/operator/pkg/controllers/hubofhubs/database/3.tables.sql
+++ b/operator/pkg/controllers/hubofhubs/database/3.tables.sql
@@ -79,7 +79,7 @@ CREATE TABLE IF NOT EXISTS  history.subscriptions (
 );
 
 CREATE TABLE IF NOT EXISTS  local_spec.placementrules (
-    leaf_hub_name text,
+    leaf_hub_name character varying(63) NOT NULL,
     payload jsonb NOT NULL,
     created_at timestamp without time zone DEFAULT now() NOT NULL,
     updated_at timestamp without time zone DEFAULT now() NOT NULL
@@ -88,13 +88,13 @@ CREATE TABLE IF NOT EXISTS  local_spec.placementrules (
 CREATE TABLE IF NOT EXISTS local_spec.policies (
     leaf_hub_name character varying(63) NOT NULL,
     payload jsonb NOT NULL,
+    created_at timestamp without time zone DEFAULT now() NOT NULL,
+    updated_at timestamp without time zone DEFAULT now() NOT NULL,
     policy_id uuid generated always as (uuid(payload->'metadata'->>'uid')) stored,
     policy_name character varying(255) generated always as (payload -> 'metadata' ->> 'name') stored,
     policy_standard character varying(255) generated always as (payload -> 'metadata' -> 'annotations' ->> 'policy.open-cluster-management.io/standards') stored,
     policy_category character varying(255) generated always as (payload -> 'metadata' -> 'annotations' ->> 'policy.open-cluster-management.io/categories') stored,
-    policy_control character varying(255) generated always as (payload -> 'metadata' -> 'annotations' ->> 'policy.open-cluster-management.io/controls') stored,
-    created_at timestamp without time zone DEFAULT now() NOT NULL,
-    updated_at timestamp without time zone DEFAULT now() NOT NULL
+    policy_control character varying(255) generated always as (payload -> 'metadata' -> 'annotations' ->> 'policy.open-cluster-management.io/controls') stored
 );
 
 CREATE TABLE IF NOT EXISTS local_status.compliance (

--- a/operator/pkg/controllers/hubofhubs/database/3.tables.sql
+++ b/operator/pkg/controllers/hubofhubs/database/3.tables.sql
@@ -86,9 +86,9 @@ CREATE TABLE IF NOT EXISTS  local_spec.placementrules (
 );
 
 CREATE TABLE IF NOT EXISTS local_spec.policies (
-    leaf_hub_name text,
+    leaf_hub_name character varying(63) NOT NULL,
     payload jsonb NOT NULL,
-    policy_id uuid NOT NULL,
+    policy_id uuid generated always as (uuid(payload->'metadata'->>'uid')) stored,
     policy_name character varying(255) generated always as (payload -> 'metadata' ->> 'name') stored,
     policy_standard character varying(255) generated always as (payload -> 'metadata' -> 'annotations' ->> 'policy.open-cluster-management.io/standards') stored,
     policy_category character varying(255) generated always as (payload -> 'metadata' -> 'annotations' ->> 'policy.open-cluster-management.io/categories') stored,
@@ -98,15 +98,17 @@ CREATE TABLE IF NOT EXISTS local_spec.policies (
 );
 
 CREATE TABLE IF NOT EXISTS local_status.compliance (
-    policy_id uuid NOT NULL,
-    cluster_id uuid NOT NULL,
+    id uuid NOT NULL,
+    cluster_name character varying(63) NOT NULL,
+    leaf_hub_name character varying(63) NOT NULL,
     error status.error_type NOT NULL,
     compliance local_status.compliance_type NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS local_status.compliance_history (
-    policy_id uuid NOT NULL,
-    cluster_id uuid NOT NULL,
+    id uuid NOT NULL,
+    cluster_name character varying(63) NOT NULL,
+    leaf_hub_name character varying(63) NOT NULL,
     updated_at timestamp without time zone DEFAULT now() NOT NULL,
     compliance local_status.compliance_type NOT NULL
 );
@@ -230,7 +232,6 @@ CREATE TABLE IF NOT EXISTS  status.leaf_hub_heartbeats (
 );
 
 CREATE TABLE IF NOT EXISTS status.managed_clusters (
-    cluster_id uuid NOT NULL PRIMARY KEY,
     leaf_hub_name character varying(63) NOT NULL,
     cluster_name character varying(63) generated always as (payload -> 'metadata' ->> 'name') stored,
     payload jsonb NOT NULL,

--- a/operator/pkg/controllers/hubofhubs/database/3.tables.sql
+++ b/operator/pkg/controllers/hubofhubs/database/3.tables.sql
@@ -93,7 +93,7 @@ CREATE TABLE IF NOT EXISTS  local_spec.policies (
 );
 
 CREATE TABLE IF NOT EXISTS local_status.compliance (
-    id uuid NOT NULL,
+    id uuid NOT NULL PRIMARY KEY,
     cluster_name character varying(63) NOT NULL,
     leaf_hub_name character varying(63) NOT NULL,
     error status.error_type NOT NULL,

--- a/operator/pkg/controllers/hubofhubs/database/3.tables.sql
+++ b/operator/pkg/controllers/hubofhubs/database/3.tables.sql
@@ -92,7 +92,7 @@ CREATE TABLE IF NOT EXISTS  local_spec.policies (
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS  local_status.compliance (
+CREATE TABLE IF NOT EXISTS local_status.compliance (
     id uuid NOT NULL,
     cluster_name character varying(63) NOT NULL,
     leaf_hub_name character varying(63) NOT NULL,
@@ -100,7 +100,13 @@ CREATE TABLE IF NOT EXISTS  local_status.compliance (
     compliance local_status.compliance_type NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS  spec.applications (
+CREATE TABLE IF NOT EXISTS local_status.compliance_history (
+    id uuid REFERENCES local_status.compliance (id),
+    updated_at timestamp without time zone DEFAULT now() NOT NULL,
+    compliance local_status.compliance_type NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS spec.applications (
     id uuid NOT NULL,
     payload jsonb NOT NULL,
     created_at timestamp without time zone DEFAULT now() NOT NULL,

--- a/operator/pkg/controllers/hubofhubs/database/3.tables.sql
+++ b/operator/pkg/controllers/hubofhubs/database/3.tables.sql
@@ -85,23 +85,28 @@ CREATE TABLE IF NOT EXISTS  local_spec.placementrules (
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS  local_spec.policies (
+CREATE TABLE IF NOT EXISTS local_spec.policies (
     leaf_hub_name text,
     payload jsonb NOT NULL,
+    policy_id uuid NOT NULL,
+    policy_name character varying(255) generated always as (payload -> 'metadata' ->> 'name') stored,
+    policy_standard character varying(255) generated always as (payload -> 'metadata' -> 'annotations' ->> 'policy.open-cluster-management.io/standards') stored,
+    policy_category character varying(255) generated always as (payload -> 'metadata' -> 'annotations' ->> 'policy.open-cluster-management.io/categories') stored,
+    policy_control character varying(255) generated always as (payload -> 'metadata' -> 'annotations' ->> 'policy.open-cluster-management.io/controls') stored,
     created_at timestamp without time zone DEFAULT now() NOT NULL,
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS local_status.compliance (
-    id uuid NOT NULL PRIMARY KEY,
-    cluster_name character varying(63) NOT NULL,
-    leaf_hub_name character varying(63) NOT NULL,
+    policy_id uuid NOT NULL,
+    cluster_id uuid NOT NULL,
     error status.error_type NOT NULL,
     compliance local_status.compliance_type NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS local_status.compliance_history (
-    id uuid REFERENCES local_status.compliance (id),
+    policy_id uuid NOT NULL,
+    cluster_id uuid NOT NULL,
     updated_at timestamp without time zone DEFAULT now() NOT NULL,
     compliance local_status.compliance_type NOT NULL
 );
@@ -224,8 +229,10 @@ CREATE TABLE IF NOT EXISTS  status.leaf_hub_heartbeats (
     last_timestamp timestamp without time zone DEFAULT now() NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS  status.managed_clusters (
+CREATE TABLE IF NOT EXISTS status.managed_clusters (
+    cluster_id uuid NOT NULL PRIMARY KEY,
     leaf_hub_name character varying(63) NOT NULL,
+    cluster_name character varying(63) generated always as (payload -> 'metadata' ->> 'name') stored,
     payload jsonb NOT NULL,
     error status.error_type NOT NULL
 );


### PR DESCRIPTION
ref: https://issues.redhat.com/browse/ACM-4101

Introduce `local_status.compliance_history` table to store the compliance history information. the table is not related with policy events. the table records can be generated directly based on `local_status.compliance` hourly or daily. We can have a worker in global hub manager to help on.

the table should be used for cluster / policy Compliance Overview.

Any comments? @bjoydeep @dislbenn @yanmxa  