### PR TITLE
repalce the `OPRAND_IMAGE_` prefix with `RELATED_IMAGE_` for downstream image refs

### DIFF
--- a/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -635,13 +635,13 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                - name: OPERAND_IMAGE_MULTICLUSTER_GLOBAL_HUB_MANAGER
+                - name: RELATED_IMAGE_MULTICLUSTER_GLOBAL_HUB_MANAGER
                   value: quay.io/stolostron/multicluster-global-hub-manager:latest
-                - name: OPERAND_IMAGE_MULTICLUSTER_GLOBAL_HUB_AGENT
+                - name: RELATED_IMAGE_MULTICLUSTER_GLOBAL_HUB_AGENT
                   value: quay.io/stolostron/multicluster-global-hub-agent:latest
-                - name: OPERAND_IMAGE_GRAFANA
+                - name: RELATED_IMAGE_GRAFANA
                   value: quay.io/stolostron/grafana:2.8.0-SNAPSHOT-2023-03-06-01-52-34
-                - name: OPERAND_IMAGE_OAUTH_PROXY
+                - name: RELATED_IMAGE_OAUTH_PROXY
                   value: quay.io/stolostron/origin-oauth-proxy:4.9
                 image: quay.io/stolostron/multicluster-global-hub-operator:latest
                 livenessProbe:
@@ -785,4 +785,13 @@ spec:
   provider:
     name: Red Hat, Inc
     url: https://github.com/stolostron/multicluster-global-hub
+  relatedImages:
+  - image: quay.io/stolostron/multicluster-global-hub-manager:latest
+    name: multicluster-global-hub-manager
+  - image: quay.io/stolostron/multicluster-global-hub-agent:latest
+    name: multicluster-global-hub-agent
+  - image: quay.io/stolostron/grafana:2.8.0-SNAPSHOT-2023-03-06-01-52-34
+    name: grafana
+  - image: quay.io/stolostron/origin-oauth-proxy:4.9
+    name: oauth-proxy
   version: 0.7.0-dev

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -38,13 +38,13 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: OPERAND_IMAGE_MULTICLUSTER_GLOBAL_HUB_MANAGER
+        - name: RELATED_IMAGE_MULTICLUSTER_GLOBAL_HUB_MANAGER
           value: quay.io/stolostron/multicluster-global-hub-manager:latest
-        - name: OPERAND_IMAGE_MULTICLUSTER_GLOBAL_HUB_AGENT
+        - name: RELATED_IMAGE_MULTICLUSTER_GLOBAL_HUB_AGENT
           value: quay.io/stolostron/multicluster-global-hub-agent:latest
-        - name: OPERAND_IMAGE_GRAFANA
+        - name: RELATED_IMAGE_GRAFANA
           value: quay.io/stolostron/grafana:2.8.0-SNAPSHOT-2023-03-06-01-52-34
-        - name: OPERAND_IMAGE_OAUTH_PROXY
+        - name: RELATED_IMAGE_OAUTH_PROXY
           value: quay.io/stolostron/origin-oauth-proxy:4.9
         securityContext:
           allowPrivilegeEscalation: false

--- a/operator/pkg/config/multiclusterglobalhub_config.go
+++ b/operator/pkg/config/multiclusterglobalhub_config.go
@@ -128,7 +128,7 @@ func GetImageOverridesConfigmap(mgh *operatorv1alpha2.MulticlusterGlobalHub) str
 }
 
 func SetImageOverrides(mgh *operatorv1alpha2.MulticlusterGlobalHub) error {
-	// first check for environment variables containing the 'OPERAND_IMAGE_' prefix
+	// first check for environment variables containing the 'RELATED_IMAGE_' prefix
 	for _, env := range os.Environ() {
 		envKeyVal := strings.SplitN(env, "=", 2)
 		if strings.HasPrefix(envKeyVal[0], operatorconstants.MGHOperandImagePrefix) {

--- a/operator/pkg/config/multiclusterglobalhub_config_test.go
+++ b/operator/pkg/config/multiclusterglobalhub_config_test.go
@@ -45,9 +45,9 @@ func TestSetImageOverrides(t *testing.T) {
 				"oauth_proxy":                     "quay.io/stolostron/multicluster-global-hub-operator:latest",
 			},
 			operandImagesEnv: map[string]string{
-				"OPERAND_IMAGE_MULTICLUSTER_GLOBAL_HUB_MANAGER": "quay.io/stolostron/multicluster-global-hub-manager:v0.6.0",
-				"OPERAND_IMAGE_MULTICLUSTER_GLOBAL_HUB_AGENT":   "quay.io/stolostron/multicluster-global-hub-agent:v0.6.0",
-				"OPERAND_IMAGE_OAUTH_PROXY":                     "quay.io/stolostron/origin-oauth-proxy:4.9",
+				"RELATED_IMAGE_MULTICLUSTER_GLOBAL_HUB_MANAGER": "quay.io/stolostron/multicluster-global-hub-manager:v0.6.0",
+				"RELATED_IMAGE_MULTICLUSTER_GLOBAL_HUB_AGENT":   "quay.io/stolostron/multicluster-global-hub-agent:v0.6.0",
+				"RELATED_IMAGE_OAUTH_PROXY":                     "quay.io/stolostron/origin-oauth-proxy:4.9",
 			},
 			mghInstance: &operatorv1alpha2.MulticlusterGlobalHub{
 				ObjectMeta: metav1.ObjectMeta{
@@ -71,9 +71,9 @@ func TestSetImageOverrides(t *testing.T) {
 				"oauth_proxy":                     "quay.io/stolostron/multicluster-global-hub-operator:latest",
 			},
 			operandImagesEnv: map[string]string{
-				"OPERAND_IMAGE_MULTICLUSTER_GLOBAL_HUB_MANAGER": "quay.io/stolostron/multicluster-global-hub-manager:v0.6.0",
-				"OPERAND_IMAGE_MULTICLUSTER_GLOBAL_HUB_AGENT":   "quay.io/stolostron/multicluster-global-hub-agent:v0.6.0",
-				"OPERAND_IMAGE_OAUTH_PROXY":                     "quay.io/stolostron/origin-oauth-proxy:4.9",
+				"RELATED_IMAGE_MULTICLUSTER_GLOBAL_HUB_MANAGER": "quay.io/stolostron/multicluster-global-hub-manager:v0.6.0",
+				"RELATED_IMAGE_MULTICLUSTER_GLOBAL_HUB_AGENT":   "quay.io/stolostron/multicluster-global-hub-agent:v0.6.0",
+				"RELATED_IMAGE_OAUTH_PROXY":                     "quay.io/stolostron/origin-oauth-proxy:4.9",
 			},
 			mghInstance: &operatorv1alpha2.MulticlusterGlobalHub{
 				ObjectMeta: metav1.ObjectMeta{

--- a/operator/pkg/constants/constants.go
+++ b/operator/pkg/constants/constants.go
@@ -36,7 +36,7 @@ const (
 	// to identify a custom configmap containing image overrides
 	AnnotationImageOverridesCM = "mgh-image-overrides-cm"
 	// MGHOperandImagePrefix ...
-	MGHOperandImagePrefix = "OPERAND_IMAGE_"
+	MGHOperandImagePrefix = "RELATED_IMAGE_"
 )
 
 // hub installation constants


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>
Refs: https://redhat-internal.slack.com/archives/C03A998ETHR/p1683824331307739?thread_ts=1683283069.326059&cid=C03A998ETHR