### PR TITLE
watch the transport and storage secret 

### DIFF
--- a/operator/main.go
+++ b/operator/main.go
@@ -36,11 +36,13 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -227,7 +229,7 @@ func buildResourceFilterMap() cache.NewCacheFunc {
 	return cache.BuilderWithOptions(cache.Options{
 		SelectorsByObject: cache.SelectorsByObject{
 			&corev1.Secret{}: {
-				Label: labelSelector,
+				Field: fields.SelectorFromSet(fields.Set{"metadata.namespace": hubofhubsconfig.GetDefaultNamespace()}),
 			},
 			&corev1.ConfigMap{}: {
 				Label: labelSelector,

--- a/operator/pkg/controllers/hubofhubs/globalhub_config.go
+++ b/operator/pkg/controllers/hubofhubs/globalhub_config.go
@@ -2,6 +2,7 @@ package hubofhubs
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
@@ -23,10 +24,19 @@ func (r *MulticlusterGlobalHubReconciler) reconcileSystemConfig(ctx context.Cont
 ) error {
 	log := r.Log.WithName("config")
 	// set image overrides
+	log.Info("set operand images; add label to storage/transport secret; reconcile global hub configmap")
 	if err := config.SetImageOverrides(mgh); err != nil {
 		return err
 	}
-	log.Info("global hub image overrides set")
+
+	if err := r.addOperatorLabel(ctx, config.GetDefaultNamespace(),
+		operatorconstants.GHStorageSecretName); err != nil {
+		return err
+	}
+	if err := r.addOperatorLabel(ctx, config.GetDefaultNamespace(),
+		operatorconstants.GHTransportSecretName); err != nil {
+		return err
+	}
 
 	if err := r.Client.Get(ctx,
 		types.NamespacedName{
@@ -93,4 +103,22 @@ func (r *MulticlusterGlobalHubReconciler) reconcileSystemConfig(ctx context.Cont
 	}
 	config.SetGlobalHubAgentConfig(expectedHoHConfigMap)
 	return nil
+}
+
+func (r *MulticlusterGlobalHubReconciler) addOperatorLabel(ctx context.Context, namespace, name string) error {
+	// the controller runtime client will not get the labels of the secret, since it is be filtered by the label
+	secret, err := r.KubeClient.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get secret %s/%s: %w", namespace, name, err)
+	}
+	if secret.Labels == nil {
+		secret.Labels = map[string]string{}
+	}
+	if val, found := secret.Labels[constants.GlobalHubOwnerLabelKey]; found &&
+		val == constants.GHOperatorOwnerLabelVal {
+		return nil
+	}
+	secret.Labels[constants.GlobalHubOwnerLabelKey] = constants.GHOperatorOwnerLabelVal
+	_, err = r.KubeClient.CoreV1().Secrets(namespace).Update(ctx, secret, metav1.UpdateOptions{})
+	return err
 }

--- a/operator/pkg/controllers/hubofhubs/globalhub_controller.go
+++ b/operator/pkg/controllers/hubofhubs/globalhub_controller.go
@@ -328,6 +328,13 @@ func (r *MulticlusterGlobalHubReconciler) SetupWithManager(mgr ctrl.Manager) err
 		},
 	}
 
+	globalHubEventHandler := handler.EnqueueRequestsFromMapFunc(func(obj client.Object) []reconcile.Request {
+		return []reconcile.Request{
+			// trigger MGH instance reconcile
+			{NamespacedName: config.GetHoHMGHNamespacedName()},
+		}
+	})
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&operatorv1alpha3.MulticlusterGlobalHub{}, builder.WithPredicates(mghPred)).
 		Owns(&appsv1.Deployment{}, builder.WithPredicates(ownPred)).
@@ -338,58 +345,23 @@ func (r *MulticlusterGlobalHubReconciler) SetupWithManager(mgr ctrl.Manager) err
 		Owns(&rbacv1.RoleBinding{}, builder.WithPredicates(ownPred)).
 		Owns(&routev1.Route{}, builder.WithPredicates(ownPred)).
 		Watches(&source.Kind{Type: &admissionregistrationv1.MutatingWebhookConfiguration{}},
-			handler.EnqueueRequestsFromMapFunc(func(obj client.Object) []reconcile.Request {
-				return []reconcile.Request{
-					// trigger MGH instance reconcile
-					{NamespacedName: config.GetHoHMGHNamespacedName()},
-				}
-			}), builder.WithPredicates(webhookPred)).
+			globalHubEventHandler, builder.WithPredicates(webhookPred)).
 		// secondary watch for configmap
 		Watches(&source.Kind{Type: &corev1.ConfigMap{}},
-			handler.EnqueueRequestsFromMapFunc(func(obj client.Object) []reconcile.Request {
-				return []reconcile.Request{
-					// trigger MGH instance reconcile
-					{NamespacedName: config.GetHoHMGHNamespacedName()},
-				}
-			}), builder.WithPredicates(resPred)).
+			globalHubEventHandler, builder.WithPredicates(resPred)).
 		// secondary watch for namespace
 		Watches(&source.Kind{Type: &corev1.Namespace{}},
-			handler.EnqueueRequestsFromMapFunc(func(obj client.Object) []reconcile.Request {
-				return []reconcile.Request{
-					// trigger MGH instance reconcile
-					{NamespacedName: config.GetHoHMGHNamespacedName()},
-				}
-			}), builder.WithPredicates(resPred)).
+			globalHubEventHandler, builder.WithPredicates(resPred)).
 		// secondary watch for clusterrole
 		Watches(&source.Kind{Type: &rbacv1.ClusterRole{}},
-			handler.EnqueueRequestsFromMapFunc(func(obj client.Object) []reconcile.Request {
-				return []reconcile.Request{
-					// trigger MGH instance reconcile
-					{NamespacedName: config.GetHoHMGHNamespacedName()},
-				}
-			}), builder.WithPredicates(resPred)).
+			globalHubEventHandler, builder.WithPredicates(resPred)).
 		// secondary watch for clusterrolebinding
 		Watches(&source.Kind{Type: &rbacv1.ClusterRoleBinding{}},
-			handler.EnqueueRequestsFromMapFunc(func(obj client.Object) []reconcile.Request {
-				return []reconcile.Request{
-					// trigger MGH instance reconcile
-					{NamespacedName: config.GetHoHMGHNamespacedName()},
-				}
-			}), builder.WithPredicates(resPred)).
+			globalHubEventHandler, builder.WithPredicates(resPred)).
 		// secondary watch for clustermanagementaddon
 		Watches(&source.Kind{Type: &addonv1alpha1.ClusterManagementAddOn{}},
-			handler.EnqueueRequestsFromMapFunc(func(obj client.Object) []reconcile.Request {
-				return []reconcile.Request{
-					// trigger MGH instance reconcile
-					{NamespacedName: config.GetHoHMGHNamespacedName()},
-				}
-			}), builder.WithPredicates(resPred)).
+			globalHubEventHandler, builder.WithPredicates(resPred)).
 		Watches(&source.Kind{Type: &corev1.Secret{}},
-			handler.EnqueueRequestsFromMapFunc(func(obj client.Object) []reconcile.Request {
-				return []reconcile.Request{
-					// trigger MGH instance reconcile
-					{NamespacedName: config.GetHoHMGHNamespacedName()},
-				}
-			}), builder.WithPredicates(secretPred)).
+			globalHubEventHandler, builder.WithPredicates(secretPred)).
 		Complete(r)
 }

