### PR TITLE
Consolidate cronjobs logging

### DIFF
--- a/manager/pkg/cronjob/task/data_partition.go
+++ b/manager/pkg/cronjob/task/data_partition.go
@@ -131,6 +131,7 @@ func traceDataRetentionLog(tableName string, startTime time.Time, err error, par
 	dataRetentionLog := &models.DataRetentionJobLog{
 		Name:    tableName,
 		StartAt: startTime,
+		EndAt:   time.Now(),
 		Error:   "none",
 	}
 	if err != nil {
@@ -149,8 +150,7 @@ func traceDataRetentionLog(tableName string, startTime time.Time, err error, par
 			dataRetentionLog.MinDeletion = minDeletionTime
 		}
 	}
-	result := db.Create(dataRetentionLog)
-	return result.Error
+	return db.Create(dataRetentionLog).Error
 }
 
 func getMinMaxPartitions(tableName string) (string, string, error) {

--- a/manager/pkg/statussyncer/syncers/compliance_handler_test.go
+++ b/manager/pkg/statussyncer/syncers/compliance_handler_test.go
@@ -168,7 +168,8 @@ var _ = Describe("Status Compliances", Ordered, func() {
 		// transport bundle
 		completeComplianceStatusBundle.BaseBundleVersion.Incr()
 		completeComplianceStatusBundle.BundleVersion.Incr()
-		policyCompleteComplianceTransportKey := fmt.Sprintf("%s.%s", leafHubName, constants.PolicyCompleteComplianceMsgKey)
+		policyCompleteComplianceTransportKey :=
+			fmt.Sprintf("%s.%s", leafHubName, constants.PolicyCompleteComplianceMsgKey)
 		completePayloadBytes, err := json.Marshal(completeComplianceStatusBundle)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -408,7 +409,8 @@ var _ = Describe("Status Compliances", Ordered, func() {
 		})
 		// transport bundle
 		minimalComplianceBundle.BundleVersion.Incr()
-		minimalPolicyComplianceTransportKey := fmt.Sprintf("%s.%s", leafHubName, constants.MinimalPolicyComplianceMsgKey)
+		minimalPolicyComplianceTransportKey :=
+			fmt.Sprintf("%s.%s", leafHubName, constants.MinimalPolicyComplianceMsgKey)
 		payloadBytes, err := json.Marshal(minimalComplianceBundle)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/database/models/history.go
+++ b/pkg/database/models/history.go
@@ -1,0 +1,17 @@
+package models
+
+import "time"
+
+type LocalComplianceJobLog struct {
+	Name     string    `gorm:"column:table_name"`
+	StartAt  time.Time `gorm:"column:start_at;default:current_timestamp"`
+	EndAt    time.Time `gorm:"column:end_at;default:current_timestamp"`
+	Total    int64     `gorm:"column:total"`
+	Inserted int64     `gorm:"column:inserted"`
+	Offsets  int64     `gorm:"column:offsets"`
+	Error    string    `gorm:"column:error"`
+}
+
+func (LocalComplianceJobLog) TableName() string {
+	return "history.local_compliance_job_log"
+}

--- a/pkg/database/models/history.go
+++ b/pkg/database/models/history.go
@@ -3,7 +3,7 @@ package models
 import "time"
 
 type LocalComplianceJobLog struct {
-	Name     string    `gorm:"column:table_name"`
+	Name     string    `gorm:"column:name"`
 	StartAt  time.Time `gorm:"column:start_at;default:current_timestamp"`
 	EndAt    time.Time `gorm:"column:end_at;default:current_timestamp"`
 	Total    int64     `gorm:"column:total"`


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>

Ref: https://issues.redhat.com/browse/ACM-7029

- Replace `sql` logging with ORM
- Fixed the log issue that the `end_at` of the retention job isn't set.