### PR TITLE
fixed the issue of potential policy events loss

### DIFF
--- a/manager/pkg/eventcollector/processor/policy_processor_test.go
+++ b/manager/pkg/eventcollector/processor/policy_processor_test.go
@@ -34,6 +34,7 @@ var _ = Describe("configmaps to database controller", func() {
 				WHEN duplicate_object THEN null;
 			END $$;
 			CREATE TABLE IF NOT EXISTS event.local_policies (
+				event_name text,
 				policy_id uuid NOT NULL,
 				cluster_id uuid NOT NULL,
 				leaf_hub_name character varying(63) NOT NULL,
@@ -43,7 +44,7 @@ var _ = Describe("configmaps to database controller", func() {
 				source jsonb,
 				created_at timestamp without time zone DEFAULT now() NOT NULL,
 				compliance local_status.compliance_type NOT NULL,
-				CONSTRAINT local_policies_unique_constraint UNIQUE (policy_id, cluster_id, count)
+				CONSTRAINT local_policies_unique_constraint UNIQUE (event_name, count)
 			);
 		`)
 		Expect(err).ToNot(HaveOccurred())

--- a/operator/pkg/controllers/hubofhubs/database/3.tables.sql
+++ b/operator/pkg/controllers/hubofhubs/database/3.tables.sql
@@ -288,6 +288,7 @@ CREATE TABLE IF NOT EXISTS status.subscription_statuses (
 );
 
 CREATE TABLE IF NOT EXISTS event.local_policies (
+    event_name character varying(63) NOT NULL,
     policy_id uuid NOT NULL,
     cluster_id uuid NOT NULL,
     leaf_hub_name character varying(63) NOT NULL,
@@ -297,10 +298,11 @@ CREATE TABLE IF NOT EXISTS event.local_policies (
     source jsonb,
     created_at timestamp without time zone DEFAULT now() NOT NULL,
     compliance local_status.compliance_type NOT NULL,
-    CONSTRAINT local_policies_unique_constraint UNIQUE (policy_id, cluster_id, count)
+    CONSTRAINT local_policies_unique_constraint UNIQUE (event_name, count)
 );
 
 CREATE TABLE IF NOT EXISTS event.local_root_policies (
+    event_name character varying(63) NOT NULL,
     policy_id uuid NOT NULL,
     leaf_hub_name character varying(63) NOT NULL,
     message text,
@@ -309,7 +311,7 @@ CREATE TABLE IF NOT EXISTS event.local_root_policies (
     source jsonb,
     created_at timestamp without time zone DEFAULT now() NOT NULL,
     compliance local_status.compliance_type NOT NULL,
-    CONSTRAINT local_root_policies_unique_constraint UNIQUE (policy_id, leaf_hub_name, count)
+    CONSTRAINT local_root_policies_unique_constraint UNIQUE (event_name, count)
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS placementrules_leaf_hub_name_id_idx ON local_spec.placementrules (leaf_hub_name, (((payload -> 'metadata'::text) ->> 'uid'::text)));

--- a/pkg/database/models/event.go
+++ b/pkg/database/models/event.go
@@ -7,6 +7,7 @@ import (
 )
 
 type BaseLocalPolicyEvent struct {
+	EventName   string         `gorm:"column:event_name;type:varchar(63);not null"`
 	PolicyID    string         `gorm:"column:policy_id;type:uuid;primaryKey"`
 	Message     string         `gorm:"column:message;type:text"`
 	LeafHubName string         `gorm:"size:63;not null"`


### PR DESCRIPTION
Currently, we use the unique constraint in the policy events table, like this:
```sql
    CONSTRAINT local_policies_unique_constraint UNIQUE (policy_id, cluster_id, count)
```
But there is a scenario: the policy may have more than one event when the `policy_id, cluster_id, and count` are the same, just like the following logs in the global hub manager:
```shell
2023-06-17 01:21:37 UTC INFO    policy-event-processor  regional-hub    {"namespace": "local-placement", "name": "policy-limitrange.17694d9b12ef02cb", "count": "1", "offset": "12"}
2023-06-17 01:21:47 UTC INFO    policy-event-processor  regional-hub    {"namespace": "managed-cluster", "name": "local-placement.policy-limitrange.17694d981e9b98f3", "count": "1", "offset
": "13"}
2023-06-17 01:21:57 UTC INFO    policy-event-processor  regional-hub    {"namespace": "managed-cluster", "name": "local-placement.policy-limitrange.17694d9923a397b2", "count": "1", "offset
": "14"}
```
This will cause the event with the name `"local-placement.policy-limitrange.17694d9923a397b2"` lost in the `event.local_polices`. Because it and the event `"local-placement.policy-limitrange.17694d981e9b98f3"` are all from the same root policy `local-placement/policy-limitrange` also in the same cluster namespace `managed-cluster` with event `count = 1`.

So we should set the `eventName, count` as the unique constraint, instead of setting the `policy_id, cluster_id, count`.