### PR TITLE
trace the log for the cronjob operation and persist it

### DIFF
--- a/manager/pkg/cronjob/sheduler.go
+++ b/manager/pkg/cronjob/sheduler.go
@@ -19,7 +19,9 @@ type GlobalHubJobScheduler struct {
 
 func AddSchedulerToManager(ctx context.Context, mgr ctrl.Manager, pool *pgxpool.Pool) error {
 	log := ctrl.Log.WithName("cronjob-scheduler")
-	scheduler := gocron.NewScheduler(time.Local) // or time.UTC
+	// Scheduler timezone:
+	// The cluster may be in a different timezones, Here we choose to be consistent with the local GH timezone.
+	scheduler := gocron.NewScheduler(time.Local)
 
 	complianceJob, err := scheduler.Every(1).Day().At("00:00").Tag("LocalComplianceHistory").DoWithJobDetails(
 		task.SyncLocalCompliance, ctx, pool)

--- a/manager/pkg/cronjob/task/compliance_history.go
+++ b/manager/pkg/cronjob/task/compliance_history.go
@@ -113,7 +113,10 @@ func insertToLocalComplianceHistory(ctx context.Context, conn *pgxpool.Conn, vie
 					fmt.Printf("rollback failed: %v\n", e)
 				}
 			}
-			traceComplianceHistory(ctx, conn, localComplianceJobName, totalCount, offset, insertCount, startTime, err)
+			e := traceComplianceHistory(ctx, conn, localComplianceJobName, totalCount, offset, insertCount, startTime, err)
+			if e != nil {
+				fmt.Printf("trace compliance job failed: %v\n", e)
+			}
 		}()
 		selectInsertSQL := `
 			INSERT INTO local_status.compliance_history (id, cluster_id, compliance) 

--- a/manager/pkg/cronjob/task/compliance_history.go
+++ b/manager/pkg/cronjob/task/compliance_history.go
@@ -69,7 +69,7 @@ func syncToLocalComplianceHistory(ctx context.Context, conn *pgxpool.Conn, batch
 		if err != nil {
 			return totalCount, syncedCount, err
 		}
-		totalCount += insertCount
+		syncedCount += insertCount
 	}
 	return totalCount, syncedCount, nil
 }
@@ -100,7 +100,7 @@ func insertToLocalComplianceHistory(ctx context.Context, conn *pgxpool.Conn, bat
 		result, err := tx.Exec(ctx, `
 				INSERT INTO local_status.compliance_history (id, cluster_id, compliance) 
 				SELECT id,cluster_id,compliance 
