### PR TITLE
Remove the unnecessary bundle from the agent syncer

### DIFF
--- a/agent/pkg/status/controller/controller_integration_test.go
+++ b/agent/pkg/status/controller/controller_integration_test.go
@@ -219,7 +219,7 @@ var _ = Describe("Agent Status Controller", Ordered, func() {
 
 		By("Check the policy bundles is synced")
 		var clustersPerPolicyBundle *statusbundle.ClustersPerPolicyBundle
-		var policyCompleteComplianceStatusBundle *statusbundle.CompleteComplianceStatusBundle
+		// var policyCompleteComplianceStatusBundle *statusbundle.CompleteComplianceStatusBundle
 		Eventually(func() bool {
 			message := <-consumer.MessageChan()
 
@@ -232,19 +232,19 @@ var _ = Describe("Agent Status Controller", Ordered, func() {
 					fmt.Printf("unexpected received bundle type, want ClustersPerPolicyBundle")
 				}
 			}
-			statusBundle, err = getStatusBundle(message,
-				constants.PolicyCompleteComplianceMsgKey)
-			if err == nil {
-				fmt.Printf("========== received %s with statusBundle: %v\n", message.ID, statusBundle)
-				ok := false
-				policyCompleteComplianceStatusBundle, ok =
-					statusBundle.(*statusbundle.CompleteComplianceStatusBundle)
-				if !ok {
-					fmt.Printf("unexpected received bundle type, want ClustersPerPolicyBundle")
-				}
-			}
-			return clustersPerPolicyBundle != nil &&
-				policyCompleteComplianceStatusBundle != nil
+			// statusBundle, err = getStatusBundle(message,
+			// 	constants.PolicyCompleteComplianceMsgKey)
+			// if err == nil {
+			// 	fmt.Printf("========== received %s with statusBundle: %v\n", message.ID, statusBundle)
+			// 	ok := false
+			// 	policyCompleteComplianceStatusBundle, ok = statusBundle.(*statusbundle.CompleteComplianceStatusBundle)
+			// 	if !ok {
+			// 		fmt.Printf("unexpected received bundle type, want ClustersPerPolicyBundle")
+			// 	}
+			// }
+			// return clustersPerPolicyBundle != nil &&
+			// 	policyCompleteComplianceStatusBundle != nil
+			return clustersPerPolicyBundle != nil
 		}, 30*time.Second, 1*time.Second).Should(BeTrue())
 
 		By("Check the clustersPerPolicyBundle")
@@ -263,19 +263,19 @@ var _ = Describe("Agent Status Controller", Ordered, func() {
 		Expect(policyGenericComplianceStatus.NonCompliantClusters[1]).Should(Equal("hub1-mc3"))
 		Expect(len(policyGenericComplianceStatus.UnknownComplianceClusters)).Should(Equal(0))
 
-		By("Check the policyCompleteComplianceStatusBundle")
-		policyCompleteComplianceStatusObjs := policyCompleteComplianceStatusBundle.GetObjects()
-		Expect(len(policyCompleteComplianceStatusObjs)).Should(Equal(1))
+		// By("Check the policyCompleteComplianceStatusBundle")
+		// policyCompleteComplianceStatusObjs := policyCompleteComplianceStatusBundle.GetObjects()
+		// Expect(len(policyCompleteComplianceStatusObjs)).Should(Equal(1))
 
-		policyCompleteComplianceStatus := policyCompleteComplianceStatusObjs[0].(*status.PolicyCompleteComplianceStatus)
-		fmt.Println(policyCompleteComplianceStatus)
+		// policyCompleteComplianceStatus := policyCompleteComplianceStatusObjs[0].(*status.PolicyCompleteComplianceStatus)
+		// fmt.Println(policyCompleteComplianceStatus)
 
-		Expect(policyCompleteComplianceStatus.PolicyID).Should(Equal(testGlobalPolicyOriginUID))
+		// Expect(policyCompleteComplianceStatus.PolicyID).Should(Equal(testGlobalPolicyOriginUID))
 
-		Expect(len(policyCompleteComplianceStatus.NonCompliantClusters)).Should(Equal(2))
-		Expect(len(policyCompleteComplianceStatus.UnknownComplianceClusters)).Should(Equal(0))
-		Expect(policyCompleteComplianceStatus.NonCompliantClusters[0]).Should(Equal("hub1-mc2"))
-		Expect(policyCompleteComplianceStatus.NonCompliantClusters[1]).Should(Equal("hub1-mc3"))
+		// Expect(len(policyCompleteComplianceStatus.NonCompliantClusters)).Should(Equal(2))
+		// Expect(len(policyCompleteComplianceStatus.UnknownComplianceClusters)).Should(Equal(0))
+		// Expect(policyCompleteComplianceStatus.NonCompliantClusters[0]).Should(Equal("hub1-mc2"))
+		// Expect(policyCompleteComplianceStatus.NonCompliantClusters[1]).Should(Equal("hub1-mc3"))
 	})
 
 	// TODO: consider to support delta bundle with cloudevents
@@ -537,8 +537,7 @@ var _ = Describe("Agent Status Controller", Ordered, func() {
 			}
 			fmt.Printf("========== received %s with statusBundle: %v\n", message.ID, statusBundle)
 
-			subscriptionReportsStatusBundle, ok :=
-				statusBundle.(*statusbundle.SubscriptionReportsBundle)
+			subscriptionReportsStatusBundle, ok := statusBundle.(*statusbundle.SubscriptionReportsBundle)
 			if !ok {
 				return errors.New("unexpected received bundle type, want PlacementDecisionsBundle")
 			}

--- a/agent/pkg/status/controller/policies/policy_status_sync.go
+++ b/agent/pkg/status/controller/policies/policy_status_sync.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/bundle/grc"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/controller/config"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/controller/generic"
-	genericbundle "github.com/stolostron/multicluster-global-hub/pkg/bundle"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 )
@@ -29,8 +28,7 @@ const (
 func AddPoliciesStatusController(mgr ctrl.Manager, producer transport.Producer, leafHubName string,
 	incarnation uint64, hubOfHubsConfig *corev1.ConfigMap, syncIntervalsData *config.SyncIntervals,
 ) (*generic.HybridSyncManager, error) {
-	bundleCollection, hybridSyncManager, err :=
-		createBundleCollection(producer, leafHubName, incarnation, hubOfHubsConfig)
+	bundleCollection, hybridSyncManager, err := createBundleCollection(producer, leafHubName, incarnation, hubOfHubsConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to add policies controller to the manager - %w", err)
 	}
@@ -82,8 +80,8 @@ func createBundleCollection(pro transport.Producer, leafHubName string,
 	// no need to send in the same cycle both clusters per policy and compliance. if CpP was sent, don't send compliance
 	return []*generic.BundleCollectionEntry{ // multiple bundles for policy status
 		generic.NewBundleCollectionEntry(clustersPerPolicyTransportKey, clustersPerPolicyBundle, fullStatusPredicate),
-		hybridSyncManager.GetBundleCollectionEntry(genericbundle.CompleteStateMode),
-		hybridSyncManager.GetBundleCollectionEntry(genericbundle.DeltaStateMode),
+		// hybridSyncManager.GetBundleCollectionEntry(genericbundle.CompleteStateMode),
+		// hybridSyncManager.GetBundleCollectionEntry(genericbundle.DeltaStateMode),
 		generic.NewBundleCollectionEntry(minimalComplianceStatusTransportKey, minimalComplianceStatusBundle,
 			minimalStatusPredicate),
 	}, hybridSyncManager, nil


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>

For the data of the same table, there may be different bundles to update it, and cut off the redundant bundle to reduce workload.