### PR TITLE
fixed the managed cluster deletion not work

### DIFF
--- a/agent/pkg/event/enhancers/policy_event.go
+++ b/agent/pkg/event/enhancers/policy_event.go
@@ -40,16 +40,12 @@ func (p *PolicyEventEnhancer) Enhance(ctx context.Context, event *kube.EnhancedE
 		p.log.Error(err, "failed to add policy compliance", "namespace", policyNamespace, "name", policyName)
 		return
 	}
-	p.log.Info("added policy compliance", "namespace", policyNamespace, "name", policyName,
-		"compliance", event.InvolvedObject.Labels[constants.PolicyEventComplianceLabelKey])
 
 	// cluster policy event, then add root policy id and cluster id
 	rootPolicyNamespacedName, ok := event.InvolvedObject.Labels[constants.PolicyEventRootPolicyNameLabelKey]
 	if !ok {
 		return
 	}
-	p.log.Info("get root policy name", "namespace", policyNamespace, "name", policyName,
-		"rootPolicyName", rootPolicyNamespacedName)
 
 	// add root policy id
 	policyNameSlice := strings.Split(rootPolicyNamespacedName, ".")
@@ -69,9 +65,6 @@ func (p *PolicyEventEnhancer) Enhance(ctx context.Context, event *kube.EnhancedE
 	}
 	event.InvolvedObject.Labels[constants.PolicyEventRootPolicyIdLabelKey] = string(rootPolicy.GetUID())
 
-	p.log.Info("add root policy id", "namespace", policyNamespace, "name", policyName,
-		"rootPolicyId", event.InvolvedObject.Labels[constants.PolicyEventRootPolicyIdLabelKey])
-
 	// add cluster id
 	clusterName, ok := event.InvolvedObject.Labels[constants.PolicyEventClusterNameLabelKey]
 	if !ok {
@@ -90,7 +83,6 @@ func (p *PolicyEventEnhancer) Enhance(ctx context.Context, event *kube.EnhancedE
 		}
 	}
 	event.InvolvedObject.Labels[constants.PolicyEventClusterIdLabelKey] = clusterId
