### PR TITLE
change the kafka `storage` type from ephemeral to persistent-claim

### DIFF
--- a/operator/config/samples/transport/kafka-cluster.yaml
+++ b/operator/config/samples/transport/kafka-cluster.yaml
@@ -39,7 +39,12 @@ spec:
       ssl.enabled.protocols: "TLSv1.2"
       ssl.protocol: "TLSv1.2"
     storage:
-      type: ephemeral
+      type: jbod       # You can add the volumes you need
+      volumes:
+      - id: 0
+        type: persistent-claim
+        size: 10Gi
+        deleteClaim: false
   zookeeper:
     replicas: 3
     logging:
@@ -47,7 +52,10 @@ spec:
       loggers:
         zookeeper.root.logger: "INFO"
     storage:
-      type: ephemeral
+      storage:
+        type: persistent-claim
+        size: 10Gi
+        deleteClaim: false
   entityOperator:
     topicOperator: {}
     userOperator: {}


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>
Fixed: https://github.com/stolostron/multicluster-global-hub/issues/367

References:
- https://github.com/strimzi/strimzi-kafka-operator/blob/main/packaging/examples/kafka/kafka-persistent.yaml
- https://strimzi.io/blog/2018/06/11/deploying-kafka-on-kubernetes-with-local-storage-using-strimzi/
- https://b-nova.com/en/home/content/heres-how-you-can-setup-kafka-with-strimzi-on-kubernetes-in-only-five-minutes