### PR TITLE
Disable the logs for event by default

### DIFF
--- a/agent/pkg/controllers/event_exporter.go
+++ b/agent/pkg/controllers/event_exporter.go
@@ -9,6 +9,7 @@ import (
 	"github.com/resmoio/kubernetes-event-exporter/pkg/exporter"
 	"github.com/resmoio/kubernetes-event-exporter/pkg/kube"
 	"github.com/resmoio/kubernetes-event-exporter/pkg/metrics"
+	"github.com/rs/zerolog"
 	"gopkg.in/yaml.v2"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -42,6 +43,14 @@ func (e *eventExporterController) Start(ctx context.Context) error {
 	metrics.Init(*flag.String("metrics-address", ":2112",
 		"The address to listen on for HTTP requests."))
 	metricsStore := metrics.NewMetricsStore(cfg.MetricsNamePrefix)
+
+	if cfg.LogLevel != "" {
+		level, err := zerolog.ParseLevel(cfg.LogLevel)
+		if err != nil {
+			log.Error(err, "invalid log level")
+		}
+		zerolog.SetGlobalLevel(level)
+	}
 
 	engine := exporter.NewEngine(&cfg, &exporter.ChannelBasedReceiverRegistry{MetricsStore: metricsStore})
 	onEvent := func(event *kube.EnhancedEvent) {

--- a/operator/pkg/controllers/addon/manifests/templates/agent/multicluster-global-hub-agent-event-configmap.yaml
+++ b/operator/pkg/controllers/addon/manifests/templates/agent/multicluster-global-hub-agent-event-configmap.yaml
@@ -8,8 +8,7 @@ metadata:
     addon.open-cluster-management.io/hosted-manifest-location: none
 data:
   config.yaml: |
-    logLevel: error
-    logFormat: json
+    logLevel: disabled
     maxEventAgeSeconds: 60
     metricsNamePrefix: "mcgh"
     # namespace: my-namespace-only # Omitting it defaults to all namespaces.

--- a/operator/pkg/controllers/addon/manifests/templates/hostedagent/multicluster-global-hub-agent-event-configmap.yaml
+++ b/operator/pkg/controllers/addon/manifests/templates/hostedagent/multicluster-global-hub-agent-event-configmap.yaml
@@ -8,8 +8,7 @@ metadata:
     addon.open-cluster-management.io/hosted-manifest-location: hosting
 data:
   config.yaml: |
-    logLevel: error
-    logFormat: json
+    logLevel: disabled
     maxEventAgeSeconds: 60
     metricsNamePrefix: "mcgh"
     # namespace: my-namespace-only # Omitting it defaults to all namespaces.


### PR DESCRIPTION
Disable the logs for event-watch by default, because it is too noisy.