-	p.log.Info("add cluster id", "namespace", policyNamespace, "name", policyName, "clusterId", clusterId)
 }
 
 func (p *PolicyEventEnhancer) addPolicyCompliance(ctx context.Context, event *kube.EnhancedEvent) error {

--- a/agent/pkg/event/enhancers/policy_event.go
+++ b/agent/pkg/event/enhancers/policy_event.go
@@ -40,12 +40,16 @@ func (p *PolicyEventEnhancer) Enhance(ctx context.Context, event *kube.EnhancedE
 		p.log.Error(err, "failed to add policy compliance", "namespace", policyNamespace, "name", policyName)
 		return
 	}
+	p.log.Info("added policy compliance", "namespace", policyNamespace, "name", policyName,
+		"compliance", event.InvolvedObject.Labels[constants.PolicyEventComplianceLabelKey])
 
 	// cluster policy event, then add root policy id and cluster id
 	rootPolicyNamespacedName, ok := event.InvolvedObject.Labels[constants.PolicyEventRootPolicyNameLabelKey]
 	if !ok {
 		return
 	}
+	p.log.Info("get root policy name", "namespace", policyNamespace, "name", policyName,
+		"rootPolicyName", rootPolicyNamespacedName)
 
 	// add root policy id
 	policyNameSlice := strings.Split(rootPolicyNamespacedName, ".")
@@ -65,6 +69,9 @@ func (p *PolicyEventEnhancer) Enhance(ctx context.Context, event *kube.EnhancedE
 	}
 	event.InvolvedObject.Labels[constants.PolicyEventRootPolicyIdLabelKey] = string(rootPolicy.GetUID())
 
+	p.log.Info("add root policy id", "namespace", policyNamespace, "name", policyName,
+		"rootPolicyId", event.InvolvedObject.Labels[constants.PolicyEventRootPolicyIdLabelKey])
+
 	// add cluster id
 	clusterName, ok := event.InvolvedObject.Labels[constants.PolicyEventClusterNameLabelKey]
 	if !ok {
@@ -83,6 +90,7 @@ func (p *PolicyEventEnhancer) Enhance(ctx context.Context, event *kube.EnhancedE
 		}
 	}
 	event.InvolvedObject.Labels[constants.PolicyEventClusterIdLabelKey] = clusterId
+	p.log.Info("add cluster id", "namespace", policyNamespace, "name", policyName, "clusterId", clusterId)
 }
 
 func (p *PolicyEventEnhancer) addPolicyCompliance(ctx context.Context, event *kube.EnhancedEvent) error {

--- a/manager/pkg/statussyncer/syncers/local_spec_policies_syncer.go
+++ b/manager/pkg/statussyncer/syncers/local_spec_policies_syncer.go
@@ -160,10 +160,7 @@ func getPolicyIdToVersionMap(db *gorm.DB, schema, tableName, leafHubName string)
 
 	err := db.Table(fmt.Sprintf("%s.%s", schema, tableName)).
 		Select("payload->'metadata'->>'uid' AS key, payload->'metadata'->>'resourceVersion' AS resource_version").
-		Where(&models.LocalSpecPolicy{ // Find soft deleted records: db.Unscoped().Where(...)
-			LeafHubName: leafHubName,
-		}).
-		Scan(&resourceVersions).Error
+		Where("leaf_hub_name = ? AND deleted_at IS NULL", leafHubName).Scan(&resourceVersions).Error
 	if err != nil {
 		return nil, err
 	}

--- a/manager/pkg/statussyncer/syncers/local_spec_policies_syncer.go
+++ b/manager/pkg/statussyncer/syncers/local_spec_policies_syncer.go
@@ -158,9 +158,10 @@ func (syncer *localSpecPoliciesSyncer) handleLocalObjectsBundle(ctx context.Cont
 func getPolicyIdToVersionMap(db *gorm.DB, schema, tableName, leafHubName string) (map[string]string, error) {
 	var resourceVersions []models.ResourceVersion
 
-	err := db.Table(fmt.Sprintf("%s.%s", schema, tableName)).
-		Select("payload->'metadata'->>'uid' AS key, payload->'metadata'->>'resourceVersion' AS resource_version").
-		Where("leaf_hub_name = ? AND deleted_at IS NULL", leafHubName).Scan(&resourceVersions).Error
+	err := db.Select("payload->'metadata'->>'uid' AS key, payload->'metadata'->>'resourceVersion' AS resource_version").
+		Where(&models.LocalSpecPolicy{ // Find soft deleted records: db.Unscoped().Where(...).Find(...)
+			LeafHubName: leafHubName,
+		}).Find(&models.LocalSpecPolicy{}).Scan(&resourceVersions).Error
 	if err != nil {
 		return nil, err
 	}

--- a/manager/pkg/statussyncer/syncers/managed_clusters_syncer.go
+++ b/manager/pkg/statussyncer/syncers/managed_clusters_syncer.go
@@ -159,9 +159,10 @@ func (syncer *ManagedClustersDBSyncer) handleManagedClustersBundle(ctx context.C
 func getClusterNameToVersionMap(db *gorm.DB, schema, tableName, leafHubName string) (map[string]string, error) {
 	var resourceVersions []models.ResourceVersion
 
-	err := db.Table(fmt.Sprintf("%s.%s", schema, tableName)).
-		Select("payload->'metadata'->>'name' AS key, payload->'metadata'->>'resourceVersion' AS resource_version").
-		Where("leaf_hub_name = ? AND deleted_at IS NULL", leafHubName).Scan(&resourceVersions).Error
+	err := db.Select("payload->'metadata'->>'name' AS key, payload->'metadata'->>'resourceVersion' AS resource_version").
+		Where(&models.ManagedCluster{
+			LeafHubName: leafHubName,
+		}).Find(&models.ManagedCluster{}).Scan(&resourceVersions).Error
 	if err != nil {
 		return nil, err
 	}

--- a/manager/pkg/statussyncer/syncers/managed_clusters_syncer.go
+++ b/manager/pkg/statussyncer/syncers/managed_clusters_syncer.go
@@ -137,7 +137,7 @@ func (syncer *ManagedClustersDBSyncer) handleManagedClustersBundle(ctx context.C
 			tx.Where(&models.ManagedCluster{
 				LeafHubName: leafHubName,
 				ClusterName: clusterName,
-			}).Delete(models.ManagedCluster{})
+			}).Delete(&models.ManagedCluster{})
 		}
 
 		// return nil will commit the whole transaction


### PR DESCRIPTION
1. When we delete the managed cluster from the database, the `deletedAt` column may not be filled if the delete obj is not a pointer.
2. When the cluster is re-imported again, the `deletedAT` should be NULL.
3. Using `Find(&obj)` to get the un-deleted records, cause `db.Table(fmt.Sprintf("%s.%s", schema, tableName))` will get all the records from database.