### PR TITLE
fix empty schedule interval.

### DIFF
--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -133,7 +133,7 @@ func parseFlags() (*managerconfig.ManagerConfig, error) {
 
 	pflag.Visit(func(f *pflag.Flag) {
 		// set enableSimulation to be true when manually set 'scheduler-interval' flag
-		if f.Name == "scheduler-interval" {
+		if f.Name == "scheduler-interval" && f.Changed {
 			enableSimulation = true
 		}
 	})

--- a/operator/pkg/controllers/hubofhubs/manifests/manager/deployment.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/manager/deployment.yaml
@@ -37,7 +37,9 @@ spec:
             - --lease-duration={{.LeaseDuration}}
             - --renew-deadline={{.RenewDeadline}}
             - --retry-period={{.RetryPeriod}}
+            {{- if .SchedulerInterval}}
             - --scheduler-interval={{.SchedulerInterval}}
+            {{- end}}
           env:
             - name: POD_NAMESPACE
               valueFrom:


### PR DESCRIPTION
ref: https://issues.redhat.com/browse/ACM-5619
if `SchedulerInterval` is not specified in MGH instance, then don't set `--scheduler-interval` to manager.