### PR TITLE
fix reconcile too long and some error in log

### DIFF
--- a/operator/pkg/condition/condition.go
+++ b/operator/pkg/condition/condition.go
@@ -74,6 +74,14 @@ const (
 	CONDITION_MESSAGE_LEAFHUB_DEPLOY_FAILED = "Leaf Hub Deployed FAILED"
 )
 
+const (
+	CONDITION_TYPE_GLOBALHUB_READY    = "Ready"
+	CONDITION_REASON_GLOBALHUB_READY  = "MulticlusterGlobalHubReady"
+	CONDITION_MESSAGE_GLOBALHUB_READY = "Multicluster Global Hub is ready"
+	CONDITION_REASON_GLOBALHUB_FAILED = "MulticlusterGlobalHubFailed"
+	CONDITION_REASON_GLOBALHUB_PAUSED = "MulticlusterGlobalHubPaused"
+)
+
 // SetConditionFunc is function type that receives the concrete condition method
 type SetConditionFunc func(ctx context.Context, c client.Client,
 	mgh *globalhubv1alpha4.MulticlusterGlobalHub,

--- a/operator/pkg/controllers/addon/addon_controller.go
+++ b/operator/pkg/controllers/addon/addon_controller.go
@@ -2,6 +2,7 @@ package addon
 
 import (
 	"context"
+	"time"
 
 	"github.com/go-logr/logr"
 	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
@@ -18,6 +19,8 @@ import (
 	addonv1alpha1client "open-cluster-management.io/api/client/addon/clientset/versioned"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/utils"
 
 	globalhubv1alpha4 "github.com/stolostron/multicluster-global-hub/operator/apis/v1alpha4"
 	operatorconstants "github.com/stolostron/multicluster-global-hub/operator/pkg/constants"
@@ -111,7 +114,10 @@ func (a *HoHAddonController) Start(ctx context.Context) error {
 		ControllerConfig:     a.ControllerConfig,
 		LogLevel:             a.LogLevel,
 	}
-
+	_, err = utils.WaitGlobalHubReady(ctx, a.client, 5*time.Second)
+	if err != nil {
+		return err
+	}
 	agentAddon, err := addonfactory.NewAgentAddonFactory(
 		operatorconstants.GHManagedClusterAddonName, FS, "manifests").
 		WithAgentHostedModeEnabledOption().

--- a/operator/pkg/controllers/addon/addoninstall_reconciler_test.go
+++ b/operator/pkg/controllers/addon/addoninstall_reconciler_test.go
@@ -19,7 +19,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	globalhubv1alpha4 "github.com/stolostron/multicluster-global-hub/operator/apis/v1alpha4"
 	operatorv1alpha4 "github.com/stolostron/multicluster-global-hub/operator/apis/v1alpha4"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/condition"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
 	operatorconstants "github.com/stolostron/multicluster-global-hub/operator/pkg/constants"
 	hubofhubsaddon "github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/addon"
@@ -89,6 +91,14 @@ func fakeMGH(name, namespace string) *operatorv1alpha4.MulticlusterGlobalHub {
 			Name:      name,
 			Namespace: namespace,
 		},
+		Status: globalhubv1alpha4.MulticlusterGlobalHubStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:   condition.CONDITION_TYPE_GLOBALHUB_READY,
+					Status: metav1.ConditionTrue,
+				},
+			},
+		},
 	}
 }
 
@@ -124,21 +134,6 @@ func TestHoHAddonReconciler(t *testing.T) {
 		req             reconcile.Request
 		validateFunc    func(t *testing.T, addon *v1alpha1.ManagedClusterAddOn, err error)
 	}{
-		{
-			name:            "mgh not ready",
-			cluster:         fakeCluster("cluster1", "", operatorconstants.GHAgentDeployModeDefault),
-			managementAddon: nil,
-			mgh:             nil,
-			req:             reconcile.Request{NamespacedName: types.NamespacedName{Name: "cluster1"}},
-			validateFunc: func(t *testing.T, addon *v1alpha1.ManagedClusterAddOn, err error) {
-				if !errors.IsNotFound(err) {
-					t.Errorf("expected not found addon, but got err %v", err)
-				}
-				if addon != nil {
-					t.Errorf("expected nil addon, but got %v", addon)
-				}
-			},
-		},
 		{
 			name:            "clustermanagementaddon not ready",
 			cluster:         fakeCluster("cluster1", "", operatorconstants.GHAgentDeployModeDefault),


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-7913
1. When Kafka or Postgre is starting, we should not return errors in reconcile. We just need to wait it started
2. We should not return `mgh is not exist` errors before `mgh` is created. just need to wait it created.