### PR TITLE
fix nil pointer error

### DIFF
--- a/manager/cmd/manager/main_test.go
+++ b/manager/cmd/manager/main_test.go
@@ -77,20 +77,19 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		panic(err)
 	}
-	defer func() {
-		// stop mock kafka cluster
-		mockKafkaCluster.Close()
-		// stop testenv
-		if err := testenv.Stop(); err != nil {
-			panic(err)
-		}
-		if err := testPostgres.Stop(); err != nil {
-			panic(err)
-		}
-	}()
 
 	// run testings
 	code := m.Run()
+
+	// stop mock kafka cluster
+	mockKafkaCluster.Close()
+	// stop testenv
+	if err := testenv.Stop(); err != nil {
+		panic(err)
+	}
+	if err := testPostgres.Stop(); err != nil {
+		panic(err)
+	}
 
 	os.Exit(code)
 }

--- a/manager/pkg/statussyncer/syncers_test.go
+++ b/manager/pkg/statussyncer/syncers_test.go
@@ -64,20 +64,18 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 
-	defer func() {
-		// stop mock kafka cluster
-		mockKafkaCluster.Close()
-		// stop testenv
-		if err := testenv.Stop(); err != nil {
-			panic(err)
-		}
-		if err := testPostgres.Stop(); err != nil {
-			panic(err)
-		}
-	}()
-
 	// run testings
 	code := m.Run()
+
+	// stop mock kafka cluster
+	mockKafkaCluster.Close()
+	// stop testenv
+	if err := testenv.Stop(); err != nil {
+		panic(err)
+	}
+	if err := testPostgres.Stop(); err != nil {
+		panic(err)
+	}
 
 	os.Exit(code)
 }

--- a/operator/pkg/controllers/hubofhubs/globalhub_controller.go
+++ b/operator/pkg/controllers/hubofhubs/globalhub_controller.go
@@ -199,14 +199,13 @@ func (r *MulticlusterGlobalHubReconciler) ReconcileMiddleware(ctx context.Contex
 	mgh *globalhubv1alpha4.MulticlusterGlobalHub,
 ) (ctrl.Result, error) {
 
-	var err error
 	// support BYO kafka
-	r.MiddlewareConfig.KafkaConnection, err = r.GenerateKafkaConnectionFromGHTransportSecret(ctx)
+	kafkaConnection, err := r.GenerateKafkaConnectionFromGHTransportSecret(ctx)
 	if err != nil && !errors.IsNotFound(err) {
 		return ctrl.Result{}, err
 	}
 	// if not-provided kafka secret, create kafka in the global hub namespace
-	if r.MiddlewareConfig.KafkaConnection == nil {
+	if kafkaConnection == nil {
 		// reconcile kafka
 		if err := r.EnsureKafkaSubscription(ctx, mgh); err != nil {
 			return ctrl.Result{}, err
@@ -214,42 +213,44 @@ func (r *MulticlusterGlobalHubReconciler) ReconcileMiddleware(ctx context.Contex
 	}
 
 	// support BYO postgres
-	r.MiddlewareConfig.PgConnection, err = r.GeneratePGConnectionFromGHStorageSecret(ctx)
+	pgConnection, err := r.GeneratePGConnectionFromGHStorageSecret(ctx)
 	if err != nil && !errors.IsNotFound(err) {
 		return ctrl.Result{}, err
 	}
 	// if not-provided postgres secret, create crunchy postgres in the global hub namespace
-	if r.MiddlewareConfig.PgConnection == nil {
+	if pgConnection == nil {
 		// reconcile crunchy postgres
 		if err := r.EnsureCrunchyPostgresSubscription(ctx, mgh); err != nil {
 			return ctrl.Result{}, err
 		}
 	}
 
-	if r.MiddlewareConfig.PgConnection == nil {
+	if pgConnection == nil {
 		if err := r.EnsureCrunchyPostgres(ctx); err != nil {
 			return ctrl.Result{RequeueAfter: 5 * time.Second}, err
 		}
 	}
 
-	if r.MiddlewareConfig.KafkaConnection == nil {
+	if kafkaConnection == nil {
 		if err := r.EnsureKafkaResources(ctx); err != nil {
 			return ctrl.Result{RequeueAfter: 5 * time.Second}, err
 		}
 	}
 
-	if r.MiddlewareConfig.KafkaConnection == nil {
-		if r.MiddlewareConfig.KafkaConnection, err = r.WaitForKafkaClusterReady(ctx); err != nil {
+	if kafkaConnection == nil {
+		if kafkaConnection, err = r.WaitForKafkaClusterReady(ctx); err != nil {
 			return ctrl.Result{RequeueAfter: 5 * time.Second}, err
 		}
 	}
 
-	if r.MiddlewareConfig.PgConnection == nil {
+	if pgConnection == nil {
 		// store crunchy postgres connection
-		if r.MiddlewareConfig.PgConnection, err = r.WaitForPostgresReady(ctx); err != nil {
+		if pgConnection, err = r.WaitForPostgresReady(ctx); err != nil {
 			return ctrl.Result{RequeueAfter: 5 * time.Second}, err
 		}
 	}
+	r.MiddlewareConfig.KafkaConnection = kafkaConnection
+	r.MiddlewareConfig.PgConnection = pgConnection
 
 	return ctrl.Result{}, nil
 }

--- a/operator/pkg/controllers/hubofhubs/globalhub_controller.go
+++ b/operator/pkg/controllers/hubofhubs/globalhub_controller.go
@@ -210,6 +210,8 @@ func (r *MulticlusterGlobalHubReconciler) ReconcileMiddleware(ctx context.Contex
 		if err := r.EnsureKafkaSubscription(ctx, mgh); err != nil {
 			return ctrl.Result{}, err
 		}
+	} else {
+		r.MiddlewareConfig.KafkaConnection = kafkaConnection
 	}
 
 	// support BYO postgres
@@ -223,6 +225,8 @@ func (r *MulticlusterGlobalHubReconciler) ReconcileMiddleware(ctx context.Contex
 		if err := r.EnsureCrunchyPostgresSubscription(ctx, mgh); err != nil {
 			return ctrl.Result{}, err
 		}
+	} else {
+		r.MiddlewareConfig.PgConnection = pgConnection
 	}
 
 	if pgConnection == nil {


### PR DESCRIPTION
ref: https://issues.redhat.com/browse/ACM-7570

`r.MiddlewareConfig.KafkaConnection` can be set to `nil` in the global hub operator reconciler, while the addon installer reconciler is using this value. so the nil pointer error occurs sometimes.