### PR TITLE
init the db globally instead of creating the table manually in each test case

### DIFF
--- a/manager/pkg/statussyncer/syncers/control_info_db_syncer_test.go
+++ b/manager/pkg/statussyncer/syncers/control_info_db_syncer_test.go
@@ -23,17 +23,6 @@ var _ = Describe("leaf hubs heartbeats", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		By("Create leaf_hub_heartbeats table in database")
-		_, err := transportPostgreSQL.GetConn().Exec(ctx, `
-			CREATE SCHEMA IF NOT EXISTS status;
-			CREATE TABLE IF NOT EXISTS  status.leaf_hub_heartbeats (
-				leaf_hub_name character varying(63) NOT NULL,
-				last_timestamp timestamp without time zone DEFAULT now() NOT NULL
-			);
-			CREATE UNIQUE INDEX IF NOT EXISTS leaf_hub_heartbeats_leaf_hub_idx ON status.leaf_hub_heartbeats USING btree (leaf_hub_name);
-		`)
-		Expect(err).ToNot(HaveOccurred())
-
 		By("Check whether the tables are created")
 		Eventually(func() error {
 			rows, err := transportPostgreSQL.GetConn().Query(ctx, "SELECT * FROM pg_tables")

--- a/manager/pkg/statussyncer/syncers/hub_cluster_info_db_syncer_test.go
+++ b/manager/pkg/statussyncer/syncers/hub_cluster_info_db_syncer_test.go
@@ -27,20 +27,6 @@ var _ = Describe("HubClusterInfoDbSyncer", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		By("Create leaf_hubs table in database")
-		_, err := transportPostgreSQL.GetConn().Exec(ctx, `
-			CREATE SCHEMA IF NOT EXISTS status;
-			CREATE TABLE IF NOT EXISTS status.leaf_hubs (
-				leaf_hub_name character varying(63) NOT NULL,
-				payload jsonb NOT NULL,
-				console_url text generated always as (payload ->> 'consoleURL') stored,
-				created_at timestamp without time zone DEFAULT now() NOT NULL,
-				updated_at timestamp without time zone DEFAULT now() NOT NULL,
-				deleted_at timestamp without time zone
-			);
-		`)
-		Expect(err).ToNot(HaveOccurred())
-
 		By("Check whether the tables are created")
 		Eventually(func() error {
 			rows, err := transportPostgreSQL.GetConn().Query(ctx, "SELECT * FROM pg_tables")

--- a/manager/pkg/statussyncer/syncers/local_spec_syncers_test.go
+++ b/manager/pkg/statussyncer/syncers/local_spec_syncers_test.go
@@ -31,32 +31,6 @@ var _ = Describe("LocalSpecDbSyncer", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		By("Create local spec table in database")
-		_, err := transportPostgreSQL.GetConn().Exec(ctx, `
-			CREATE SCHEMA IF NOT EXISTS local_spec;
-			CREATE TABLE IF NOT EXISTS  local_spec.placementrules (
-				leaf_hub_name text,
-				payload jsonb NOT NULL,
-				created_at timestamp without time zone DEFAULT now() NOT NULL,
-				updated_at timestamp without time zone DEFAULT now() NOT NULL
-			);
-			CREATE TABLE IF NOT EXISTS local_spec.policies (
-				leaf_hub_name character varying(63) NOT NULL,
-				payload jsonb NOT NULL,
-				created_at timestamp without time zone,
-				updated_at timestamp without time zone,
-				deleted_at timestamp without time zone,
-				policy_id uuid,
-				policy_name character varying(255) generated always as (payload -> 'metadata' ->> 'name') stored,
-				policy_standard character varying(255) generated always as (payload -> 'metadata' -> 'annotations' ->> 'policy.open-cluster-management.io/standards') stored,
-				policy_category character varying(255) generated always as (payload -> 'metadata' -> 'annotations' ->> 'policy.open-cluster-management.io/categories') stored,
-				policy_control character varying(255) generated always as (payload -> 'metadata' -> 'annotations' ->> 'policy.open-cluster-management.io/controls') stored
-			);
-			CREATE UNIQUE INDEX IF NOT EXISTS placementrules_leaf_hub_name_id_idx ON local_spec.placementrules USING btree (leaf_hub_name, (((payload -> 'metadata'::text) ->> 'uid'::text)));
-			CREATE UNIQUE INDEX IF NOT EXISTS policies_leaf_hub_name_id_idx ON local_spec.policies USING btree (leaf_hub_name, (((payload -> 'metadata'::text) ->> 'uid'::text)));
-		`)
-		Expect(err).ToNot(HaveOccurred())
-
 		By("Check whether the tables are created")
 		Eventually(func() error {
 			rows, err := transportPostgreSQL.GetConn().Query(ctx, "SELECT * FROM pg_tables")

--- a/manager/pkg/statussyncer/syncers/local_spec_syncers_test.go
+++ b/manager/pkg/statussyncer/syncers/local_spec_syncers_test.go
@@ -6,10 +6,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 	placementrulev1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/placementrule/v1"
 
@@ -61,6 +63,7 @@ var _ = Describe("LocalSpecDbSyncer", Ordered, func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "testLocalPolicy",
 				Namespace: "default",
+				UID:       types.UID(uuid.New().String()),
 			},
 			Spec: policiesv1.PolicySpec{},
 		}

--- a/manager/pkg/statussyncer/syncers/local_status_policies_syncer_test.go
+++ b/manager/pkg/statussyncer/syncers/local_status_policies_syncer_test.go
@@ -24,35 +24,6 @@ var _ = Describe("LocalStatusPoliciesSyncer", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		By("Create local spec table in database")
-		_, err := transportPostgreSQL.GetConn().Exec(ctx, `
-			CREATE SCHEMA IF NOT EXISTS event;
-			CREATE SCHEMA IF NOT EXISTS local_status;
-			DO $$ BEGIN
-				CREATE TYPE local_status.compliance_type AS ENUM (
-					'compliant',
-					'non_compliant',
-					'unknown'
-				);
-			EXCEPTION
-				WHEN duplicate_object THEN null;
-			END $$;
-			CREATE TABLE IF NOT EXISTS event.local_policies (
-				event_name character varying(63) NOT NULL,
-				policy_id uuid NOT NULL,
-				cluster_id uuid NOT NULL,
-				leaf_hub_name character varying(63) NOT NULL,
-				message text,
-				reason text,
-				count integer NOT NULL DEFAULT 0,
-				source jsonb,
-				created_at timestamp without time zone DEFAULT now() NOT NULL,
-				compliance local_status.compliance_type NOT NULL,
-				CONSTRAINT local_policies_unique_constraint UNIQUE (event_name, count)
-		);
-		`)
-		Expect(err).ToNot(HaveOccurred())
-
 		By("Check whether the tables are created")
 		Eventually(func() error {
 			rows, err := transportPostgreSQL.GetConn().Query(ctx, "SELECT * FROM pg_tables")

--- a/manager/pkg/statussyncer/syncers/managed_clusters_syncer_test.go
+++ b/manager/pkg/statussyncer/syncers/managed_clusters_syncer_test.go
@@ -27,32 +27,6 @@ var _ = Describe("ManagedClustersDbSyncer", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		By("Create managed_clusters table in database")
-		_, err := transportPostgreSQL.GetConn().Exec(ctx, `
-			CREATE SCHEMA IF NOT EXISTS status;
-			DO $$ BEGIN
-				CREATE TYPE status.error_type AS ENUM (
-					'disconnected',
-					'none'
-				);
-			EXCEPTION
-				WHEN duplicate_object THEN null;
-			END $$;
-			CREATE TABLE IF NOT EXISTS status.managed_clusters (
-				leaf_hub_name character varying(63) NOT NULL,
-				cluster_name character varying(63) generated always as (payload -> 'metadata' ->> 'name') stored,
-				cluster_id uuid NOT NULL,
-				payload jsonb NOT NULL,
-				error status.error_type NOT NULL,
-				created_at timestamp without time zone,
-				updated_at timestamp without time zone,
-				deleted_at timestamp without time zone
-			);
-			CREATE UNIQUE INDEX IF NOT EXISTS managed_clusters_leaf_hub_name_metadata_uid_idx ON status.managed_clusters USING btree (leaf_hub_name, (((payload -> 'metadata'::text) ->> 'uid'::text)));
-			CREATE INDEX IF NOT EXISTS managed_clusters_metadata_name_idx ON status.managed_clusters USING btree ((((payload -> 'metadata'::text) ->> 'name'::text)));
-		`)
-		Expect(err).ToNot(HaveOccurred())
-
 		By("Check whether the tables are created")
 		Eventually(func() error {
 			rows, err := transportPostgreSQL.GetConn().Query(ctx, "SELECT * FROM pg_tables")

--- a/manager/pkg/statussyncer/syncers/placement_decisions_db_syncer_test.go
+++ b/manager/pkg/statussyncer/syncers/placement_decisions_db_syncer_test.go
@@ -26,19 +26,6 @@ var _ = Describe("PlacementDecisionsDbSyncer", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		By("Create placementdecisions table in database")
-		_, err := transportPostgreSQL.GetConn().Exec(ctx, `
-			CREATE SCHEMA IF NOT EXISTS status;
-			CREATE TABLE IF NOT EXISTS  status.placementdecisions (
-				id uuid NOT NULL,
-				leaf_hub_name character varying(63) NOT NULL,
-				payload jsonb NOT NULL
-			);
-			CREATE UNIQUE INDEX IF NOT EXISTS placementdecisions_leaf_hub_name_and_payload_id_namespace_idx ON status.placementdecisions USING btree (leaf_hub_name, id, (((payload -> 'metadata'::text) ->> 'namespace'::text)));
-			CREATE INDEX IF NOT EXISTS placementdecisions_payload_name_and_namespace_idx ON status.placementdecisions USING btree ((((payload -> 'metadata'::text) ->> 'name'::text)), (((payload -> 'metadata'::text) ->> 'namespace'::text)));
-		`)
-		Expect(err).ToNot(HaveOccurred())
-
 		By("Check whether the tables are created")
 		Eventually(func() error {
 			rows, err := transportPostgreSQL.GetConn().Query(ctx, "SELECT * FROM pg_tables")

--- a/manager/pkg/statussyncer/syncers/placement_rules_db_syncer_test.go
+++ b/manager/pkg/statussyncer/syncers/placement_rules_db_syncer_test.go
@@ -26,17 +26,6 @@ var _ = Describe("PlacementRulesDbSyncer", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		By("Create placementrule table in database")
-		_, err := transportPostgreSQL.GetConn().Exec(ctx, `
-			CREATE SCHEMA IF NOT EXISTS status;
-			CREATE TABLE IF NOT EXISTS  status.placementrules (
-				id uuid NOT NULL,
-				leaf_hub_name character varying(63) NOT NULL,
-				payload jsonb NOT NULL
-			);
-		`)
-		Expect(err).ToNot(HaveOccurred())
-
 		By("Check whether the tables are created")
 		Eventually(func() error {
 			rows, err := transportPostgreSQL.GetConn().Query(ctx, "SELECT * FROM pg_tables")

--- a/manager/pkg/statussyncer/syncers/placements_db_syncer_test.go
+++ b/manager/pkg/statussyncer/syncers/placements_db_syncer_test.go
@@ -26,17 +26,6 @@ var _ = Describe("PlacementDbSyncer", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		By("Create placements table in database")
-		_, err := transportPostgreSQL.GetConn().Exec(ctx, `
-			CREATE SCHEMA IF NOT EXISTS status;
-			CREATE TABLE IF NOT EXISTS  status.placements (
-				id uuid NOT NULL,
-				leaf_hub_name character varying(63) NOT NULL,
-				payload jsonb NOT NULL
-			);
-		`)
-		Expect(err).ToNot(HaveOccurred())
-
 		By("Check whether the tables are created")
 		Eventually(func() error {
 			rows, err := transportPostgreSQL.GetConn().Query(ctx, "SELECT * FROM pg_tables")

--- a/manager/pkg/statussyncer/syncers/policies_db_syncer_test.go
+++ b/manager/pkg/statussyncer/syncers/policies_db_syncer_test.go
@@ -27,42 +27,6 @@ var _ = Describe("Policies", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		By("Create status compliance table in database")
-		_, err := transportPostgreSQL.GetConn().Exec(ctx, `
-			CREATE SCHEMA IF NOT EXISTS status;
-			DO $$ BEGIN
-				CREATE TYPE status.compliance_type AS ENUM (
-					'compliant',
-					'non_compliant',
-					'unknown'
-				);
-			EXCEPTION
-				WHEN duplicate_object THEN null;
-			END $$;
-			DO $$ BEGIN
-				CREATE TYPE status.error_type AS ENUM (
-					'disconnected',
-					'none'
-				);
-			EXCEPTION
-				WHEN duplicate_object THEN null;
-			END $$;
-			CREATE TABLE IF NOT EXISTS status.compliance (
-				policy_id uuid NOT NULL,
-				cluster_name character varying(63) NOT NULL,
-				leaf_hub_name character varying(63) NOT NULL,
-				error status.error_type NOT NULL,
-				compliance status.compliance_type NOT NULL
-			);
-			CREATE TABLE IF NOT EXISTS status.aggregated_compliance (
-				policy_id uuid NOT NULL,
-				leaf_hub_name character varying(63) NOT NULL,
-				applied_clusters integer NOT NULL,
-				non_compliant_clusters integer NOT NULL
-			);
-		`)
-		Expect(err).ToNot(HaveOccurred())
-
 		By("Check whether the tables are created")
 		Eventually(func() error {
 			rows, err := transportPostgreSQL.GetConn().Query(ctx, "SELECT * FROM pg_tables")
@@ -200,8 +164,7 @@ var _ = Describe("Policies", Ordered, func() {
 			UnknownComplianceClusters: []string{"cluster3"},
 		})
 		// transport bundle
-		policyCompleteComplianceTransportKey :=
-			fmt.Sprintf("%s.%s", leafHubName, constants.PolicyCompleteComplianceMsgKey)
+		policyCompleteComplianceTransportKey := fmt.Sprintf("%s.%s", leafHubName, constants.PolicyCompleteComplianceMsgKey)
 		completePayloadBytes, err := json.Marshal(transportCompletePayload)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -437,8 +400,7 @@ var _ = Describe("Policies", Ordered, func() {
 			AppliedClusters:      3,
 		})
 		// transport bundle
-		minimalPolicyComplianceTransportKey :=
-			fmt.Sprintf("%s.%s", leafHubName, constants.MinimalPolicyComplianceMsgKey)
+		minimalPolicyComplianceTransportKey := fmt.Sprintf("%s.%s", leafHubName, constants.MinimalPolicyComplianceMsgKey)
 		payloadBytes, err := json.Marshal(transportPayload)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/manager/pkg/statussyncer/syncers/subscription_reports_db_syncer_test.go
+++ b/manager/pkg/statussyncer/syncers/subscription_reports_db_syncer_test.go
@@ -26,17 +26,6 @@ var _ = Describe("SubscriptionReportsDbSyncer", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		By("Create subscription reports table in database")
-		_, err := transportPostgreSQL.GetConn().Exec(ctx, `
-			CREATE SCHEMA IF NOT EXISTS status;
-			CREATE TABLE IF NOT EXISTS  status.subscription_reports (
-				id uuid NOT NULL,
-				leaf_hub_name character varying(63) NOT NULL,
-				payload jsonb NOT NULL
-			);
-		`)
-		Expect(err).ToNot(HaveOccurred())
-
 		By("Check whether the tables are created")
 		Eventually(func() error {
 			rows, err := transportPostgreSQL.GetConn().Query(ctx, "SELECT * FROM pg_tables")

--- a/manager/pkg/statussyncer/syncers/subscription_status_db_syncer_test.go
+++ b/manager/pkg/statussyncer/syncers/subscription_status_db_syncer_test.go
@@ -26,17 +26,6 @@ var _ = Describe("SubscriptionStatusDbSyncer", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		By("Create subscription status table in database")
-		_, err := transportPostgreSQL.GetConn().Exec(ctx, `
-			CREATE SCHEMA IF NOT EXISTS status;
-			CREATE TABLE IF NOT EXISTS  status.subscription_statuses (
-				id uuid NOT NULL,
-				leaf_hub_name character varying(63) NOT NULL,
-				payload jsonb NOT NULL
-			);
-		`)
-		Expect(err).ToNot(HaveOccurred())
-
 		By("Check whether the tables are created")
 		Eventually(func() error {
 			rows, err := transportPostgreSQL.GetConn().Query(ctx, "SELECT * FROM pg_tables")

--- a/manager/pkg/statussyncer/syncers/suite_test.go
+++ b/manager/pkg/statussyncer/syncers/suite_test.go
@@ -69,6 +69,9 @@ var _ = BeforeSuite(func() {
 
 	By("Prepare postgres database")
 	testPostgres, err = testpostgres.NewTestPostgres()
+	Expect(err).NotTo(HaveOccurred())
+	err = testpostgres.InitDatabase(testPostgres.URI)
+	Expect(err).NotTo(HaveOccurred())
 
 	By("Create test postgres")
 	managerConfig := &config.ManagerConfig{

--- a/test/pkg/testpostgres/testdatabase.go
+++ b/test/pkg/testpostgres/testdatabase.go
@@ -1,0 +1,54 @@
+package testpostgres
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/database"
+)
+
+func InitDatabase(uri string) error {
+	err := database.InitGormInstance(&database.DatabaseConfig{
+		URL:      uri,
+		Dialect:  database.PostgresDialect,
+		PoolSize: 1,
+	})
+	if err != nil {
+		return err
+	}
+
+	db := database.GetGorm()
+
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		return fmt.Errorf("failed to get current dir: no caller information")
+	}
+	dirname := filepath.Dir(currentFile)
+	dirname = filepath.Dir(dirname)
+	dirname = filepath.Dir(dirname)
+	dirname = filepath.Dir(dirname)
+
+	sqlDir := filepath.Join(dirname, "operator", "pkg", "controllers", "hubofhubs", "database")
+	files, err := os.ReadDir(sqlDir)
+	if err != nil {
+		return err
+	}
+
+	for _, file := range files {
+		filePath := filepath.Join(sqlDir, file.Name())
+		fileContent, err := ioutil.ReadFile(filePath)
+		if err != nil {
+			return err
+		}
+
+		result := db.Exec(string(fileContent))
+		if result.Error != nil {
+			return result.Error
+		}
+		fmt.Printf("Script %s executed successfully.\n", file.Name())
+	}
+	return nil
+}

--- a/test/pkg/testpostgres/testdatabase.go
+++ b/test/pkg/testpostgres/testdatabase.go
@@ -48,7 +48,7 @@ func InitDatabase(uri string) error {
 		if result.Error != nil {
 			return result.Error
 		}
-		fmt.Printf("Script %s executed successfully.\n", file.Name())
+		fmt.Printf("script %s executed successfully.\n", file.Name())
 	}
 	return nil
 }


### PR DESCRIPTION
add the following code before testing, and it will init a global hub database and create the tables, indexes and triggers
```golang
err = testpostgres.InitDatabase(testPostgres.URI)
Expect(err).NotTo(HaveOccurred())
```
resolved: https://github.com/stolostron/multicluster-global-hub/issues/466