--- a/operator/pkg/controllers/hubofhubs/globalhub_grafana.go
+++ b/operator/pkg/controllers/hubofhubs/globalhub_grafana.go
@@ -147,6 +147,9 @@ func (r *MulticlusterGlobalHubReconciler) GenerateGrafanaDataSourceSecret(
 		return dsSecret.GetName(), err
 	}
 
+	if grafanaDSFound.Data == nil {
+		grafanaDSFound.Data = make(map[string][]byte)
+	}
 	grafanaDSFound.Data[datasourceKey] = datasourceVal
 	if err = r.Client.Update(ctx, grafanaDSFound); err != nil {
 		return dsSecret.GetName(), err

--- a/operator/pkg/controllers/hubofhubs/globalhub_grafana.go
+++ b/operator/pkg/controllers/hubofhubs/globalhub_grafana.go
@@ -147,6 +147,11 @@ func (r *MulticlusterGlobalHubReconciler) GenerateGrafanaDataSourceSecret(
 		return dsSecret.GetName(), err
 	}
 
+	grafanaDSFound.Data[datasourceKey] = datasourceVal
+	if err = r.Client.Update(ctx, grafanaDSFound); err != nil {
+		return dsSecret.GetName(), err
+	}
+
 	return dsSecret.GetName(), nil
 }
 


### PR DESCRIPTION
Refers: https://issues.redhat.com/browse/ACM-4732
Propagate the transport/storage secret to the regional hub when they are updated

Previous, the global hub only watch the secret with the [owner lablel](https://github.com/stolostron/multicluster-global-hub/blob/dd3e9127bf199c17f3e5c1311a2beaa51573bc61/operator/main.go#L79). Then it will filter the `transport/storage secret`. 
Because the cache selector of the controller runtime manager does not have an OR operation, we can cache both types of secret at the same time.

In order to avoid caching a large number of secrets, at the same time, the above two types of secrets will not be missed. A compromise is to only cache the secrets under the global hub namespace, and then use the event handler to filter the secrets that need to be reconciled.