### PR TITLE
Fix cluster_id is NULL in local_status.compliance table sometimes

### DIFF
--- a/operator/pkg/controllers/hubofhubs/database/4.trigger.sql
+++ b/operator/pkg/controllers/hubofhubs/database/4.trigger.sql
@@ -69,8 +69,8 @@ DROP TRIGGER IF EXISTS set_timestamp ON spec.subscriptions;
 CREATE TRIGGER set_timestamp BEFORE UPDATE ON spec.subscriptions FOR EACH ROW EXECUTE FUNCTION public.trigger_set_timestamp();
 
 DROP TRIGGER IF EXISTS update_compliance_table ON local_status.compliance;
-CREATE TRIGGER update_compliance_table AFTER INSERT ON local_status.compliance FOR EACH ROW EXECUTE FUNCTION public.set_cluster_id_to_local_compliance();
-CREATE TRIGGER update_compliance_table BEFORE UPDATE ON local_status.compliance FOR EACH ROW EXECUTE FUNCTION public.set_cluster_id_to_local_compliance();
+CREATE TRIGGER update_compliance_table_after_insert AFTER INSERT ON local_status.compliance FOR EACH ROW EXECUTE FUNCTION public.set_cluster_id_to_local_compliance();
+CREATE TRIGGER update_compliance_table_before_update BEFORE UPDATE ON local_status.compliance FOR EACH ROW EXECUTE FUNCTION public.set_cluster_id_to_local_compliance();
 DROP TRIGGER IF EXISTS update_compliance_table ON status.compliance;
-CREATE TRIGGER update_compliance_table AFTER INSERT ON status.compliance FOR EACH ROW EXECUTE FUNCTION public.set_cluster_id_to_compliance();
-CREATE TRIGGER update_compliance_table BEFORE UPDATE ON local_status.compliance FOR EACH ROW EXECUTE FUNCTION public.set_cluster_id_to_compliance();
+CREATE TRIGGER update_compliance_table_after_insert AFTER INSERT ON status.compliance FOR EACH ROW EXECUTE FUNCTION public.set_cluster_id_to_compliance();
+CREATE TRIGGER update_compliance_table_before_update BEFORE UPDATE ON status.compliance FOR EACH ROW EXECUTE FUNCTION public.set_cluster_id_to_compliance();

--- a/operator/pkg/controllers/hubofhubs/database/4.trigger.sql
+++ b/operator/pkg/controllers/hubofhubs/database/4.trigger.sql
@@ -68,11 +68,7 @@ CREATE TRIGGER set_timestamp BEFORE UPDATE ON spec.policies FOR EACH ROW EXECUTE
 DROP TRIGGER IF EXISTS set_timestamp ON spec.subscriptions;
 CREATE TRIGGER set_timestamp BEFORE UPDATE ON spec.subscriptions FOR EACH ROW EXECUTE FUNCTION public.trigger_set_timestamp();
 
-DROP TRIGGER IF EXISTS update_compliance_table_after_insert ON local_status.compliance;
-CREATE TRIGGER update_compliance_table_after_insert AFTER INSERT ON local_status.compliance FOR EACH ROW EXECUTE FUNCTION public.set_cluster_id_to_local_compliance();
-DROP TRIGGER IF EXISTS update_compliance_table_before_update ON local_status.compliance;
-CREATE TRIGGER update_compliance_table_before_update BEFORE UPDATE ON local_status.compliance FOR EACH ROW EXECUTE FUNCTION public.set_cluster_id_to_local_compliance();
-DROP TRIGGER IF EXISTS update_compliance_table_after_insert ON status.compliance;
-CREATE TRIGGER update_compliance_table_after_insert AFTER INSERT ON status.compliance FOR EACH ROW EXECUTE FUNCTION public.set_cluster_id_to_compliance();
-DROP TRIGGER IF EXISTS update_compliance_table_before_update ON status.compliance;
-CREATE TRIGGER update_compliance_table_before_update BEFORE UPDATE ON status.compliance FOR EACH ROW EXECUTE FUNCTION public.set_cluster_id_to_compliance();
+DROP TRIGGER IF EXISTS update_compliance_table ON local_status.compliance;
+CREATE TRIGGER update_compliance_table AFTER INSERT OR UPDATE ON local_status.compliance FOR EACH ROW WHEN (pg_trigger_depth() < 1) EXECUTE FUNCTION public.set_cluster_id_to_local_compliance();
+DROP TRIGGER IF EXISTS update_compliance_table ON status.compliance;
+CREATE TRIGGER update_compliance_table AFTER INSERT OR UPDATE ON status.compliance FOR EACH ROW WHEN (pg_trigger_depth() < 1) EXECUTE FUNCTION public.set_cluster_id_to_compliance();

