### PR TITLE
generate the default value/struct for the global hub operand

### DIFF
--- a/operator/apis/v1alpha4/multiclusterglobalhub_types.go
+++ b/operator/apis/v1alpha4/multiclusterglobalhub_types.go
@@ -49,6 +49,8 @@ type MulticlusterGlobalHub struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	// +kubebuilder:default={dataLayer: {postgres: {retention: "18m"}, kafka: {transportFormat: cloudEvents}}}
+	// +kubebuilder:validation:Required
 	Spec   MulticlusterGlobalHubSpec   `json:"spec,omitempty"`
 	Status MulticlusterGlobalHubStatus `json:"status,omitempty"`
 }
@@ -67,16 +69,17 @@ type MulticlusterGlobalHubSpec struct {
 	// Tolerations causes all components to tolerate any taints.
 	// +optional
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
-	// DataLayer can be configured to use a different data layer, only support largeScale now.
-	// largeScale: large scale data layer served by kafka and postgres.
+	// DataLayer can be configured to use a different data layer.
 	// +kubebuilder:validation:Required
+	// +kubebuilder:default={postgres: {retention: "18m"}, kafka: {transportFormat: cloudEvents}}
 	DataLayer DataLayerConfig `json:"dataLayer"`
 }
 
 // DataLayerConfig is a discriminated union of data layer specific configuration.
-// +union
 type DataLayerConfig struct {
-	Kafka    KafkaConfig    `json:"kafka,omitempty"`
+	// +kubebuilder:default={transportFormat: cloudEvents}
+	Kafka KafkaConfig `json:"kafka,omitempty"`
+	// +kubebuilder:default={retention: "18m"}
 	Postgres PostgresConfig `json:"postgres,omitempty"`
 }
 

--- a/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -26,7 +26,7 @@ metadata:
     categories: Integration & Delivery,OpenShift Optional
     certified: "false"
     containerImage: quay.io/stolostron/multicluster-global-hub-operator:latest
-    createdAt: "2023-08-29T07:09:49Z"
+    createdAt: "2023-08-30T08:24:32Z"
     description: Manages the installation and upgrade of the Multicluster Global Hub.
     operatorframework.io/suggested-namespace: open-cluster-management
     operators.operatorframework.io/builder: operator-sdk-v1.28.0+git

--- a/operator/bundle/manifests/operator.open-cluster-management.io_multiclusterglobalhubs.yaml
+++ b/operator/bundle/manifests/operator.open-cluster-management.io_multiclusterglobalhubs.yaml
@@ -36,14 +36,25 @@ spec:
           metadata:
             type: object
           spec:
+            default:
+              dataLayer:
+                kafka:
+                  transportFormat: cloudEvents
+                postgres:
+                  retention: 18m
             description: MulticlusterGlobalHubSpec defines the desired state of MulticlusterGlobalHub
             properties:
               dataLayer:
-                description: 'DataLayer can be configured to use a different data
-                  layer, only support largeScale now. largeScale: large scale data
-                  layer served by kafka and postgres.'
+                default:
+                  kafka:
+                    transportFormat: cloudEvents
+                  postgres:
+                    retention: 18m
+                description: DataLayer can be configured to use a different data layer.
                 properties:
                   kafka:
+                    default:
+                      transportFormat: cloudEvents
                     description: KafkaConfig defines the desired state of kafka
                     properties:
                       transportFormat:
@@ -56,6 +67,8 @@ spec:
                         type: string
                     type: object
                   postgres:
+                    default:
+                      retention: 18m
                     description: PostgresConfig defines the desired state of postgres
                     properties:
                       retention:

--- a/operator/config/crd/bases/operator.open-cluster-management.io_multiclusterglobalhubs.yaml
+++ b/operator/config/crd/bases/operator.open-cluster-management.io_multiclusterglobalhubs.yaml
@@ -37,14 +37,25 @@ spec:
           metadata:
             type: object
           spec:
+            default:
+              dataLayer:
+                kafka:
+                  transportFormat: cloudEvents
+                postgres:
+                  retention: 18m
             description: MulticlusterGlobalHubSpec defines the desired state of MulticlusterGlobalHub
             properties:
               dataLayer:
-                description: 'DataLayer can be configured to use a different data
-                  layer, only support largeScale now. largeScale: large scale data
-                  layer served by kafka and postgres.'
+                default:
+                  kafka:
+                    transportFormat: cloudEvents
+                  postgres:
+                    retention: 18m
+                description: DataLayer can be configured to use a different data layer.
                 properties:
                   kafka:
+                    default:
+                      transportFormat: cloudEvents
                     description: KafkaConfig defines the desired state of kafka
                     properties:
                       transportFormat:
@@ -57,6 +68,8 @@ spec:
                         type: string
                     type: object
                   postgres:
+                    default:
+                      retention: 18m
                     description: PostgresConfig defines the desired state of postgres
                     properties:
                       retention:


### PR DESCRIPTION
ref: https://issues.redhat.com/browse/ACM-6780

support the cases:
```bash
cat <<EOF | oc apply -f -
apiVersion: operator.open-cluster-management.io/v1alpha4
kind: MulticlusterGlobalHub
metadata:
  annotations:
    mgh-image-repository: quay.io/stolostron
  name: multiclusterglobalhub
  namespace: open-cluster-management
EOF


cat <<EOF | oc apply -f -
apiVersion: operator.open-cluster-management.io/v1alpha4
kind: MulticlusterGlobalHub
metadata:
  annotations:
    mgh-image-repository: quay.io/stolostron
  name: multiclusterglobalhub
  namespace: open-cluster-management
spec:
  dataLayer:
    postgres: 
      retention: 18m
EOF

cat <<EOF | oc apply -f -
apiVersion: operator.open-cluster-management.io/v1alpha4
kind: MulticlusterGlobalHub
metadata:
  annotations:
    mgh-image-repository: quay.io/stolostron
  name: multiclusterglobalhub
  namespace: open-cluster-management
spec:
  dataLayer:
    kafka:
      transportFormat: cloudEvents # or message
EOF

```