### PR TITLE
format the logger with controller runtime zap

### DIFF
--- a/agent/cmd/agent/main.go
+++ b/agent/cmd/agent/main.go
@@ -110,9 +110,10 @@ func parseFlags() *config.AgentConfig {
 			enc.AppendString(t.Format("2006-01-02 15:04:05 MST"))
 		},
 	}
-	opts.BindFlags(flag.CommandLine)
+	defaultFlags := flag.CommandLine
+	opts.BindFlags(defaultFlags)
+	pflag.CommandLine.AddGoFlagSet(defaultFlags)
 
-	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.StringVar(&agentConfig.LeafHubName, "leaf-hub-name", "", "The name of the leaf hub.")
 	pflag.StringVar(&agentConfig.TransportConfig.KafkaConfig.BootstrapServer, "kafka-bootstrap-server", "",
 		"The bootstrap server for kafka.")
@@ -188,7 +189,9 @@ func completeConfig(agentConfig *config.AgentConfig) error {
 	return nil
 }
 
-func createManager(ctx context.Context, restConfig *rest.Config, agentConfig *config.AgentConfig) (ctrl.Manager, error) {
+func createManager(ctx context.Context, restConfig *rest.Config, agentConfig *config.AgentConfig) (
+	ctrl.Manager, error,
+) {
 	leaseDuration := time.Duration(agentConfig.ElectionConfig.LeaseDuration) * time.Second
 	renewDeadline := time.Duration(agentConfig.ElectionConfig.RenewDeadline) * time.Second
 	retryPeriod := time.Duration(agentConfig.ElectionConfig.RetryPeriod) * time.Second

--- a/agent/cmd/agent/main.go
+++ b/agent/cmd/agent/main.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/spf13/pflag"
 	mchv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
-	"go.uber.org/zap/zapcore"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
@@ -104,12 +103,7 @@ func parseFlags() *config.AgentConfig {
 	}
 
 	// add flags for logger
-	opts := zap.Options{
-		Development: true,
-		TimeEncoder: func(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
-			enc.AppendString(t.Format("2006-01-02 15:04:05 MST"))
-		},
-	}
+	opts := utils.CtrlZapOptions()
 	defaultFlags := flag.CommandLine
 	opts.BindFlags(defaultFlags)
 	pflag.CommandLine.AddGoFlagSet(defaultFlags)

--- a/agent/cmd/agent/main.go
+++ b/agent/cmd/agent/main.go
@@ -186,6 +186,9 @@ func completeConfig(agentConfig *config.AgentConfig) error {
 			agentConfig.TransportConfig.KafkaConfig.ProducerConfig.MessageSizeLimitKB, producer.MaxMessageSizeLimit)
 	}
 	agentConfig.TransportConfig.KafkaConfig.EnableTLS = true
+	if agentConfig.MetricsAddress == "" {
+		agentConfig.MetricsAddress = fmt.Sprintf("%s:%d", metricsHost, metricsPort)
+	}
 	return nil
 }
 
