### PR TITLE
Set the resources cpu and memory for global hub components

### DIFF
--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -75,10 +75,11 @@ spec:
         # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            # cpu: 50m
+            # https://home.robusta.dev/blog/stop-using-cpu-limits
+            memory: 200Mi
           requests:
-            cpu: 10m
-            memory: 64Mi
+            cpu: 1m
+            memory: 100Mi
       serviceAccountName: multicluster-global-hub-operator
       terminationGracePeriodSeconds: 10

--- a/operator/pkg/controllers/addon/manifests/templates/agent/multicluster-global-hub-agent-deployment.yaml
+++ b/operator/pkg/controllers/addon/manifests/templates/agent/multicluster-global-hub-agent-deployment.yaml
@@ -20,6 +20,12 @@ spec:
       containers:
         - name: multicluster-global-hub-agent
           image: {{ .HoHAgentImage }}
+          resources:
+            requests:
+              memory: 200Mi
+              cpu: 10m
+            limits:
+              memory: 1000Mi
           imagePullPolicy: {{ .ImagePullPolicy }}
           args:
             - '--zap-devel=true'

--- a/operator/pkg/controllers/hubofhubs/manifests/manager/deployment.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/manager/deployment.yaml
@@ -19,6 +19,12 @@ spec:
       containers:
         - name: multicluster-global-hub-manager
           image: {{.Image}}
+          resources:
+            requests:
+              memory: 100Mi
+              cpu: 100m
+            limits:
+              memory: 300Mi
           imagePullPolicy: {{.ImagePullPolicy}}
           args:
             - --zap-devel=true


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>
Ref: https://issues.redhat.com/browse/ACM-6381

Note: https://home.robusta.dev/blog/stop-using-cpu-limits