### PR TITLE
fixed version of Policy Progator Operator

### DIFF
--- a/test/setup/common.sh
+++ b/test/setup/common.sh
@@ -218,7 +218,7 @@ function initPolicy() {
     policyPropagator=$(kubectl get pods -n "${HUB_NAMESPACE}" --context "${hub}" --ignore-not-found | grep "governance-policy-propagator" || true)
     if [[ ${policyPropagator} == "" ]]; then 
       kubectl create ns "${HUB_NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
-      GIT_PATH="https://raw.githubusercontent.com/open-cluster-management-io/governance-policy-propagator/v0.10.0/deploy"
+      GIT_PATH="https://raw.githubusercontent.com/open-cluster-management-io/governance-policy-propagator/v0.11.0/deploy"
       ## Apply the CRDs
       kubectl apply -f ${GIT_PATH}/crds/policy.open-cluster-management.io_policies.yaml 
       kubectl apply -f ${GIT_PATH}/crds/policy.open-cluster-management.io_placementbindings.yaml 

--- a/test/setup/common.sh
+++ b/test/setup/common.sh
@@ -218,7 +218,7 @@ function initPolicy() {
     policyPropagator=$(kubectl get pods -n "${HUB_NAMESPACE}" --context "${hub}" --ignore-not-found | grep "governance-policy-propagator" || true)
     if [[ ${policyPropagator} == "" ]]; then 
       kubectl create ns "${HUB_NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
-      GIT_PATH="https://raw.githubusercontent.com/open-cluster-management-io/governance-policy-propagator/v0.11.0/deploy"
+      GIT_PATH="https://raw.githubusercontent.com/open-cluster-management-io/governance-policy-propagator/v0.10.0/deploy"
       ## Apply the CRDs
       kubectl apply -f ${GIT_PATH}/crds/policy.open-cluster-management.io_policies.yaml 
       kubectl apply -f ${GIT_PATH}/crds/policy.open-cluster-management.io_placementbindings.yaml 
@@ -226,6 +226,7 @@ function initPolicy() {
       kubectl apply -f ${GIT_PATH}/crds/policy.open-cluster-management.io_policysets.yaml
       ## Deploy the policy-propagator
       kubectl apply -f ${GIT_PATH}/operator.yaml -n ${HUB_NAMESPACE}
+      kubectl patch deployment governance-policy-propagator -n ${HUB_NAMESPACE} -p '{"spec":{"template":{"spec":{"containers":[{"name":"governance-policy-propagator","image":"quay.io/open-cluster-management/governance-policy-propagator:v0.11.0"}]}}}}'
     elif [[ $(echo "${policyPropagator}" | awk '{print $3}')  == "Running" ]]; then 
       (( componentCount = componentCount + 1 ))
       echo "Policy: step${componentCount} ${hub} ${policyPropagator} is Running" 

--- a/test/setup/common.sh
+++ b/test/setup/common.sh
@@ -218,7 +218,7 @@ function initPolicy() {
     policyPropagator=$(kubectl get pods -n "${HUB_NAMESPACE}" --context "${hub}" --ignore-not-found | grep "governance-policy-propagator" || true)
     if [[ ${policyPropagator} == "" ]]; then 
       kubectl create ns "${HUB_NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
-      GIT_PATH="https://raw.githubusercontent.com/open-cluster-management-io/governance-policy-propagator/main/deploy"
+      GIT_PATH="https://raw.githubusercontent.com/open-cluster-management-io/governance-policy-propagator/v0.11.0/deploy"
       ## Apply the CRDs
       kubectl apply -f ${GIT_PATH}/crds/policy.open-cluster-management.io_policies.yaml 
       kubectl apply -f ${GIT_PATH}/crds/policy.open-cluster-management.io_placementbindings.yaml 


### PR DESCRIPTION
After the policy operator has been added the `propagator-webhook-validating-configuration` [validating webhook](https://github.com/open-cluster-management-io/governance-policy-propagator/commit/c93f938892c18f3fe84655246ee1a92a963ad62e#diff-3cbaaa330e7ffeab27fc2751c0454be7d83bb82914ea948d6d7c09f5029e0e34). The following issues arise with the `governance-policy-propagator` component setup:
```bash
  Warning  FailedMount  61s (x4 over 14m)    kubelet            Unable to attach or mount volumes: unmounted volumes=[cert], unattached volumes=[kube-api-access-bs2rm cert]: timed out waiting for the condition
  Warning  FailedMount  48s (x18 over 21m)   kubelet            MountVolume.SetUp failed for volume "cert" : secret "propagator-webhook-server-cert" not found
```