### PR TITLE
Add observability Grafana url into status.leaf_hubs

### DIFF
--- a/agent/pkg/status/bundle/hubcluster/hub_cluster_bundle.go
+++ b/agent/pkg/status/bundle/hubcluster/hub_cluster_bundle.go
@@ -35,18 +35,28 @@ func (bundle *LeafHubClusterInfoStatusBundle) UpdateObject(object agentbundle.Ob
 
 	route := object.(*routev1.Route)
 
-	if route.GetName() == constants.OpenShiftConsoleRouteName {
-		bundle.Objects = append(bundle.Objects,
-			&statusbundle.LeafHubClusterInfo{
-				LeafHubName: bundle.LeafHubName,
-				ConsoleURL:  "https://" + route.Spec.Host,
-			})
-	} else if route.GetName() == constants.ObservabilityGrafanaRouteName {
-		bundle.Objects = append(bundle.Objects,
-			&statusbundle.LeafHubClusterInfo{
-				LeafHubName: bundle.LeafHubName,
-				GrafanaURL:  "https://" + route.Spec.Host,
-			})
+	if len(bundle.Objects) == 0 {
+		if route.GetName() == constants.OpenShiftConsoleRouteName {
+			bundle.Objects = []*statusbundle.LeafHubClusterInfo{
+				{
+					LeafHubName: bundle.LeafHubName,
+					ConsoleURL:  "https://" + route.Spec.Host,
+				},
+			}
+		} else if route.GetName() == constants.ObservabilityGrafanaRouteName {
+			bundle.Objects = []*statusbundle.LeafHubClusterInfo{
+				{
+					LeafHubName: bundle.LeafHubName,
+					GrafanaURL:  "https://" + route.Spec.Host,
+				},
+			}
+		}
+	} else {
+		if route.GetName() == constants.OpenShiftConsoleRouteName {
+			bundle.Objects[0].ConsoleURL = "https://" + route.Spec.Host
+		} else if route.GetName() == constants.ObservabilityGrafanaRouteName {
+			bundle.Objects[0].GrafanaURL = "https://" + route.Spec.Host
+		}
 	}
 	bundle.BundleVersion.Incr()
 }

--- a/agent/pkg/status/bundle/hubcluster/hub_cluster_bundle.go
+++ b/agent/pkg/status/bundle/hubcluster/hub_cluster_bundle.go
@@ -34,28 +34,29 @@ func (bundle *LeafHubClusterInfoStatusBundle) UpdateObject(object agentbundle.Ob
 	defer bundle.lock.Unlock()
 
 	route := object.(*routev1.Route)
+	routeURL := "https://" + route.Spec.Host
 
 	if len(bundle.Objects) == 0 {
 		if route.GetName() == constants.OpenShiftConsoleRouteName {
 			bundle.Objects = []*statusbundle.LeafHubClusterInfo{
 				{
 					LeafHubName: bundle.LeafHubName,
-					ConsoleURL:  "https://" + route.Spec.Host,
+					ConsoleURL:  routeURL,
 				},
 			}
 		} else if route.GetName() == constants.ObservabilityGrafanaRouteName {
 			bundle.Objects = []*statusbundle.LeafHubClusterInfo{
 				{
 					LeafHubName: bundle.LeafHubName,
-					GrafanaURL:  "https://" + route.Spec.Host,
+					GrafanaURL:  routeURL,
 				},
 			}
 		}
 	} else {
 		if route.GetName() == constants.OpenShiftConsoleRouteName {
-			bundle.Objects[0].ConsoleURL = "https://" + route.Spec.Host
+			bundle.Objects[0].ConsoleURL = routeURL
 		} else if route.GetName() == constants.ObservabilityGrafanaRouteName {
-			bundle.Objects[0].GrafanaURL = "https://" + route.Spec.Host
+			bundle.Objects[0].GrafanaURL = routeURL
 		}
 	}
 	bundle.BundleVersion.Incr()

--- a/agent/pkg/status/bundle/hubcluster/hub_cluster_bundle.go
+++ b/agent/pkg/status/bundle/hubcluster/hub_cluster_bundle.go
@@ -7,6 +7,7 @@ import (
 
 	agentbundle "github.com/stolostron/multicluster-global-hub/agent/pkg/status/bundle"
 	statusbundle "github.com/stolostron/multicluster-global-hub/pkg/bundle/status"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 )
 
 // LeafHubClusterInfoStatusBundle creates a new instance of LeafHubClusterInfoStatusBundle.
@@ -34,11 +35,19 @@ func (bundle *LeafHubClusterInfoStatusBundle) UpdateObject(object agentbundle.Ob
 
 	route := object.(*routev1.Route)
 
-	bundle.Objects = append(bundle.Objects,
-		&statusbundle.LeafHubClusterInfo{
-			LeafHubName: bundle.LeafHubName,
-			ConsoleURL:  "https://" + route.Spec.Host,
-		})
+	if route.GetName() == constants.OpenShiftConsoleRouteName {
+		bundle.Objects = append(bundle.Objects,
+			&statusbundle.LeafHubClusterInfo{
+				LeafHubName: bundle.LeafHubName,
+				ConsoleURL:  "https://" + route.Spec.Host,
+			})
+	} else if route.GetName() == constants.ObservabilityGrafanaRouteName {
+		bundle.Objects = append(bundle.Objects,
+			&statusbundle.LeafHubClusterInfo{
+				LeafHubName: bundle.LeafHubName,
+				GrafanaURL:  "https://" + route.Spec.Host,
+			})
+	}
 	bundle.BundleVersion.Incr()
 }
 

--- a/agent/pkg/status/controller/controller_integration_test.go
+++ b/agent/pkg/status/controller/controller_integration_test.go
@@ -138,11 +138,11 @@ var _ = Describe("Agent Status Controller", Ordered, func() {
 
 		Expect(kubeClient.Create(ctx, &routev1.Route{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      constants.ObservabilityNamespace,
-				Namespace: constants.ObservabilityGrafanaRouteName,
+				Name:      constants.ObservabilityGrafanaRouteName,
+				Namespace: constants.ObservabilityNamespace,
 			},
 			Spec: routev1.RouteSpec{
-				Host: "//grafana-open-cluster-management-observability.apps.test-cluster",
+				Host: "grafana-open-cluster-management-observability.apps.test-cluster",
 				To: routev1.RouteTargetReference{
 					Kind: "Service",
 					Name: constants.ObservabilityGrafanaRouteName,

--- a/agent/pkg/status/controller/controller_integration_test.go
+++ b/agent/pkg/status/controller/controller_integration_test.go
@@ -97,7 +97,7 @@ var _ = Describe("Agent Status Controller", Ordered, func() {
 		}, 30*time.Second, 1*time.Second).Should(Succeed())
 	})
 
-	It("should be able to sync hub cluster info", func() {
+	It("should be able to sync hub cluster info with openshift console url", func() {
 		By("Create openshift route for hub cluster")
 		Expect(kubeClient.Create(ctx, &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{Name: constants.OpenShiftConsoleNamespace},
@@ -113,6 +113,39 @@ var _ = Describe("Agent Status Controller", Ordered, func() {
 				To: routev1.RouteTargetReference{
 					Kind: "Service",
 					Name: constants.OpenShiftConsoleRouteName,
+				},
+			},
+		})).Should(Succeed())
+
+		By("Check the hub cluster info bundle can be read from cloudevents consumer")
+		Eventually(func() error {
+			message := <-consumer.MessageChan()
+
+			statusBundle, err := getStatusBundle(message, constants.HubClusterInfoMsgKey)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("========== received %s with statusBundle: %v\n", message.ID, statusBundle)
+			return nil
+		}, 30*time.Second, 1*time.Second).Should(Succeed())
+	})
+
+	It("should be able to sync hub cluster info with grafana url", func() {
+		By("Create observability grafana route in the managed hub cluster")
+		Expect(kubeClient.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: constants.ObservabilityNamespace},
+		})).Should(Succeed())
+
+		Expect(kubeClient.Create(ctx, &routev1.Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      constants.ObservabilityNamespace,
+				Namespace: constants.ObservabilityGrafanaRouteName,
+			},
+			Spec: routev1.RouteSpec{
+				Host: "//grafana-open-cluster-management-observability.apps.test-cluster",
+				To: routev1.RouteTargetReference{
+					Kind: "Service",
+					Name: constants.ObservabilityGrafanaRouteName,
 				},
 			},
 		})).Should(Succeed())

--- a/agent/pkg/status/controller/hubcluster/clusters_status_sync.go
+++ b/agent/pkg/status/controller/hubcluster/clusters_status_sync.go
@@ -44,8 +44,10 @@ func AddHubClusterController(mgr ctrl.Manager, producer transport.Producer) erro
 	}
 
 	hubClusterControllerPredicate := predicate.NewPredicateFuncs(func(object client.Object) bool {
-		return object.GetNamespace() == constants.OpenShiftConsoleNamespace &&
-			object.GetName() == constants.OpenShiftConsoleRouteName
+		return (object.GetNamespace() == constants.OpenShiftConsoleNamespace &&
+			object.GetName() == constants.OpenShiftConsoleRouteName) ||
+			(object.GetNamespace() == constants.ObservabilityNamespace &&
+				object.GetName() == constants.ObservabilityGrafanaRouteName)
 	})
 
 	if err := ctrl.NewControllerManagedBy(mgr).

--- a/operator/pkg/controllers/hubofhubs/database/2.tables.sql
+++ b/operator/pkg/controllers/hubofhubs/database/2.tables.sql
@@ -47,6 +47,7 @@ CREATE TABLE IF NOT EXISTS status.leaf_hubs (
     leaf_hub_name character varying(254) NOT NULL PRIMARY KEY,
     payload jsonb NOT NULL,
     console_url text generated always as (payload ->> 'consoleURL') stored,
+    grafana_url text generated always as (payload ->> 'grafanaURL') stored,
     created_at timestamp without time zone DEFAULT now() NOT NULL,
     updated_at timestamp without time zone DEFAULT now() NOT NULL,
     deleted_at timestamp without time zone

--- a/pkg/bundle/status/hub_cluster_info_bundle.go
+++ b/pkg/bundle/status/hub_cluster_info_bundle.go
@@ -4,6 +4,7 @@ package status
 type LeafHubClusterInfo struct {
 	LeafHubName string `json:"leafHubName"`
 	ConsoleURL  string `json:"consoleURL"`
+	GrafanaURL  string `json:"grafanaURL"`
 }
 
 // HubClusterInfoBundle the bundle for the hub cluster info.

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -15,6 +15,10 @@ const (
 	OpenShiftConsoleNamespace = "openshift-console"
 	// OpenShift console route name
 	OpenShiftConsoleRouteName = "console"
+	// Observability grafana namespace
+	ObservabilityNamespace = "open-cluster-management-observability"
+	// Observability grafana route name
+	ObservabilityGrafanaRouteName = "grafana"
 )
 
 const (

--- a/pkg/database/models/status.go
+++ b/pkg/database/models/status.go
@@ -27,6 +27,7 @@ type LeafHub struct {
 	LeafHubName string         `gorm:"column:leaf_hub_name;not null"`
 	Payload     datatypes.JSON `gorm:"column:payload;type:jsonb"`
 	ConsoleURL  string         `gorm:"column:console_url;default:(-)"`
+	GrafanaURL  string         `gorm:"column:grafana_url;default:(-)"`
 	CreatedAt   time.Time      `gorm:"column:created_at;default:(-)"` // https://gorm.io/docs/conventions.html#CreatedAt
 	UpdatedAt   time.Time      `gorm:"column:updated_at;default:(-)"`
 	DeletedAt   gorm.DeletedAt `gorm:"column:deleted_at;default:(-)"`


### PR DESCRIPTION
```
select * from status.leaf_hubs;

leaf_hub_name |                                                                                                                                        payload                                                                                                                                        |                                             console_url                                             |                                                       grafana_url                                                       |         created_at         |         updated_at         | deleted_at
---------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------+----------------------------+----------------------------+------------
 hub1          | {"consoleURL": "https://console-openshift-console.apps.obs-hub-of-hubs-aws-412-sno-68h2p.scale.red-chesterfield.com", "grafanaURL": "https://grafana-open-cluster-management-observability.apps.obs-hub-of-hubs-aws-412-sno-68h2p.scale.red-chesterfield.com", "leafHubName": "hub1"} | https://console-openshift-console.apps.obs-hub-of-hubs-aws-412-sno-68h2p.scale.red-chesterfield.com | https://grafana-open-cluster-management-observability.apps.obs-hub-of-hubs-aws-412-sno-68h2p.scale.red-chesterfield.com | 2023-09-20 09:12:44.476141 | 2023-09-20 14:30:50.121697 |
```