### PR TITLE
Extend the postgres disk for the high scale global hub

### DIFF
--- a/operator/pkg/postgres/postgres.go
+++ b/operator/pkg/postgres/postgres.go
@@ -39,9 +39,9 @@ var (
 	replicas3 int32 = 3
 	// need append "?sslmode=verify-ca" to the end of the uri to access postgres
 	PostgresURIWithSslmode = "?sslmode=verify-ca"
-	// postgres storage size: 20Gi should be enough for 18 months data
-	// 3 managed hubs with 250 managed cluster each and 50 policies per managed hub cluster
-	storageSize = "20Gi"
+	// postgres storage size: 30Gi should be enough for 18 months data
+	// 5 managed hubs with 300 managed cluster each and 50 policies per managed hub cluster
+	storageSize = "30Gi"
 )
 
 type PostgresConnection struct {

--- a/operator/pkg/postgres/postgres.go
+++ b/operator/pkg/postgres/postgres.go
@@ -39,9 +39,9 @@ var (
 	replicas3 int32 = 3
 	// need append "?sslmode=verify-ca" to the end of the uri to access postgres
 	PostgresURIWithSslmode = "?sslmode=verify-ca"
-	// postgres storage size: 30Gi should be enough for 18 months data
+	// postgres storage size: 25Gi should be enough for 18 months data
 	// 5 managed hubs with 300 managed cluster each and 50 policies per managed hub cluster
-	storageSize = "30Gi"
+	storageSize = "25Gi"
 )
 
 type PostgresConnection struct {


### PR DESCRIPTION
There is insufficient storage(`20 GB`) for `5` hubs each with `300` managed clusters and `50` root policies. When rotating the policies' status, The storage was up to about `22 GB` and stabilized at around `20 GB` after several minutes. 

Based on the policies events might be remained for a long time(let's say 18 months). I recommend set it up to `25 GB`.

<img width="1390" alt="image" src="https://github.com/stolostron/multicluster-global-hub/assets/19286664/6bd448ca-a542-4463-af38-cea236506bbd">
