### PR TITLE
Fixed the policy bug when managed hub rejoin with a different name

### DIFF
--- a/manager/pkg/statussyncer/syncers/local_spec_policies_syncer.go
+++ b/manager/pkg/statussyncer/syncers/local_spec_policies_syncer.go
@@ -123,8 +123,7 @@ func (syncer *localSpecPoliciesSyncer) handleLocalObjectsBundle(ctx context.Cont
 			}
 			err = tx.Model(&models.LocalSpecPolicy{}).
 				Where(&models.LocalSpecPolicy{
-					LeafHubName: leafHubName,
-					PolicyID:    uid,
+					PolicyID: uid,
 				}).
 				Updates(models.LocalSpecPolicy{
 					Payload:     payload,
@@ -139,8 +138,8 @@ func (syncer *localSpecPoliciesSyncer) handleLocalObjectsBundle(ctx context.Cont
 		for uid := range policyIdToVersionMapFromDB {
 			// https://gorm.io/docs/delete.html#Soft-Delete
 			err = tx.Where(&models.LocalSpecPolicy{
-				LeafHubName: leafHubName,
-				PolicyID:    uid,
+				// LeafHubName: leafHubName,
+				PolicyID: uid,
 			}).Delete(&models.LocalSpecPolicy{}).Error
 			if err != nil {
 				return err
@@ -161,10 +160,9 @@ func (syncer *localSpecPoliciesSyncer) handleLocalObjectsBundle(ctx context.Cont
 func getPolicyIdToVersionMap(db *gorm.DB, schema, tableName, leafHubName string) (map[string]string, error) {
 	var resourceVersions []models.ResourceVersion
 
+	// Find soft deleted records: db.Unscoped().Where(...).Find(...)
 	err := db.Select("payload->'metadata'->>'uid' AS key, payload->'metadata'->>'resourceVersion' AS resource_version").
-		Where(&models.LocalSpecPolicy{ // Find soft deleted records: db.Unscoped().Where(...).Find(...)
-			LeafHubName: leafHubName,
-		}).Find(&models.LocalSpecPolicy{}).Scan(&resourceVersions).Error
+		Find(&models.LocalSpecPolicy{}).Scan(&resourceVersions).Error
 	if err != nil {
 		return nil, err
 	}

--- a/manager/pkg/statussyncer/syncers/managed_clusters_syncer.go
+++ b/manager/pkg/statussyncer/syncers/managed_clusters_syncer.go
@@ -106,7 +106,6 @@ func (syncer *ManagedClustersDBSyncer) handleManagedClustersBundle(ctx context.C
 			if !exist { // cluster not found in the db table
 				syncer.log.Info("cluster created", "leafHubName", leafHubName, "clusterId", clusterId)
 				tx.Unscoped().Where(&models.ManagedCluster{
-					LeafHubName: leafHubName,
 					ClusterID:   clusterId,
 				}).Delete(&models.ManagedCluster{})
 				tx.Create(&models.ManagedCluster{
@@ -128,11 +127,11 @@ func (syncer *ManagedClustersDBSyncer) handleManagedClustersBundle(ctx context.C
 			syncer.log.Info("cluster updated", "leafHubName", leafHubName, "clusterId", clusterId)
 			tx.Model(&models.ManagedCluster{}).
 				Where(&models.ManagedCluster{
-					LeafHubName: leafHubName,
 					ClusterID:   clusterId,
 				}).
 				Updates(models.ManagedCluster{
 					Payload: payload,
+					LeafHubName: leafHubName,
 				})
 		}
 


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>

Manager Log:
```bash
2023/09/08 08:17:37 /workspace/manager/pkg/statussyncer/syncers/local_spec_policies_syncer.go:110 pq: duplicate key value violates unique constraint "policies_pkey"
[2.836ms] [rows:0] INSERT INTO "local_spec"."policies" ("leaf_hub_name","payload") VALUES ('regional-28','{"kind":"Policy","apiVersion":"policy.open-cluster-management.io/v1","metadata":{"name":"backup-restore-enabled","namespace":"open-cluster-management-backup","uid":"6f3be17e-6882-4989-8dc2-c7b7889925dc","resourceVersion":"261875","creationTimestamp":"2023-09-05T07:08:37Z","labels":{"app":"cluster-backup-chart","app.kubernetes.io/instance":"cluster-backup-chart","app.kubernetes.io/managed-by":"Helm","app.kubernetes.io/name":"cluster-backup-chart","chart":"cluster-backup-chart","component":"policy","helm.sh/chart":"cluster-backup-chart","heritage":"Helm","installer.name":"multiclusterhub","installer.namespace":"open-cluster-management","release":"cluster-backup-chart","velero.io/exclude-from-backup":"true"},"annotations":{"policy.open-cluster-management.io/categories":"PR.IP Information Protection Processes and Procedures","policy.open-cluster-management.io/controls":"PR.IP-4 Backups of information are conducted maintained and tested","policy.open-cluster-management.io/source":"system","policy.open-cluster-management.io/standards":"NIST-CSF"}},"spec":{"disabled":false,"remediationAction":"inform","policy-templates":[{"objectDefinition":{"apiVersion":"policy.open-cluster-management.io/v1","kind":"ConfigurationPolicy","metadata":{"name":"acm-backup-pod-running"},"spec":{"object-templates":[{"complianceType":"musthave","objectDefinition":{"apiVersion":"v1","kind":"Pod","metadata":{"labels":{"app":"cluster-backup-chart"},"namespace":"open-cluster-management-backup"},"status":{"phase":"Running"}}}],"remediationAction":"inform","severity":"high"}}},{"objectDefinition":{"apiVersion":"policy.open-cluster-management.io/v1","kind":"ConfigurationPolicy","metadata":{"name":"oadp-pod-running"},"spec":{"object-templates":[{"complianceType":"musthave","objectDefinition":{"apiVersion":"v1","kind":"Pod","metadata":{"annotations":{"repository":"https://github.com/openshift/oadp-operator"},"namespace":"open-cluster-management-backup"},"status":{"phase":"Running"}}}],"remediationAction":"inform","severity":"high"}}},{"objectDefinition":{"apiVersion":"policy.open-cluster-management.io/v1","kind":"ConfigurationPolicy","metadata":{"name":"velero-pod-running"},"spec":{"object-templates":[{"complianceType":"musthave","objectDefinition":{"apiVersion":"v1","kind":"Pod","metadata":{"labels":{"app.kubernetes.io/name":"velero"},"namespace":"open-cluster-management-backup"},"status":{"phase":"Running"}}}],"remediationAction":"inform","severity":"high"}}},{"objectDefinition":{"apiVersion":"policy.open-cluster-management.io/v1","kind":"ConfigurationPolicy","metadata":{"name":"data-protection-application-available"},"spec":{"object-templates":[{"complianceType":"musthave","objectDefinition":{"apiVersion":"oadp.openshift.io/v1alpha1","kind":"DataProtectionApplication","metadata":{"namespace":"open-cluster-management-backup"}}}],"remediationAction":"inform","severity":"high"}}},{"objectDefinition":{"apiVersion":"policy.open-cluster-management.io/v1","kind":"ConfigurationPolicy","metadata":{"name":"backup-storage-location-available"},"spec":{"object-templates":[{"complianceType":"musthave","objectDefinition":{"apiVersion":"velero.io/v1","kind":"BackupStorageLocation","metadata":{"namespace":"open-cluster-management-backup"},"status":{"phase":"Available"}}}],"remediationAction":"inform","severity":"high"}}},{"objectDefinition":{"apiVersion":"policy.open-cluster-management.io/v1","kind":"ConfigurationPolicy","metadata":{"name":"backup-schedule-cron-enabled"},"spec":{"object-templates":[{"complianceType":"musthave","objectDefinition":{"apiVersion":"velero.io/v1","kind":"Backup","metadata":{"labels":{"velero.io/schedule-name":"acm-validation-policy-schedule"},"namespace":"open-cluster-management-backup"}}}],"remediationAction":"inform","severity":"high"}}},{"objectDefinition":{"apiVersion":"policy.open-cluster-management.io/v1","kind":"ConfigurationPolicy","metadata":{"name":"acm-managed-clusters-schedule-backups-available"},"spec":{"object-templates":[{"complianceType":"musthave","objectDefinition":{"apiVersion":"velero.io/v1","kind":"Backup","metadata":{"labels":{"velero.io/schedule-name":"acm-managed-clusters-schedule"},"namespace":"open-cluster-management-backup"},"status":{"phase":"Completed"}}}],"remediationAction":"inform","severity":"high"}}},{"objectDefinition":{"apiVersion":"policy.open-cluster-management.io/v1","kind":"ConfigurationPolicy","metadata":{"name":"acm-resources-schedule-backups-available"},"spec":{"object-templates":[{"complianceType":"musthave","objectDefinition":{"apiVersion":"velero.io/v1","kind":"Backup","metadata":{"labels":{"velero.io/schedule-name":"acm-resources-schedule"},"namespace":"open-cluster-management-backup"},"status":{"phase":"Completed"}}}],"remediationAction":"inform","severity":"high"}}},{"objectDefinition":{"apiVersion":"policy.open-cluster-management.io/v1","kind":"ConfigurationPolicy","metadata":{"name":"acm-backup-in-progress-report"},"spec":{"object-templates":[{"complianceType":"mustnothave","objectDefinition":{"apiVersion":"velero.io/v1","kind":"Backup","metadata":{"namespace":"open-cluster-management-backup"},"status":{"phase":"InProgress"}}}],"remediationAction":"inform","severity":"medium"}}},{"objectDefinition":{"apiVersion":"policy.open-cluster-management.io/v1","kind":"ConfigurationPolicy","metadata":{"name":"acm-backup-clusters-collision-report"},"spec":{"object-templates":[{"complianceType":"mustnothave","objectDefinition":{"apiVersion":"cluster.open-cluster-management.io/v1beta1","kind":"BackupSchedule","metadata":{"namespace":"open-cluster-management-backup"},"status":{"phase":"BackupCollision"}}}],"remediationAction":"inform","severity":"high"}}},{"objectDefinition":{"apiVersion":"policy.open-cluster-management.io/v1","kind":"ConfigurationPolicy","metadata":{"name":"acm-backup-phase-validation"},"spec":{"object-templates":[{"complianceType":"mustnothave","objectDefinition":{"apiVersion":"cluster.open-cluster-management.io/v1beta1","kind":"BackupSchedule","metadata":{"namespace":"open-cluster-management-backup"},"status":{"phase":"FailedValidation"}}},{"complianceType":"mustnothave","objectDefinition":{"apiVersion":"cluster.open-cluster-management.io/v1beta1","kind":"BackupSchedule","metadata":{"namespace":"open-cluster-management-backup"},"status":{"phase":"Failed"}}},{"complianceType":"mustnothave","objectDefinition":{"apiVersion":"cluster.open-cluster-management.io/v1beta1","kind":"BackupSchedule","metadata":{"namespace":"open-cluster-management-backup"},"status":{"phase":""}}},{"complianceType":"mustnothave","objectDefinition":{"apiVersion":"cluster.open-cluster-management.io/v1beta1","kind":"Restore","metadata":{"namespace":"open-cluster-management-backup"},"status":{"phase":""}}},{"complianceType":"mustnothave","objectDefinition":{"apiVersion":"cluster.open-cluster-management.io/v1beta1","kind":"Restore","metadata":{"namespace":"open-cluster-management-backup"},"status":{"phase":"Error"}}}],"remediationAction":"inform","severity":"high"}}}]},"status":{}}') RETURNING "policy_id","policy_name","policy_standard","policy_category","policy_control","created_at","updated_at","deleted_at"
```