### PR TITLE
[ACM-6056][ACM-6057][ACM-6058][ACM-6060] Remove name label from dropdown & split what's changed dashboard for policy/cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Multicluster Global Hub Overview
+
 [![Build](https://img.shields.io/badge/build-Prow-informational)](https://prow.ci.openshift.org/?repo=stolostron%2F${multicluster-global-hub})
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=open-cluster-management_hub-of-hubs&metric=coverage)](https://sonarcloud.io/dashboard?id=open-cluster-management_hub-of-hubs)
 [![Go Reference](https://pkg.go.dev/badge/github.com/stolostron/multicluster-global-hub.svg)](https://pkg.go.dev/github.com/stolostron/multicluster-global-hub)
@@ -7,21 +8,25 @@
 This document attempts to explain how the different components in multicluster global hub come together to deliver multicluster management at very high scale. The multicluster-global-hub operator is the root operator which pulls in all things needed.
 
 ## Conceptual Diagram
- 
+
 ![ArchitectureDiagram](doc/architecture/multicluster-global-hub-arch.png)
 
 ### Multicluster Global Hub Operator
+
 Operator is for multicluster global hub. It is used to deploy all required components for multicluster management. The components include multicluster-global-hub-manager in the global hub cluster and multicluster-global-hub-agent in the regional hub clusters.
 
 The Operator also leverages the manifestwork to deploy the Advanced Cluster Management for Kubernetes in the managed cluster. So the managed cluster is switched to a standard ACM Hub cluster (regional hub cluster).
 
 ### Multicluster Global Hub Manager
+
 The manager is used to persist the data into the postgreSQL. The data is from Kafka transport. The manager is also used to post the data to Kafka transport so that it can be synced to the regional hub clusters.
 
 ### Multicluster Global Hub Agent
+
 The agent is running in the regional hub clusters. It is responsible to sync-up the data between the global cluster hub and the regional hub clusters. For instance, sync-up the managed clusters' info from the regional hub clusters to the global hub cluster and sync-up the policy or application from the global hub cluster to the regional hub clusters.
 
 ### Multicluster Global Hub Observability
+
 Grafana runs on the global hub cluster, as the main service for Global Hub Observability. The Postgres data collected by the Global Hub Manager services as its default DataSource. By exposing the service via route(`multicluster-global-hub-grafana`), you can access the global hub grafana dashboards just like accessing the openshift console.
 
 ## Quick Start Guide
@@ -37,8 +42,8 @@ kubectl create secret generic multicluster-global-hub-storage -n "open-cluster-m
     --from-literal=database_uri=<postgresql-uri> \
     --from-file=ca.crt=<CA-for-postgres-server>
 ```
-> You can run this sample script `./operator/config/samples/storage/deploy_postgres.sh`(Note: the client version of kubectl must be v1.21+) to install postgres in `hoh-postgres` namespace and create the secret `multicluster-global-hub-storage` in namespace `open-cluster-management` automatically. To override the secret namespace, set `TARGET_NAMESPACE` environment variable to the ACM installation namespace before executing the script. By default, we are using `ClusterIP` for accessing the postgres database, because we assume run this sample script in global hub cluster. If you want to deploy postgres in another cluster, you can consider to use the service type with `nodePort` or `LoadBalancer`. For more information, please refer to [this document](./doc/README.md#access-to-the-provisioned-postgres-database).
 
+> You can run this sample script `./operator/config/samples/storage/deploy_postgres.sh`(Note: the client version of kubectl must be v1.21+) to install postgres in `hoh-postgres` namespace and create the secret `multicluster-global-hub-storage` in namespace `open-cluster-management` automatically. To override the secret namespace, set `TARGET_NAMESPACE` environment variable to the ACM installation namespace before executing the script. By default, we are using `ClusterIP` for accessing the postgres database, because we assume run this sample script in global hub cluster. If you want to deploy postgres in another cluster, you can consider to use the service type with `nodePort` or `LoadBalancer`. For more information, please refer to [this document](./doc/README.md#access-to-the-provisioned-postgres-database).
 
 4. Kafka is installed and three topics `spec` `status` and `event` are created, also a secret with name `multicluster-global-hub-transport` that contains the kafka access information should be created in `open-cluster-management` namespace:
 
@@ -50,6 +55,7 @@ kubectl create secret generic multicluster-global-hub-transport -n "open-cluster
     --from-file=client.key=<Client-key-for-kafka-server> 
 
 ```
+
 > As above, You can run this sample script `./operator/config/samples/transport/deploy_kafka.sh` to install kafka in kafka namespace and create the secret `multicluster-global-hub-transport` in namespace `open-cluster-management` automatically. To override the secret namespace, set `TARGET_NAMESPACE` environment variable to the ACM installation namespace before executing the script.
 
 ### Run the operator in the cluster
@@ -59,6 +65,7 @@ _Note:_ You can also install Multicluster Global Hub Operator from [Operator Hub
 Follow the steps below to instal Multicluster Global Hub Operator in developing environment:
 
 1. Check out the multicluster-global-hub repository
+
 ```bash
 git clone git@github.com:stolostron/multicluster-global-hub.git
 cd multicluster-global-hub/operator

--- a/operator/pkg/controllers/hubofhubs/manifests/grafana/acm-global-cluster-group-compliancy-overview.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/grafana/acm-global-cluster-group-compliancy-overview.yaml
@@ -24,7 +24,7 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "iteration": 1686808590424,
+      "iteration": 1687363144671,
       "links": [
         {
           "asDropdown": false,
@@ -80,7 +80,7 @@ data:
                 {
                   "targetBlank": true,
                   "title": "View Offending Clusters by ${label}:${__field.name}",
-                  "url": "d/0e0ddb7f16b946f99d96a483a4a3f95f/global-hub-offending-clusters?orgId=1&from=${__value.time}&to=${__value.time}&var-label=${label}&var-value=${__field.name}"
+                  "url": "d/0e0ddb7f16b946f99d96a483a4a3f95f/global-hub-offending-clusters?orgId=1&from=${__value.time}&to=${__value.time}&var-label=${label}&var-value=${__field.name}&${standard:queryparam}&${category:queryparam}&${control:queryparam}"
                 }
               ],
               "mappings": [],
@@ -126,7 +126,7 @@ data:
               "group": [],
               "metricColumn": "none",
               "rawQuery": true,
-              "rawSql": "WITH data as (\n  SELECT\n    ch.compliance_date as \"time\",\n    mc.payload -> 'metadata' -> 'labels' ->> '$label' AS \"$label\",\n    COUNT(CASE WHEN ch.compliance = 'compliant' THEN 1 END) AS \"compliant\",\n    COUNT(CASE WHEN ch.compliance = 'non_compliant' THEN 1 END) AS \"non_compliant\",\n    COUNT(CASE WHEN ch.compliance = 'unknown' THEN 1 END) AS \"unknown\"\n  FROM\n    status.managed_clusters mc\n  JOIN\n    history.local_compliance ch ON mc.cluster_id = ch.cluster_id\n  JOIN\n    local_spec.policies p ON ch.policy_id = p.policy_id\n  WHERE\n    $__timeFilter(ch.compliance_date)\n  AND\n    p.policy_standard IN ($standard) AND p.policy_category IN ($category) AND p.policy_control IN ($control)\n  AND\n    mc.payload -> 'metadata' -> 'labels' ->> '$label' IN ($value)\n  GROUP BY (ch.compliance_date, mc.payload -> 'metadata' -> 'labels' ->> '$label')\n  ORDER BY (ch.compliance_date)\n),\nordermetric as (\n  SELECT\n    $label,\n    ROW_NUMBER () OVER (ORDER BY (SUM(non_compliant)/NULLIF((SUM(non_compliant) + SUM(compliant) + SUM(unknown)), 0)) DESC) as row_number\n  FROM\n    data\n  GROUP BY($label)\n)\nSELECT\n  time,\n  dc.$label as \"metric\",\n  compliant::float / NULLIF((compliant::float + non_compliant + unknown), 0) as \"value\"\nFROM\n  ordermetric tc\nJOIN\n  data dc on dc.$label = tc.$label\nWHERE\n  tc.row_number >= $topmin AND tc.row_number <= $topmax\nORDER BY (time)",
+              "rawSql": "WITH data as (\n  SELECT\n    lc.compliance_date as \"time\",\n    mc.payload -> 'metadata' -> 'labels' ->> '$label' AS \"$label\",\n    COUNT(CASE WHEN lc.compliance = 'compliant' THEN 1 END) AS \"compliant\",\n    COUNT(CASE WHEN lc.compliance = 'non_compliant' THEN 1 END) AS \"non_compliant\",\n    COUNT(CASE WHEN lc.compliance = 'unknown' THEN 1 END) AS \"unknown\"\n  FROM\n    status.managed_clusters mc\n  JOIN\n    history.local_compliance lc ON mc.cluster_id = lc.cluster_id\n  JOIN\n    local_spec.policies p ON lc.policy_id = p.policy_id\n  WHERE\n    $__timeFilter(lc.compliance_date)\n  AND\n    p.policy_standard IN ($standard) AND p.policy_category IN ($category) AND p.policy_control IN ($control)\n  AND\n    mc.payload -> 'metadata' -> 'labels' ->> '$label' IN ($value)\n  GROUP BY (lc.compliance_date, mc.payload -> 'metadata' -> 'labels' ->> '$label')\n  ORDER BY (lc.compliance_date)\n)\nSELECT\n  time,\n  $label as \"metric\",\n  compliant::float / NULLIF((compliant::float + non_compliant + unknown), 0) as \"value\"\nFROM\n  data",
               "refId": "A",
               "select": [
                 [
@@ -235,80 +235,6 @@ data:
             "allValue": null,
             "current": {
               "selected": true,
-              "text": "1:10",
-              "value": "1:10"
-            },
-            "description": "Top N Non Compliance Values",
-            "error": null,
-            "hide": 1,
-            "includeAll": false,
-            "label": "Top",
-            "multi": false,
-            "name": "top",
-            "options": [
-              {
-                "selected": true,
-                "text": "1:10",
-                "value": "1:10"
-              }
-            ],
-            "query": "1:10",
-            "queryValue": "",
-            "skipUrlSync": false,
-            "type": "custom"
-          },
-          {
-            "allValue": null,
-            "current": {
-              "selected": false,
-              "text": "1",
-              "value": "1"
-            },
-            "datasource": null,
-            "definition": "SELECT SPLIT_PART('$top', ':', 1);",
-            "description": null,
-            "error": null,
-            "hide": 2,
-            "includeAll": false,
-            "label": "",
-            "multi": false,
-            "name": "topmin",
-            "options": [],
-            "query": "SELECT SPLIT_PART('$top', ':', 1);",
-            "refresh": 1,
-            "regex": "",
-            "skipUrlSync": false,
-            "sort": 0,
-            "type": "query"
-          },
-          {
-            "allValue": null,
-            "current": {
-              "selected": false,
-              "text": "10",
-              "value": "10"
-            },
-            "datasource": null,
-            "definition": "SELECT SPLIT_PART('$top', ':', 2);",
-            "description": null,
-            "error": null,
-            "hide": 2,
-            "includeAll": false,
-            "label": "",
-            "multi": false,
-            "name": "topmax",
-            "options": [],
-            "query": "SELECT SPLIT_PART('$top', ':', 2);",
-            "refresh": 1,
-            "regex": "",
-            "skipUrlSync": false,
-            "sort": 0,
-            "type": "query"
-          },
-          {
-            "allValue": null,
-            "current": {
-              "selected": true,
               "text": [
                 "All"
               ],
@@ -399,7 +325,7 @@ data:
       "timezone": "utc",
       "title": "Global Hub - Cluster Group Compliancy Overview",
       "uid": "868845a4d1334958bd62303c5ccb4c19",
-      "version": 2
+      "version": 1
     }
 kind: ConfigMap
 metadata:

--- a/operator/pkg/controllers/hubofhubs/manifests/grafana/acm-global-cluster-group-compliancy-overview.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/grafana/acm-global-cluster-group-compliancy-overview.yaml
@@ -24,7 +24,7 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "iteration": 1686808590424,
+      "iteration": 1687542352983,
       "links": [
         {
           "asDropdown": false,
@@ -84,6 +84,7 @@ data:
                 }
               ],
               "mappings": [],
+              "max": 1,
               "noValue": "N/A",
               "thresholds": {
                 "mode": "absolute",

--- a/operator/pkg/controllers/hubofhubs/manifests/grafana/acm-global-cluster-group-compliancy-overview.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/grafana/acm-global-cluster-group-compliancy-overview.yaml
@@ -198,7 +198,7 @@ data:
             "options": [],
             "query": "WITH compcluster as(\n  SELECT DISTINCT cluster_id\n  FROM\n  history.local_compliance ch\n  WHERE\n  $__timeFilter(ch.compliance_date)\n)\nSELECT\n  DISTINCT jsonb_object_keys(payload -> 'metadata' -> 'labels')\nFROM\n  status.managed_clusters mc \nJOIN\n  compcluster ch \nON\n mc.cluster_id = ch.cluster_id",
             "refresh": 2,
-            "regex": "/^[a-z]+$/",
+            "regex": "\\b(?!name\\b)(\\b[a-z]+)",
             "skipUrlSync": false,
             "sort": 5,
             "type": "query"

--- a/operator/pkg/controllers/hubofhubs/manifests/grafana/acm-global-cluster-group-compliancy-overview.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/grafana/acm-global-cluster-group-compliancy-overview.yaml
@@ -24,7 +24,7 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "iteration": 1687363144671,
+      "iteration": 1686808590424,
       "links": [
         {
           "asDropdown": false,
@@ -33,7 +33,7 @@ data:
           "keepTime": true,
           "tags": [],
           "targetBlank": true,
-          "title": "Offending Clusters",
+          "title": "Global Hub - Offending Clusters",
           "tooltip": "",
           "type": "link",
           "url": "d/0e0ddb7f16b946f99d96a483a4a3f95f/global-hub-offending-clusters?orgId=1"

--- a/operator/pkg/controllers/hubofhubs/manifests/grafana/acm-global-offending-clusters.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/grafana/acm-global-offending-clusters.yaml
@@ -701,7 +701,7 @@ data:
             "options": [],
             "query": "WITH compcluster as(\n  SELECT DISTINCT cluster_id\n  FROM\n  history.local_compliance ch\n  WHERE\n  $__timeFilter(ch.compliance_date)\n)\nSELECT\n  DISTINCT jsonb_object_keys(payload -> 'metadata' -> 'labels')\nFROM\n  status.managed_clusters mc\nJOIN\n  compcluster ch \nON\n mc.cluster_id = ch.cluster_id",
             "refresh": 2,
-            "regex": "/^[a-z]+$/",
+            "regex": "\\b(?!name\\b)(\\b[a-z]+)",
             "skipUrlSync": false,
             "sort": 5,
             "type": "query"

--- a/operator/pkg/controllers/hubofhubs/manifests/grafana/acm-global-offending-clusters.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/grafana/acm-global-offending-clusters.yaml
@@ -24,7 +24,7 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "iteration": 1686809061250,
+      "iteration": 1687372326721,
       "links": [
         {
           "asDropdown": false,
@@ -33,7 +33,7 @@ data:
           "keepTime": true,
           "tags": [],
           "targetBlank": true,
-          "title": "Cluster Group Compliancy Overview",
+          "title": "Global Hub - Cluster Group Compliancy Overview",
           "tooltip": "",
           "type": "link",
           "url": "d/868845a4d1334958bd62303c5ccb4c19/global-hub-cluster-group-compliancy-overview?orgId=1"
@@ -45,10 +45,10 @@ data:
           "keepTime": true,
           "tags": [],
           "targetBlank": true,
-          "title": "What's Changed",
+          "title": "Global Hub - What's Changed / Clusters",
           "tooltip": "",
           "type": "link",
-          "url": "d/5a3a577af7894943aa6e7ca8408502fa/global-hub-whats-changed?orgId=1"
+          "url": "d/5a3a577af7894943aa6e7ca8408502fb/global-hub-whats-changed-clusters?orgId=1"
         }
       ],
       "panels": [
@@ -422,7 +422,7 @@ data:
                       {
                         "targetBlank": true,
                         "title": "View What's Changed dashboard for cluster \"${__value.text}\"",
-                        "url": "d/5a3a577af7894943aa6e7ca8408502fa/global-hub-whats-changed?orgId=1&var-cluster=${__value.text}&var-policy=All&from=${__value.time}"
+                        "url": "d/5a3a577af7894943aa6e7ca8408502fb/global-hub-whats-changed-clusters?orgId=1&from=${__value.time}&var-hub=${__data.fields.Hub}&var-cluster=${__value.text}&var-policy=All"
                       }
                     ]
                   }
@@ -828,7 +828,7 @@ data:
       "timezone": "utc",
       "title": "Global Hub - Offending Clusters",
       "uid": "0e0ddb7f16b946f99d96a483a4a3f95f",
-      "version": 2
+      "version": 1
     }
 kind: ConfigMap
 metadata:

--- a/operator/pkg/controllers/hubofhubs/manifests/grafana/acm-global-offending-clusters.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/grafana/acm-global-offending-clusters.yaml
@@ -24,7 +24,7 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "iteration": 1687372326721,
+      "iteration": 1687540075765,
       "links": [
         {
           "asDropdown": false,
@@ -422,7 +422,7 @@ data:
                       {
                         "targetBlank": true,
                         "title": "View What's Changed dashboard for cluster \"${__value.text}\"",
-                        "url": "d/5a3a577af7894943aa6e7ca8408502fb/global-hub-whats-changed-clusters?orgId=1&from=${__value.time}&var-hub=${__data.fields.Hub}&var-cluster=${__value.text}&var-policy=All"
+                        "url": "d/5a3a577af7894943aa6e7ca8408502fb/global-hub-whats-changed-clusters?orgId=1&from=${__value.time}&var-hub=${__data.fields.Hub}&var-cluster=${__value.text}"
                       }
                     ]
                   }
@@ -554,7 +554,7 @@ data:
                           {
                             "targetBlank": true,
                             "title": "View What's Changed dashboard for cluster \"${__value.text}\"",
-                            "url": "d/5a3a577af7894943aa6e7ca8408502fa/global-hub-whats-changed?orgId=1&var-cluster=${__value.text}&var-policy=All&from=${__value.time}"
+                            "url": "d/5a3a577af7894943aa6e7ca8408502fb/global-hub-whats-changed-clusters?orgId=1&from=${__value.time}&var-hub=${__data.fields.Hub}&var-cluster=${__value.text}"
                           }
                         ]
                       }

--- a/operator/pkg/controllers/hubofhubs/manifests/grafana/acm-global-offending-policies.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/grafana/acm-global-offending-policies.yaml
@@ -24,7 +24,7 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "iteration": 1686809323467,
+      "iteration": 1687372326934,
       "links": [
         {
           "asDropdown": false,
@@ -45,10 +45,10 @@ data:
           "keepTime": true,
           "tags": [],
           "targetBlank": true,
-          "title": "What's Changed",
+          "title": "Global Hub - What's Changed / Policies",
           "tooltip": "",
           "type": "link",
-          "url": "d/5a3a577af7894943aa6e7ca8408502fa/global-hub-whats-changed?orgId=1"
+          "url": "d/5a3a577af7894943aa6e7ca8408502fa/global-hub-whats-changed-policies?orgId=1"
         }
       ],
       "panels": [
@@ -424,7 +424,7 @@ data:
                       {
                         "targetBlank": true,
                         "title": "View What's Changed dashboard for policy \"${__value.text}\"",
-                        "url": "d/5a3a577af7894943aa6e7ca8408502fa/global-hub-whats-changed?orgId=1&var-policy=${__value.text}&var-cluster=All&from=${__value.time}"
+                        "url": "d/5a3a577af7894943aa6e7ca8408502fa/global-hub-whats-changed-policies?orgId=1&from=${__value.time}&var-hub=${__data.fields.Hub}&var-cluster=All&var-policy=${__value.text}"
                       }
                     ]
                   }

--- a/operator/pkg/controllers/hubofhubs/manifests/grafana/acm-global-offending-policies.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/grafana/acm-global-offending-policies.yaml
@@ -24,7 +24,7 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "iteration": 1687372326934,
+      "iteration": 1687539714830,
       "links": [
         {
           "asDropdown": false,
@@ -424,7 +424,7 @@ data:
                       {
                         "targetBlank": true,
                         "title": "View What's Changed dashboard for policy \"${__value.text}\"",
-                        "url": "d/5a3a577af7894943aa6e7ca8408502fa/global-hub-whats-changed-policies?orgId=1&from=${__value.time}&var-hub=${__data.fields.Hub}&var-cluster=All&var-policy=${__value.text}"
+                        "url": "d/5a3a577af7894943aa6e7ca8408502fa/global-hub-whats-changed-policies?orgId=1&from=${__value.time}&var-hub=${__data.fields.Hub}&var-policy=${__value.text}"
                       }
                     ]
                   }
@@ -569,7 +569,7 @@ data:
                           {
                             "targetBlank": true,
                             "title": "View What's Changed dashboard for policy \"${__value.text}\"",
-                            "url": "d/5a3a577af7894943aa6e7ca8408502fa/global-hub-whats-changed?orgId=1&var-policy=${__value.text}&var-cluster=All&from=${__value.time}"
+                            "url": "d/5a3a577af7894943aa6e7ca8408502fa/global-hub-whats-changed-policies?orgId=1&from=${__value.time}&var-hub=${__data.fields.Hub}&var-policy=${__value.text}"
                           }
                         ]
                       }

--- a/operator/pkg/controllers/hubofhubs/manifests/grafana/acm-global-policy-group-compliancy-overview.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/grafana/acm-global-policy-group-compliancy-overview.yaml
@@ -24,7 +24,8 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "iteration": 1686809195525,
+      "id": 3,
+      "iteration": 1687368735376,
       "links": [
         {
           "asDropdown": false,
@@ -80,7 +81,7 @@ data:
                 {
                   "targetBlank": true,
                   "title": "View Offending Policies for $group group: ${__field.name}",
-                  "url": "d/b67e0727891f4121ae2dde09671520ae/global-hub-offending-policies?orgId=1&from=${__value.time}&to=${__value.time}&var-${group}=${__field.name}"
+                  "url": "d/b67e0727891f4121ae2dde09671520ae/global-hub-offending-policies?orgId=1&from=${__value.time}&to=${__value.time}&${standard:queryparam}&${category:queryparam}&${control:queryparam}"
                 }
               ],
               "mappings": [],

--- a/operator/pkg/controllers/hubofhubs/manifests/grafana/acm-global-policy-group-compliancy-overview.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/grafana/acm-global-policy-group-compliancy-overview.yaml
@@ -24,7 +24,8 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "iteration": 1686809195525,
+      "id": 2,
+      "iteration": 1687542417113,
       "links": [
         {
           "asDropdown": false,
@@ -84,6 +85,7 @@ data:
                 }
               ],
               "mappings": [],
+              "max": 1,
               "noValue": "N/A",
               "thresholds": {
                 "mode": "absolute",

--- a/operator/pkg/controllers/hubofhubs/manifests/grafana/acm-global-policy-group-compliancy-overview.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/grafana/acm-global-policy-group-compliancy-overview.yaml
@@ -24,8 +24,7 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "id": 3,
-      "iteration": 1687368735376,
+      "iteration": 1686809195525,
       "links": [
         {
           "asDropdown": false,
@@ -34,7 +33,7 @@ data:
           "keepTime": true,
           "tags": [],
           "targetBlank": true,
-          "title": "Offending Policies",
+          "title": "Global Hub - Offending Policies",
           "tooltip": "",
           "type": "link",
           "url": "d/b67e0727891f4121ae2dde09671520ae/global-hub-offending-policies?orgId=1"

--- a/operator/pkg/controllers/hubofhubs/manifests/grafana/acm-global-whats-changed-clusters.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/grafana/acm-global-whats-changed-clusters.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  acm-global-whats-changed.json: |
+  acm-global-whats-changed-clusters.json: |
     {
       "annotations": {
         "list": [
@@ -24,7 +24,7 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "iteration": 1686722565387,
+      "iteration": 1687543397254,
       "links": [
         {
           "asDropdown": false,
@@ -33,22 +33,10 @@ data:
           "keepTime": true,
           "tags": [],
           "targetBlank": true,
-          "title": "Offending Clusters",
+          "title": "Global Hub - Offending Clusters",
           "tooltip": "",
           "type": "link",
           "url": "d/0e0ddb7f16b946f99d96a483a4a3f95f/global-hub-offending-clusters?orgId=1"
-        },
-        {
-          "asDropdown": false,
-          "icon": "dashboard",
-          "includeVars": true,
-          "keepTime": true,
-          "tags": [],
-          "targetBlank": true,
-          "title": "Offending Policies",
-          "tooltip": "",
-          "type": "link",
-          "url": "d/b67e0727891f4121ae2dde09671520ae/global-hub-offending-policies?orgId=1"
         }
       ],
       "panels": [
@@ -113,7 +101,7 @@ data:
               "group": [],
               "metricColumn": "none",
               "rawQuery": true,
-              "rawSql": "WITH data as (\n  SELECT \n    $__timeGroupAlias(ch.compliance_date, $__interval),\n    mc.cluster_name,\n    COUNT(CASE WHEN ch.compliance = 'compliant' THEN 1 END) AS \"compliant\",\n    COUNT(CASE WHEN ch.compliance = 'non_compliant' THEN 1 END) AS \"non_compliant\",\n    COUNT(CASE WHEN ch.compliance = 'unknown' THEN 1 END) AS \"unknown\"\n  FROM\n    history.local_compliance ch\n  INNER JOIN\n    local_spec.policies p ON ch.policy_id = p.policy_id\n  INNER JOIN\n    status.managed_clusters mc ON ch.cluster_id = mc.cluster_id\n  WHERE\n    $__timeFilter(ch.compliance_date)\n  AND\n    mc.cluster_name IN ($cluster)\n  AND\n    policy_name IN ($policy)\n  GROUP BY (ch.compliance_date, mc.cluster_name)\n  ORDER BY (time)\n),\norderclusters as (\n  SELECT\n    cluster_name,\n    ROW_NUMBER () OVER (ORDER BY(SUM(non_compliant)/NULLIF((SUM(non_compliant) + SUM(compliant) + SUM(unknown)), 0)) DESC) as row_number\n  FROM\n    data\n  GROUP BY(cluster_name)\n)\nSELECT\n  time,\n  dc.cluster_name as \"metric\",\n  compliant::float / NULLIF((compliant::float + non_compliant + unknown), 0) as \"value\"\nFROM\n  orderclusters tc\nJOIN\n  data dc on dc.cluster_name = tc.cluster_name\nWHERE\n  tc.row_number >= $topmin AND tc.row_number <= $topmax\nORDER BY (time)",
+              "rawSql": "WITH data as (\n  SELECT \n    $__timeGroupAlias(lc.compliance_date, $__interval),\n    p.policy_name,\n    COUNT(CASE WHEN lc.compliance = 'compliant' THEN 1 END) AS \"compliant\",\n    COUNT(CASE WHEN lc.compliance = 'non_compliant' THEN 1 END) AS \"non_compliant\",\n    COUNT(CASE WHEN lc.compliance = 'unknown' THEN 1 END) AS \"unknown\"\n  FROM\n    history.local_compliance lc\n  INNER JOIN\n    local_spec.policies p ON lc.policy_id = p.policy_id\n  INNER JOIN\n    status.managed_clusters mc ON lc.cluster_id = mc.cluster_id\n  WHERE\n    $__timeFilter(lc.compliance_date)\n  AND\n    mc.cluster_name = '$cluster'\n  GROUP BY (lc.compliance_date, p.policy_name)\n  ORDER BY (time)\n),\norderclusters as (\n  SELECT\n    policy_name,\n    ROW_NUMBER () OVER (ORDER BY(SUM(non_compliant)/NULLIF((SUM(non_compliant) + SUM(compliant) + SUM(unknown)), 0)) DESC) as row_number\n  FROM\n    data\n  GROUP BY(policy_name)\n)\nSELECT\n  time,\n  dc.policy_name as \"metric\",\n  compliant::float / NULLIF((compliant::float + non_compliant + unknown), 0) as \"value\"\nFROM\n  orderclusters tc\nJOIN\n  data dc on dc.policy_name = tc.policy_name\nWHERE\n  tc.row_number >= $topmin AND tc.row_number <= $topmax\nORDER BY (time)",
               "refId": "A",
               "select": [
                 [
@@ -206,6 +194,24 @@ data:
                     "value": "color-background"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Hub"
+                },
+                "properties": [
+                  {
+                    "id": "links",
+                    "value": [
+                      {
+                        "targetBlank": true,
+                        "title": "https://console-openshift-console.apps.${__data.fields.BaseDomain}/multicloud/governance/policies/details/${__data.fields.Namespace}/${__data.fields.Policy}",
+                        "url": "https://console-openshift-console.apps.${__data.fields.BaseDomain}/multicloud/governance/policies/details/${__data.fields.Namespace}/${__data.fields.Policy}"
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           },
@@ -215,16 +221,11 @@ data:
             "x": 0,
             "y": 12
           },
-          "id": 4,
+          "id": 15,
           "interval": null,
           "options": {
             "showHeader": true,
-            "sortBy": [
-              {
-                "desc": true,
-                "displayName": "date_id"
-              }
-            ]
+            "sortBy": []
           },
           "pluginVersion": "8.5.20",
           "targets": [
@@ -233,7 +234,7 @@ data:
               "group": [],
               "metricColumn": "none",
               "rawQuery": true,
-              "rawSql": "SELECT\n  $__timeGroupAlias(lp.created_at, $__interval),\n  p.policy_name,\n  mc.cluster_name,\n  lp.message,\n  lp.reason,\n  lp.compliance\nFROM\n  event.local_policies lp\nINNER JOIN\n  local_spec.policies p ON lp.policy_id = p.policy_id\nINNER JOIN\n  status.managed_clusters mc ON lp.cluster_id = mc.cluster_id\nWHERE\n  $__timeFilter(lp.created_at)\nAND\n  policy_name IN ($policy)\nAND\n  cluster_name IN ($cluster)\nORDER BY (lp.created_at) DESC",
+              "rawSql": "SELECT\n  rp.created_at as \"time\",\n  p.leaf_hub_name as \"hub\",\n  p.payload -> 'metadata' -> 'namespace' as \"namespace\",\n  p.policy_name,\n  rp.message,\n  rp.reason,\n  rp.compliance\nFROM\n  event.local_root_policies rp\nINNER JOIN\n  local_spec.policies p ON rp.policy_id = p.policy_id\nWHERE\n  $__timeFilter(rp.created_at)\nAND\n  p.leaf_hub_name = '$hub'\nAND\n  rp.message LIKE '%$cluster%'\nORDER BY (rp.created_at) DESC",
               "refId": "A",
               "select": [
                 [
@@ -256,25 +257,186 @@ data:
             }
           ],
           "timeFrom": null,
-          "title": "Policy Events",
+          "title": "Policy Propagation Events",
           "transformations": [
             {
               "id": "organize",
               "options": {
-                "excludeByName": {},
+                "excludeByName": {
+                  "hub": false
+                },
                 "indexByName": {
-                  "cluster_name": 2,
-                  "message": 3,
+                  "compliance": 6,
+                  "hub": 2,
+                  "message": 4,
+                  "namespace": 3,
                   "policy_name": 1,
-                  "reason": 4,
-                  "source": 5,
+                  "reason": 5,
                   "time": 0
                 },
                 "renameByName": {
                   "cluster_id": "ClusterID",
                   "cluster_name": "Cluster",
                   "compliance": "Compliance",
+                  "hub": "Hub",
                   "message": "Message",
+                  "namespace": "Namespace",
+                  "policy_name": "Policy",
+                  "reason": "Reason",
+                  "source": "Source",
+                  "time": "Time"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "datasource": "${datasource}",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto",
+                "filterable": true
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "compliant": {
+                      "color": "green",
+                      "index": 0,
+                      "text": "true"
+                    },
+                    "non_compliant": {
+                      "color": "red",
+                      "index": 1,
+                      "text": "false"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "dark-yellow",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "compliance"
+                },
+                "properties": [
+                  {
+                    "id": "custom.displayMode",
+                    "value": "color-background"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Hub"
+                },
+                "properties": [
+                  {
+                    "id": "links",
+                    "value": [
+                      {
+                        "targetBlank": true,
+                        "title": "View policy \"${__data.fields.Policy}\" on hub cluster \"${__data.fields.Hub}\"",
+                        "url": "https://console-openshift-console.apps.${__data.fields.BaseDomain}/multicloud/governance/policies/details/${__data.fields.Namespace}/${__data.fields.Policy}"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 21
+          },
+          "id": 17,
+          "interval": null,
+          "options": {
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "date_id"
+              }
+            ]
+          },
+          "pluginVersion": "8.5.20",
+          "targets": [
+            {
+              "format": "table",
+              "group": [],
+              "metricColumn": "none",
+              "rawQuery": true,
+              "rawSql": "SELECT\n  lp.created_at as \"time\",\n  p.leaf_hub_name as \"hub\",\n  p.policy_name,\n  mc.cluster_name,\n  p.payload -> 'metadata' -> 'namespace' as \"namespace\",\n  lp.message,\n  lp.reason,\n  lp.compliance\nFROM\n  event.local_policies lp\nINNER JOIN\n  local_spec.policies p ON lp.policy_id = p.policy_id\nINNER JOIN\n  status.managed_clusters mc ON lp.cluster_id = mc.cluster_id\nWHERE\n  $__timeFilter(lp.created_at)\nAND\n  mc.leaf_hub_name = '$hub'\nAND\n  mc.cluster_name = '$cluster'\nORDER BY (lp.created_at) DESC",
+              "refId": "A",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "column"
+                  }
+                ]
+              ],
+              "timeColumn": "time",
+              "where": [
+                {
+                  "name": "$__timeFilter",
+                  "params": [],
+                  "type": "macro"
+                }
+              ]
+            }
+          ],
+          "timeFrom": null,
+          "title": "Policy Compliance Events",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {},
+                "indexByName": {
+                  "cluster_name": 3,
+                  "compliance": 7,
+                  "hub": 2,
+                  "message": 5,
+                  "namespace": 4,
+                  "policy_name": 1,
+                  "reason": 6,
+                  "time": 0
+                },
+                "renameByName": {
+                  "cluster_id": "ClusterID",
+                  "cluster_name": "Cluster",
+                  "compliance": "Compliance",
+                  "hub": "Hub",
+                  "message": "Message",
+                  "namespace": "Namespace",
                   "policy_name": "Policy",
                   "reason": "Reason",
                   "source": "Source",
@@ -316,24 +478,44 @@ data:
             "allValue": null,
             "current": {
               "selected": true,
-              "text": [
-                "All"
-              ],
-              "value": [
-                "$__all"
-              ]
+              "text": "",
+              "value": ""
             },
             "datasource": "${datasource}",
-            "definition": "WITH compcluster as(\n  SELECT DISTINCT cluster_id\n  FROM\n  history.local_compliance ch\n  WHERE\n  $__timeFilter(ch.compliance_date)\n)\nSELECT\n  cluster_name\nFROM\n  status.managed_clusters mc\nINNER JOIN\n  compcluster ch ON mc.cluster_id = ch.cluster_id",
+            "definition": "WITH compcluster as(\n  SELECT DISTINCT cluster_id\n  FROM\n  history.local_compliance ch\n  WHERE\n  $__timeFilter(ch.compliance_date)\n)\nSELECT\n  leaf_hub_name\nFROM\n  status.managed_clusters mc\nINNER JOIN\n  compcluster ch ON mc.cluster_id = ch.cluster_id",
+            "description": "Regional hub cluster name",
+            "error": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": "Hub",
+            "multi": false,
+            "name": "hub",
+            "options": [],
+            "query": "WITH compcluster as(\n  SELECT DISTINCT cluster_id\n  FROM\n  history.local_compliance ch\n  WHERE\n  $__timeFilter(ch.compliance_date)\n)\nSELECT\n  leaf_hub_name\nFROM\n  status.managed_clusters mc\nINNER JOIN\n  compcluster ch ON mc.cluster_id = ch.cluster_id",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 5,
+            "type": "query"
+          },
+          {
+            "allValue": null,
+            "current": {
+              "selected": false,
+              "text": "",
+              "value": ""
+            },
+            "datasource": "${datasource}",
+            "definition": "WITH compcluster as(\n  SELECT DISTINCT cluster_id\n  FROM\n  history.local_compliance lc\n  WHERE\n  $__timeFilter(lc.compliance_date)\n)\nSELECT\n  cluster_name\nFROM\n  status.managed_clusters mc\nINNER JOIN\n  compcluster ch ON mc.cluster_id = ch.cluster_id\nWHERE\n  mc.leaf_hub_name = '$hub'",
             "description": null,
             "error": null,
             "hide": 0,
-            "includeAll": true,
+            "includeAll": false,
             "label": "Cluster",
-            "multi": true,
+            "multi": false,
             "name": "cluster",
             "options": [],
-            "query": "WITH compcluster as(\n  SELECT DISTINCT cluster_id\n  FROM\n  history.local_compliance ch\n  WHERE\n  $__timeFilter(ch.compliance_date)\n)\nSELECT\n  cluster_name\nFROM\n  status.managed_clusters mc\nINNER JOIN\n  compcluster ch ON mc.cluster_id = ch.cluster_id",
+            "query": "WITH compcluster as(\n  SELECT DISTINCT cluster_id\n  FROM\n  history.local_compliance lc\n  WHERE\n  $__timeFilter(lc.compliance_date)\n)\nSELECT\n  cluster_name\nFROM\n  status.managed_clusters mc\nINNER JOIN\n  compcluster ch ON mc.cluster_id = ch.cluster_id\nWHERE\n  mc.leaf_hub_name = '$hub'",
             "refresh": 2,
             "regex": "",
             "skipUrlSync": false,
@@ -341,58 +523,26 @@ data:
             "type": "query"
           },
           {
-            "allValue": null,
             "current": {
               "selected": true,
-              "text": [
-                "All"
-              ],
-              "value": [
-                "$__all"
-              ]
-            },
-            "datasource": "${datasource}",
-            "definition": "WITH compcluster as(\n  SELECT DISTINCT cluster_id,policy_id\n  FROM\n  history.local_compliance ch\n  WHERE\n  $__timeFilter(ch.compliance_date)\n)\nSELECT\n  policy_name\nFROM\n  local_spec.policies p\nINNER JOIN\n  compcluster ch ON p.policy_id = ch.policy_id\nINNER JOIN\n  status.managed_clusters mc ON ch.cluster_id = mc.cluster_id\nWHERE\n  cluster_name IN ($cluster)",
-            "description": null,
-            "error": null,
-            "hide": 0,
-            "includeAll": true,
-            "label": "Policy",
-            "multi": true,
-            "name": "policy",
-            "options": [],
-            "query": "WITH compcluster as(\n  SELECT DISTINCT cluster_id,policy_id\n  FROM\n  history.local_compliance ch\n  WHERE\n  $__timeFilter(ch.compliance_date)\n)\nSELECT\n  policy_name\nFROM\n  local_spec.policies p\nINNER JOIN\n  compcluster ch ON p.policy_id = ch.policy_id\nINNER JOIN\n  status.managed_clusters mc ON ch.cluster_id = mc.cluster_id\nWHERE\n  cluster_name IN ($cluster)",
-            "refresh": 2,
-            "regex": "",
-            "skipUrlSync": false,
-            "sort": 5,
-            "type": "query"
-          },
-          {
-            "allValue": null,
-            "current": {
-              "selected": true,
-              "text": "1:10",
-              "value": "1:10"
+              "text": "1:5",
+              "value": "1:5"
             },
             "description": "Top N Non Compliance Clusters",
             "error": null,
-            "hide": 1,
-            "includeAll": false,
+            "hide": 0,
             "label": "Top",
-            "multi": false,
             "name": "top",
             "options": [
               {
                 "selected": true,
-                "text": "1:10",
-                "value": "1:10"
+                "text": "1:5",
+                "value": "1:5"
               }
             ],
-            "query": "1:10",
-            "queryValue": "",
+            "query": "1:5",
             "skipUrlSync": false,
-            "type": "custom"
+            "type": "textbox"
           },
           {
             "allValue": null,
@@ -422,8 +572,8 @@ data:
             "allValue": null,
             "current": {
               "selected": false,
-              "text": "10",
-              "value": "10"
+              "text": "5",
+              "value": "5"
             },
             "datasource": null,
             "definition": "SELECT SPLIT_PART('$top', ':', 2);",
@@ -450,11 +600,11 @@ data:
       },
       "timepicker": {},
       "timezone": "utc",
-      "title": "Global Hub - What's Changed",
-      "uid": "5a3a577af7894943aa6e7ca8408502fa",
+      "title": "Global Hub - What's Changed / Clusters",
+      "uid": "5a3a577af7894943aa6e7ca8408502fb",
       "version": 1
     }
 kind: ConfigMap
 metadata:
-  name: grafana-dashboard-acm-global-whats-changed
+  name: grafana-dashboard-acm-global-whats-changed-clusters
   namespace: {{.Namespace}}

--- a/operator/pkg/controllers/hubofhubs/manifests/grafana/acm-global-whats-changed-policies.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/grafana/acm-global-whats-changed-policies.yaml
@@ -1,0 +1,608 @@
+apiVersion: v1
+data:
+  acm-global-whats-changed-policies.json: |
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [],
+              "type": "dashboard"
+            },
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "iteration": 1687543370621,
+      "links": [
+        {
+          "asDropdown": false,
+          "icon": "dashboard",
+          "includeVars": true,
+          "keepTime": true,
+          "tags": [],
+          "targetBlank": true,
+          "title": "Global Hub - Offending Policies",
+          "tooltip": "",
+          "type": "link",
+          "url": "d/b67e0727891f4121ae2dde09671520ae/global-hub-offending-policies?orgId=1"
+        }
+      ],
+      "panels": [
+        {
+          "datasource": "${datasource}",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "fillOpacity": 70,
+                "lineWidth": 0
+              },
+              "mappings": [],
+              "noValue": "-",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "dark-yellow",
+                    "value": 0.5
+                  },
+                  {
+                    "color": "green",
+                    "value": 0.9
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 11,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 12,
+          "options": {
+            "alignValue": "left",
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "mergeValues": true,
+            "rowHeight": 0.9,
+            "showValue": "auto",
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.5.20",
+          "targets": [
+            {
+              "format": "time_series",
+              "group": [],
+              "metricColumn": "none",
+              "rawQuery": true,
+              "rawSql": "WITH data as (\n  SELECT \n    $__timeGroupAlias(ch.compliance_date, $__interval),\n    mc.cluster_name,\n    COUNT(CASE WHEN ch.compliance = 'compliant' THEN 1 END) AS \"compliant\",\n    COUNT(CASE WHEN ch.compliance = 'non_compliant' THEN 1 END) AS \"non_compliant\",\n    COUNT(CASE WHEN ch.compliance = 'unknown' THEN 1 END) AS \"unknown\"\n  FROM\n    history.local_compliance ch\n  INNER JOIN\n    local_spec.policies p ON ch.policy_id = p.policy_id\n  INNER JOIN\n    status.managed_clusters mc ON ch.cluster_id = mc.cluster_id\n  WHERE\n    $__timeFilter(ch.compliance_date)\n  AND\n    policy_name = '$policy'\n  GROUP BY (ch.compliance_date, mc.cluster_name)\n  ORDER BY (time)\n),\norderclusters as (\n  SELECT\n    cluster_name,\n    ROW_NUMBER () OVER (ORDER BY(SUM(non_compliant)/NULLIF((SUM(non_compliant) + SUM(compliant) + SUM(unknown)), 0)) DESC) as row_number\n  FROM\n    data\n  GROUP BY(cluster_name)\n)\nSELECT\n  time,\n  dc.cluster_name as \"metric\",\n  compliant::float / NULLIF((compliant::float + non_compliant + unknown), 0) as \"value\"\nFROM\n  orderclusters tc\nJOIN\n  data dc on dc.cluster_name = tc.cluster_name\nWHERE\n  tc.row_number >= $topmin AND tc.row_number <= $topmax\nORDER BY (time)",
+              "refId": "A",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "column"
+                  }
+                ]
+              ],
+              "timeColumn": "time",
+              "where": [
+                {
+                  "name": "$__timeFilter",
+                  "params": [],
+                  "type": "macro"
+                }
+              ]
+            }
+          ],
+          "timeFrom": null,
+          "title": "Cluster State Timeline",
+          "type": "state-timeline"
+        },
+        {
+          "datasource": null,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 11
+          },
+          "id": 6,
+          "title": "Policy Events",
+          "type": "row"
+        },
+        {
+          "datasource": "${datasource}",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto",
+                "filterable": true
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "compliant": {
+                      "color": "green",
+                      "index": 0,
+                      "text": "true"
+                    },
+                    "non_compliant": {
+                      "color": "red",
+                      "index": 1,
+                      "text": "false"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "dark-yellow",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "compliance"
+                },
+                "properties": [
+                  {
+                    "id": "custom.displayMode",
+                    "value": "color-background"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Hub"
+                },
+                "properties": [
+                  {
+                    "id": "links",
+                    "value": [
+                      {
+                        "targetBlank": true,
+                        "title": "View policy \"${__data.fields.Policy}\" on hub cluster \"${__data.fields.Hub}\"",
+                        "url": "https://console-openshift-console.apps.${__data.fields.BaseDomain}/multicloud/governance/policies/details/${__data.fields.Namespace}/${__data.fields.Policy}"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 12
+          },
+          "id": 4,
+          "interval": null,
+          "options": {
+            "showHeader": true,
+            "sortBy": []
+          },
+          "pluginVersion": "8.5.20",
+          "targets": [
+            {
+              "format": "table",
+              "group": [],
+              "metricColumn": "none",
+              "rawQuery": true,
+              "rawSql": "SELECT\n  rp.created_at as \"time\",\n  p.leaf_hub_name as \"hub\",\n  p.payload -> 'metadata' -> 'namespace' as \"namespace\",\n  p.policy_name,\n  rp.message,\n  rp.reason,\n  rp.compliance\nFROM\n  event.local_root_policies rp\nINNER JOIN\n  local_spec.policies p ON rp.policy_id = p.policy_id\nWHERE\n  $__timeFilter(rp.created_at)\nAND\n  p.leaf_hub_name = '$hub'\nAND\n  policy_name = '$policy'\nORDER BY (rp.created_at) DESC",
+              "refId": "A",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "column"
+                  }
+                ]
+              ],
+              "timeColumn": "time",
+              "where": [
+                {
+                  "name": "$__timeFilter",
+                  "params": [],
+                  "type": "macro"
+                }
+              ]
+            }
+          ],
+          "timeFrom": null,
+          "title": "Policy Propagation Events",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {},
+                "indexByName": {
+                  "compliance": 6,
+                  "hub": 2,
+                  "message": 4,
+                  "namespace": 3,
+                  "policy_name": 1,
+                  "reason": 5,
+                  "time": 0
+                },
+                "renameByName": {
+                  "cluster_id": "ClusterID",
+                  "cluster_name": "Cluster",
+                  "compliance": "Compliance",
+                  "hub": "Hub",
+                  "message": "Message",
+                  "namespace": "Namespace",
+                  "policy_name": "Policy",
+                  "reason": "Reason",
+                  "source": "Source",
+                  "time": "Time"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "datasource": "${datasource}",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto",
+                "filterable": true
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "compliant": {
+                      "color": "green",
+                      "index": 0,
+                      "text": "true"
+                    },
+                    "non_compliant": {
+                      "color": "red",
+                      "index": 1,
+                      "text": "false"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "dark-yellow",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "compliance"
+                },
+                "properties": [
+                  {
+                    "id": "custom.displayMode",
+                    "value": "color-background"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Hub"
+                },
+                "properties": [
+                  {
+                    "id": "links",
+                    "value": [
+                      {
+                        "targetBlank": true,
+                        "title": "View policy \"${__data.fields.Policy}\" on hub cluster \"${__data.fields.Hub}\"",
+                        "url": "https://console-openshift-console.apps.${__data.fields.BaseDomain}/multicloud/governance/policies/details/${__data.fields.Namespace}/${__data.fields.Policy}"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 21
+          },
+          "id": 13,
+          "interval": null,
+          "options": {
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "date_id"
+              }
+            ]
+          },
+          "pluginVersion": "8.5.20",
+          "targets": [
+            {
+              "format": "table",
+              "group": [],
+              "metricColumn": "none",
+              "rawQuery": true,
+              "rawSql": "SELECT\n  lp.created_at as \"time\",\n  p.policy_name,\n  p.leaf_hub_name as \"hub\",\n  p.payload -> 'metadata' -> 'namespace' as \"namespace\",\n  mc.cluster_name,\n  lp.message,\n  lp.reason,\n  lp.compliance\nFROM\n  event.local_policies lp\nINNER JOIN\n  local_spec.policies p ON lp.policy_id = p.policy_id\nINNER JOIN\n  status.managed_clusters mc ON lp.cluster_id = mc.cluster_id\nWHERE\n  $__timeFilter(lp.created_at)\nAND\n  mc.leaf_hub_name = '$hub'\nAND\n  policy_name = '$policy'\nORDER BY (lp.created_at) DESC",
+              "refId": "A",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "column"
+                  }
+                ]
+              ],
+              "timeColumn": "time",
+              "where": [
+                {
+                  "name": "$__timeFilter",
+                  "params": [],
+                  "type": "macro"
+                }
+              ]
+            }
+          ],
+          "timeFrom": null,
+          "title": "Policy Compliance Events",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {},
+                "indexByName": {
+                  "cluster_name": 4,
+                  "compliance": 7,
+                  "hub": 2,
+                  "message": 5,
+                  "namespace": 3,
+                  "policy_name": 1,
+                  "reason": 6,
+                  "time": 0
+                },
+                "renameByName": {
+                  "cluster_id": "ClusterID",
+                  "cluster_name": "Cluster",
+                  "compliance": "Compliance",
+                  "hub": "Hub",
+                  "message": "Message",
+                  "namespace": "Namespace",
+                  "policy_name": "Policy",
+                  "reason": "Reason",
+                  "source": "Source",
+                  "time": "Time"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        }
+      ],
+      "refresh": false,
+      "schemaVersion": 30,
+      "style": "dark",
+      "tags": [],
+      "templating": {
+        "list": [
+          {
+            "current": {
+              "selected": false,
+              "text": "Global-Hub-DataSource",
+              "value": "Global-Hub-DataSource"
+            },
+            "description": null,
+            "error": null,
+            "hide": 2,
+            "includeAll": false,
+            "label": "Datasource",
+            "multi": false,
+            "name": "datasource",
+            "options": [],
+            "query": "postgres",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "type": "datasource"
+          },
+          {
+            "allValue": null,
+            "current": {
+              "selected": true,
+              "text": "",
+              "value": ""
+            },
+            "datasource": "${datasource}",
+            "definition": "WITH compcluster as(\n    SELECT DISTINCT policy_id\n  FROM\n    history.local_compliance lc\n  WHERE\n    $__timeFilter(lc.compliance_date)\n)\nSELECT\n  leaf_hub_name\nFROM\n  local_spec.policies p\nINNER JOIN\n  compcluster ch ON p.policy_id = ch.policy_id",
+            "description": "Regional hub cluster name",
+            "error": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": "Hub",
+            "multi": false,
+            "name": "hub",
+            "options": [],
+            "query": "WITH compcluster as(\n    SELECT DISTINCT policy_id\n  FROM\n    history.local_compliance lc\n  WHERE\n    $__timeFilter(lc.compliance_date)\n)\nSELECT\n  leaf_hub_name\nFROM\n  local_spec.policies p\nINNER JOIN\n  compcluster ch ON p.policy_id = ch.policy_id",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 5,
+            "type": "query"
+          },
+          {
+            "allValue": null,
+            "current": {
+              "selected": false,
+              "text": "",
+              "value": ""
+            },
+            "datasource": "${datasource}",
+            "definition": "WITH compcluster as(\n  SELECT DISTINCT policy_id\n  FROM\n  history.local_compliance lc\n  WHERE\n  $__timeFilter(lc.compliance_date)\n)\nSELECT\n  policy_name\nFROM\n  local_spec.policies p\nINNER JOIN\n  compcluster ch ON p.policy_id = ch.policy_id\nWHERE\n  p.leaf_hub_name = '$hub'",
+            "description": null,
+            "error": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": "Policy",
+            "multi": false,
+            "name": "policy",
+            "options": [],
+            "query": "WITH compcluster as(\n  SELECT DISTINCT policy_id\n  FROM\n  history.local_compliance lc\n  WHERE\n  $__timeFilter(lc.compliance_date)\n)\nSELECT\n  policy_name\nFROM\n  local_spec.policies p\nINNER JOIN\n  compcluster ch ON p.policy_id = ch.policy_id\nWHERE\n  p.leaf_hub_name = '$hub'",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 5,
+            "type": "query"
+          },
+          {
+            "current": {
+              "selected": true,
+              "text": "1:10",
+              "value": "1:10"
+            },
+            "description": "Top N Non Compliance Clusters",
+            "error": null,
+            "hide": 0,
+            "label": "Top",
+            "name": "top",
+            "options": [
+              {
+                "selected": true,
+                "text": "1:10",
+                "value": "1:10"
+              }
+            ],
+            "query": "1:10",
+            "skipUrlSync": false,
+            "type": "textbox"
+          },
+          {
+            "allValue": null,
+            "current": {
+              "selected": false,
+              "text": "1",
+              "value": "1"
+            },
+            "datasource": null,
+            "definition": "SELECT SPLIT_PART('$top', ':', 1);",
+            "description": null,
+            "error": null,
+            "hide": 2,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "topmin",
+            "options": [],
+            "query": "SELECT SPLIT_PART('$top', ':', 1);",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "type": "query"
+          },
+          {
+            "allValue": null,
+            "current": {
+              "selected": false,
+              "text": "10",
+              "value": "10"
+            },
+            "datasource": null,
+            "definition": "SELECT SPLIT_PART('$top', ':', 2);",
+            "description": null,
+            "error": null,
+            "hide": 2,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "topmax",
+            "options": [],
+            "query": "SELECT SPLIT_PART('$top', ':', 2);",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "type": "query"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-7d",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "utc",
+      "title": "Global Hub - What's Changed / Policies",
+      "uid": "5a3a577af7894943aa6e7ca8408502fa",
+      "version": 1
+    }
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-acm-global-whats-changed
+  namespace: {{.Namespace}}

--- a/operator/pkg/controllers/hubofhubs/manifests/grafana/deployment.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/grafana/deployment.yaml
@@ -68,8 +68,10 @@ spec:
           name: grafana-dashboard-acm-global-offending-clusters
         - mountPath: /grafana-dashboards/0/acm-global-offending-policies
           name: grafana-dashboard-acm-global-offending-policies
-        - mountPath: /grafana-dashboards/0/acm-global-whats-changed
-          name: grafana-dashboard-acm-global-whats-changed
+        - mountPath: /grafana-dashboards/0/acm-global-whats-changed-clusters
+          name: grafana-dashboard-acm-global-whats-changed-clusters
+        - mountPath: /grafana-dashboards/0/acm-global-whats-changed-policies
+          name: grafana-dashboard-acm-global-whats-changed-policies
         - mountPath: /etc/grafana
           name: grafana-config
       - readinessProbe:
@@ -158,8 +160,12 @@ spec:
         name: grafana-dashboard-acm-global-offending-policies
       - configMap:
           defaultMode: 420
-          name: grafana-dashboard-acm-global-whats-changed
-        name: grafana-dashboard-acm-global-whats-changed
+          name: grafana-dashboard-acm-global-whats-changed-clusters
+        name: grafana-dashboard-acm-global-whats-changed-clusters
+      - configMap:
+          defaultMode: 420
+          name: grafana-dashboard-acm-global-whats-changed-policies
+        name: grafana-dashboard-acm-global-whats-changed-policies
       - name: grafana-config
         secret:
           defaultMode: 420


### PR DESCRIPTION
Jira issues:

- [ACM-6056](https://issues.redhat.com/browse/ACM-6056) - Remove the name from managedcluster label dropdown
  - Removes the `name` label from the drop down list in the `Global Hub - Cluster Group Compliancy Overview` and `Global Hub - Offending Clusters` dashboard.

- [ACM-6057](https://issues.redhat.com/browse/ACM-6057) - The standard,category and control filter should pass to next view when drilling down to offending policy/clusters
  - Update the data links in the `Global Hub - Cluster Group Compliancy Overview` and `Global Hub - Policy Group Compliancy Overview` dashboards to pass the `standard`, `category`, and `control` variable values in the URL.

- [ACM-6058](https://issues.redhat.com/browse/ACM-6058) - should able to filter the policy/clusters based on the regional hub name
  - Add the regional `hub` name filter to the `Global Hub - What's Changed / Clusters` and `Global Hub - What's Changed / Policies` dashboard.
 
- [ACM-6060](https://issues.redhat.com/browse/ACM-6060) - split the what change dashboard to show policy and cluster separate
  - Creates individual what's changed dashboard for cluster/policy.