### PR TITLE
fixed the view is not exist when simulating the local compliance

### DIFF
--- a/manager/pkg/cronjob/task/compliance_history.go
+++ b/manager/pkg/cronjob/task/compliance_history.go
@@ -78,7 +78,7 @@ func syncToLocalComplianceHistoryByLocalStatus(ctx context.Context, pool *pgxpoo
 	// Then the a race condition will arise: the previous and next jobs will using the same view, which will cause the
 	// next job to fail. To avoid this, we create a materialized view with a unique name for each job.
 	if enableSimulation {
-		viewTable = fmt.Sprintf("%s_%d", rand.Intn(10001))
+		viewTable = fmt.Sprintf("%s_%d", viewTable, rand.Intn(10001))
 	}
 	viewName := fmt.Sprintf("%s.%s", viewSchema, viewTable)
 	createViewTemplate := `

--- a/manager/pkg/cronjob/task/compliance_history.go
+++ b/manager/pkg/cronjob/task/compliance_history.go
@@ -3,7 +3,7 @@ package task
 import (
 	"context"
 	"fmt"
-	"math/rand"
+	"sync"
 	"time"
 
 	"github.com/go-co-op/gocron"
@@ -22,6 +22,7 @@ var (
 	dateFormat              = "2006-01-02"
 	dateInterval            = 1
 	simulationCounter       = 1
+	counterLock             sync.Mutex
 	batchSize               = int64(1000)
 	// batchSize = 1000 for now
 	// The suitable batchSize for selecting and inserting a lot of records from a table in PostgreSQL depends on
@@ -37,7 +38,14 @@ func SyncLocalCompliance(ctx context.Context, pool *pgxpool.Pool, enableSimulati
 
 	interval := dateInterval
 	if enableSimulation {
+		// When the interval is so small that the previous job has not finished running, the next job has already started.
+		// Then the a race condition will arise: the previous and next jobs will using the same view, which will cause the
+		// next job to fail. To avoid this, lock the counter so only one goroutine can access the it and each goroutine
+		// will get a different simulatorCounter value.
+		counterLock.Lock()
 		interval = simulationCounter
+		simulationCounter++
+		counterLock.Unlock()
 	}
 
 	historyDate := startTime.AddDate(0, 0, -interval)
@@ -54,7 +62,6 @@ func SyncLocalCompliance(ctx context.Context, pool *pgxpool.Pool, enableSimulati
 	log.Info("with local_status.compliance", "totalCount", statusTotal, "insertedCount", statusInsert)
 
 	if enableSimulation {
-		simulationCounter++
 		return
 	}
 
@@ -73,13 +80,8 @@ func syncToLocalComplianceHistoryByLocalStatus(ctx context.Context, pool *pgxpoo
 	enableSimulation bool) (totalCount int64, insertedCount int64, err error,
 ) {
 	viewSchema := "history"
-	viewTable := fmt.Sprintf("local_compliance_view_%s", startTime.AddDate(0, 0, -interval).Format("2006_01_02"))
-	// When the interval is so small that the previous job has not finished running, the next job has already started.
-	// Then the a race condition will arise: the previous and next jobs will using the same view, which will cause the
-	// next job to fail. To avoid this, we create a materialized view with a unique name for each job.
-	if enableSimulation {
-		viewTable = fmt.Sprintf("%s_%d", viewTable, rand.Intn(10001))
-	}
+	viewTable := fmt.Sprintf("local_compliance_view_%s",
+		startTime.AddDate(0, 0, -interval).Format("2006_01_02"))
 	viewName := fmt.Sprintf("%s.%s", viewSchema, viewTable)
 	createViewTemplate := `
 		CREATE MATERIALIZED VIEW IF NOT EXISTS %s AS

--- a/manager/pkg/cronjob/task/compliance_history_test.go
+++ b/manager/pkg/cronjob/task/compliance_history_test.go
@@ -113,7 +113,7 @@ var _ = Describe("sync the compliance data", Ordered, func() {
 	It("sync the data from the event.local_policies to the history.local_compliance", func() {
 		By("Create the sync job")
 		s := gocron.NewScheduler(time.UTC)
-		complianceJob, err := s.Every(1).Second().Tag("LocalCompliance").DoWithJobDetails(
+		complianceJob, err := s.Every(1).Day().Tag("LocalCompliance").DoWithJobDetails(
 			task.SyncLocalCompliance, ctx, pool, false)
 		Expect(err).ToNot(HaveOccurred())
 		fmt.Println("set local compliance job", "scheduleAt", complianceJob.ScheduledAtTime())


### PR DESCRIPTION
When the interval is so small that the previous job has not finished running, the next job has already started.
Then a **race condition** will arise: the previous and next jobs will use the same view, which will cause the next job to fail. To avoid this, lock the counter so only one goroutine can access the it and each goroutine will get a different simulatorCounter value.