### PR TITLE
remove unnecessary parameters from global hub api

### DIFF
--- a/operator/apis/v1alpha3/multiclusterglobalhub_types.go
+++ b/operator/apis/v1alpha3/multiclusterglobalhub_types.go
@@ -21,28 +21,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// AggregationLevel specifies the level of aggregation leaf hubs should do before sending the information
-// +kubebuilder:validation:Enum=full;minimal
-type AggregationLevel string
-
-const (
-	// Full is an AggregationLevel
-	Full AggregationLevel = "full"
-	// Minimal is an AggregationLevel
-	Minimal AggregationLevel = "minimal"
-)
-
-// MessageCompressionType specifies the compression type of transport message between global hub and regional hubs
-// +kubebuilder:validation:Enum=gzip;no-op
-type MessageCompressionType string
-
-const (
-	// GzipCompressType is an MessageCompressionType
-	GzipCompressType MessageCompressionType = "gzip"
-	// NoopCompressType is an MessageCompressionType
-	NoopCompressType MessageCompressionType = "no-op"
-)
-
 // DataLayerType specifies the type of data layer that global hub stores and transports the data.
 // +kubebuilder:validation:Enum:="native";"largeScale"
 type DataLayerType string
@@ -77,12 +55,6 @@ type MulticlusterGlobalHub struct {
 
 // MulticlusterGlobalHubSpec defines the desired state of MulticlusterGlobalHub
 type MulticlusterGlobalHubSpec struct {
-	// +kubebuilder:default:=full
-	AggregationLevel AggregationLevel `json:"aggregationLevel,omitempty"` // full or minimal
-	// +kubebuilder:default:=gzip
-	MessageCompressionType MessageCompressionType `json:"messageCompressionType,omitempty"` // gzip or no-op
-	// +kubebuilder:default:=true
-	EnableLocalPolicies bool `json:"enableLocalPolicies,omitempty"`
 	// Pull policy of the multicluster global hub images
 	// +optional
 	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`

--- a/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -26,7 +26,7 @@ metadata:
     categories: Integration & Delivery,OpenShift Optional
     certified: "false"
     containerImage: quay.io/stolostron/multicluster-global-hub-operator:latest
-    createdAt: "2023-06-07T08:21:46Z"
+    createdAt: "2023-06-09T01:18:53Z"
     description: Manages the installation and upgrade of the Multicluster Global Hub.
     operatorframework.io/suggested-namespace: open-cluster-management
     operators.operatorframework.io/builder: operator-sdk-v1.28.0+git
@@ -60,9 +60,10 @@ spec:
     you must create database for the multicluster global hub. You must create a secret
     named multicluster-global-hub-storage that contains the database access credential
     in `open-cluster-management` namespace. You can run the following command to create
-    the secret: \n\n```\nkubectl create secret generic storage-secret -n open-cluster-management
-    \\\n  --from-literal=database_uri=<postgresql-uri> \\\n --from-file=ca.crt=<CA-for-postgres-server>
-    \n```\n>_Note:_ There is a sample script available [here](https://github.com/stolostron/multicluster-global-hub/tree/main/operator/config/samples/storage)(Note:
+    the secret: \n\n```\nkubectl create secret generic multicluster-global-hub-storage
+    -n open-cluster-management \\\n  --from-literal=database_uri=<postgresql-uri>
+    \\\n --from-file=ca.crt=<CA-for-postgres-server> \n```\n>_Note:_ There is a sample
+    script available [here](https://github.com/stolostron/multicluster-global-hub/tree/main/operator/config/samples/storage)(Note:
     the client version of kubectl must be v1.21+) to install postgres in `hoh-postgres`
     namespace and create the secret `multicluster-global-hub-storage` in namespace
     `open-cluster-management` automatically. To override the secret namespace, set

--- a/operator/bundle/manifests/operator.open-cluster-management.io_multiclusterglobalhubs.yaml
+++ b/operator/bundle/manifests/operator.open-cluster-management.io_multiclusterglobalhubs.yaml
@@ -38,14 +38,6 @@ spec:
           spec:
             description: MulticlusterGlobalHubSpec defines the desired state of MulticlusterGlobalHub
             properties:
-              aggregationLevel:
-                default: full
-                description: AggregationLevel specifies the level of aggregation leaf
-                  hubs should do before sending the information
-                enum:
-                - full
-                - minimal
-                type: string
               dataLayer:
                 description: 'DataLayer can be configured to use a different data
                   layer. native: use the native data layer (default). largeScale:
@@ -84,22 +76,11 @@ spec:
                 required:
                 - type
                 type: object
-              enableLocalPolicies:
-                default: true
-                type: boolean
               imagePullPolicy:
                 description: Pull policy of the multicluster global hub images
                 type: string
               imagePullSecret:
                 description: Pull secret of the multicluster global hub images
-                type: string
-              messageCompressionType:
-                default: gzip
-                description: MessageCompressionType specifies the compression type
-                  of transport message between global hub and regional hubs
-                enum:
-                - gzip
-                - no-op
                 type: string
               nodeSelector:
                 additionalProperties:

--- a/operator/bundle/metadata/annotations.yaml
+++ b/operator/bundle/metadata/annotations.yaml
@@ -6,7 +6,7 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: multicluster-global-hub-operator
   operators.operatorframework.io.bundle.channels.v1: prerelease-2.8
   operators.operatorframework.io.bundle.channel.default.v1: prerelease-2.8
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.23.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.28.0+git
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 

--- a/operator/config/crd/bases/operator.open-cluster-management.io_multiclusterglobalhubs.yaml
+++ b/operator/config/crd/bases/operator.open-cluster-management.io_multiclusterglobalhubs.yaml
@@ -39,14 +39,6 @@ spec:
           spec:
             description: MulticlusterGlobalHubSpec defines the desired state of MulticlusterGlobalHub
             properties:
-              aggregationLevel:
-                default: full
-                description: AggregationLevel specifies the level of aggregation leaf
-                  hubs should do before sending the information
-                enum:
-                - full
-                - minimal
-                type: string
               dataLayer:
                 description: 'DataLayer can be configured to use a different data
                   layer. native: use the native data layer (default). largeScale:
@@ -85,22 +77,11 @@ spec:
                 required:
                 - type
                 type: object
-              enableLocalPolicies:
-                default: true
-                type: boolean
               imagePullPolicy:
                 description: Pull policy of the multicluster global hub images
                 type: string
               imagePullSecret:
                 description: Pull secret of the multicluster global hub images
-                type: string
-              messageCompressionType:
-                default: gzip
-                description: MessageCompressionType specifies the compression type
-                  of transport message between global hub and regional hubs
-                enum:
-                - gzip
-                - no-op
                 type: string
               nodeSelector:
                 additionalProperties:

--- a/operator/config/manifests/bases/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -43,9 +43,10 @@ spec:
     you must create database for the multicluster global hub. You must create a secret
     named multicluster-global-hub-storage that contains the database access credential
     in `open-cluster-management` namespace. You can run the following command to create
-    the secret: \n\n```\nkubectl create secret generic multicluster-global-hub-storage -n open-cluster-management
-    \\\n  --from-literal=database_uri=<postgresql-uri> \\\n --from-file=ca.crt=<CA-for-postgres-server>
-    \n```\n>_Note:_ There is a sample script available [here](https://github.com/stolostron/multicluster-global-hub/tree/main/operator/config/samples/storage)(Note:
+    the secret: \n\n```\nkubectl create secret generic multicluster-global-hub-storage
+    -n open-cluster-management \\\n  --from-literal=database_uri=<postgresql-uri>
+    \\\n --from-file=ca.crt=<CA-for-postgres-server> \n```\n>_Note:_ There is a sample
+    script available [here](https://github.com/stolostron/multicluster-global-hub/tree/main/operator/config/samples/storage)(Note:
     the client version of kubectl must be v1.21+) to install postgres in `hoh-postgres`
     namespace and create the secret `multicluster-global-hub-storage` in namespace
     `open-cluster-management` automatically. To override the secret namespace, set

--- a/operator/pkg/constants/constants.go
+++ b/operator/pkg/constants/constants.go
@@ -95,3 +95,25 @@ const (
 	// GHAgentInstallACMHubLabelKey is to indicate whether to install ACM hub on the agent
 	GHAgentACMHubInstallLabelKey = "global-hub.open-cluster-management.io/hub-cluster-install"
 )
+
+// AggregationLevel specifies the level of aggregation leaf hubs should do before sending the information
+// Enum=full;minimal
+type AggregationLevel string
+
+const (
+	// FullAggregation is an AggregationLevel
+	FullAggregation AggregationLevel = "full"
+	// MinimalAggregation is an AggregationLevel
+	MinimalAggregation AggregationLevel = "minimal"
+)
+
+// MessageCompressionType specifies the compression type of transport message between global hub and regional hubs
+// Enum=gzip;no-op
+type MessageCompressionType string
+
+const (
+	// GzipCompressType is an MessageCompressionType
+	GzipCompressType MessageCompressionType = "gzip"
+	// NoopCompressType is an MessageCompressionType
+	NoopCompressType MessageCompressionType = "no-op"
+)

--- a/operator/pkg/controllers/addon/addon_manifests.go
+++ b/operator/pkg/controllers/addon/addon_manifests.go
@@ -155,11 +155,6 @@ func (a *HohAgentAddon) GetValues(cluster *clusterv1.ManagedCluster,
 		return nil, err
 	}
 
-	messageCompressionType := string(mgh.Spec.MessageCompressionType)
-	if messageCompressionType == "" {
-		messageCompressionType = string(operatorv1alpha3.GzipCompressType)
-	}
-
 	image, err := a.getOverrideImage(mgh, cluster)
 	if err != nil {
 		return nil, err
@@ -178,7 +173,7 @@ func (a *HohAgentAddon) GetValues(cluster *clusterv1.ManagedCluster,
 		KafkaCACert:            kafkaCACert,
 		KafkaClientCert:        kafkaClientCert,
 		KafkaClientKey:         kafkaClientKey,
-		MessageCompressionType: messageCompressionType,
+		MessageCompressionType: string(operatorconstants.GzipCompressType),
 		TransportType:          string(transport.Kafka),
 		TransportFormat:        string(mgh.Spec.DataLayer.LargeScale.Kafka.TransportFormat),
 		LeaseDuration:          strconv.Itoa(a.leaderElectionConfig.LeaseDuration),

--- a/operator/pkg/controllers/hubofhubs/globalhub_manager.go
+++ b/operator/pkg/controllers/hubofhubs/globalhub_manager.go
@@ -48,11 +48,6 @@ func (r *MulticlusterGlobalHubReconciler) reconcileManager(ctx context.Context,
 		return fmt.Errorf("failed to get random session secret for oauth-proxy: %v", err)
 	}
 
-	messageCompressionType := string(mgh.Spec.MessageCompressionType)
-	if messageCompressionType == "" {
-		messageCompressionType = string(operatorv1alpha3.GzipCompressType)
-	}
-
 	// create new HoHRenderer and HoHDeployer
 	hohRenderer, hohDeployer := renderer.NewHoHRenderer(fs), deployer.NewHoHDeployer(r.Client)
 
@@ -103,7 +98,7 @@ func (r *MulticlusterGlobalHubReconciler) reconcileManager(ctx context.Context,
 			KafkaClientCert:        kafkaClientCert,
 			KafkaClientKey:         kafkaClientKey,
 			KafkaBootstrapServer:   kafkaBootstrapServer,
-			MessageCompressionType: messageCompressionType,
+			MessageCompressionType: string(operatorconstants.GzipCompressType),
 			TransportType:          string(transport.Kafka),
 			TransportFormat:        string(mgh.Spec.DataLayer.LargeScale.Kafka.TransportFormat),
 			Namespace:              config.GetDefaultNamespace(),

--- a/operator/pkg/controllers/hubofhubs/integration_test.go
+++ b/operator/pkg/controllers/hubofhubs/integration_test.go
@@ -107,10 +107,6 @@ var _ = Describe("MulticlusterGlobalHub controller", Ordered, func() {
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
-			// make sure the default values are filled
-			Expect(createdMGH.Spec.AggregationLevel).Should(Equal(operatorv1alpha3.Full))
-			Expect(createdMGH.Spec.EnableLocalPolicies).Should(Equal(true))
-
 			// check finalizer is not added to MGH instance
 			By("By checking finalizer is not added to MGH instance")
 			Expect(createdMGH.GetFinalizers()).Should(BeNil())
@@ -150,8 +146,8 @@ var _ = Describe("MulticlusterGlobalHub controller", Ordered, func() {
 			}, timeout, interval).Should(BeTrue())
 
 			// make sure the default values are filled
-			Expect(createdMGH.Spec.AggregationLevel).Should(Equal(operatorv1alpha3.Full))
-			Expect(createdMGH.Spec.EnableLocalPolicies).Should(Equal(true))
+			// Expect(createdMGH.Spec.AggregationLevel).Should(Equal(operatorv1alpha3.Full))
+			// Expect(createdMGH.Spec.EnableLocalPolicies).Should(Equal(true))
 
 			// check finalizer is not added to MGH instance
 			By("By checking finalizer is not added to MGH instance")
@@ -195,8 +191,8 @@ var _ = Describe("MulticlusterGlobalHub controller", Ordered, func() {
 			}, timeout, interval).Should(BeTrue())
 
 			// make sure the default values are filled
-			Expect(createdMGH.Spec.AggregationLevel).Should(Equal(operatorv1alpha3.Full))
-			Expect(createdMGH.Spec.EnableLocalPolicies).Should(Equal(true))
+			// Expect(createdMGH.Spec.AggregationLevel).Should(Equal(operatorv1alpha3.Full))
+			// Expect(createdMGH.Spec.EnableLocalPolicies).Should(Equal(true))
 
 			// check finalizer should not be added to MGH instance
 			Eventually(func() error {
@@ -312,8 +308,8 @@ var _ = Describe("MulticlusterGlobalHub controller", Ordered, func() {
 			}, timeout, interval).Should(Succeed())
 
 			// make sure the default values are filled
-			Expect(createdMGH.Spec.AggregationLevel).Should(Equal(operatorv1alpha3.Full))
-			Expect(createdMGH.Spec.EnableLocalPolicies).Should(Equal(true))
+			// Expect(createdMGH.Spec.AggregationLevel).Should(Equal(operatorv1alpha3.Full))
+			// Expect(createdMGH.Spec.EnableLocalPolicies).Should(Equal(true))
 
 			Eventually(func() error {
 				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(mgh), createdMGH)).Should(Succeed())
@@ -351,11 +347,6 @@ var _ = Describe("MulticlusterGlobalHub controller", Ordered, func() {
 			hohRenderer := renderer.NewHoHRenderer(testFS)
 
 			By("By checking the multicluster-global-hub-manager resources are created as expected")
-			messageCompressionType := string(mgh.Spec.MessageCompressionType)
-			if messageCompressionType == "" {
-				messageCompressionType = string(operatorv1alpha3.GzipCompressType)
-			}
-
 			imagePullPolicy := corev1.PullAlways
 			if mgh.Spec.ImagePullPolicy != "" {
 				imagePullPolicy = mgh.Spec.ImagePullPolicy
@@ -397,7 +388,7 @@ var _ = Describe("MulticlusterGlobalHub controller", Ordered, func() {
 					KafkaClientCert:        base64.RawStdEncoding.EncodeToString([]byte(kafkaClientCert)),
 					KafkaClientKey:         base64.RawStdEncoding.EncodeToString([]byte(KafkaClientKey)),
 					KafkaBootstrapServer:   kafkaBootstrapServer,
-					MessageCompressionType: messageCompressionType,
+					MessageCompressionType: string(operatorconstants.GzipCompressType),
 					TransportType:          string(transport.Kafka),
 					TransportFormat:        string(mgh.Spec.DataLayer.LargeScale.Kafka.TransportFormat),
 					Namespace:              config.GetDefaultNamespace(),


### PR DESCRIPTION
Refers: https://issues.redhat.com/browse/ACM-5848
Remove the following fields from API:
- `AggregationLevel`: set the `AggregationLevel` value always with `full`
- `MessageCompressionType`: set the value always with `gzip`, there is an issue if cloudevents haven't used it to compress the event payload. I will enhance the use of this parameter when other things are done
- `EnableLocalPolicies`: set it with always, since this feature is necessary for this delivery. 