### PR TITLE
customize scheduler interval.

### DIFF
--- a/agent/pkg/spec/controller/syncers/syncers_suite_test.go
+++ b/agent/pkg/spec/controller/syncers/syncers_suite_test.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -52,7 +53,10 @@ var _ = BeforeSuite(func() {
 	cfg, err = testenv.Start()
 	Expect(err).NotTo(HaveOccurred())
 
-	mgr, err := ctrl.NewManager(cfg, ctrl.Options{})
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		MetricsBindAddress: "0",
+		Scheme:             scheme.Scheme,
+	})
 	Expect(err).NotTo(HaveOccurred())
 
 	// add scheme

--- a/doc/simulation/local-policies/README.md
+++ b/doc/simulation/local-policies/README.md
@@ -72,7 +72,7 @@ batchSize: 1000, insert: 1000, offset: 10000
 5. After about 6 hours, check the row count of `local_status.compliance_history` table:
 
 ```bash
- kubectl exec -it $(kubectl get pods -n hoh-postgres -l postgres-operator.crunchydata.com/role=master -o jsonpath='{.items..metadata.name}') -c database -n hoh-postgres -- psql -U postgres -d hoh -c "SELECT count(*) from local_status.compliance_history"
+# oc exec -it $(oc get pods -n hoh-postgres -l postgres-operator.crunchydata.com/role=master -o jsonpath='{.items..metadata.name}') -c database -n hoh-postgres -- psql -U postgres -d hoh -c "SELECT count(*) from local_status.compliance_history"
  count
 --------
  7942000
@@ -90,7 +90,7 @@ tmpfs            64M     0   64M   0% /dev
 tmpfs            31G     0   31G   0% /sys/fs/cgroup
 tmpfs            31G   84M   31G   1% /etc/passwd
 /dev/nvme0n1p4  120G   30G   90G  26% /tmp
-/dev/nvme4n1     20G    3G   20G   2% /pgdata
+/dev/nvme4n1     20G  1.3G   20G   2% /pgdata
 tmpfs            61G   24K   61G   1% /pgconf/tls
 tmpfs            61G   24K   61G   1% /etc/database-containerinfo
 tmpfs            61G   16K   61G   1% /etc/patroni

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -75,7 +75,7 @@ func parseFlags() (*managerconfig.ManagerConfig, error) {
 		"The watching namespace of the controllers, multiple namespace must be splited by comma.")
 	pflag.StringVar(&managerConfig.SchedulerInterval, "scheduler-interval", "day",
 		"The job scheduler interval for moving policy compliance history, "+
-			"can be 'month', 'week', 'day', 'hour' or 'minute', default value is 'day'.")
+			"can be 'month', 'week', 'day', 'hour', 'minute' or 'second', default value is 'day'.")
 	pflag.DurationVar(&managerConfig.SyncerConfig.SpecSyncInterval, "spec-sync-interval", 5*time.Second,
 		"The synchronization interval of resources in spec.")
 	pflag.DurationVar(&managerConfig.SyncerConfig.StatusSyncInterval, "status-sync-interval", 5*time.Second,

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -73,6 +73,9 @@ func parseFlags() (*managerconfig.ManagerConfig, error) {
 		"The manager running namespace, also used as leader election namespace.")
 	pflag.StringVar(&managerConfig.WatchNamespace, "watch-namespace", "",
 		"The watching namespace of the controllers, multiple namespace must be splited by comma.")
+	pflag.StringVar(&managerConfig.SchedulerInterval, "scheduler-interval", "day",
+		"The job scheduler interval for moving policy compliance history, "+
+			"can be 'month', 'week', 'day', 'hour' or 'minute', default value is 'day'.")
 	pflag.DurationVar(&managerConfig.SyncerConfig.SpecSyncInterval, "spec-sync-interval", 5*time.Second,
 		"The synchronization interval of resources in spec.")
 	pflag.DurationVar(&managerConfig.SyncerConfig.StatusSyncInterval, "status-sync-interval", 5*time.Second,
@@ -218,7 +221,8 @@ func createManager(ctx context.Context, restConfig *rest.Config, managerConfig *
 		return nil, fmt.Errorf("failed to add transport-to-db syncers: %w", err)
 	}
 
-	if err := cronjob.AddSchedulerToManager(ctx, mgr, processPostgreSQL.GetConn()); err != nil {
+	if err := cronjob.AddSchedulerToManager(ctx, mgr, processPostgreSQL.GetConn(),
+		managerConfig.SchedulerInterval); err != nil {
 		return nil, fmt.Errorf("failed to add scheduler to manager: %w", err)
 	}
 

--- a/manager/pkg/config/manager_config.go
+++ b/manager/pkg/config/manager_config.go
@@ -15,6 +15,7 @@ import (
 type ManagerConfig struct {
 	ManagerNamespace      string
 	WatchNamespace        string
+	SchedulerInterval     string
 	SyncerConfig          *SyncerConfig
 	DatabaseConfig        *DatabaseConfig
 	TransportConfig       *transport.TransportConfig

--- a/manager/pkg/cronjob/scheduler_suite_test.go
+++ b/manager/pkg/cronjob/scheduler_suite_test.go
@@ -71,6 +71,11 @@ var _ = BeforeSuite(func() {
 
 	// By("Add to Scheme")
 	// Expect(managerscheme.AddToScheme(mgr.GetScheme())).NotTo(HaveOccurred())
+	Expect(cronjob.AddSchedulerToManager(context.TODO(), mgr, pool, "month")).Should(Succeed())
+	Expect(cronjob.AddSchedulerToManager(context.TODO(), mgr, pool, "week")).Should(Succeed())
+	Expect(cronjob.AddSchedulerToManager(context.TODO(), mgr, pool, "day")).Should(Succeed())
+	Expect(cronjob.AddSchedulerToManager(context.TODO(), mgr, pool, "hour")).Should(Succeed())
+	Expect(cronjob.AddSchedulerToManager(context.TODO(), mgr, pool, "minute")).Should(Succeed())
 	Expect(cronjob.AddSchedulerToManager(context.TODO(), mgr, pool, "second")).Should(Succeed())
 })
 

--- a/manager/pkg/cronjob/scheduler_suite_test.go
+++ b/manager/pkg/cronjob/scheduler_suite_test.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2022 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package cronjob_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v4/pgxpool"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/stolostron/multicluster-global-hub/manager/pkg/cronjob"
+	"github.com/stolostron/multicluster-global-hub/test/pkg/testpostgres"
+	// managerscheme "github.com/stolostron/multicluster-global-hub/manager/pkg/scheme"
+	"github.com/stolostron/multicluster-global-hub/pkg/database"
+)
+
+var (
+	testenv      *envtest.Environment
+	cfg          *rest.Config
+	ctx          context.Context
+	cancel       context.CancelFunc
+	mgr          ctrl.Manager
+	pool         *pgxpool.Pool
+	testPostgres *testpostgres.TestPostgres
+)
+
+func TestScheduler(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Scheduler Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	ctx, cancel = context.WithCancel(context.Background())
+
+	By("Prepare envtest environment")
+	var err error
+	testenv = &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "..", "pkg", "testdata", "crds"),
+		},
+		ErrorIfCRDPathMissing: true,
+	}
+	cfg, err = testenv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	By("Create test postgres")
+	testPostgres, err = testpostgres.NewTestPostgres()
+	Expect(err).NotTo(HaveOccurred())
+
+	pool, err = database.PostgresConnPool(ctx, testPostgres.URI, "ca-cert-path")
+	Expect(err).NotTo(HaveOccurred())
+
+	mgr, err = ctrl.NewManager(cfg, ctrl.Options{
+		MetricsBindAddress: "0",
+		Scheme:             scheme.Scheme,
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	// By("Add to Scheme")
+	// Expect(managerscheme.AddToScheme(mgr.GetScheme())).NotTo(HaveOccurred())
+	Expect(cronjob.AddSchedulerToManager(context.TODO(), mgr, pool, "second")).Should(Succeed())
+})
+
+var _ = AfterSuite(func() {
+	cancel()
+	Expect(testPostgres.Stop()).NotTo(HaveOccurred())
+
+	By("Tearing down the test environment")
+	err := testenv.Stop()
+	// https://github.com/kubernetes-sigs/controller-runtime/issues/1571
+	// Set 4 with random
+	if err != nil {
+		time.Sleep(4 * time.Second)
+	}
+	Expect(testenv.Stop()).NotTo(HaveOccurred())
+})

--- a/manager/pkg/cronjob/scheduler_test.go
+++ b/manager/pkg/cronjob/scheduler_test.go
@@ -1,0 +1,174 @@
+// Copyright (c) 2022 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package cronjob_test
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("sync the compliance data", Ordered, func() {
+	const targetSchema = "local_status"
+	const sourceTable = "compliance"
+	const targetTable = "compliance_history"
+
+	BeforeAll(func() {
+		By("Creating test table in the database")
+		conn, err := pool.Acquire(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		defer conn.Release()
+		_, err = conn.Exec(ctx, `
+			CREATE SCHEMA IF NOT EXISTS local_status;
+			CREATE SCHEMA IF NOT EXISTS status;
+			DO $$ BEGIN
+				CREATE TYPE local_status.compliance_type AS ENUM (
+					'compliant',
+					'non_compliant',
+					'unknown'
+				);
+			EXCEPTION
+				WHEN duplicate_object THEN null;
+			END $$;
+			DO $$ BEGIN
+				CREATE TYPE status.error_type AS ENUM (
+					'disconnected',
+					'none'
+				);
+			EXCEPTION
+				WHEN duplicate_object THEN null;
+			END $$;
+			CREATE TABLE IF NOT EXISTS local_status.compliance (
+				id uuid NOT NULL,
+				cluster_name character varying(63) NOT NULL,
+				leaf_hub_name character varying(63) NOT NULL,
+				error status.error_type NOT NULL,
+				compliance local_status.compliance_type NOT NULL,
+				cluster_id uuid
+			);
+			CREATE TABLE IF NOT EXISTS local_status.compliance_history (
+				id uuid NOT NULL,
+				cluster_id uuid NOT NULL,
+				updated_at timestamp without time zone DEFAULT now() NOT NULL,
+				compliance local_status.compliance_type NOT NULL,
+				compliance_changed_frequency integer NOT NULL DEFAULT 0
+			);
+			CREATE TABLE IF NOT EXISTS local_status.compliance_history_job_log (
+				name varchar(63) NOT NULL,
+				start_at timestamp NOT NULL DEFAULT now(),
+				end_at timestamp NOT NULL DEFAULT now(),
+				total int8,
+				inserted int8,
+				offsets int8, 
+				error TEXT
+			);`)
+		Expect(err).ToNot(HaveOccurred())
+		By("Check whether the tables are created")
+		Eventually(func() error {
+			rows, err := conn.Query(ctx, "SELECT * FROM pg_tables")
+			if err != nil {
+				return err
+			}
+			defer rows.Close()
+			expectedTableSet := map[string]bool{
+				sourceTable: true,
+				targetTable: true,
+			}
+
+			for rows.Next() {
+				columnValues, _ := rows.Values()
+				schema := columnValues[0]
+				table := columnValues[1]
+				if schema == targetSchema && expectedTableSet[table.(string)] {
+					delete(expectedTableSet, table.(string))
+				}
+			}
+			if len(expectedTableSet) > 0 {
+				return fmt.Errorf("tables %v are not created", expectedTableSet)
+			}
+			return nil
+		}, 10*time.Second, 2*time.Second).ShouldNot(HaveOccurred())
+
+		By("Start the manager")
+		go func() {
+			defer GinkgoRecover()
+			Expect(mgr.Start(ctx)).ToNot(HaveOccurred(), "failed to run manager")
+		}()
+		By("Waiting for the manager to be ready")
+		Expect(mgr.GetCache().WaitForCacheSync(ctx)).To(BeTrue())
+	})
+
+	It("sync the data from the source table to the target", func() {
+		By("Create the data to the source table")
+		_, err := pool.Exec(ctx, `
+			INSERT INTO local_status.compliance (id, cluster_name, leaf_hub_name, error, compliance, cluster_id) VALUES
+			('f8c4479f-fec5-44d8-8060-da9a92d5e138', 'local_cluster1', 'leaf1', 'none', 'compliant', 
+			'0cd723ab-4649-42e8-b8aa-aa094ccf06b4'),
+			('f8c4479f-fec5-44d8-8060-da9a92d5e139', 'local_cluster2', 'leaf2', 'none', 'compliant', 
+			'0cd723ab-4649-42e8-b8aa-aa094ccf06b4'),
+			('f8c4479f-fec5-44d8-8060-da9a92d5e137', 'local_cluster3', 'leaf3', 'none', 'compliant', 
+			'0cd723ab-4649-42e8-b8aa-aa094ccf06b4');
+		`)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Check whether the data is copied to the target table")
+		Eventually(func() error {
+			rows, err := pool.Query(ctx, "SELECT id, cluster_id, compliance FROM local_status.compliance_history")
+			if err != nil {
+				return err
+			}
+			defer rows.Close()
+			syncCount := 0
+			expectRecordMap := map[string]string{
+				"f8c4479f-fec5-44d8-8060-da9a92d5e138": "compliant",
+				"f8c4479f-fec5-44d8-8060-da9a92d5e139": "compliant",
+				"f8c4479f-fec5-44d8-8060-da9a92d5e137": "compliant",
+			}
+			for rows.Next() {
+				var id, cluster_id, compliance string
+				err := rows.Scan(&id, &cluster_id, &compliance)
+				if err != nil {
+					return err
+				}
+				fmt.Println("found record", "id", id, "cluster_id", cluster_id, "compliance", compliance)
+				if status, ok := expectRecordMap[id]; ok && status == compliance {
+					syncCount++
+					delete(expectRecordMap, id)
+				}
+			}
+			if syncCount != 3 {
+				return fmt.Errorf("table local_status.compliance_history records are not synced")
+			}
+			return nil
+		}, 20*time.Second, 2*time.Second).ShouldNot(HaveOccurred())
+
+		By("Check whether the job log is created")
+		Eventually(func() error {
+			rows, err := pool.Query(ctx, `SELECT name, total, inserted, offsets, error FROM 
+			local_status.compliance_history_job_log`)
+			if err != nil {
+				return err
+			}
+			defer rows.Close()
+
+			logCount := 0
+			for rows.Next() {
+				var name, errMessage string
+				var total, inserted, offsets int64
+				err := rows.Scan(&name, &total, &inserted, &offsets, &errMessage)
+				if err != nil {
+					return err
+				}
+				logCount += 1
+				fmt.Println("found log", "name", name, "total", total, "inserted", inserted, "offsets", offsets)
+			}
+			if logCount == 0 {
+				return fmt.Errorf("table local_status.compliance_history_job_log records are not synced")
+			}
+			return nil
+		}, 20*time.Second, 2*time.Second).ShouldNot(HaveOccurred())
+	})
+})

--- a/manager/pkg/cronjob/sheduler.go
+++ b/manager/pkg/cronjob/sheduler.go
@@ -12,18 +12,40 @@ import (
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/cronjob/task"
 )
 
+const (
+	EveryMonth  string = "month"
+	EveryWeek   string = "week"
+	EveryDay    string = "day"
+	EveryHour   string = "hour"
+	EveryMinute string = "minute"
+	EverySecond string = "second"
+)
+
 type GlobalHubJobScheduler struct {
 	log       logr.Logger
 	scheduler *gocron.Scheduler
 }
 
-func AddSchedulerToManager(ctx context.Context, mgr ctrl.Manager, pool *pgxpool.Pool) error {
+func AddSchedulerToManager(ctx context.Context, mgr ctrl.Manager, pool *pgxpool.Pool, interval string) error {
 	log := ctrl.Log.WithName("cronjob-scheduler")
 	// Scheduler timezone:
 	// The cluster may be in a different timezones, Here we choose to be consistent with the local GH timezone.
 	scheduler := gocron.NewScheduler(time.Local)
 
-	complianceJob, err := scheduler.Every(1).Day().At("00:00").Tag("LocalComplianceHistory").DoWithJobDetails(
+	switch interval {
+	case EveryMonth:
+		scheduler = scheduler.Every(1).Month()
+	case EveryWeek:
+		scheduler = scheduler.Every(1).Week()
+	case EveryHour:
+		scheduler = scheduler.Every(1).Hour()
+	case EveryMinute:
+		scheduler = scheduler.Every(1).Minute()
+	default:
+		scheduler = scheduler.Every(1).Day()
+	}
+
+	complianceJob, err := scheduler.Tag("LocalComplianceHistory").DoWithJobDetails(
 		task.SyncLocalCompliance, ctx, pool)
 	if err != nil {
 		return err

--- a/manager/pkg/cronjob/sheduler.go
+++ b/manager/pkg/cronjob/sheduler.go
@@ -34,13 +34,15 @@ func AddSchedulerToManager(ctx context.Context, mgr ctrl.Manager, pool *pgxpool.
 
 	switch interval {
 	case EveryMonth:
-		scheduler = scheduler.Every(1).Month()
+		scheduler = scheduler.Every(1).Month(1)
 	case EveryWeek:
 		scheduler = scheduler.Every(1).Week()
 	case EveryHour:
 		scheduler = scheduler.Every(1).Hour()
 	case EveryMinute:
 		scheduler = scheduler.Every(1).Minute()
+	case EverySecond:
+		scheduler = scheduler.Every(1).Second()
 	default:
 		scheduler = scheduler.Every(1).Day()
 	}

--- a/operator/pkg/config/multiclusterglobalhub_config.go
+++ b/operator/pkg/config/multiclusterglobalhub_config.go
@@ -122,6 +122,11 @@ func SkipDBInit(mgh *operatorv1alpha2.MulticlusterGlobalHub) bool {
 	return false
 }
 
+// GetSchedulerInterval returns the scheduler interval for moving policy compliance history
+func GetSchedulerInterval(mgh *operatorv1alpha2.MulticlusterGlobalHub) string {
+	return getAnnotation(mgh, operatorconstants.AnnotationMGHSchedulerInterval)
+}
+
 // GetImageOverridesConfigmap returns the images override configmap annotation, or an empty string if not set
 func GetImageOverridesConfigmap(mgh *operatorv1alpha2.MulticlusterGlobalHub) string {
 	return getAnnotation(mgh, operatorconstants.AnnotationImageOverridesCM)

--- a/operator/pkg/constants/constants.go
+++ b/operator/pkg/constants/constants.go
@@ -37,7 +37,7 @@ const (
 	AnnotationImageOverridesCM = "mgh-image-overrides-cm"
 	// AnnotationMGHSchedulerInterval sits in MulticlusterGlobalHub annotations
 	// to identify the scheduler interval for moving policy compliance history
-	// valid value can be "month, week, day, hour, minute"
+	// valid value can be "month, week, day, hour, minute, second"
 	AnnotationMGHSchedulerInterval = "mgh-scheduler-interval"
 	// MGHOperandImagePrefix ...
 	MGHOperandImagePrefix = "RELATED_IMAGE_"

--- a/operator/pkg/constants/constants.go
+++ b/operator/pkg/constants/constants.go
@@ -35,6 +35,10 @@ const (
 	// AnnotationImageOverridesCM sits in MulticlusterGlobalHub annotations
 	// to identify a custom configmap containing image overrides
 	AnnotationImageOverridesCM = "mgh-image-overrides-cm"
+	// AnnotationMGHSchedulerInterval sits in MulticlusterGlobalHub annotations
+	// to identify the scheduler interval for moving policy compliance history
+	// valid value can be "month, week, day, hour, minute"
+	AnnotationMGHSchedulerInterval = "mgh-scheduler-interval"
 	// MGHOperandImagePrefix ...
 	MGHOperandImagePrefix = "RELATED_IMAGE_"
 )

--- a/operator/pkg/controllers/hubofhubs/globalhub_manager.go
+++ b/operator/pkg/controllers/hubofhubs/globalhub_manager.go
@@ -88,6 +88,7 @@ func (r *MulticlusterGlobalHubReconciler) reconcileManager(ctx context.Context,
 			LeaseDuration          string
 			RenewDeadline          string
 			RetryPeriod            string
+			SchedulerInterval      string
 			NodeSelector           map[string]string
 			Tolerations            []corev1.Toleration
 		}{
@@ -108,6 +109,7 @@ func (r *MulticlusterGlobalHubReconciler) reconcileManager(ctx context.Context,
 			LeaseDuration:          strconv.Itoa(r.LeaderElection.LeaseDuration),
 			RenewDeadline:          strconv.Itoa(r.LeaderElection.RenewDeadline),
 			RetryPeriod:            strconv.Itoa(r.LeaderElection.RetryPeriod),
+			SchedulerInterval:      config.GetSchedulerInterval(mgh),
 			NodeSelector:           mgh.Spec.NodeSelector,
 			Tolerations:            mgh.Spec.Tolerations,
 		}, nil

--- a/operator/pkg/controllers/hubofhubs/integration_test.go
+++ b/operator/pkg/controllers/hubofhubs/integration_test.go
@@ -375,6 +375,7 @@ var _ = Describe("MulticlusterGlobalHub controller", Ordered, func() {
 					LeaseDuration          string
 					RenewDeadline          string
 					RetryPeriod            string
+					SchedulerInterval      string
 					NodeSelector           map[string]string
 					Tolerations            []corev1.Toleration
 				}{
@@ -395,6 +396,7 @@ var _ = Describe("MulticlusterGlobalHub controller", Ordered, func() {
 					LeaseDuration:          "137",
 					RenewDeadline:          "107",
 					RetryPeriod:            "26",
+					SchedulerInterval:      config.GetSchedulerInterval(mgh),
 					NodeSelector:           map[string]string{"foo": "bar"},
 					Tolerations: []corev1.Toleration{
 						{

--- a/operator/pkg/controllers/hubofhubs/manifests/manager/deployment.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/manager/deployment.yaml
@@ -37,6 +37,7 @@ spec:
             - --lease-duration={{.LeaseDuration}}
             - --renew-deadline={{.RenewDeadline}}
             - --retry-period={{.RetryPeriod}}
+            - --scheduler-interval={{.SchedulerInterval}}
           env:
             - name: POD_NAMESPACE
               valueFrom:


### PR DESCRIPTION
This PR tries to support customize scheduler interval for moving policy compliance to history, can be 'month', 'week', 'day', 'hour', 'minute' or 'second'.