-				FROM local_compliance_view 
+				FROM local_compliance_mv 
 				ORDER BY id, cluster_id
 				LIMIT $1 
 				OFFSET $2`,

--- a/manager/pkg/cronjob/task/compliance_history.go
+++ b/manager/pkg/cronjob/task/compliance_history.go
@@ -9,16 +9,16 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/go-co-op/gocron"
-	"github.com/go-logr/logr"
 	"github.com/jackc/pgx/v4/pgxpool"
 )
 
-var batchSize = 1000
-
 func SyncLocalCompliance(ctx context.Context, pool *pgxpool.Pool, job gocron.Job) {
-	log := ctrl.Log.WithName("local-compliance-job")
+	jobName := "local-compliance-job"
+	log := ctrl.Log.WithName(jobName)
+
 	log.Info("start running", "LastRun", job.LastRun().Format("2006-01-02 15:04:05"),
 		"NextRun", job.NextRun().Format("2006-01-02 15:04:05"))
+	start := time.Now()
 
 	conn, err := pool.Acquire(ctx)
 	if err != nil {
@@ -26,62 +26,113 @@ func SyncLocalCompliance(ctx context.Context, pool *pgxpool.Pool, job gocron.Job
 	}
 	defer conn.Release()
 
-	// create view
-	_, err = conn.Exec(ctx, `
-	CREATE OR REPLACE VIEW local_compliance_view AS 
-		SELECT id,cluster_id,compliance 
-		FROM local_status.compliance`)
+	// batchSize = 1000 for now
+	// The suitable batchSize for selecting and inserting a lot of records from a table in PostgreSQL depends on several factors such as the size of the table, available memory, network bandwidth, and hardware specifications. However, as a general rule of thumb, a batch size of around 1000 to 5000 records is a good starting point. This size provides a balance between minimizing the number of queries sent to the server while still being efficient and not overloading the system. To determine the optimal batchSize, it may be helpful to test different batch sizes and measure the performance of the queries.
+	totalCount, syncedCount, err := syncToLocalComplianceHistory(ctx, conn, 1000)
 	if err != nil {
-		log.Error(err, "create local_compliance_view failed")
+		log.Error(err, "sync to local_status.compliance_history failed")
 	}
-	defer func(ctx context.Context) {
-		_, err = conn.Exec(ctx, `DROP VIEW IF EXISTS local_compliance_view`)
-		if err != nil {
-			log.Error(err, "drop local_compliance_view failed")
-		}
-	}(ctx)
 
-	// batch insert
-	var count int64
-	err = conn.QueryRow(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", "local_compliance_view")).Scan(&count)
-	if err != nil {
-		log.Error(err, "query count failed")
+	if err := traceJob(ctx, conn, jobName, "local_status.compliance", "local_status.compliance_history",
+		totalCount, syncedCount, start, err); err != nil {
+		log.Error(err, "trace job failed")
 	}
-	log.Info("total rows", "count", count)
 
-	for offset := 0; offset < int(count); offset += batchSize {
-		// retry until success, use timeout context to avoid long running
-		timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
-		defer cancel()
-		if err := wait.PollUntilWithContext(timeoutCtx, 5*time.Second, func(ctx context.Context) (done bool, err error) {
-			if err := syncBatchData(ctx, conn, batchSize, offset, log); err != nil {
-				log.Error(err, "retry to sync data", "batchSize", batchSize, "offset", offset)
-				return false, nil
-			}
-			return true, nil
-		}); err != nil {
-			log.Error(err, "sync data failed", "batchSize", batchSize, "offset", offset)
-		}
-	}
-	log.Info("finish running")
+	log.Info("finish running", "totalCount", totalCount, "syncedCount", syncedCount)
 }
 
-func syncBatchData(ctx context.Context, conn *pgxpool.Conn, batchSize, offset int, log logr.Logger) error {
-	tx, err := conn.Begin(ctx)
-	if err != nil {
-		return err
-	}
-	result, err := tx.Exec(ctx, `
-			INSERT INTO local_status.compliance_history (id, cluster_id, compliance) 
+func syncToLocalComplianceHistory(ctx context.Context, conn *pgxpool.Conn, batchSize int,
+) (totalCount int64, syncedCount int64, err error) {
+	// create materialized view
+	_, err = conn.Exec(ctx, `
+		CREATE MATERIALIZED VIEW IF NOT EXISTS local_compliance_mv AS 
 			SELECT id,cluster_id,compliance 
-			FROM local_compliance_view LIMIT $1 OFFSET $2`, batchSize, offset)
+			FROM local_status.compliance;
+		CREATE INDEX IF NOT EXISTS idx_local_compliance_mv ON local_compliance_mv (id, cluster_id);
+		`)
 	if err != nil {
-		return err
+		return totalCount, syncedCount, err
 	}
-	if err := tx.Commit(ctx); err != nil {
-		return err
-	} else {
-		log.Info("insert rows", "batchSize", batchSize, "offset", offset, "insertCount", result.RowsAffected())
-		return nil
+	// refresh the materialized view
+	_, err = conn.Exec(ctx, "REFRESH MATERIALIZED VIEW local_compliance_mv")
+	if err != nil {
+		return totalCount, syncedCount, err
 	}
+
+	err = conn.QueryRow(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", "local_compliance_mv")).Scan(&totalCount)
+	if err != nil {
+		return totalCount, syncedCount, err
+	}
+
+	for offset := 0; offset < int(totalCount); offset += batchSize {
+		insertCount, err := insertToLocalComplianceHistory(ctx, conn, batchSize, offset)
+		if err != nil {
+			return totalCount, syncedCount, err
+		}
+		totalCount += insertCount
+	}
+	return totalCount, syncedCount, nil
+}
+
+func insertToLocalComplianceHistory(ctx context.Context, conn *pgxpool.Conn, batchSize, offset int) (int64, error) {
+	// retry until success, use timeout context to avoid long running
+	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+
+	insertCount := int64(0)
+	err := wait.PollUntilWithContext(timeoutCtx, 5*time.Second, func(ctx context.Context) (done bool, err error) {
+		// insert data with transaction
+		tx, err := conn.Begin(ctx)
+		if err != nil {
+			fmt.Printf("begin failed: %v\n", err)
+			return false, nil
+		}
+
+		// Defer rollback in case of error
+		defer func() {
+			if err != nil {
+				if e := tx.Rollback(ctx); e != nil {
+					fmt.Printf("rollback failed: %v\n", e)
+				}
+			}
+		}()
+
+		result, err := tx.Exec(ctx, `
+				INSERT INTO local_status.compliance_history (id, cluster_id, compliance) 
+				SELECT id,cluster_id,compliance 
+				FROM local_compliance_view 
+				ORDER BY id, cluster_id
+				LIMIT $1 
+				OFFSET $2`,
+			batchSize, offset)
+		if err != nil {
+			fmt.Printf("exec failed: %v\n", err)
+			return false, nil
+		}
+		if err := tx.Commit(ctx); err != nil {
+			fmt.Printf("commit failed: %v\n", err)
+			return false, nil
+		} else {
+			insertCount = result.RowsAffected()
+			fmt.Printf("batchSize: %d, insert: %d, offset: %d\n", batchSize, insertCount, offset)
+			return true, nil
+		}
+	})
+	return insertCount, err
+}
+
+func traceJob(ctx context.Context, conn *pgxpool.Conn, name, source, target string, total, synced int64,
+	start time.Time, err error,
+) error {
+	end := time.Now()
+	errMessage := ""
+	if err != nil {
+		errMessage = err.Error()
+	}
+	_, err = conn.Exec(ctx, `
+	INSERT INTO local_status.job_log (name, start_at, end_at, source, target, synced_count, total_count, error) 
+	VALUES ($1, $2, $3, $4, $5, $6, $7, $8);`,
+		name, start, end, source, target, synced, total, errMessage)
+
+	return err
 }

--- a/manager/pkg/cronjob/task/compliance_history_test.go
+++ b/manager/pkg/cronjob/task/compliance_history_test.go
@@ -55,6 +55,16 @@ var _ = Describe("sync the compliance data", Ordered, func() {
 				compliance local_status.compliance_type NOT NULL,
 				compliance_changed_frequency integer NOT NULL DEFAULT 0
 			);
+			CREATE TABLE IF NOT EXISTS local_status.job_log (
+				name varchar(63) NOT NULL,
+				start_at timestamp NOT NULL DEFAULT now(),
+				end_at timestamp NOT NULL DEFAULT now(),
+				source varchar(63) NOT NULL,
+				target varchar(63) NOT NULL,
+				synced_count int8,
+				total_count int8,
+				error TEXT
+			);
 		`)
 		Expect(err).ToNot(HaveOccurred())
 		By("Check whether the tables are created")
