### PR TITLE
Limit uncontrolled growth of the postgre `pg_wal` dir

### DIFF
--- a/operator/config/samples/storage/postgres-cluster.yaml
+++ b/operator/config/samples/storage/postgres-cluster.yaml
@@ -16,7 +16,7 @@ spec:
     dynamicConfiguration:
       postgresql:
         parameters:
-          max_wal_size: 2048MB
+          max_wal_size: 3GB
           wal_recycle: true
           wal_init_zero: false
           wal_compression: true

--- a/operator/config/samples/storage/postgres-cluster.yaml
+++ b/operator/config/samples/storage/postgres-cluster.yaml
@@ -12,6 +12,15 @@ spec:
     - name: "guest"
       databases: ["hoh"]
       options: "LOGIN"
+  patroni:
+    dynamicConfiguration:
+      postgresql:
+        parameters:
+          max_wal_size: 2Gi
+          wal_buffers: 50MB
+          wal_recycle: off
+          wal_init_zero: off
+          wal_compression: on
   instances:
     - name: pgha1
       replicas: 3

--- a/operator/config/samples/storage/postgres-cluster.yaml
+++ b/operator/config/samples/storage/postgres-cluster.yaml
@@ -16,11 +16,10 @@ spec:
     dynamicConfiguration:
       postgresql:
         parameters:
-          max_wal_size: 2Gi
-          wal_buffers: 50MB
-          wal_recycle: off
-          wal_init_zero: off
-          wal_compression: on
+          max_wal_size: 2048MB
+          wal_recycle: true
+          wal_init_zero: false
+          wal_compression: true
   instances:
     - name: pgha1
       replicas: 3

--- a/operator/pkg/postgres/postgres.go
+++ b/operator/pkg/postgres/postgres.go
@@ -57,7 +57,8 @@ type PostgresConnection struct {
 
 // NewSubscription returns an CrunchyPostgres subscription with desired default values
 func NewSubscription(m *globalhubv1alpha4.MulticlusterGlobalHub, c *subv1alpha1.SubscriptionConfig,
-	community bool) *subv1alpha1.Subscription {
+	community bool,
+) *subv1alpha1.Subscription {
 	chName, pkgName, catSourceName := channel, packageName, catalogSourceName
 	if community {
 		chName = communityChannel
@@ -94,7 +95,8 @@ func NewSubscription(m *globalhubv1alpha4.MulticlusterGlobalHub, c *subv1alpha1.
 
 // RenderSubscription returns a subscription by modifying the spec of an existing subscription based on overrides
 func RenderSubscription(existingSubscription *subv1alpha1.Subscription, config *subv1alpha1.SubscriptionConfig,
-	community bool) *subv1alpha1.Subscription {
+	community bool,
+) *subv1alpha1.Subscription {
 	copy := existingSubscription.DeepCopy()
 	copy.ManagedFields = nil
 	copy.TypeMeta = metav1.TypeMeta{
@@ -145,6 +147,17 @@ func NewPostgres(name, namespace string) *postgresv1beta1.PostgresCluster {
 					Name:      postgresv1beta1.PostgresIdentifier(PostgresGuestUser),
 					Databases: []postgresv1beta1.PostgresIdentifier{"hoh"},
 					Options:   "LOGIN",
+				},
+			},
+			Patroni: &postgresv1beta1.PatroniSpec{
+				DynamicConfiguration: map[string]interface{}{
+					"postgresql": map[string]interface{}{
+						"parameters": map[string]interface{}{
+							"max_wal_size":  "2048MB",
+							"wal_recycle":   true,
+							"wal_init_zero": false,
+						},
+					},
 				},
 			},
 			InstanceSets: []postgresv1beta1.PostgresInstanceSetSpec{

--- a/operator/pkg/postgres/postgres.go
+++ b/operator/pkg/postgres/postgres.go
@@ -153,7 +153,7 @@ func NewPostgres(name, namespace string) *postgresv1beta1.PostgresCluster {
 				DynamicConfiguration: map[string]interface{}{
 					"postgresql": map[string]interface{}{
 						"parameters": map[string]interface{}{
-							"max_wal_size":  "2048MB",
+							"max_wal_size":  "3GB",
 							"wal_recycle":   true,
 							"wal_init_zero": false,
 						},

--- a/test/setup/hoh/postgres/postgres-cluster/postgres-cluster.yaml
+++ b/test/setup/hoh/postgres/postgres-cluster/postgres-cluster.yaml
@@ -9,6 +9,15 @@ spec:
   users:
     - name: "postgres"
       databases: ["hoh"]
+  patroni:
+    dynamicConfiguration:
+      postgresql:
+        parameters:
+          max_wal_size: 2Gi
+          wal_buffers: 50MB
+          wal_recycle: off
+          wal_init_zero: off
+          wal_compression: on
   instances:
     - name: pgha1
       replicas: 1

--- a/test/setup/hoh/postgres/postgres-cluster/postgres-cluster.yaml
+++ b/test/setup/hoh/postgres/postgres-cluster/postgres-cluster.yaml
@@ -13,11 +13,10 @@ spec:
     dynamicConfiguration:
       postgresql:
         parameters:
-          max_wal_size: 2Gi
-          wal_buffers: 50MB
-          wal_recycle: off
-          wal_init_zero: off
-          wal_compression: on
+          max_wal_size: 2048MB
+          wal_recycle: true
+          wal_init_zero: false
+          wal_compression: true
   instances:
     - name: pgha1
       replicas: 1

--- a/test/setup/hoh/postgres/postgres-cluster/postgres-cluster.yaml
+++ b/test/setup/hoh/postgres/postgres-cluster/postgres-cluster.yaml
@@ -13,7 +13,7 @@ spec:
     dynamicConfiguration:
       postgresql:
         parameters:
-          max_wal_size: 2048MB
+          max_wal_size: 1GB
           wal_recycle: true
           wal_init_zero: false
           wal_compression: true


### PR DESCRIPTION
If there is some issue happening with the transaction. The logs in this file will continue to accumulate until all disk space is consumed. Like:
```
sh-4.4$ pwd
/pgdata
sh-4.4$ du -sh ./*
16K	./lost+found
7.1G	./pg14
30G	./pg14_wal
8.0K	./pgbackrest
```
ref: https://github.com/CrunchyData/postgres-operator/issues/2115, https://github.com/CrunchyData/postgres-operator/issues/2813,  https://thebuild.com/blog/2023/03/23/the-importance-of-max_wal_size/
