### PR TITLE
upgrade go version from go1.18 to go1.19

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Open Cluster Management project
 
 # Stage 1: build the target binaries
-FROM registry.ci.openshift.org/stolostron/builder:go1.18-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.19-linux AS builder
 
 WORKDIR /workspace
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/multicluster-global-hub
 
-go 1.18
+go 1.19
 
 require (
 	github.com/Shopify/sarama v1.38.1

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -2,7 +2,7 @@
 # Copyright Contributors to the Open Cluster Management project
 
 # Stage 1: build the target binaries
-FROM registry.ci.openshift.org/stolostron/builder:go1.18-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.19-linux AS builder
 
 WORKDIR /workspace
 COPY go.sum go.mod ./

--- a/test/setup/e2e_dependencies.sh
+++ b/test/setup/e2e_dependencies.sh
@@ -37,16 +37,16 @@ function versionCompare() {
 function checkGolang() {
   export PATH=$PATH:/usr/local/go/bin
   if ! command -v go >/dev/null 2>&1; then
-    wget https://dl.google.com/go/go1.18.4.linux-amd64.tar.gz >/dev/null 2>&1
-    sudo tar -C /usr/local/ -xvf go1.18.4.linux-amd64.tar.gz >/dev/null 2>&1
+    wget https://dl.google.com/go/go1.19.8.linux-amd64.tar.gz >/dev/null 2>&1
+    sudo tar -C /usr/local/ -xvf go1.19.8.linux-amd64.tar.gz >/dev/null 2>&1
     sudo rm go1.18.4.linux-amd64.tar.gz
   fi
-  if [[ $(go version) < "go version go1.18" ]]; then
-    echo "go version is less than 1.18, update to 1.18"
+  if [[ $(go version) < "go version go1.19" ]]; then
+    echo "go version is less than 1.19, update to 1.19"
     sudo rm -rf /usr/local/go
-    wget https://dl.google.com/go/go1.18.4.linux-amd64.tar.gz >/dev/null 2>&1
-    sudo tar -C /usr/local/ -xvf go1.18.4.linux-amd64.tar.gz >/dev/null 2>&1
-    sudo rm go1.18.4.linux-amd64.tar.gz
+    wget https://dl.google.com/go/go1.19.8.linux-amd64.tar.gz >/dev/null 2>&1
+    sudo tar -C /usr/local/ -xvf go1.19.8.linux-amd64.tar.gz >/dev/null 2>&1
+    sudo rm go1.19.8.linux-amd64.tar.gz
     sleep 2
   fi
   echo "go version: $(go version)"


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>
Refers: https://github.com/openshift/release/pull/39026