@@ -133,6 +143,32 @@ var _ = Describe("sync the compliance data", Ordered, func() {
 			}
 			if syncCount != 3 {
 				return fmt.Errorf("table local_status.compliance_history records are not synced")
+			}
+			return nil
+		}, 10*time.Second, 2*time.Second).ShouldNot(HaveOccurred())
+
+		By("Check whether the job log is created")
+		Eventually(func() error {
+			rows, err := pool.Query(ctx, "SELECT name, source, target, synced_count, total_count, error FROM local_status.job_log")
+			if err != nil {
+				return err
+			}
+			defer rows.Close()
+
+			logCount := 0
+			for rows.Next() {
+				var name, source, target, errMessage string
+				var syncedCount, totalCount int64
+				err := rows.Scan(&name, &source, &target, &syncedCount, &totalCount, &errMessage)
+				if err != nil {
+					return err
+				}
+				logCount += 1
+				fmt.Println("found job log", "name", name, "source", source, "target", target,
+					"synced_count", syncedCount, "total_count", totalCount, "error", errMessage)
+			}
+			if logCount == 0 {
+				return fmt.Errorf("table local_status.job_log records are not synced")
 			}
 			return nil
 		}, 10*time.Second, 2*time.Second).ShouldNot(HaveOccurred())

