### PR TITLE
forbidd the cluster policy events from managed hub

### DIFF
--- a/agent/pkg/event/enhancers/policy_event_test.go
+++ b/agent/pkg/event/enhancers/policy_event_test.go
@@ -66,19 +66,20 @@ var _ = Describe("policy enhancer", Ordered, func() {
 				},
 			},
 		}
-		NewPolicyEventEnhancer(runtimeClient).Enhance(ctx, &in)
-		Eventually(func() error {
-			if in.InvolvedObject.Labels[constants.PolicyEventComplianceLabelKey] != "Compliant" {
-				return fmt.Errorf("compliance from message should be Compliant")
-			}
-			if in.InvolvedObject.Labels[constants.PolicyEventRootPolicyIdLabelKey] != string(rootPolicy.GetUID()) {
-				return fmt.Errorf("the label value of root policy id should be %s", rootPolicy.GetUID())
-			}
-			if in.InvolvedObject.Labels[constants.PolicyEventClusterIdLabelKey] != string(cluster.GetUID()) {
-				return fmt.Errorf("the label value of cluster id should be %s", cluster.GetUID())
-			}
-			return nil
-		}).Should(Succeed())
+		sync := NewPolicyEventEnhancer(runtimeClient).Enhance(ctx, &in)
+		Expect(sync).To(BeFalse())
+		// Eventually(func() error {
+		// 	if in.InvolvedObject.Labels[constants.PolicyEventComplianceLabelKey] != "Compliant" {
+		// 		return fmt.Errorf("compliance from message should be Compliant")
+		// 	}
+		// 	if in.InvolvedObject.Labels[constants.PolicyEventRootPolicyIdLabelKey] != string(rootPolicy.GetUID()) {
+		// 		return fmt.Errorf("the label value of root policy id should be %s", rootPolicy.GetUID())
+		// 	}
+		// 	if in.InvolvedObject.Labels[constants.PolicyEventClusterIdLabelKey] != string(cluster.GetUID()) {
+		// 		return fmt.Errorf("the label value of cluster id should be %s", cluster.GetUID())
+		// 	}
+		// 	return nil
+		// }).Should(Succeed())
 	})
 
 	It("should pass root policy event enhancer", func() {

--- a/manager/pkg/cronjob/task/task_suite_test.go
+++ b/manager/pkg/cronjob/task/task_suite_test.go
@@ -68,9 +68,9 @@ var _ = AfterSuite(func() {
 	// Set 4 with random
 	if err != nil {
 		time.Sleep(4 * time.Second)
+		Expect(testenv.Stop()).NotTo(HaveOccurred())
 	}
 	pool.Close()
 	Expect(testPostgres.Stop()).NotTo(HaveOccurred())
-	Expect(testenv.Stop()).NotTo(HaveOccurred())
 	cancel()
 })

--- a/manager/pkg/specsyncer/spec2db/controller/controllers_suite_test.go
+++ b/manager/pkg/specsyncer/spec2db/controller/controllers_suite_test.go
@@ -127,7 +127,6 @@ var _ = AfterSuite(func() {
 		time.Sleep(4 * time.Second)
 		Expect(testenv.Stop()).NotTo(HaveOccurred())
 	}
-	postgresSQL.Stop()
 	Expect(testPostgres.Stop()).NotTo(HaveOccurred())
 	cancel()
 })


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/ACM-6593


The following cluster policy events will reported after I create an informed policy and then enforce it:

![image](https://github.com/stolostron/multicluster-global-hub/assets/19286664/20ac5de7-1521-47c5-8ecc-9ab4ba91fa3e)

However, we can find that the red boxes in the figure are not helpful for analyzing the reasons for the policy state, so it is recommended to remove them.