### PR TITLE
force delete the global hub addons when waiting for the deletion timeout

### DIFF
--- a/operator/pkg/controllers/hubofhubs/globalhub_prune.go
+++ b/operator/pkg/controllers/hubofhubs/globalhub_prune.go
@@ -193,19 +193,12 @@ func (r *MulticlusterGlobalHubReconciler) waitUtilAddonDeleted(ctx context.Conte
 				return false, nil
 			}
 		})
-	if err == nil {
-		return nil
-	}
 
-	if err.Error() == wait.ErrWaitTimeout.Error() {
+	if err != nil && err.Error() == wait.ErrWaitTimeout.Error() {
 		log.Info("timed out waiting for all addons to be deleted and force delete them")
-		if err := ForceDeleteAllManagedClusterAddons(ctx, r.Client); err != nil {
-			return err
-		}
-	} else if err != nil {
-		return err
+		return ForceDeleteAllManagedClusterAddons(ctx, r.Client)
 	}
-	return nil
+	return err
 }
 
 // refer: https://github.com/stolostron/managedcluster-import-controller/blob/main/pkg/helpers/helpers.go#L661

--- a/operator/pkg/controllers/hubofhubs/integration_test.go
+++ b/operator/pkg/controllers/hubofhubs/integration_test.go
@@ -603,6 +603,7 @@ var _ = Describe("MulticlusterGlobalHub controller", Ordered, func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "test-placement-1",
 					Namespace:  config.GetDefaultNamespace(),
+					Labels:     map[string]string{constants.GlobalHubGlobalResourceLabel: ""},
 					Finalizers: []string{constants.GlobalHubCleanupFinalizer},
 				},
 				Spec: clusterv1beta1.PlacementSpec{},
