### PR TITLE
Implicitly pass the postgres url to manager

### DIFF
--- a/operator/pkg/constants/constants.go
+++ b/operator/pkg/constants/constants.go
@@ -87,9 +87,10 @@ const (
 
 // global hub transport and storage secret names
 const (
-	GHTransportSecretName     = "multicluster-global-hub-transport" // #nosec G101
-	GHStorageSecretName       = "multicluster-global-hub-storage"   // #nosec G101
-	GHDefaultStorageRetention = "18m"                               // 18 months
+	GHTransportSecretName      = "multicluster-global-hub-transport" // #nosec G101
+	GHStorageSecretName        = "multicluster-global-hub-storage"   // #nosec G101
+	GHBuiltInStorageSecretName = "multicluster-global-hub-postgres"  // #nosec G101
+	GHDefaultStorageRetention  = "18m"                               // 18 months
 )
 
 const (

--- a/operator/pkg/controllers/hubofhubs/globalhub_controller.go
+++ b/operator/pkg/controllers/hubofhubs/globalhub_controller.go
@@ -232,7 +232,7 @@ func (r *MulticlusterGlobalHubReconciler) ReconcileMiddleware(ctx context.Contex
 			}
 		} else {
 			// create the statefulset postgres and initialize the r.MiddlewareConfig.PgConnection
-			if e := r.initPostgresByStatefulset(ctx, mgh); e != nil {
+			if e := r.InitPostgresByStatefulset(ctx, mgh); e != nil {
 				return ctrl.Result{}, e
 			}
 		}

--- a/operator/pkg/controllers/hubofhubs/globalhub_controller.go
+++ b/operator/pkg/controllers/hubofhubs/globalhub_controller.go
@@ -211,12 +211,10 @@ func (r *MulticlusterGlobalHubReconciler) ReconcileMiddleware(ctx context.Contex
 	kafkaConnection, err := r.GenerateKafkaConnectionFromGHTransportSecret(ctx)
 	if err != nil && !errors.IsNotFound(err) {
 		return ctrl.Result{}, err
-	}
-
-	if kafkaConnection == nil {
-		// reconcile kafka
-		if err := r.EnsureKafkaSubscription(ctx, mgh); err != nil {
-			return ctrl.Result{}, err
+	} else if errors.IsNotFound(err) {
+		// create kafka operator by subscription
+		if e := r.EnsureKafkaSubscription(ctx, mgh); e != nil {
+			return ctrl.Result{}, e
 		}
 	} else {
 		r.MiddlewareConfig.KafkaConnection = kafkaConnection
@@ -226,13 +224,16 @@ func (r *MulticlusterGlobalHubReconciler) ReconcileMiddleware(ctx context.Contex
 	pgConnection, err := r.GeneratePGConnectionFromGHStorageSecret(ctx)
 	if err != nil && !errors.IsNotFound(err) {
 		return ctrl.Result{}, err
-	}
-	// if not-provided postgres secret, create crunchy postgres in the global hub namespace
-	if pgConnection == nil {
-		// reconcile crunchy postgres
+	} else if errors.IsNotFound(err) {
+		// if not-provided postgres secret, create crunchy postgres operator by subscription
 		if config.GetInstallCrunchyOperator(mgh) {
-			if err := r.EnsureCrunchyPostgresSubscription(ctx, mgh); err != nil {
-				return ctrl.Result{}, err
+			if e := r.EnsureCrunchyPostgresSubscription(ctx, mgh); e != nil {
+				return ctrl.Result{}, e
+			}
+		} else {
+			// create the statefulset postgres and initialize the r.MiddlewareConfig.PgConnection
+			if e := r.initPostgresByStatefulset(ctx, mgh); e != nil {
+				return ctrl.Result{}, e
 			}
 		}
 	} else {
@@ -255,6 +256,7 @@ func (r *MulticlusterGlobalHubReconciler) ReconcileMiddleware(ctx context.Contex
 		if kafkaConnection, err = r.WaitForKafkaClusterReady(ctx); err != nil {
 			return ctrl.Result{RequeueAfter: 5 * time.Second}, err
 		}
+		r.MiddlewareConfig.KafkaConnection = kafkaConnection
 	}
 
 	if pgConnection == nil && config.GetInstallCrunchyOperator(mgh) {
@@ -262,9 +264,8 @@ func (r *MulticlusterGlobalHubReconciler) ReconcileMiddleware(ctx context.Contex
 		if pgConnection, err = r.WaitForPostgresReady(ctx); err != nil {
 			return ctrl.Result{RequeueAfter: 5 * time.Second}, err
 		}
+		r.MiddlewareConfig.PgConnection = pgConnection
 	}
-	r.MiddlewareConfig.KafkaConnection = kafkaConnection
-	r.MiddlewareConfig.PgConnection = pgConnection
 
 	return ctrl.Result{}, nil
 }
@@ -469,8 +470,9 @@ var globalHubEventHandler = handler.EnqueueRequestsFromMapFunc(
 )
 
 func secretCond(obj client.Object) bool {
-	return obj.GetName() == operatorconstants.GHStorageSecretName ||
-		obj.GetName() == operatorconstants.GHTransportSecretName ||
+	return obj.GetName() == operatorconstants.GHTransportSecretName ||
+		obj.GetName() == operatorconstants.GHStorageSecretName ||
+		obj.GetName() == operatorconstants.GHBuiltInStorageSecretName ||
 		obj.GetName() == operatorconstants.CustomGrafanaIniName ||
 		obj.GetName() == config.GetImagePullSecretName()
 }

--- a/operator/pkg/controllers/hubofhubs/globalhub_database.go
+++ b/operator/pkg/controllers/hubofhubs/globalhub_database.go
@@ -10,21 +10,10 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/go-logr/logr"
 	"github.com/jackc/pgx/v4"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/discovery"
-	"k8s.io/client-go/discovery/cached/memory"
-	"k8s.io/client-go/restmapper"
 
 	globalhubv1alpha4 "github.com/stolostron/multicluster-global-hub/operator/apis/v1alpha4"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/condition"
-	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
-	"github.com/stolostron/multicluster-global-hub/operator/pkg/deployer"
-	"github.com/stolostron/multicluster-global-hub/operator/pkg/postgres"
-	"github.com/stolostron/multicluster-global-hub/operator/pkg/renderer"
 	"github.com/stolostron/multicluster-global-hub/pkg/database"
 )
 
@@ -36,30 +25,10 @@ var databaseFS embed.FS
 //go:embed database.old
 var databaseOldFS embed.FS
 
-type postgresCredential struct {
-	postgresAdminUsername        string
-	postgresAdminUserPassword    string
-	postgresReadonlyUsername     string
-	postgresReadonlyUserPassword string
-}
-
-const (
-	postgresAdminUsername    = "postgres"
-	postgresReadonlyUsername = "global-hub-readonly-user" // #nosec G101
-	postgresCA               = "multicluster-global-hub-postgres-ca"
-)
-
-var partialPostgresURI = "@multicluster-global-hub-postgres." +
-	config.GetDefaultNamespace() + ".svc:5432/hoh?sslmode=verify-ca"
-
 func (r *MulticlusterGlobalHubReconciler) ReconcileDatabase(ctx context.Context,
 	mgh *globalhubv1alpha4.MulticlusterGlobalHub,
 ) error {
 	log := r.Log.WithName("database")
-
-	if err := r.createPostgres(ctx, mgh, log); err != nil {
-		return err
-	}
 
 	if condition.ContainConditionStatus(mgh, condition.CONDITION_TYPE_DATABASE_INIT, condition.CONDITION_STATUS_TRUE) {
 		log.V(7).Info("database has been initialized, checking the reconcile counter")
@@ -146,125 +115,4 @@ func generatePassword(length int) string {
 		buf[i] = chars[nBig.Int64()]
 	}
 	return string(buf)
-}
-
-func (r *MulticlusterGlobalHubReconciler) createPostgres(ctx context.Context,
-	mgh *globalhubv1alpha4.MulticlusterGlobalHub, log logr.Logger,
-) error {
-	// check if the customer provides the postgres
-	var err error
-	r.MiddlewareConfig.PgConnection, _ = r.GeneratePGConnectionFromGHStorageSecret(ctx)
-	if r.MiddlewareConfig.PgConnection != nil {
-		return nil
-	}
-	// check if install crunchy operator
-	if config.GetInstallCrunchyOperator(mgh) {
-		return nil
-	}
-
-	// install the postgres statefulset only
-	credential, err := getPostgresCredential(ctx, mgh, r)
-	if err != nil {
-		return err
-	}
-
-	imagePullPolicy := corev1.PullAlways
-	if mgh.Spec.ImagePullPolicy != "" {
-		imagePullPolicy = mgh.Spec.ImagePullPolicy
-	}
-	// get the postgres objects
-	postgresRenderer, postgresDeployer := renderer.NewHoHRenderer(fs), deployer.NewHoHDeployer(r.Client)
-	postgresObjects, err := postgresRenderer.Render("manifests/postgres", "",
-		func(profile string) (interface{}, error) {
-			return struct {
-				Namespace                    string
-				PostgresImage                string
-				StorageSize                  string
-				ImagePullSecret              string
-				ImagePullPolicy              string
-				NodeSelector                 map[string]string
-				Tolerations                  []corev1.Toleration
-				PostgresAdminUserPassword    string
-				PostgresReadonlyUsername     string
-				PostgresReadonlyUserPassword string
-				StorageClass                 string
-			}{
-				Namespace:                    config.GetDefaultNamespace(),
-				PostgresImage:                config.GetImage(config.PostgresImageKey),
-				ImagePullSecret:              mgh.Spec.ImagePullSecret,
-				ImagePullPolicy:              string(imagePullPolicy),
-				NodeSelector:                 mgh.Spec.NodeSelector,
-				Tolerations:                  mgh.Spec.Tolerations,
-				StorageSize:                  config.GetPostgresStorageSize(mgh),
-				PostgresAdminUserPassword:    credential.postgresAdminUserPassword,
-				PostgresReadonlyUsername:     credential.postgresReadonlyUsername,
-				PostgresReadonlyUserPassword: credential.postgresReadonlyUserPassword,
-				StorageClass:                 mgh.Spec.DataLayer.StorageClass,
-			}, nil
-		})
-	if err != nil {
-		return fmt.Errorf("failed to render postgres manifests: %w", err)
-	}
-
-	// create restmapper for deployer to find GVR
-	dc, err := discovery.NewDiscoveryClientForConfig(r.Manager.GetConfig())
-	if err != nil {
-		return err
-	}
-	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(dc))
-
-	if err = r.manipulateObj(ctx, postgresDeployer, mapper, postgresObjects, mgh, log); err != nil {
-		return fmt.Errorf("failed to create/update postgres objects: %w", err)
-	}
-
-	ca, err := getPostgresCA(ctx, mgh, r)
-	if err != nil {
-		return err
-	}
-	r.MiddlewareConfig.PgConnection = &postgres.PostgresConnection{
-		SuperuserDatabaseURI: "postgresql://" + credential.postgresAdminUsername + ":" +
-			credential.postgresAdminUserPassword + partialPostgresURI,
-		ReadonlyUserDatabaseURI: "postgresql://" + credential.postgresReadonlyUsername + ":" +
-			credential.postgresReadonlyUserPassword + partialPostgresURI,
-		CACert: []byte(ca),
-	}
-	return nil
-}
-
-func getPostgresCredential(ctx context.Context, mgh *globalhubv1alpha4.MulticlusterGlobalHub,
-	r *MulticlusterGlobalHubReconciler,
-) (*postgresCredential, error) {
-	postgres := &corev1.Secret{}
-	if err := r.Client.Get(ctx, types.NamespacedName{
-		Name:      "multicluster-global-hub-postgres",
-		Namespace: mgh.Namespace,
-	}, postgres); err != nil && errors.IsNotFound(err) {
-		return &postgresCredential{
-			postgresAdminUsername:        postgresAdminUsername,
-			postgresAdminUserPassword:    generatePassword(16),
-			postgresReadonlyUsername:     postgresReadonlyUsername,
-			postgresReadonlyUserPassword: generatePassword(16),
-		}, nil
-	} else if err != nil {
-		return nil, err
-	}
-	return &postgresCredential{
-		postgresAdminUsername:        postgresAdminUsername,
-		postgresAdminUserPassword:    string(postgres.Data["database-admin-password"]),
-		postgresReadonlyUsername:     string(postgres.Data["database-readonly-user"]),
-		postgresReadonlyUserPassword: string(postgres.Data["database-readonly-password"]),
-	}, nil
-}
-
-func getPostgresCA(ctx context.Context,
-	mgh *globalhubv1alpha4.MulticlusterGlobalHub, r *MulticlusterGlobalHubReconciler,
-) (string, error) {
-	ca := &corev1.ConfigMap{}
-	if err := r.Client.Get(ctx, types.NamespacedName{
-		Name:      postgresCA,
-		Namespace: mgh.Namespace,
-	}, ca); err != nil {
-		return "", err
-	}
-	return ca.Data["service-ca.crt"], nil
 }

--- a/operator/pkg/controllers/hubofhubs/globalhub_kafka.go
+++ b/operator/pkg/controllers/hubofhubs/globalhub_kafka.go
@@ -62,20 +62,20 @@ func (r *MulticlusterGlobalHubReconciler) EnsureKafkaSubscription(ctx context.Co
 // EnsureKafkaResources verifies resources needed for Kafka are created
 // including kafka/kafkatopic/kafkauser
 func (r *MulticlusterGlobalHubReconciler) EnsureKafkaResources(ctx context.Context,
-	mgh *globalhubv1alpha4.MulticlusterGlobalHub) error {
+	mgh *globalhubv1alpha4.MulticlusterGlobalHub,
+) error {
 	kafkaCluster := &kafkav1beta2.Kafka{}
 	err := r.Client.Get(ctx, types.NamespacedName{
 		Name:      kafka.KafkaClusterName,
 		Namespace: config.GetDefaultNamespace(),
 	}, kafkaCluster)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			err = r.Client.Create(ctx, kafka.NewKafka(mgh, kafka.KafkaClusterName, config.GetDefaultNamespace()))
-			if err != nil && !errors.IsAlreadyExists(err) {
-				return err
-			}
-		} else {
-			return err
+
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	} else if errors.IsNotFound(err) {
+		e := r.Client.Create(ctx, kafka.NewKafka(mgh, kafka.KafkaClusterName, config.GetDefaultNamespace()))
+		if e != nil && !errors.IsAlreadyExists(e) {
+			return e
 		}
 	}
 

--- a/operator/pkg/controllers/hubofhubs/globalhub_manager.go
+++ b/operator/pkg/controllers/hubofhubs/globalhub_manager.go
@@ -109,13 +109,14 @@ func (r *MulticlusterGlobalHubReconciler) reconcileManager(ctx context.Context,
 			EnableGlobalResource   bool
 			LogLevel               string
 		}{
-			Image:                  config.GetImage(config.GlobalHubManagerImageKey),
-			Replicas:               replicas,
-			ProxyImage:             config.GetImage(config.OauthProxyImageKey),
-			ImagePullSecret:        mgh.Spec.ImagePullSecret,
-			ImagePullPolicy:        string(imagePullPolicy),
-			ProxySessionSecret:     proxySessionSecret,
-			DatabaseURL:            r.MiddlewareConfig.PgConnection.SuperuserDatabaseURI,
+			Image:              config.GetImage(config.GlobalHubManagerImageKey),
+			Replicas:           replicas,
+			ProxyImage:         config.GetImage(config.OauthProxyImageKey),
+			ImagePullSecret:    mgh.Spec.ImagePullSecret,
+			ImagePullPolicy:    string(imagePullPolicy),
+			ProxySessionSecret: proxySessionSecret,
+			DatabaseURL: base64.StdEncoding.EncodeToString(
+				[]byte(r.MiddlewareConfig.PgConnection.SuperuserDatabaseURI)),
 			PostgresCACert:         base64.StdEncoding.EncodeToString(r.MiddlewareConfig.PgConnection.CACert),
 			KafkaCACert:            r.MiddlewareConfig.KafkaConnection.CACert,
 			KafkaClientCert:        r.MiddlewareConfig.KafkaConnection.ClientCert,

--- a/operator/pkg/controllers/hubofhubs/globalhub_postgres.go
+++ b/operator/pkg/controllers/hubofhubs/globalhub_postgres.go
@@ -187,7 +187,6 @@ func (r *MulticlusterGlobalHubReconciler) InitPostgresByStatefulset(ctx context.
 				PostgresAdminUserPassword    string
 				PostgresReadonlyUsername     string
 				PostgresReadonlyUserPassword string
-				PostgresCACert               string
 				StorageClass                 string
 			}{
 				Namespace:                    config.GetDefaultNamespace(),

--- a/operator/pkg/controllers/hubofhubs/globalhub_postgres.go
+++ b/operator/pkg/controllers/hubofhubs/globalhub_postgres.go
@@ -159,7 +159,7 @@ func (r *MulticlusterGlobalHubReconciler) GeneratePGConnectionFromGHStorageSecre
 	}, nil
 }
 
-func (r *MulticlusterGlobalHubReconciler) initPostgresByStatefulset(ctx context.Context,
+func (r *MulticlusterGlobalHubReconciler) InitPostgresByStatefulset(ctx context.Context,
 	mgh *globalhubv1alpha4.MulticlusterGlobalHub,
 ) error {
 	// install the postgres statefulset only

--- a/operator/pkg/controllers/hubofhubs/integration_test.go
+++ b/operator/pkg/controllers/hubofhubs/integration_test.go
@@ -903,6 +903,7 @@ var _ = Describe("MulticlusterGlobalHub controller", Ordered, func() {
 			mghReconciler.MiddlewareConfig.PgConnection = nil
 			mghReconciler.MiddlewareConfig.KafkaConnection = nil
 			_, err := mghReconciler.ReconcileMiddleware(ctx, mcgh)
+			fmt.Println("Reconcile the Middlewares", err.Error())
 			Expect(err).Should(HaveOccurred())
 			// has multicluster-global-hub-storage secret
 			Expect(mghReconciler.MiddlewareConfig.PgConnection).ShouldNot(BeNil())
@@ -970,7 +971,7 @@ var _ = Describe("MulticlusterGlobalHub controller", Ordered, func() {
 
 		It("Should get the postgres connection", func() {
 			mghReconciler.MiddlewareConfig.PgConnection = nil
-			mghReconciler.ReconcileDatabase(ctx, mcgh)
+			mghReconciler.ReconcileMiddleware(ctx, mcgh)
 			Expect(mghReconciler.MiddlewareConfig.PgConnection).ShouldNot(BeNil())
 		})
 	})

--- a/operator/pkg/controllers/hubofhubs/integration_test.go
+++ b/operator/pkg/controllers/hubofhubs/integration_test.go
@@ -971,7 +971,10 @@ var _ = Describe("MulticlusterGlobalHub controller", Ordered, func() {
 
 		It("Should get the postgres connection", func() {
 			mghReconciler.MiddlewareConfig.PgConnection = nil
-			mghReconciler.ReconcileMiddleware(ctx, mcgh)
+			_, err := mghReconciler.ReconcileMiddleware(ctx, mcgh)
+			if !errors.IsAlreadyExists(err) {
+				Expect(err).Should(Succeed())
+			}
 			Expect(mghReconciler.MiddlewareConfig.PgConnection).ShouldNot(BeNil())
 		})
 	})

--- a/operator/pkg/controllers/hubofhubs/integration_test.go
+++ b/operator/pkg/controllers/hubofhubs/integration_test.go
@@ -971,10 +971,7 @@ var _ = Describe("MulticlusterGlobalHub controller", Ordered, func() {
 
 		It("Should get the postgres connection", func() {
 			mghReconciler.MiddlewareConfig.PgConnection = nil
-			_, err := mghReconciler.ReconcileMiddleware(ctx, mcgh)
-			if !errors.IsAlreadyExists(err) {
-				Expect(err).Should(Succeed())
-			}
+			mghReconciler.InitPostgresByStatefulset(ctx, mcgh)
 			Expect(mghReconciler.MiddlewareConfig.PgConnection).ShouldNot(BeNil())
 		})
 	})

--- a/operator/pkg/controllers/hubofhubs/integration_test.go
+++ b/operator/pkg/controllers/hubofhubs/integration_test.go
@@ -956,7 +956,7 @@ var _ = Describe("MulticlusterGlobalHub controller", Ordered, func() {
 		})
 	})
 
-	Context("Reconcile the Postgres database", func() {
+	Context("Reconcile the Postgres database", Ordered, func() {
 		mcgh := &globalhubv1alpha4.MulticlusterGlobalHub{}
 		It("Should create the MGH instance", func() {
 			mcgh = &globalhubv1alpha4.MulticlusterGlobalHub{
@@ -971,7 +971,10 @@ var _ = Describe("MulticlusterGlobalHub controller", Ordered, func() {
 
 		It("Should get the postgres connection", func() {
 			mghReconciler.MiddlewareConfig.PgConnection = nil
-			mghReconciler.InitPostgresByStatefulset(ctx, mcgh)
+			err := mghReconciler.InitPostgresByStatefulset(ctx, mcgh)
+			if err != nil {
+				fmt.Println("InitPostgresBystatefuleset Error", err.Error())
+			}
 			Expect(mghReconciler.MiddlewareConfig.PgConnection).ShouldNot(BeNil())
 		})
 	})

--- a/operator/pkg/controllers/hubofhubs/integration_test.go
+++ b/operator/pkg/controllers/hubofhubs/integration_test.go
@@ -344,7 +344,7 @@ var _ = Describe("MulticlusterGlobalHub controller", Ordered, func() {
 					ImagePullPolicy:        string(imagePullPolicy),
 					ImagePullSecret:        mgh.Spec.ImagePullSecret,
 					ProxySessionSecret:     "testing",
-					DatabaseURL:            testPostgres.URI,
+					DatabaseURL:            base64.StdEncoding.EncodeToString([]byte(testPostgres.URI)),
 					PostgresCACert:         base64.StdEncoding.EncodeToString([]byte("")),
 					KafkaCACert:            base64.RawStdEncoding.EncodeToString([]byte(kafkaCACert)),
 					KafkaClientCert:        base64.RawStdEncoding.EncodeToString([]byte(kafkaClientCert)),

--- a/operator/pkg/controllers/hubofhubs/manifests/manager/deployment.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/manager/deployment.yaml
@@ -38,8 +38,8 @@ spec:
             - --kafka-client-key-path=/kafka-certs/client.key
             - --postgres-ca-path=/postgres-credential/ca.crt
             - --transport-message-compression-type={{.MessageCompressionType}}
-            - --process-database-url=/postgres-credential/database-url
-            - --transport-bridge-database-url=/postgres-credential/database-url
+            - --process-database-url=$(DATABASE_URL)
+            - --transport-bridge-database-url=$(DATABASE_URL)
             - --lease-duration={{.LeaseDuration}}
             - --renew-deadline={{.RenewDeadline}}
             - --retry-period={{.RetryPeriod}}
@@ -58,6 +58,11 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credential-secret
+                  key: database-url
             - name: WATCH_NAMESPACE
             {{- if .LaunchJobNames}}
             - name: LAUNCH_JOB_NAMES

--- a/operator/pkg/controllers/hubofhubs/manifests/manager/deployment.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/manager/deployment.yaml
@@ -36,10 +36,10 @@ spec:
             - --kafka-ca-cert-path=/kafka-certs/ca.crt
             - --kafka-client-cert-path=/kafka-certs/client.crt
             - --kafka-client-key-path=/kafka-certs/client.key
-            - --postgres-ca-path=/postgres-ca/ca.crt
+            - --postgres-ca-path=/postgres-credential/ca.crt
             - --transport-message-compression-type={{.MessageCompressionType}}
-            - --process-database-url=$(DATABASE_URL)
-            - --transport-bridge-database-url=$(DATABASE_URL)
+            - --process-database-url=/postgres-credential/database-url
+            - --transport-bridge-database-url=/postgres-credential/database-url
             - --lease-duration={{.LeaseDuration}}
             - --renew-deadline={{.RenewDeadline}}
             - --retry-period={{.RetryPeriod}}
@@ -59,8 +59,6 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.namespace
             - name: WATCH_NAMESPACE
-            - name: DATABASE_URL
-              value: {{.DatabaseURL}}
             {{- if .LaunchJobNames}}
             - name: LAUNCH_JOB_NAMES
               value: {{.LaunchJobNames}}
@@ -84,8 +82,8 @@ spec:
           - mountPath: /kafka-certs
             name: kafka-certs
             readOnly: true
-          - mountPath: /postgres-ca
-            name: postgres-ca
+          - mountPath: /postgres-credential
+            name: postgres-credential
             readOnly: true
         {{ if .EnableGlobalResource }}
         - name: oauth-proxy
@@ -155,9 +153,9 @@ spec:
       - name: kafka-certs
         secret:
           secretName: kafka-certs-secret
-      - name: postgres-ca
+      - name: postgres-credential
         secret:
-          secretName: postgres-certs-secret
+          secretName: postgres-credential-secret
       {{ if .EnableGlobalResource }}
       - name: apiserver-certs
         secret:

--- a/operator/pkg/controllers/hubofhubs/manifests/manager/postgres-credential-secret.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/manager/postgres-credential-secret.yaml
@@ -1,10 +1,11 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: postgres-certs-secret
+  name: postgres-credential-secret
   namespace: {{.Namespace}}
   labels:
     name: multicluster-global-hub-manager
 type: Opaque
 data:
   "ca.crt": "{{.PostgresCACert}}"
+  "database-url": "{{.DatabaseURL}}"

--- a/operator/pkg/controllers/hubofhubs/manifests/postgres/secret.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/postgres/secret.yaml
@@ -12,4 +12,3 @@ stringData:
   database-admin-password: "{{.PostgresAdminUserPassword}}"
   database-readonly-user: "{{.PostgresReadonlyUsername}}"
   database-readonly-password: "{{.PostgresReadonlyUserPassword}}"
-  "ca.crt": "{{.PostgresCACert}}"

--- a/operator/pkg/controllers/hubofhubs/manifests/postgres/secret.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/postgres/secret.yaml
@@ -12,3 +12,4 @@ stringData:
   database-admin-password: "{{.PostgresAdminUserPassword}}"
   database-readonly-user: "{{.PostgresReadonlyUsername}}"
   database-readonly-password: "{{.PostgresReadonlyUserPassword}}"
+  "ca.crt": "{{.PostgresCACert}}"


### PR DESCRIPTION
Resolved: https://github.com/stolostron/multicluster-global-hub/issues/687
Signed-off-by: myan <myan@redhat.com>

Ref: https://issues.redhat.com/browse/ACM-8230

https://github.com/stolostron/multicluster-global-hub/issues/691: If we want to dynamically load the values of the Postgres credential into the pod, we need a separate controller to load and update the connection of the database, the same as Kafka. 
