### PR TITLE
cluster id is not synced to the local_status.compliance

### DIFF
--- a/operator/pkg/controllers/hubofhubs/database/2.functions.sql
+++ b/operator/pkg/controllers/hubofhubs/database/2.functions.sql
@@ -294,7 +294,7 @@ CREATE OR REPLACE FUNCTION public.set_cluster_id_to_local_compliance() RETURNS t
 BEGIN
   UPDATE local_status.compliance set cluster_id=(SELECT cluster_id FROM status.managed_clusters
   WHERE payload -> 'metadata' ->> 'name' = NEW.cluster_name AND leaf_hub_name = NEW.leaf_hub_name)
-  WHERE cluster_name = NEW.cluster_name AND leaf_hub_name = NEW.leaf_hub_name AND cluster_id IS NULL;
+  WHERE cluster_name = NEW.cluster_name AND leaf_hub_name = NEW.leaf_hub_name;
   RETURN NEW;
 END;
 $$;
@@ -305,7 +305,7 @@ CREATE OR REPLACE FUNCTION public.set_cluster_id_to_compliance() RETURNS trigger
 BEGIN
   UPDATE status.compliance set cluster_id=(SELECT cluster_id FROM status.managed_clusters
   WHERE payload -> 'metadata' ->> 'name' = NEW.cluster_name AND leaf_hub_name = NEW.leaf_hub_name)
-  WHERE cluster_name = NEW.cluster_name AND leaf_hub_name = NEW.leaf_hub_name AND cluster_id IS NULL;
+  WHERE cluster_name = NEW.cluster_name AND leaf_hub_name = NEW.leaf_hub_name;
   RETURN NEW;
 END;
 $$;

--- a/operator/pkg/controllers/hubofhubs/database/4.trigger.sql
+++ b/operator/pkg/controllers/hubofhubs/database/4.trigger.sql
@@ -79,3 +79,16 @@ CREATE TRIGGER trigger_backup_deleted_managed_cluster
 AFTER DELETE ON status.managed_clusters
 FOR EACH ROW
 EXECUTE FUNCTION history.move_managed_cluster_to_history();
+--- set cluster_id to local_status/status compliance history
+DROP TRIGGER IF EXISTS set_cluster_id_to_compliance ON local_status.compliance;
+CREATE TRIGGER set_cluster_id_to_compliance
+BEFORE INSERT OR UPDATE ON local_status.compliance
+FOR EACH ROW
+EXECUTE FUNCTION local_status.set_cluster_id_to_compliance();
+
+
+DROP TRIGGER IF EXISTS set_cluster_id_to_compliance ON status.compliance;
+CREATE TRIGGER set_cluster_id_to_compliance
+BEFORE INSERT OR UPDATE ON status.compliance
+FOR EACH ROW
+EXECUTE FUNCTION status.set_cluster_id_to_compliance();


### PR DESCRIPTION
Refers: https://issues.redhat.com/browse/ACM-5467

The `cluster_id` in `status.managed_clusters` table may be changed over time. So we need to update the `cluster_id` in `local_status.compliance`
https://github.com/stolostron/multicluster-global-hub/blob/4c86a47c93193c58c9053ba8b5fd2a05ef676fd0/manager/pkg/statussyncer/transport2db/syncer/dbsyncer/managed_clusters_db_syncer.go#L88-L94