### PR TITLE
fixed the issue with BYO postgres

### DIFF
--- a/pkg/database/gorm_conn.go
+++ b/pkg/database/gorm_conn.go
@@ -90,7 +90,9 @@ func completePostgres(postgresUri string, caCertPath string) (*url.URL, error) {
 	query := urlObj.Query()
 	if query.Get("sslmode") == "verify-ca" && utils.Validate(caCertPath) {
 		query.Set("sslrootcert", caCertPath)
-		urlObj.RawQuery = query.Encode()
+	} else {
+		query.Add("sslmode", "disable")
 	}
+	urlObj.RawQuery = query.Encode()
 	return urlObj, nil
 }


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/ACM-6246
When bringing your own Postgres without `rootca` cert, it will throw the following bug:
```bash
2023-07-17 05:47:24 UTC ERROR   setup   failed to initialize GORM instance      {"error": "pq: SSL is not enabled on the server"}
``` 