--- a/operator/pkg/controllers/hubofhubs/database/4.trigger.sql
+++ b/operator/pkg/controllers/hubofhubs/database/4.trigger.sql
@@ -68,9 +68,11 @@ CREATE TRIGGER set_timestamp BEFORE UPDATE ON spec.policies FOR EACH ROW EXECUTE
 DROP TRIGGER IF EXISTS set_timestamp ON spec.subscriptions;
 CREATE TRIGGER set_timestamp BEFORE UPDATE ON spec.subscriptions FOR EACH ROW EXECUTE FUNCTION public.trigger_set_timestamp();
 
-DROP TRIGGER IF EXISTS update_compliance_table ON local_status.compliance;
+DROP TRIGGER IF EXISTS update_compliance_table_after_insert ON local_status.compliance;
 CREATE TRIGGER update_compliance_table_after_insert AFTER INSERT ON local_status.compliance FOR EACH ROW EXECUTE FUNCTION public.set_cluster_id_to_local_compliance();
+DROP TRIGGER IF EXISTS update_compliance_table_before_update ON local_status.compliance;
 CREATE TRIGGER update_compliance_table_before_update BEFORE UPDATE ON local_status.compliance FOR EACH ROW EXECUTE FUNCTION public.set_cluster_id_to_local_compliance();
-DROP TRIGGER IF EXISTS update_compliance_table ON status.compliance;
+DROP TRIGGER IF EXISTS update_compliance_table_after_insert ON status.compliance;
 CREATE TRIGGER update_compliance_table_after_insert AFTER INSERT ON status.compliance FOR EACH ROW EXECUTE FUNCTION public.set_cluster_id_to_compliance();
+DROP TRIGGER IF EXISTS update_compliance_table_before_update ON status.compliance;
 CREATE TRIGGER update_compliance_table_before_update BEFORE UPDATE ON status.compliance FOR EACH ROW EXECUTE FUNCTION public.set_cluster_id_to_compliance();

--- a/operator/pkg/controllers/hubofhubs/database/4.trigger.sql
+++ b/operator/pkg/controllers/hubofhubs/database/4.trigger.sql
@@ -70,5 +70,7 @@ CREATE TRIGGER set_timestamp BEFORE UPDATE ON spec.subscriptions FOR EACH ROW EX
 
 DROP TRIGGER IF EXISTS update_compliance_table ON local_status.compliance;
 CREATE TRIGGER update_compliance_table AFTER INSERT ON local_status.compliance FOR EACH ROW EXECUTE FUNCTION public.set_cluster_id_to_local_compliance();
+CREATE TRIGGER update_compliance_table BEFORE UPDATE ON local_status.compliance FOR EACH ROW EXECUTE FUNCTION public.set_cluster_id_to_local_compliance();
 DROP TRIGGER IF EXISTS update_compliance_table ON status.compliance;
 CREATE TRIGGER update_compliance_table AFTER INSERT ON status.compliance FOR EACH ROW EXECUTE FUNCTION public.set_cluster_id_to_compliance();
+CREATE TRIGGER update_compliance_table BEFORE UPDATE ON local_status.compliance FOR EACH ROW EXECUTE FUNCTION public.set_cluster_id_to_compliance();


### PR DESCRIPTION
there is a case that the cluster_id in status.managed_clusters table is empty before insert the data into local_status.compliance table. so create trigger before update to ensure the cluster_id is inserted.