### PR TITLE
remove relatedImages from CSV

### DIFF
--- a/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -785,13 +785,4 @@ spec:
   provider:
     name: Red Hat, Inc
     url: https://github.com/stolostron/multicluster-global-hub
-  relatedImages:
-  - image: quay.io/stolostron/multicluster-global-hub-manager:latest
-    name: multicluster-global-hub-manager
-  - image: quay.io/stolostron/multicluster-global-hub-agent:latest
-    name: multicluster-global-hub-agent
-  - image: quay.io/stolostron/grafana:2.8.0-SNAPSHOT-2023-03-06-01-52-34
-    name: grafana
-  - image: quay.io/stolostron/origin-oauth-proxy:4.9
-    name: oauth-proxy
   version: 0.7.0-dev


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>
Since the `operator-sdk` hasn't have the feature to remove `relatedImages` field when generate bundle/manifests. Here we just manually remove it from bundle CSV file.