--- a/manager/pkg/cronjob/task/compliance_history_test.go
+++ b/manager/pkg/cronjob/task/compliance_history_test.go
@@ -59,8 +59,6 @@ var _ = Describe("sync the compliance data", Ordered, func() {
 				name varchar(63) NOT NULL,
 				start_at timestamp NOT NULL DEFAULT now(),
 				end_at timestamp NOT NULL DEFAULT now(),
-				source varchar(63) NOT NULL,
-				target varchar(63) NOT NULL,
 				synced_count int8,
 				total_count int8,
 				error TEXT
@@ -149,7 +147,7 @@ var _ = Describe("sync the compliance data", Ordered, func() {
 
 		By("Check whether the job log is created")
 		Eventually(func() error {
-			rows, err := pool.Query(ctx, "SELECT name, source, target, synced_count, total_count, error FROM local_status.job_log")
+			rows, err := pool.Query(ctx, "SELECT name, synced_count, total_count, error FROM local_status.job_log")
 			if err != nil {
 				return err
 			}
@@ -157,15 +155,15 @@ var _ = Describe("sync the compliance data", Ordered, func() {
 
 			logCount := 0
 			for rows.Next() {
-				var name, source, target, errMessage string
+				var name, errMessage string
 				var syncedCount, totalCount int64
-				err := rows.Scan(&name, &source, &target, &syncedCount, &totalCount, &errMessage)
+				err := rows.Scan(&name, &syncedCount, &totalCount, &errMessage)
 				if err != nil {
 					return err
 				}
 				logCount += 1
-				fmt.Println("found job log", "name", name, "source", source, "target", target,
-					"synced_count", syncedCount, "total_count", totalCount, "error", errMessage)
+				fmt.Println("found job log", "name", name, "synced_count", syncedCount, "total_count", totalCount,
+					"error", errMessage)
 			}
 			if logCount == 0 {
 				return fmt.Errorf("table local_status.job_log records are not synced")

--- a/operator/pkg/controllers/hubofhubs/database/3.tables.sql
+++ b/operator/pkg/controllers/hubofhubs/database/3.tables.sql
@@ -118,8 +118,6 @@ CREATE TABLE IF NOT EXISTS local_status.job_log (
     name varchar(63) NOT NULL,
     start_at timestamp NOT NULL DEFAULT now(),
     end_at timestamp NOT NULL DEFAULT now(),
-    source varchar(63) NOT NULL,
-    target varchar(63) NOT NULL,
     synced_count int8,
     total_count int8,
     error TEXT

--- a/operator/pkg/controllers/hubofhubs/database/3.tables.sql
+++ b/operator/pkg/controllers/hubofhubs/database/3.tables.sql
@@ -114,12 +114,13 @@ CREATE TABLE IF NOT EXISTS local_status.compliance_history (
     compliance_changed_frequency integer NOT NULL DEFAULT 0
 );
 
-CREATE TABLE IF NOT EXISTS local_status.job_log (
+CREATE TABLE IF NOT EXISTS local_status.compliance_history_job_log (
     name varchar(63) NOT NULL,
     start_at timestamp NOT NULL DEFAULT now(),
     end_at timestamp NOT NULL DEFAULT now(),
-    synced_count int8,
-    total_count int8,
+    total int8,
+    inserted int8,
+    offsets int8, 
     error TEXT
 );
 

--- a/operator/pkg/controllers/hubofhubs/database/3.tables.sql
+++ b/operator/pkg/controllers/hubofhubs/database/3.tables.sql
@@ -114,6 +114,17 @@ CREATE TABLE IF NOT EXISTS local_status.compliance_history (
     compliance_changed_frequency integer NOT NULL DEFAULT 0
 );
 
+CREATE TABLE IF NOT EXISTS local_status.job_log (
+    name varchar(63) NOT NULL,
+    start_at timestamp NOT NULL DEFAULT now(),
+    end_at timestamp NOT NULL DEFAULT now(),
+    source varchar(63) NOT NULL,
+    target varchar(63) NOT NULL,
+    synced_count int8,
+    total_count int8,
+    error TEXT
+);
+
 CREATE TABLE IF NOT EXISTS spec.applications (
     id uuid NOT NULL,
     payload jsonb NOT NULL,


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>
Fixed: https://github.com/stolostron/multicluster-global-hub/issues/407

According to @bjoydeep 's comment to the previous PR(https://github.com/stolostron/multicluster-global-hub/pull/408), this PR is also a supplement to it.
- Use the `MATERIALIZED VIEW` instead of `VIEW` as a snapshot. which makes sure the original table updates will not reflect on the `MATERIALIZED VIEW` automatically.
- Add the `ORDER BY` when using `OFFSET` and `LIMIT` to synchronize data in batches, which ensures consistent and predictable rows for the query result. 
- Also add an index(`id`, `cluster_id`) to the `MATERIALIZED VIEW` to improve the performance of queries with an `ORDER BY` clause.

**synchronized data**:
```bash
» kubectl exec -it $(kubectl get pods -n hoh-postgres -l postgres-operator.crunchydata.com/role=master -o jsonpath='{.items..metadata.name}') -c database -n hoh-postgres -- psql -U postgres -d hoh -c "select * from $table"
                  id                  |              cluster_id              | compliance_date |  compliance   | compliance_changed_frequency
--------------------------------------+--------------------------------------+-----------------+---------------+------------------------------
 a9c01431-f716-4e6f-927d-f1ec5dad24c2 | 693f16f0-5338-4db6-b9c1-ba94489b50b4 | 2023-05-05      | non_compliant |                            0
 a9c01431-f716-4e6f-927d-f1ec5dad24c3 | 693f16f0-5338-4db6-b9c1-ba94489b50b4 | 2023-05-05      | non_compliant |                            0
 a9c01431-f716-4e6f-927d-f1ec5dad24c4 | 693f16f0-5338-4db6-b9c1-ba94489b50b4 | 2023-05-05      | non_compliant |                            0
 a9c01431-f716-4e6f-927d-f1ec5dad24c2 | 693f16f0-5338-4db6-b9c1-ba94489b50b4 | 2023-05-05      | non_compliant |                            0
 a9c01431-f716-4e6f-927d-f1ec5dad24c3 | 693f16f0-5338-4db6-b9c1-ba94489b50b4 | 2023-05-05      | non_compliant |                            0
 a9c01431-f716-4e6f-927d-f1ec5dad24c4 | 693f16f0-5338-4db6-b9c1-ba94489b50b4 | 2023-05-05      | non_compliant |                            0
 a9c01431-f716-4e6f-927d-f1ec5dad24c2 | 693f16f0-5338-4db6-b9c1-ba94489b50b4 | 2023-05-05      | non_compliant |                            0
 a9c01431-f716-4e6f-927d-f1ec5dad24c3 | 693f16f0-5338-4db6-b9c1-ba94489b50b4 | 2023-05-05      | non_compliant |                            0
 a9c01431-f716-4e6f-927d-f1ec5dad24c4 | 693f16f0-5338-4db6-b9c1-ba94489b50b4 | 2023-05-05      | non_compliant |                            0
(9 rows)

```
**runtime log table**:
```bash
 » kubectl exec -it $(kubectl get pods -n hoh-postgres -l postgres-operator.crunchydata.com/role=master -o jsonpath='{.items..metadata.name}') -c database -n hoh-postgres -- psql -U postgres -d hoh -c "select * from $table"
         name         |          start_at          |           end_at           | synced_count | total_count | error
----------------------+----------------------------+----------------------------+--------------+-------------+-------
 local-compliance-job | 2023-05-06 08:01:12.585493 | 2023-05-06 08:01:22.598122 |            3 |           3 | none
 local-compliance-job | 2023-05-06 08:02:12.585644 | 2023-05-06 08:02:22.596036 |            3 |           3 | none
 local-compliance-job | 2023-05-06 08:03:12.585998 | 2023-05-06 08:03:22.594953 |            3 |           3 | none
(3 rows)
```