### PR TITLE
Remove pgBouncer

### DIFF
--- a/operator/config/samples/storage/postgres-cluster.yaml
+++ b/operator/config/samples/storage/postgres-cluster.yaml
@@ -43,20 +43,6 @@ spec:
               resources:
                 requests:
                   storage: 1Gi
-  proxy:
-    pgBouncer:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:ubi8-1.17-1
-      replicas: 3
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 1
-              podAffinityTerm:
-                topologyKey: kubernetes.io/hostname
-                labelSelector:
-                  matchLabels:
-                    postgres-operator.crunchydata.com/cluster: hoh
-                    postgres-operator.crunchydata.com/role: pgbouncer
 ---
 # The configMap is used to set/unset HA configuration
 # To set HA:

--- a/test/setup/hoh/postgres/postgres-cluster/postgres-cluster.yaml
+++ b/test/setup/hoh/postgres/postgres-cluster/postgres-cluster.yaml
@@ -11,7 +11,7 @@ spec:
       databases: ["hoh"]
   instances:
     - name: pgha1
-      replicas: 3
+      replicas: 1
       dataVolumeClaimSpec:
         accessModes:
           - "ReadWriteOnce"
@@ -40,32 +40,3 @@ spec:
               resources:
                 requests:
                   storage: 1Gi
-  proxy:
-    pgBouncer:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:ubi8-1.17-1
-      replicas: 3
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 1
-              podAffinityTerm:
-                topologyKey: kubernetes.io/hostname
-                labelSelector:
-                  matchLabels:
-                    postgres-operator.crunchydata.com/cluster: hoh
-                    postgres-operator.crunchydata.com/role: pgbouncer
----
-# The configMap is used to set/unset HA configuration
-# To set HA:
-#   1. Use DisableAutofail: "false" or omit it
-#   2. Define at least 2 replicas in "instances" and "proxy" sections of the above PostgresCluster CR
-# To unset HA:
-#   1. Use DisableAutofail: "true"
-#   2. Define 1 replica in "instances" and "proxy" sections of the above PostgresCluster CR
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: pgo-config
-  namespace: hoh-postgres
-data:
-  DisableAutofail: "false"

--- a/test/setup/hoh/postgres/postgres-operator/bases/manager/manager.yaml
+++ b/test/setup/hoh/postgres/postgres-operator/bases/manager/manager.yaml
@@ -10,22 +10,10 @@ spec:
     spec:
       containers:
       - name: operator
-        # since the k8s v1.25 compatible fix has not been released yet, this image is used for now.
-        # https://github.com/CrunchyData/postgres-operator/issues/3365
-        image: quay.io/myan/postgres-operator:ubi8-k8s.1.25       
+        image: registry.connect.redhat.com/crunchydata/postgres-operator@sha256:707a7718017ee5f195e269c66275d731aa2412bc5115731c82b710dfb640037a       
         env:
         - name: CRUNCHY_DEBUG
           value: "true"
-        - name: RELATED_IMAGE_POSTGRES_13
-          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-13.8-1"
-        - name: RELATED_IMAGE_POSTGRES_13_GIS_3.1
-          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-13.8-3.1-1"
-        - name: RELATED_IMAGE_PGBACKREST
-          value: "registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.40-1"
-        - name: RELATED_IMAGE_PGBOUNCER
-          value: "registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:ubi8-1.17-1"
-        - name: RELATED_IMAGE_PGEXPORTER
-          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-exporter:ubi8-5.2.0-0"
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/test/setup/hoh/postgres/postgres-operator/bases/manager/manager.yaml
+++ b/test/setup/hoh/postgres/postgres-operator/bases/manager/manager.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: operator
-        image: registry.connect.redhat.com/crunchydata/postgres-operator@sha256:707a7718017ee5f195e269c66275d731aa2412bc5115731c82b710dfb640037a       
+        image: registry.developers.crunchydata.com/crunchydata/postgres-operator:ubi8-5.3.3-0
         env:
         - name: CRUNCHY_DEBUG
           value: "true"

--- a/test/setup/hoh/postgres/postgres_setup.sh
+++ b/test/setup/hoh/postgres/postgres_setup.sh
@@ -43,10 +43,6 @@ echo "storage secret is ready in $targetNamespace namespace!"
 # expose the postgres service as NodePort
 pgnamespace="hoh-postgres"
 kubectl --kubeconfig $KUBECONFIG patch postgrescluster hoh -n $pgnamespace -p '{"spec":{"service":{"type":"NodePort", "nodePort": 32432}}}'  --type merge
-# unset HA
-kubectl --kubeconfig $KUBECONFIG patch configmap pgo-config -n hoh-postgres --type json -p='[{"op": "replace", "path": "/data/DisableAutofail", "value": "true"}]'
-kubectl --kubeconfig $KUBECONFIG patch postgrescluster hoh -n hoh-postgres --type json -p='[{"op": "replace", "path": "/spec/instances/0/replicas", "value": 1}]'
-kubectl --kubeconfig $KUBECONFIG patch postgrescluster hoh -n hoh-postgres --type merge --patch '{"spec":{"proxy":{"pgBouncer":{"replicas":1}}}}'
 
 stss=$(kubectl --kubeconfig $KUBECONFIG get statefulset -n $pgnamespace -o jsonpath={.items..metadata.name})
 for sts in ${stss}; do


### PR DESCRIPTION
[pgBouncer](https://www.pgbouncer.org/) is a lightweight connection poooler and state manager that provides an efficient gateway to metering connections to PostgreSQL. We connect to postgres via `hoh-primary` service. We do not use hoh-primary so far.