@@ -614,6 +615,7 @@ var _ = Describe("MulticlusterGlobalHub controller", Ordered, func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "test-application-1",
 					Namespace:  config.GetDefaultNamespace(),
+					Labels:     map[string]string{constants.GlobalHubGlobalResourceLabel: ""},
 					Finalizers: []string{constants.GlobalHubCleanupFinalizer},
 				},
 				Spec: applicationv1beta1.ApplicationSpec{
@@ -629,6 +631,7 @@ var _ = Describe("MulticlusterGlobalHub controller", Ordered, func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "test-policy-1",
 					Namespace:  config.GetDefaultNamespace(),
+					Labels:     map[string]string{constants.GlobalHubGlobalResourceLabel: ""},
 					Finalizers: []string{constants.GlobalHubCleanupFinalizer},
 				},
 				Spec: policyv1.PolicySpec{
@@ -643,6 +646,7 @@ var _ = Describe("MulticlusterGlobalHub controller", Ordered, func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "test-placementrule-1",
 					Namespace:  config.GetDefaultNamespace(),
+					Labels:     map[string]string{constants.GlobalHubGlobalResourceLabel: ""},
 					Finalizers: []string{constants.GlobalHubCleanupFinalizer},
 				},
 				Spec: placementrulesv1.PlacementRuleSpec{
@@ -656,6 +660,7 @@ var _ = Describe("MulticlusterGlobalHub controller", Ordered, func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "test-managedclustersetbinding-1",
 					Namespace:  config.GetDefaultNamespace(),
+					Labels:     map[string]string{constants.GlobalHubGlobalResourceLabel: ""},
 					Finalizers: []string{constants.GlobalHubCleanupFinalizer},
 				},
 				Spec: clusterv1beta2.ManagedClusterSetBindingSpec{
@@ -670,6 +675,7 @@ var _ = Describe("MulticlusterGlobalHub controller", Ordered, func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "test-channel-1",
 					Namespace:  config.GetDefaultNamespace(),
+					Labels:     map[string]string{constants.GlobalHubGlobalResourceLabel: ""},
 					Finalizers: []string{constants.GlobalHubCleanupFinalizer},
 				},
 				Spec: chnv1.ChannelSpec{

--- a/pkg/jobs/prune_finalizer.go
+++ b/pkg/jobs/prune_finalizer.go
@@ -28,6 +28,13 @@ type PruneFinalizer struct {
 	finalizer string
 }
 
+// only delete the finalizer from the global resources.
+var globalResourceListOptions = []client.ListOption{
+	client.MatchingLabels(map[string]string{
+		constants.GlobalHubGlobalResourceLabel: "",
+	}),
+}
+
 func NewPruneFinalizer(ctx context.Context, runtimeClient client.Client) Runnable {
 	return &PruneFinalizer{
 		ctx:       ctx,
@@ -72,7 +79,7 @@ func (p *PruneFinalizer) pruneFinalizer(object client.Object) error {
 func (p *PruneFinalizer) prunePlacementResources() error {
 	p.log.Info("clean up the placement finalizer")
 	placements := &clusterv1beta1.PlacementList{}
-	if err := p.client.List(p.ctx, placements, &client.ListOptions{}); err != nil {
+	if err := p.client.List(p.ctx, placements, globalResourceListOptions...); err != nil {
 		p.log.Error(err, "failed to list placements")
 	}
 	for idx := range placements.Items {
@@ -83,7 +90,7 @@ func (p *PruneFinalizer) prunePlacementResources() error {
 
 	p.log.Info("clean up the managedclusterset finalizer")
 	managedclustersets := &clusterv1beta2.ManagedClusterSetList{}
-	if err := p.client.List(p.ctx, managedclustersets, &client.ListOptions{}); err != nil {
+	if err := p.client.List(p.ctx, managedclustersets, globalResourceListOptions...); err != nil {
 		p.log.Error(err, "failed to list managedclustersets")
 	}
 	for idx := range managedclustersets.Items {
@@ -94,7 +101,7 @@ func (p *PruneFinalizer) prunePlacementResources() error {
 
 	p.log.Info("clean up the managedclustersetbinding finalizer")
 	managedclustersetbindings := &clusterv1beta2.ManagedClusterSetBindingList{}
-	if err := p.client.List(p.ctx, managedclustersetbindings, &client.ListOptions{}); err != nil {
+	if err := p.client.List(p.ctx, managedclustersetbindings, globalResourceListOptions...); err != nil {
 		p.log.Error(err, "failed to list managedclustersetbindings")
 	}
 	for idx := range managedclustersetbindings.Items {
@@ -105,7 +112,7 @@ func (p *PruneFinalizer) prunePlacementResources() error {
 
 	p.log.Info("clean up the managedclusterset finalizer")
 	managedclustersetv1beta1 := &clusterv1beta1.ManagedClusterSetList{}
-	if err := p.client.List(p.ctx, managedclustersetv1beta1, &client.ListOptions{}); err != nil {
+	if err := p.client.List(p.ctx, managedclustersetv1beta1, globalResourceListOptions...); err != nil {
 		p.log.Error(err, "failed to list managedclustersets")
 	}
 	for idx := range managedclustersetv1beta1.Items {
@@ -116,7 +123,7 @@ func (p *PruneFinalizer) prunePlacementResources() error {
 
 	p.log.Info("clean up the managedclustersetbinding finalizer")
 	managedclustersetbindingv1beta1 := &clusterv1beta1.ManagedClusterSetBindingList{}
-	if err := p.client.List(p.ctx, managedclustersetbindingv1beta1, &client.ListOptions{}); err != nil {
+	if err := p.client.List(p.ctx, managedclustersetbindingv1beta1, globalResourceListOptions...); err != nil {
 		p.log.Error(err, "failed to list managedclustersetbindings")
 	}
 	for idx := range managedclustersetbindingv1beta1.Items {
@@ -127,7 +134,7 @@ func (p *PruneFinalizer) prunePlacementResources() error {
 
 	p.log.Info("clean up the application placementrule finalizer")
 	palcementrules := &placementrulesv1.PlacementRuleList{}
-	if err := p.client.List(p.ctx, palcementrules, &client.ListOptions{}); err != nil {
+	if err := p.client.List(p.ctx, palcementrules, globalResourceListOptions...); err != nil {
 		p.log.Error(err, "failed to list placementrules")
 	}
 	for idx := range palcementrules.Items {
@@ -138,7 +145,7 @@ func (p *PruneFinalizer) prunePlacementResources() error {
 
 	p.log.Info("clean up the placementbindings finalizer")
 	placementbindings := &policyv1.PlacementBindingList{}
-	if err := p.client.List(p.ctx, placementbindings, &client.ListOptions{}); err != nil {
+	if err := p.client.List(p.ctx, placementbindings, globalResourceListOptions...); err != nil {
 		p.log.Error(err, "failed to list placementbindings")
 	}
 	for idx := range placementbindings.Items {
@@ -154,7 +161,7 @@ func (p *PruneFinalizer) prunePlacementResources() error {
 func (p *PruneFinalizer) pruneApplication() error {
 	p.log.Info("clean up the application finalizer")
 	applications := &appv1beta1.ApplicationList{}
-	if err := p.client.List(p.ctx, applications, &client.ListOptions{}); err != nil {
+	if err := p.client.List(p.ctx, applications, globalResourceListOptions...); err != nil {
 		p.log.Error(err, "failed to list applications")
 	}
 	for idx := range applications.Items {
@@ -165,7 +172,7 @@ func (p *PruneFinalizer) pruneApplication() error {
 
 	p.log.Info("clean up the application subscription finalizer")
 	appsubs := &appsubv1.SubscriptionList{}
-	if err := p.client.List(p.ctx, appsubs, &client.ListOptions{}); err != nil {
+	if err := p.client.List(p.ctx, appsubs, globalResourceListOptions...); err != nil {
 		p.log.Error(err, "failed to list application subscriptions")
 	}
 	for idx := range appsubs.Items {
@@ -176,7 +183,7 @@ func (p *PruneFinalizer) pruneApplication() error {
 
 	p.log.Info("clean up the application channel finalizer")
 	channels := &chnv1.ChannelList{}
-	if err := p.client.List(p.ctx, channels, &client.ListOptions{}); err != nil {
+	if err := p.client.List(p.ctx, channels, globalResourceListOptions...); err != nil {
 		p.log.Error(err, "failed to list application channels")
 	}
 	for idx := range channels.Items {
@@ -191,7 +198,7 @@ func (p *PruneFinalizer) pruneApplication() error {
 func (p *PruneFinalizer) prunePolicy() error {
 	p.log.Info("clean up the policies finalizer")
 	policies := &policyv1.PolicyList{}
-	if err := p.client.List(p.ctx, policies, &client.ListOptions{}); err != nil {
+	if err := p.client.List(p.ctx, policies, globalResourceListOptions...); err != nil {
 		p.log.Error(err, "failed to list policies")
 	}
 	for idx := range policies.Items {

--- a/pkg/jobs/prune_finalizer_test.go
+++ b/pkg/jobs/prune_finalizer_test.go
@@ -41,6 +41,7 @@ var _ = Describe("Prune Resource Finalizer", Ordered, func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       "app1",
 				Namespace:  "default",
+				Labels:     map[string]string{constants.GlobalHubGlobalResourceLabel: ""},
 				Finalizers: []string{constants.GlobalHubCleanupFinalizer},
 			},
 		}
@@ -54,6 +55,7 @@ var _ = Describe("Prune Resource Finalizer", Ordered, func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       "appsub1",
 				Namespace:  "default",
+				Labels:     map[string]string{constants.GlobalHubGlobalResourceLabel: ""},
 				Finalizers: []string{constants.GlobalHubCleanupFinalizer},
 			},
 		}
@@ -67,6 +69,7 @@ var _ = Describe("Prune Resource Finalizer", Ordered, func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       "channel1",
 				Namespace:  "default",
+				Labels:     map[string]string{constants.GlobalHubGlobalResourceLabel: ""},
 				Finalizers: []string{constants.GlobalHubCleanupFinalizer},
 			},
 			Spec: chnv1.ChannelSpec{
@@ -85,6 +88,7 @@ var _ = Describe("Prune Resource Finalizer", Ordered, func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       "placementrule1",
 				Namespace:  "default",
+				Labels:     map[string]string{constants.GlobalHubGlobalResourceLabel: ""},
 				Finalizers: []string{constants.GlobalHubCleanupFinalizer},
 			},
 			Spec: placementrulesv1.PlacementRuleSpec{
@@ -101,6 +105,7 @@ var _ = Describe("Prune Resource Finalizer", Ordered, func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       "placement1",
 				Namespace:  "default",
+				Labels:     map[string]string{constants.GlobalHubGlobalResourceLabel: ""},
 				Finalizers: []string{constants.GlobalHubCleanupFinalizer},
 			},
 			Spec: clusterv1beta1.PlacementSpec{},
@@ -115,6 +120,7 @@ var _ = Describe("Prune Resource Finalizer", Ordered, func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       "policy1",
 				Namespace:  "default",
+				Labels:     map[string]string{constants.GlobalHubGlobalResourceLabel: ""},
 				Finalizers: []string{constants.GlobalHubCleanupFinalizer},
 			},
 			Spec: policyv1.PolicySpec{
@@ -143,6 +149,7 @@ var _ = Describe("Prune Resource Finalizer", Ordered, func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "test-managedclustersetbinding-1",
 					Namespace:  "default",
+					Labels:     map[string]string{constants.GlobalHubGlobalResourceLabel: ""},
 					Finalizers: []string{constants.GlobalHubCleanupFinalizer},
 				},
 				Spec: clusterv1beta2.ManagedClusterSetBindingSpec{
@@ -161,6 +168,7 @@ var _ = Describe("Prune Resource Finalizer", Ordered, func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "test-managedclusterset-1",
 					Namespace:  "default",
+					Labels:     map[string]string{constants.GlobalHubGlobalResourceLabel: ""},
 					Finalizers: []string{constants.GlobalHubCleanupFinalizer},
 				},
 			}
@@ -175,6 +183,7 @@ var _ = Describe("Prune Resource Finalizer", Ordered, func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       "test-placementbinding-1",
 				Namespace:  "default",
+				Labels:     map[string]string{constants.GlobalHubGlobalResourceLabel: ""},
 				Finalizers: []string{constants.GlobalHubCleanupFinalizer},
 			},
 			PlacementRef: policyv1.PlacementSubject{


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>
Resolves: https://issues.redhat.com/browse/ACM-5029

- Add force deletion of the global hub addons 
- Prune job only removes the global hub finalizer from the global resources