### PR TITLE
update the TLS configration for event exporter

### DIFF
--- a/agent/pkg/controllers/clusterclaim_controllers_test.go
+++ b/agent/pkg/controllers/clusterclaim_controllers_test.go
@@ -25,7 +25,7 @@ const (
 	MCHVersion = "2.6.0"
 )
 
-var _ = Describe("controller", Ordered, func() {
+var _ = Describe("claim controllers", Ordered, func() {
 	BeforeEach(func() {
 		cleanup(ctx, mgr.GetClient())
 	})

--- a/agent/pkg/controllers/controllers_suite_test.go
+++ b/agent/pkg/controllers/controllers_suite_test.go
@@ -11,7 +11,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/stolostron/multicluster-global-hub/agent/pkg/controllers"
 	mchv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -22,6 +21,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/controllers"
 )
 
 func TestControllers(t *testing.T) {

--- a/agent/pkg/controllers/event_exporter.go
+++ b/agent/pkg/controllers/event_exporter.go
@@ -35,7 +35,7 @@ func (e *eventExporterController) Start(ctx context.Context) error {
 	}
 
 	// issue: https://github.com/resmoio/kubernetes-event-exporter/pull/80
-	validateEventConfig(&cfg, log)
+	ValidateEventConfig(&cfg, log)
 	log.Info("starting event exporter", "config", cfg)
 
 	metrics.Init(*flag.String("metrics-address", ":2112",
@@ -49,7 +49,7 @@ func (e *eventExporterController) Start(ctx context.Context) error {
 	return nil
 }
 
-func validateEventConfig(eventConfig *exporter.Config, log logr.Logger) {
+func ValidateEventConfig(eventConfig *exporter.Config, log logr.Logger) {
 	if len(eventConfig.Receivers) == 0 || eventConfig.Receivers[0].Kafka == nil {
 		log.Info("No kafka config found, skipping validate kafka sinker for event exporter")
 		return

--- a/agent/pkg/controllers/event_exporter_test.go
+++ b/agent/pkg/controllers/event_exporter_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2022 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package controllers_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/resmoio/kubernetes-event-exporter/pkg/exporter"
+	"github.com/resmoio/kubernetes-event-exporter/pkg/sinks"
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/controllers"
+)
+
+var _ = Describe("event exporter", func() {
+	It("validate event config", func() {
+		cfg := &exporter.Config{
+			Route:     exporter.Route{},
+			Receivers: make([]sinks.ReceiverConfig, 1),
+		}
+		cfg.Receivers[0].Kafka = &sinks.KafkaConfig{
+			Topic: "test-topic",
+			Brokers: []string{
+				"localhost:9092",
+			},
+			TLS: struct {
+				Enable             bool   `yaml:"enable"`
+				CaFile             string `yaml:"caFile"`
+				CertFile           string `yaml:"certFile"`
+				KeyFile            string `yaml:"keyFile"`
+				InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
+			}{
+				Enable:             true,
+				CaFile:             "caFile",
+				CertFile:           "certFile",
+				KeyFile:            "keyFile",
+				InsecureSkipVerify: false,
+			},
+		}
+		controllers.ValidateEventConfig(cfg, ctrl.Log.WithName("event-exporter-test"))
+		Expect(cfg.Receivers[0].Kafka.TLS.InsecureSkipVerify).Should(Equal(true))
+		Expect(cfg.Receivers[0].Kafka.TLS.CertFile).Should(Equal(""))
+		Expect(cfg.Receivers[0].Kafka.TLS.KeyFile).Should(Equal(""))
+	})
+})

--- a/operator/pkg/controllers/addon/manifests/templates/agent/multicluster-global-hub-agent-event-configmap.yaml
+++ b/operator/pkg/controllers/addon/manifests/templates/agent/multicluster-global-hub-agent-event-configmap.yaml
@@ -30,7 +30,7 @@ data:
           tls:
             enable: true
             caFile: /kafka-certs/ca.crt
-            certFile: ""   # need to be empty for now. https://github.com/resmoio/kubernetes-event-exporter/pull/80
-            keyFile: ""
-            insecureSkipVerify: true
+            certFile: /kafka-certs/client.crt
+            keyFile: /kafka-certs/client.key
+            insecureSkipVerify: false
 {{ end }}

--- a/operator/pkg/controllers/addon/manifests/templates/hostedagent/multicluster-global-hub-agent-event-configmap.yaml
+++ b/operator/pkg/controllers/addon/manifests/templates/hostedagent/multicluster-global-hub-agent-event-configmap.yaml
@@ -30,7 +30,7 @@ data:
           tls:
             enable: true
             caFile: /kafka-certs/ca.crt
-            certFile: ""   # need to be empty for now. https://github.com/resmoio/kubernetes-event-exporter/pull/80
-            keyFile: ""
-            insecureSkipVerify: true
+            certFile: /kafka-certs/client.crt
+            keyFile: /kafka-certs/client.key
+            insecureSkipVerify: false
 {{ end }}

--- a/pkg/testdata/event/kube-event-exporter-good-config.yaml
+++ b/pkg/testdata/event/kube-event-exporter-good-config.yaml
@@ -1,12 +1,16 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: kubernetes-event-exporter-config
-  labels:
-    addon.open-cluster-management.io/hosted-manifest-location: none
-data:
-  config.yaml: |
-    logLevel: error
-    logFormat: json
-    maxEventAgeSeconds: 60
-    metricsNamePrefix: "mcgh"
+logLevel: error
+logFormat: json
+maxEventAgeSeconds: 60
+metricsNamePrefix: "mcgh"
+# namespace: my-namespace-only # Omitting it defaults to all namespaces.
+route:
+  # Main route
+  routes:
+    - drop:
+        - minCount: 6
+          apiVersion: v33
+      match:
+        - receiver: stdout
+receivers:
+  - name: "stdout"
+    stdout: {}

--- a/pkg/transport/config/confluent_config.go
+++ b/pkg/transport/config/confluent_config.go
@@ -21,7 +21,7 @@ func GetConfluentConfigMap(kafkaConfig *transport.KafkaConfig) (*kafka.ConfigMap
 		"log.connection.close": "false",
 	}
 
-	if kafkaConfig.EnableTLS && validate(kafkaConfig.CaCertPath) {
+	if kafkaConfig.EnableTLS && Validate(kafkaConfig.CaCertPath) {
 		if err := kafkaConfigMap.SetKey("security.protocol", "ssl"); err != nil {
 			return nil, err
 		}
@@ -29,7 +29,7 @@ func GetConfluentConfigMap(kafkaConfig *transport.KafkaConfig) (*kafka.ConfigMap
 			return nil, err
 		}
 
-		if validate(kafkaConfig.ClientCertPath) && validate(kafkaConfig.ClientKeyPath) {
+		if Validate(kafkaConfig.ClientCertPath) && Validate(kafkaConfig.ClientKeyPath) {
 			_ = kafkaConfigMap.SetKey("ssl.certificate.location", kafkaConfig.ClientCertPath)
 			_ = kafkaConfigMap.SetKey("ssl.key.location", kafkaConfig.ClientKeyPath)
 		}
@@ -37,8 +37,8 @@ func GetConfluentConfigMap(kafkaConfig *transport.KafkaConfig) (*kafka.ConfigMap
 	return kafkaConfigMap, nil
 }
 
-// validate checks if the file exists and the content is not empty
-func validate(filePath string) bool {
+// Validate checks if the file exists and the content is not empty
+func Validate(filePath string) bool {
 	if len(filePath) == 0 {
 		return false
 	}

--- a/pkg/transport/config/saram_config.go
+++ b/pkg/transport/config/saram_config.go
@@ -14,7 +14,7 @@ func GetSaramaConfig(kafkaConfig *transport.KafkaConfig) (*sarama.Config, error)
 	saramaConfig := sarama.NewConfig()
 	saramaConfig.Version = sarama.V2_0_0_0
 
-	if kafkaConfig.EnableTLS && validate(kafkaConfig.CaCertPath) {
+	if kafkaConfig.EnableTLS && Validate(kafkaConfig.CaCertPath) {
 		var err error
 		saramaConfig.Net.TLS.Enable = true
 		saramaConfig.Net.TLS.Config, err = NewTLSConfig(kafkaConfig.ClientCertPath, kafkaConfig.ClientKeyPath,
@@ -31,7 +31,7 @@ func NewTLSConfig(clientCertFile, clientKeyFile, caCertFile string) (*tls.Config
 	tlsConfig := tls.Config{}
 
 	// Load client cert
-	if validate(clientCertFile) && validate(clientKeyFile) {
+	if Validate(clientCertFile) && Validate(clientKeyFile) {
 		cert, err := tls.LoadX509KeyPair(clientCertFile, clientKeyFile)
 		if err != nil {
 			return &tlsConfig, err


### PR DESCRIPTION
There are two cases for event exporter connection:

- production environment: we need to enable the TLS.
    - the /kafka-certs/client.crt and /kafka-certs/client.key file are valid.
    - insecureSkipVerify is false
- e2e test environment: since the e2e pod id(hostname) can't be signed by the client ca, we need to disable the TLS.
    - the /kafka-certs/client.crt and /kafka-certs/client.key files exist but are empty. Which might cause the [Kafka sinker initialize](https://github.com/resmoio/kubernetes-event-exporter/blob/f4b7ad969e5c78fd0538d5807ac3363066f8b17c/pkg/sinks/kafka.go#L156) error, and it will be fixed once this [PR](https://github.com/resmoio/kubernetes-event-exporter/pull/80) is merged.
    - insecureSkipVerify is true.