@@ -208,7 +211,7 @@ func createManager(ctx context.Context, restConfig *rest.Config, agentConfig *co
 	}
 
 	options := ctrl.Options{
-		MetricsBindAddress:      fmt.Sprintf("%s:%d", metricsHost, metricsPort),
+		MetricsBindAddress:      agentConfig.MetricsAddress,
 		LeaderElection:          true,
 		LeaderElectionConfig:    leaderElectionConfig,
 		LeaderElectionID:        leaderElectionLockID,

--- a/agent/cmd/agent/main.go
+++ b/agent/cmd/agent/main.go
@@ -5,13 +5,11 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"runtime"
 	"time"
 
-	"github.com/go-logr/logr"
-	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 	"github.com/spf13/pflag"
 	mchv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
+	"go.uber.org/zap/zapcore"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
@@ -20,6 +18,7 @@ import (
 	operatorv1 "open-cluster-management.io/api/operator/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/config"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/controllers"
@@ -33,6 +32,7 @@ import (
 	commonobjects "github.com/stolostron/multicluster-global-hub/pkg/objects"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport/producer"
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
 const (
@@ -41,10 +41,13 @@ const (
 	leaderElectionLockID       = "multicluster-global-hub-agent-lock"
 )
 
+var setupLog = ctrl.Log.WithName("setup")
+
 func main() {
 	// adding and parsing flags should be done before the call of 'ctrl.GetConfigOrDie()',
 	// otherwise kubeconfig will not be passed to agent main process
 	agentConfig := parseFlags()
+	utils.PrintVersion(setupLog)
 	if agentConfig.Terminating {
 		os.Exit(doTermination(ctrl.SetupSignalHandler(), ctrl.GetConfigOrDie()))
 	}
@@ -52,18 +55,17 @@ func main() {
 }
 
 func doTermination(ctx context.Context, restConfig *rest.Config) int {
-	log := initLog()
 	if err := agentscheme.AddToScheme(scheme.Scheme); err != nil {
-		log.Error(err, "failed to add to scheme")
+		setupLog.Error(err, "failed to add to scheme")
 		return 1
 	}
 	client, err := client.New(restConfig, client.Options{Scheme: scheme.Scheme})
 	if err != nil {
-		log.Error(err, "failed to int controller runtime client")
+		setupLog.Error(err, "failed to int controller runtime client")
 		return 1
 	}
 	if err := jobs.NewPruneFinalizer(ctx, client).Run(); err != nil {
-		log.Error(err, "failed to prune resources finalizer")
+		setupLog.Error(err, "failed to prune resources finalizer")
 		return 1
 	}
 	return 0
@@ -71,33 +73,23 @@ func doTermination(ctx context.Context, restConfig *rest.Config) int {
 
 // function to handle defers with exit, see https://stackoverflow.com/a/27629493/553720.
 func doMain(ctx context.Context, restConfig *rest.Config, agentConfig *config.AgentConfig) int {
-	log := initLog()
-
 	if err := completeConfig(agentConfig); err != nil {
-		log.Error(err, "failed to get regional hub configuration from command line flags")
+		setupLog.Error(err, "failed to get regional hub configuration from command line flags")
 		return 1
 	}
 
-	mgr, err := createManager(ctx, log, restConfig, agentConfig)
+	mgr, err := createManager(ctx, restConfig, agentConfig)
 	if err != nil {
-		log.Error(err, "failed to create manager")
+		setupLog.Error(err, "failed to create manager")
 		return 1
 	}
 
-	log.Info("starting the agent controller manager")
+	setupLog.Info("starting the agent controller manager")
 	if err := mgr.Start(ctx); err != nil {
-		log.Error(err, "manager exited non-zero")
+		setupLog.Error(err, "manager exited non-zero")
 		return 1
 	}
 	return 0
-}
-
-func initLog() logr.Logger {
-	ctrl.SetLogger(zap.Logger())
-	log := ctrl.Log.WithName("cmd")
-	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
-	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
-	return log
 }
 
 func parseFlags() *config.AgentConfig {
@@ -112,9 +104,15 @@ func parseFlags() *config.AgentConfig {
 	}
 
 	// add flags for logger
-	pflag.CommandLine.AddFlagSet(zap.FlagSet())
-	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	opts := zap.Options{
+		Development: true,
+		TimeEncoder: func(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
+			enc.AppendString(t.Format("2006-01-02 15:04:05 MST"))
+		},
+	}
+	opts.BindFlags(flag.CommandLine)
 
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.StringVar(&agentConfig.LeafHubName, "leaf-hub-name", "", "The name of the leaf hub.")
 	pflag.StringVar(&agentConfig.TransportConfig.KafkaConfig.BootstrapServer, "kafka-bootstrap-server", "",
 		"The bootstrap server for kafka.")
@@ -163,6 +161,10 @@ func parseFlags() *config.AgentConfig {
 		"The configuration file for the kubernetes event exporter")
 
 	pflag.Parse()
+
+	// set zap logger
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
 	return agentConfig
 }
 
@@ -186,9 +188,7 @@ func completeConfig(agentConfig *config.AgentConfig) error {
 	return nil
 }
 
-func createManager(ctx context.Context, log logr.Logger, restConfig *rest.Config,
-	agentConfig *config.AgentConfig,
-) (ctrl.Manager, error) {
+func createManager(ctx context.Context, restConfig *rest.Config, agentConfig *config.AgentConfig) (ctrl.Manager, error) {
 	leaseDuration := time.Duration(agentConfig.ElectionConfig.LeaseDuration) * time.Second
 	renewDeadline := time.Duration(agentConfig.ElectionConfig.RenewDeadline) * time.Second
 	retryPeriod := time.Duration(agentConfig.ElectionConfig.RetryPeriod) * time.Second
@@ -231,17 +231,17 @@ func createManager(ctx context.Context, log logr.Logger, restConfig *rest.Config
 		return nil, fmt.Errorf("failed to create dynamic client %v", err)
 	}
 	// check the acm is installed and then add the following controllers to mgr
-	mchExists, err := ensureMulticlusterHub(ctx, log, dynamicClient)
+	mchExists, err := ensureMulticlusterHub(ctx, dynamicClient)
 	if err != nil {
-		log.Error(err, "You need install ACM before using the agent")
+		setupLog.Error(err, "You need install ACM before using the agent")
 	}
 
 	var clusterManagerExists bool
 	if !mchExists {
 		// we are using ocm for e2e test
-		clusterManagerExists, err = ensureClusterManager(ctx, log, dynamicClient)
+		clusterManagerExists, err = ensureClusterManager(ctx, dynamicClient)
 		if err != nil {
-			log.Error(err, "You need install OCM before using the agent")
+			setupLog.Error(err, "You need install OCM before using the agent")
 		}
 	}
 
@@ -251,13 +251,13 @@ func createManager(ctx context.Context, log logr.Logger, restConfig *rest.Config
 		if err != nil {
 			return nil, fmt.Errorf("failed to get incarnation version: %w", err)
 		}
-		log.Info("start agent with incarnation version", "version", incarnation)
+		setupLog.Info("start agent with incarnation version", "version", incarnation)
 
 		// add spec controllers
 		if err := specController.AddToManager(mgr, agentConfig); err != nil {
 			return nil, fmt.Errorf("failed to add spec syncer: %w", err)
 		}
-		log.Info("add spec controllers to manager")
+		setupLog.Info("add spec controllers to manager")
 
 		if err := statusController.AddControllers(mgr, agentConfig, incarnation); err != nil {
 			return nil, fmt.Errorf("failed to add status syncer: %w", err)
@@ -283,7 +283,7 @@ func createManager(ctx context.Context, log logr.Logger, restConfig *rest.Config
 	return mgr, nil
 }
 
-func ensureMulticlusterHub(ctx context.Context, log logr.Logger, dynamicClient dynamic.Interface) (bool, error) {
+func ensureMulticlusterHub(ctx context.Context, dynamicClient dynamic.Interface) (bool, error) {
 	mch, err := dynamicClient.Resource(mchv1.GroupVersion.WithResource("multiclusterhubs")).
 		Namespace("").
 		List(ctx, metav1.ListOptions{})
@@ -293,7 +293,7 @@ func ensureMulticlusterHub(ctx context.Context, log logr.Logger, dynamicClient d
 	return len(mch.Items) > 0, nil
 }
 
-func ensureClusterManager(ctx context.Context, log logr.Logger, dynamicClient dynamic.Interface) (
+func ensureClusterManager(ctx context.Context, dynamicClient dynamic.Interface) (
 	bool, error,
 ) {
 	clusterManager, err := dynamicClient.Resource(

--- a/agent/cmd/agent/main_test.go
+++ b/agent/cmd/agent/main_test.go
@@ -183,7 +183,6 @@ func TestNoMCHClusterManagerCRD(t *testing.T) {
 		CRDDirectoryPaths:     []string{},
 		ErrorIfCRDPathMissing: true,
 	}
-	log := initLog()
 
 	cfg, err := testenv.Start()
 	if err != nil {
@@ -195,7 +194,7 @@ func TestNoMCHClusterManagerCRD(t *testing.T) {
 		}
 	}()
 
-	_, err = createManager(context.Background(), log, cfg, initMockAgentConfig())
+	_, err = createManager(context.Background(), cfg, initMockAgentConfig())
 	if err != nil {
 		panic(err)
 	}
@@ -208,7 +207,6 @@ func TestHasMCHCRDWithoutCR(t *testing.T) {
 		},
 		ErrorIfCRDPathMissing: true,
 	}
-	log := initLog()
 
 	cfg, err := testenv.Start()
 	if err != nil {
@@ -221,7 +219,7 @@ func TestHasMCHCRDWithoutCR(t *testing.T) {
 		}
 	}()
 
-	_, err = createManager(context.Background(), log, cfg, initMockAgentConfig())
+	_, err = createManager(context.Background(), cfg, initMockAgentConfig())
 	if err != nil {
 		panic(err)
 	}
@@ -234,7 +232,6 @@ func TestHasMCHCRDCR(t *testing.T) {
 		},
 		ErrorIfCRDPathMissing: true,
 	}
-	log := initLog()
 
 	cfg, err := testenv.Start()
 	if err != nil {
@@ -273,7 +270,7 @@ func TestHasMCHCRDCR(t *testing.T) {
 		panic(err)
 	}
 
-	_, err = createManager(context.Background(), log, cfg, initMockAgentConfig())
+	_, err = createManager(context.Background(), cfg, initMockAgentConfig())
 	if !strings.Contains(err.Error(), "failed to create incarnation config-map") {
 		t.Fatalf("expect to have `failed to create incarnation config-map` error, but we got %v", err)
 	}
@@ -287,7 +284,6 @@ func TestHNoMCHCRDHasClusterManagerCRD(t *testing.T) {
 		},
 		ErrorIfCRDPathMissing: true,
 	}
-	log := initLog()
 
 	cfg, err := testenv.Start()
 	if err != nil {
@@ -299,7 +295,7 @@ func TestHNoMCHCRDHasClusterManagerCRD(t *testing.T) {
 		}
 	}()
 
-	_, err = createManager(context.Background(), log, cfg, initMockAgentConfig())
+	_, err = createManager(context.Background(), cfg, initMockAgentConfig())
 	if err != nil {
 		panic(err)
 	}
@@ -313,7 +309,6 @@ func TestHNoMCHCRDHasClusterManagerCRDCR(t *testing.T) {
 		},
 		ErrorIfCRDPathMissing: true,
 	}
-	log := initLog()
 
 	cfg, err := testenv.Start()
 	if err != nil {
@@ -350,7 +345,7 @@ func TestHNoMCHCRDHasClusterManagerCRDCR(t *testing.T) {
 		panic(err)
 	}
 
-	_, err = createManager(context.Background(), log, cfg, initMockAgentConfig())
+	_, err = createManager(context.Background(), cfg, initMockAgentConfig())
 	if !strings.Contains(err.Error(), "failed to create incarnation config-map") {
 		t.Fatalf("expect to have `failed to create incarnation config-map` error, but we got %v", err)
 	}

--- a/agent/cmd/agent/main_test.go
+++ b/agent/cmd/agent/main_test.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -146,6 +147,7 @@ func TestAgent(t *testing.T) {
 	for _, tc := range cases {
 		// this call is required because otherwise flags panics, if args are set between flag.Parse call
 		pflag.CommandLine = pflag.NewFlagSet(tc.name, pflag.ExitOnError)
+		flag.CommandLine = flag.NewFlagSet(tc.name, flag.ExitOnError)
 		// we need a value to set Args[0] to cause flag begins parsing at Args[1]
 		os.Args = append([]string{tc.name}, tc.args...)
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/agent/cmd/agent/main_test.go
+++ b/agent/cmd/agent/main_test.go
@@ -177,6 +177,7 @@ func initMockAgentConfig() *config.AgentConfig {
 	return &config.AgentConfig{
 		PodNameSpace:   "default",
 		ElectionConfig: &commonobjects.LeaderElectionConfig{},
+		MetricsAddress: "0",
 	}
 }
 
@@ -195,7 +196,6 @@ func TestNoMCHClusterManagerCRD(t *testing.T) {
 			panic(err)
 		}
 	}()
-
 	_, err = createManager(context.Background(), cfg, initMockAgentConfig())
 	if err != nil {
 		panic(err)
@@ -220,7 +220,6 @@ func TestHasMCHCRDWithoutCR(t *testing.T) {
 			panic(err)
 		}
 	}()
-
 	_, err = createManager(context.Background(), cfg, initMockAgentConfig())
 	if err != nil {
 		panic(err)

--- a/agent/pkg/config/agent_config.go
+++ b/agent/pkg/config/agent_config.go
@@ -15,4 +15,5 @@ type AgentConfig struct {
 	ElectionConfig               *commonobjects.LeaderElectionConfig
 	Terminating                  bool
 	KubeEventExporterConfigPath  string
+	MetricsAddress               string
 }

--- a/go.mod
+++ b/go.mod
@@ -198,7 +198,7 @@ require (
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
-	go.uber.org/zap v1.21.0 // indirect
+	go.uber.org/zap v1.21.0
 	golang.org/x/crypto v0.6.0 // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/oauth2 v0.3.0 // indirect

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/mohae/deepcopy"
 	"github.com/spf13/pflag"
-	"go.uber.org/zap/zapcore"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -72,12 +71,7 @@ func parseFlags() *managerconfig.ManagerConfig {
 	}
 
 	// add zap flags
-	opts := zap.Options{
-		Development: true,
-		TimeEncoder: func(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
-			enc.AppendString(t.Format("2006-01-02 15:04:05 MST"))
-		},
-	}
+	opts := utils.CtrlZapOptions()
 	defaultFlags := flag.CommandLine
 	opts.BindFlags(defaultFlags)
 	pflag.CommandLine.AddGoFlagSet(defaultFlags)

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -78,9 +78,10 @@ func parseFlags() *managerconfig.ManagerConfig {
 			enc.AppendString(t.Format("2006-01-02 15:04:05 MST"))
 		},
 	}
-	opts.BindFlags(flag.CommandLine)
+	defaultFlags := flag.CommandLine
+	opts.BindFlags(defaultFlags)
+	pflag.CommandLine.AddGoFlagSet(defaultFlags)
 
-	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.StringVar(&managerConfig.ManagerNamespace, "manager-namespace", "open-cluster-management",
 		"The manager running namespace, also used as leader election namespace.")
 	pflag.StringVar(&managerConfig.WatchNamespace, "watch-namespace", "",

--- a/manager/cmd/manager/main_test.go
+++ b/manager/cmd/manager/main_test.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -138,6 +139,7 @@ func TestManager(t *testing.T) {
 	for _, tc := range cases {
 		// this call is required because otherwise flags panics, if args are set between flag.Parse call
 		pflag.CommandLine = pflag.NewFlagSet(tc.name, pflag.ExitOnError)
+		flag.CommandLine = flag.NewFlagSet(tc.name, flag.ExitOnError)
 		// we need a value to set Args[0] to cause flag begins parsing at Args[1]
 		os.Args = append([]string{tc.name}, tc.args...)
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/manager/pkg/eventcollector/event_collector_test.go
+++ b/manager/pkg/eventcollector/event_collector_test.go
@@ -119,9 +119,10 @@ func TestEventCollector(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	messageChan := make(chan *sarama.ConsumerMessage)
 	eventDispatcher := newEventDispatcher(messageChan)
-	eventDispatcher.RegisterProcessor(policyv1.Kind, eventprocessor.NewPolicyProcessor(ctx, pool, &offsetManagerMock{}))
+	eventDispatcher.RegisterProcessor(policyv1.Kind,
+		eventprocessor.NewPolicyProcessor(ctx, pool, &offsetManagerMock{}))
 	go func() {
-		eventDispatcher.Start(ctx)
+		_ = eventDispatcher.Start(ctx)
 	}()
 	event := getEvent()
 	val, err := json.Marshal(event)

--- a/manager/pkg/specsyncer/spec2db/controller/controllers_suite_test.go
+++ b/manager/pkg/specsyncer/spec2db/controller/controllers_suite_test.go
@@ -125,9 +125,9 @@ var _ = AfterSuite(func() {
 	// Set 4 with random
 	if err != nil {
 		time.Sleep(4 * time.Second)
+		Expect(testenv.Stop()).NotTo(HaveOccurred())
 	}
-	cancel()
 	postgresSQL.Stop()
 	Expect(testPostgres.Stop()).NotTo(HaveOccurred())
-	Expect(testenv.Stop()).NotTo(HaveOccurred())
+	cancel()
 })

--- a/operator/main.go
+++ b/operator/main.go
@@ -25,7 +25,9 @@ import (
 
 	routev1 "github.com/openshift/api/route/v1"
 	operatorsv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
+	"github.com/spf13/pflag"
 	hypershiftdeploymentv1alpha1 "github.com/stolostron/hypershift-deployment-controller/api/v1alpha1"
+	"go.uber.org/zap/zapcore"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -38,6 +40,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -65,6 +68,7 @@ import (
 	hubofhubscontrollers "github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/hubofhubs"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	commonobjects "github.com/stolostron/multicluster-global-hub/pkg/objects"
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
 var (
@@ -111,6 +115,7 @@ func main() {
 
 func doMain(ctx context.Context, cfg *rest.Config) int {
 	operatorConfig := parseFlags()
+	utils.PrintVersion(setupLog)
 
 	// build filtered resource map
 	newCacheFunc := buildResourceFilterMap()
@@ -194,21 +199,29 @@ func doMain(ctx context.Context, cfg *rest.Config) int {
 }
 
 func parseFlags() *operatorConfig {
-	config := &operatorConfig{}
-	flag.StringVar(&config.MetricsAddress, "metrics-bind-address", ":8080",
-		"The address the metric endpoint binds to.")
-	flag.StringVar(&config.ProbeAddress, "health-probe-bind-address", ":8081",
-		"The address the probe endpoint binds to.")
-	flag.BoolVar(&config.LeaderElection, "leader-election", false,
-		"Enable leader election for controller manager. ")
+	config := &operatorConfig{
+		PodNamespace: hubofhubsconfig.GetDefaultNamespace(),
+	}
+
+	// add zap flags
 	opts := zap.Options{
 		Development: true,
+		TimeEncoder: func(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
+			enc.AppendString(t.Format("2006-01-02 15:04:05 MST"))
+		},
 	}
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 	opts.BindFlags(flag.CommandLine)
-	flag.Parse()
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	pflag.StringVar(&config.MetricsAddress, "metrics-bind-address", ":8080",
+		"The address the metric endpoint binds to.")
+	pflag.StringVar(&config.ProbeAddress, "health-probe-bind-address", ":8081",
+		"The address the probe endpoint binds to.")
+	pflag.BoolVar(&config.LeaderElection, "leader-election", false,
+		"Enable leader election for controller manager. ")
+	pflag.Parse()
 
-	config.PodNamespace = hubofhubsconfig.GetDefaultNamespace()
+	// set zap logger
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 	return config
 }
 

--- a/operator/main.go
+++ b/operator/main.go
@@ -27,7 +27,6 @@ import (
 	operatorsv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
 	"github.com/spf13/pflag"
 	hypershiftdeploymentv1alpha1 "github.com/stolostron/hypershift-deployment-controller/api/v1alpha1"
-	"go.uber.org/zap/zapcore"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -204,12 +203,7 @@ func parseFlags() *operatorConfig {
 	}
 
 	// add zap flags
-	opts := zap.Options{
-		Development: true,
-		TimeEncoder: func(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
-			enc.AppendString(t.Format("2006-01-02 15:04:05 MST"))
-		},
-	}
+	opts := utils.CtrlZapOptions()
 	defaultFlags := flag.CommandLine
 	opts.BindFlags(defaultFlags)
 	pflag.CommandLine.AddGoFlagSet(defaultFlags)

--- a/operator/main.go
+++ b/operator/main.go
@@ -210,8 +210,9 @@ func parseFlags() *operatorConfig {
 			enc.AppendString(t.Format("2006-01-02 15:04:05 MST"))
 		},
 	}
-	opts.BindFlags(flag.CommandLine)
-	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	defaultFlags := flag.CommandLine
+	opts.BindFlags(defaultFlags)
+	pflag.CommandLine.AddGoFlagSet(defaultFlags)
 	pflag.StringVar(&config.MetricsAddress, "metrics-bind-address", ":8080",
 		"The address the metric endpoint binds to.")
 	pflag.StringVar(&config.ProbeAddress, "health-probe-bind-address", ":8081",

--- a/operator/main_test.go
+++ b/operator/main_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
+	"github.com/spf13/pflag"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
 	operatorconstants "github.com/stolostron/multicluster-global-hub/operator/pkg/constants"
 )
@@ -69,25 +70,25 @@ func TestOperator(t *testing.T) {
 		expectedExit         int
 	}{
 		{"flag set with leader-election disabled", []string{
-			"-leader-election",
+			"--leader-election",
 			"false",
-			"-metrics-bind-address",
+			"--metrics-bind-address",
 			":18080",
-			"-health-probe-bind-address",
+			"--health-probe-bind-address",
 			":18081",
 		}, nil, 0},
 		{"flag set with leader-election enabled", []string{
-			"-leader-election",
-			"-metrics-bind-address",
+			"--leader-election",
+			"--metrics-bind-address",
 			":18080",
-			"-health-probe-bind-address",
+			"--health-probe-bind-address",
 			":18081",
 		}, nil, 0},
 		{"flag set with customized leader-election configuration", []string{
-			"-leader-election",
-			"-metrics-bind-address",
+			"--leader-election",
+			"--metrics-bind-address",
 			":18080",
-			"-health-probe-bind-address",
+			"--health-probe-bind-address",
 			":18081",
 		}, &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -100,6 +101,7 @@ func TestOperator(t *testing.T) {
 	for _, tc := range cases {
 		// this call is required because otherwise flags panics, if args are set between flag.Parse call
 		flag.CommandLine = flag.NewFlagSet(tc.name, flag.ExitOnError)
+		pflag.CommandLine = pflag.NewFlagSet(tc.name, pflag.ExitOnError)
 		// we need a value to set Args[0] to cause flag begins parsing at Args[1]
 		os.Args = append([]string{tc.name}, tc.args...)
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -3,11 +3,24 @@ package utils
 import (
 	"fmt"
 	"runtime"
+	"time"
 
 	"github.com/go-logr/logr"
+	"go.uber.org/zap/zapcore"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 func PrintVersion(log logr.Logger) {
 	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
 	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
+}
+
+func CtrlZapOptions() zap.Options {
+	opts := zap.Options{
+		Development: true,
+		TimeEncoder: func(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
+			enc.AppendString(t.Format("2006-01-02 15:04:05 MST"))
+		},
+	}
+	return opts
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,13 @@
+package utils
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/go-logr/logr"
+)
+
+func PrintVersion(log logr.Logger) {
+	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
+	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
+}


### PR DESCRIPTION
Before formatting
```bash
{"level":"info","ts":1684912250.9639475,"logger":"db-worker-pool","msg":"started worker","WorkerID":3}
{"level":"info","ts":1684912250.9639482,"logger":"db-worker-pool","msg":"started worker","WorkerID":8}
{"level":"info","ts":1684912250.963958,"logger":"db-worker-pool","msg":"started worker","WorkerID":9}
{"level":"info","ts":1684912250.9638596,"logger":"db-worker-pool","msg":"started worker","WorkerID":16}
{"level":"info","ts":1684912250.963951,"logger":"db-worker-pool","msg":"started worker","WorkerID":15}
```
After formatting
```bash
2023-05-24 08:35:36 UTC INFO    condition-reconciler    updating deployment status      {"name": "multicluster-global-hub-grafana", "message": "Deployment has minimum availability."}
2023-05-24 08:35:41 UTC INFO    addon-controller.values rendering manifests     {"cluster": "kind-hub2", "pullSecret": "", "image": "quay.io/myan/multicluster-global-hub-agent:latest"}
2023-05-24 08:35:41 UTC INFO    addon-controller.values rendering manifests     {"cluster": "kind-hub2", "pullSecret": "", "image": "quay.io/myan/multicluster-global-hub-agent:latest"}
2023-05-24 08:35:41 UTC INFO    addon-controller.values rendering manifests     {"cluster": "kind-hub1", "pullSecret": "", "image": "quay.io/myan/multicluster-global-hub-agent:latest"}
```