### PR TITLE
[ACM-5821] Updated offending clusters/policies unknown table headers

### DIFF
--- a/operator/pkg/controllers/hubofhubs/manifests/grafana/acm-global-offending-clusters.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/grafana/acm-global-offending-clusters.yaml
@@ -24,7 +24,7 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "iteration": 1686272805186,
+      "iteration": 1686596642857,
       "links": [
         {
           "asDropdown": false,
@@ -384,6 +384,7 @@ data:
         },
         {
           "datasource": null,
+          "description": "List of offending managed clusters by label: $label.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -514,6 +515,7 @@ data:
           "panels": [
             {
               "datasource": null,
+              "description": "List of unknown managed clusters by label: $label.",
               "fieldConfig": {
                 "defaults": {
                   "color": {
@@ -627,7 +629,7 @@ data:
                   ]
                 }
               ],
-              "title": "Offending Clusters (By $label)",
+              "title": "Unknown Clusters (By $label)",
               "transformations": [
                 {
                   "id": "organize",

--- a/operator/pkg/controllers/hubofhubs/manifests/grafana/acm-global-offending-policies.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/grafana/acm-global-offending-policies.yaml
@@ -785,8 +785,8 @@ data:
         ]
       },
       "time": {
-        "from": "2023-06-11T00:00:00.000Z",
-        "to": "2023-06-11T00:00:00.000Z"
+        "from": "now-7d",
+        "to": "now"
       },
       "timepicker": {},
       "timezone": "utc",

--- a/operator/pkg/controllers/hubofhubs/manifests/grafana/acm-global-offending-policies.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/grafana/acm-global-offending-policies.yaml
@@ -24,7 +24,7 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "iteration": 1686215172874,
+      "iteration": 1686595096776,
       "links": [
         {
           "asDropdown": false,
@@ -531,7 +531,7 @@ data:
           "panels": [
             {
               "datasource": "${datasource}",
-              "description": "List of offending managed cluster policies by standard, category, and control.",
+              "description": "List of unknown managed cluster policies by standard, category, and control.",
               "fieldConfig": {
                 "defaults": {
                   "color": {
@@ -644,7 +644,7 @@ data:
                   ]
                 }
               ],
-              "title": "Offending Policies",
+              "title": "Unknown Policies",
               "transformations": [
                 {
                   "id": "organize",
@@ -785,8 +785,8 @@ data:
         ]
       },
       "time": {
-        "from": "now-7d",
-        "to": "now"
+        "from": "2023-06-11T00:00:00.000Z",
+        "to": "2023-06-11T00:00:00.000Z"
       },
       "timepicker": {},
       "timezone": "utc",


### PR DESCRIPTION
Updating the `Policy Status > Unknown` and `Cluster Status > Unknown` table headers to `unknown` instead of `offending`.