### PR TITLE
Create Kafka certs for each managed hub

### DIFF
--- a/cicd-scripts/run-prow-e2e-test.sh
+++ b/cicd-scripts/run-prow-e2e-test.sh
@@ -28,7 +28,5 @@ ssh "${OPT[@]}" "$HOST" "sudo sh -c 'echo \"fs.inotify.max_user_watches=524288\"
 echo "setup e2e environment"
 ssh "${OPT[@]}" "$HOST" "cd $HOST_DIR && . test/resources/env.list && sudo make e2e-setup-dependencies && make e2e-setup-start" > >(tee "$ARTIFACT_DIR/run-e2e-setup.log") 2>&1
 
-sleep 3600
-
 echo "runn e2e tests"
 ssh "${OPT[@]}" "$HOST" "cd $HOST_DIR && . test/resources/env.list && make e2e-tests-all && make e2e-tests-prune" > >(tee "$ARTIFACT_DIR/run-e2e-test.log") 2>&1

--- a/cicd-scripts/run-prow-e2e-test.sh
+++ b/cicd-scripts/run-prow-e2e-test.sh
@@ -28,5 +28,7 @@ ssh "${OPT[@]}" "$HOST" "sudo sh -c 'echo \"fs.inotify.max_user_watches=524288\"
 echo "setup e2e environment"
 ssh "${OPT[@]}" "$HOST" "cd $HOST_DIR && . test/resources/env.list && sudo make e2e-setup-dependencies && make e2e-setup-start" > >(tee "$ARTIFACT_DIR/run-e2e-setup.log") 2>&1
 
+sleep 3600
+
 echo "runn e2e tests"
 ssh "${OPT[@]}" "$HOST" "cd $HOST_DIR && . test/resources/env.list && make e2e-tests-all && make e2e-tests-prune" > >(tee "$ARTIFACT_DIR/run-e2e-test.log") 2>&1

--- a/operator/main.go
+++ b/operator/main.go
@@ -31,6 +31,7 @@ import (
 	routeV1Client "github.com/openshift/client-go/route/clientset/versioned"
 	subv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	operatorsv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
+
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -173,7 +174,7 @@ func doMain(ctx context.Context, cfg *rest.Config) int {
 	middlewareCfg := &hubofhubscontrollers.MiddlewareConfig{}
 
 	// start addon controller
-	if err = (&hubofhubsaddon.HoHAddonInstallReconciler{
+	if err = (&hubofhubsaddon.HoHAddonInstaller{
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("addon-reconciler"),
 	}).SetupWithManager(ctx, mgr); err != nil {

--- a/operator/pkg/config/multiclusterglobalhub_config.go
+++ b/operator/pkg/config/multiclusterglobalhub_config.go
@@ -83,11 +83,11 @@ func GetDefaultNamespace() string {
 	return defaultNamespace
 }
 
-func SetHoHMGHNamespacedName(namespacedName types.NamespacedName) {
+func SetMGHNamespacedName(namespacedName types.NamespacedName) {
 	hohMGHNamespacedName = namespacedName
 }
 
-func GetHoHMGHNamespacedName() types.NamespacedName {
+func GetMGHNamespacedName() types.NamespacedName {
 	return hohMGHNamespacedName
 }
 

--- a/operator/pkg/controllers/addon/addon_installer_test.go
+++ b/operator/pkg/controllers/addon/addon_installer_test.go
@@ -249,11 +249,11 @@ func TestHoHAddonReconciler(t *testing.T) {
 			}
 			if tc.mgh != nil {
 				objects = append(objects, tc.mgh)
-				config.SetHoHMGHNamespacedName(types.NamespacedName{
+				config.SetMGHNamespacedName(types.NamespacedName{
 					Namespace: tc.mgh.Namespace, Name: tc.mgh.Name,
 				})
 			} else {
-				config.SetHoHMGHNamespacedName(types.NamespacedName{Namespace: "", Name: ""})
+				config.SetMGHNamespacedName(types.NamespacedName{Namespace: "", Name: ""})
 			}
 			mgr, err := ctrl.NewManager(kubeCfg, ctrl.Options{
 				MetricsBindAddress: "0", // disable the metrics serving
@@ -261,7 +261,7 @@ func TestHoHAddonReconciler(t *testing.T) {
 			if err != nil {
 				t.Errorf("failed to create manager: %v", err)
 			}
-			r := &hubofhubsaddon.HoHAddonInstallReconciler{
+			r := &hubofhubsaddon.HoHAddonInstaller{
 				Client: fake.NewClientBuilder().WithScheme(addonTestScheme).WithObjects(objects...).Build(),
 				Log:    ctrl.Log.WithName("test"),
 			}

--- a/operator/pkg/controllers/addon/addon_integration_test.go
+++ b/operator/pkg/controllers/addon/addon_integration_test.go
@@ -19,6 +19,7 @@ import (
 	workv1 "open-cluster-management.io/api/work/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
 	operatorconstants "github.com/stolostron/multicluster-global-hub/operator/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 )
@@ -56,6 +57,13 @@ func prepareCluster(name string, labels, annotations map[string]string,
 	Expect(k8sClient.Create(ctx, &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
+		},
+	})).Should(Succeed())
+
+	Expect(k8sClient.Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-kafka-user", name),
+			Namespace: config.GetMGHNamespacedName().Namespace,
 		},
 	})).Should(Succeed())
 }

--- a/operator/pkg/controllers/addon/addon_manifests.go
+++ b/operator/pkg/controllers/addon/addon_manifests.go
@@ -243,7 +243,7 @@ func (a *HohAgentAddon) getKakaConnection(cluster *clusterv1.ManagedCluster) (*k
 	kafkaUserSecret := &corev1.Secret{}
 	err = a.client.Get(a.ctx, types.NamespacedName{
 		Namespace: config.GetMGHNamespacedName().Namespace,
-		Name:      getKafkaUserName(cluster.Name),
+		Name:      getKafkaUser(cluster.Name).Name,
 	}, kafkaUserSecret)
 	if err != nil {
 		return nil, err

--- a/operator/pkg/controllers/addon/addon_manifests.go
+++ b/operator/pkg/controllers/addon/addon_manifests.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/stolostron/cluster-lifecycle-api/helpers/imageregistry"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -22,6 +23,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
 	operatorconstants "github.com/stolostron/multicluster-global-hub/operator/pkg/constants"
 	hubofhubscontroller "github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/hubofhubs"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/kafka"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	commonobjects "github.com/stolostron/multicluster-global-hub/pkg/objects"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
@@ -158,10 +160,6 @@ func (a *HohAgentAddon) GetValues(cluster *clusterv1.ManagedCluster,
 		return nil, err
 	}
 
-	if a.MiddlewareConfig.KafkaConnection == nil {
-		return nil, fmt.Errorf("failed to get kafka connection config")
-	}
-
 	image, err := a.getOverrideImage(mgh, cluster)
 	if err != nil {
 		return nil, err
@@ -174,20 +172,7 @@ func (a *HohAgentAddon) GetValues(cluster *clusterv1.ManagedCluster,
 
 	agentQPS, agentBurst := a.getAgentRestConfig(a.ControllerConfig)
 
-	kafkaClusterCertSecret := &corev1.Secret{}
-	err = a.client.Get(a.ctx, types.NamespacedName{
-		Namespace: config.GetMGHNamespacedName().Namespace,
-		Name:      getKafkaUserName(cluster.Name),
-	}, kafkaClusterCertSecret)
-	if err != nil {
-		return nil, err
-	}
-
-	kafkaUserSecret := &corev1.Secret{}
-	err = a.client.Get(a.ctx, types.NamespacedName{
-		Namespace: config.GetMGHNamespacedName().Namespace,
-		Name:      getKafkaUserName(cluster.Name),
-	}, kafkaUserSecret)
+	kafkaConnection, err := a.getKakaConnection(cluster)
 	if err != nil {
 		return nil, err
 	}
@@ -196,10 +181,10 @@ func (a *HohAgentAddon) GetValues(cluster *clusterv1.ManagedCluster,
 		HoHAgentImage:          image,
 		ImagePullPolicy:        string(imagePullPolicy),
 		LeafHubID:              cluster.Name,
-		KafkaBootstrapServer:   a.MiddlewareConfig.KafkaConnection.BootstrapServer,
-		KafkaCACert:            base64.StdEncoding.EncodeToString(kafkaClusterCertSecret.Data["ca.crt"]),
-		KafkaClientCert:        base64.StdEncoding.EncodeToString(kafkaUserSecret.Data["user.crt"]),
-		KafkaClientKey:         base64.StdEncoding.EncodeToString(kafkaUserSecret.Data["user.key"]),
+		KafkaBootstrapServer:   kafkaConnection.BootstrapServer,
+		KafkaCACert:            kafkaConnection.CACert,
+		KafkaClientCert:        kafkaConnection.ClientCert,
+		KafkaClientKey:         kafkaConnection.ClientKey,
 		MessageCompressionType: string(operatorconstants.GzipCompressType),
 		TransportType:          string(transport.Kafka),
 		TransportFormat:        string(globalhubv1alpha4.CloudEvents),
@@ -237,6 +222,39 @@ func (a *HohAgentAddon) GetValues(cluster *clusterv1.ManagedCluster,
 	a.setInstallHostedMode(cluster, &manifestsConfig)
 
 	return addonfactory.StructToValues(manifestsConfig), nil
+}
+
+func (a *HohAgentAddon) getKakaConnection(cluster *clusterv1.ManagedCluster) (*kafka.KafkaConnection, error) {
+	// support BYO, the transport secret as the only credential for all the managed hubs
+	kafkaConnection, err := kafka.GenerateKafkaConnectionFromGHTransportSecret(a.ctx, a.client)
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, err
+	}
+	if kafkaConnection != nil {
+		return kafkaConnection, nil
+	}
+
+	// get the global hub manager kafka connection, which contain the cluster CA
+	if a.MiddlewareConfig.KafkaConnection == nil {
+		return nil, fmt.Errorf("failed to get the manager kafka connection config")
+	}
+
+	// get client certificate
+	kafkaUserSecret := &corev1.Secret{}
+	err = a.client.Get(a.ctx, types.NamespacedName{
+		Namespace: config.GetMGHNamespacedName().Namespace,
+		Name:      getKafkaUserName(cluster.Name),
+	}, kafkaUserSecret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &kafka.KafkaConnection{
+		BootstrapServer: a.MiddlewareConfig.KafkaConnection.BootstrapServer,
+		CACert:          a.MiddlewareConfig.KafkaConnection.CACert,
+		ClientCert:      base64.StdEncoding.EncodeToString(kafkaUserSecret.Data["user.crt"]),
+		ClientKey:       base64.StdEncoding.EncodeToString(kafkaUserSecret.Data["user.key"]),
+	}, nil
 }
 
 // getAgentRestConfig return the agent qps and burst, if not set, use default QPS and Burst

--- a/operator/pkg/controllers/addon/addon_manifests.go
+++ b/operator/pkg/controllers/addon/addon_manifests.go
@@ -22,7 +22,6 @@ import (
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
 	operatorconstants "github.com/stolostron/multicluster-global-hub/operator/pkg/constants"
 	hubofhubscontroller "github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/hubofhubs"
-	"github.com/stolostron/multicluster-global-hub/operator/pkg/kafka"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	commonobjects "github.com/stolostron/multicluster-global-hub/pkg/objects"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
@@ -178,7 +177,7 @@ func (a *HohAgentAddon) GetValues(cluster *clusterv1.ManagedCluster,
 	kafkaClusterCertSecret := &corev1.Secret{}
 	err = a.client.Get(a.ctx, types.NamespacedName{
 		Namespace: config.GetMGHNamespacedName().Namespace,
-		Name:      fmt.Sprintf("%s-cluster-ca-cert", kafka.KafkaClusterName),
+		Name:      getKafkaUserName(cluster.Name),
 	}, kafkaClusterCertSecret)
 	if err != nil {
 		return nil, err
@@ -187,7 +186,7 @@ func (a *HohAgentAddon) GetValues(cluster *clusterv1.ManagedCluster,
 	kafkaUserSecret := &corev1.Secret{}
 	err = a.client.Get(a.ctx, types.NamespacedName{
 		Namespace: config.GetMGHNamespacedName().Namespace,
-		Name:      cluster.Name,
+		Name:      getKafkaUserName(cluster.Name),
 	}, kafkaUserSecret)
 	if err != nil {
 		return nil, err

--- a/operator/pkg/controllers/addon/addon_suite_test.go
+++ b/operator/pkg/controllers/addon/addon_suite_test.go
@@ -188,7 +188,6 @@ var _ = AfterSuite(func() {
 const (
 	MGHName              = "test-mgh"
 	StorageSecretName    = operatorconstants.GHStorageSecretName
-	TransportSecretName  = operatorconstants.GHTransportSecretName
 	kafkaCA              = "foobar"
 	kafkaBootstrapServer = "https://test-kafka.example.com"
 
@@ -220,6 +219,10 @@ func prepareBeforeTest() {
 	By("By creating a new MGH instance")
 	mgh.SetNamespace(config.GetDefaultNamespace())
 	Expect(k8sClient.Create(ctx, mgh)).Should(Succeed())
+	config.SetMGHNamespacedName(types.NamespacedName{
+		Namespace: mgh.Namespace,
+		Name:      mgh.Name,
+	})
 
 	Expect(k8sClient.Status().Update(ctx, mgh)).Should(Succeed())
 

--- a/operator/pkg/controllers/addon/addon_suite_test.go
+++ b/operator/pkg/controllers/addon/addon_suite_test.go
@@ -139,7 +139,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	By("Add the addon install reconciler to the manager")
-	err = (&addon.HoHAddonInstallReconciler{
+	err = (&addon.HoHAddonInstaller{
 		Client: k8sClient,
 		Log:    ctrl.Log.WithName("addon install controller"),
 	}).SetupWithManager(ctx, k8sManager)
@@ -234,7 +234,7 @@ func prepareBeforeTest() {
 
 	// 	After creating this MGH instance, check that the MGH instance's Spec fields are failed with default values.
 	mghLookupKey := types.NamespacedName{Namespace: config.GetDefaultNamespace(), Name: MGHName}
-	config.SetHoHMGHNamespacedName(mghLookupKey)
+	config.SetMGHNamespacedName(mghLookupKey)
 	createdMGH := &globalhubv1alpha4.MulticlusterGlobalHub{}
 
 	// get this newly created MGH instance, given that creation may not immediately happen.

--- a/operator/pkg/controllers/hubofhubs/globalhub_config.go
+++ b/operator/pkg/controllers/hubofhubs/globalhub_config.go
@@ -5,6 +5,7 @@ import (
 
 	globalhubv1alpha4 "github.com/stolostron/multicluster-global-hub/operator/apis/v1alpha4"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // reconcileSystemConfig tries to create hoh resources if they don't exist
@@ -13,6 +14,12 @@ func (r *MulticlusterGlobalHubReconciler) reconcileSystemConfig(ctx context.Cont
 ) error {
 	log := r.Log.WithName("config")
 	log.Info("set operand images; service monitor interval; set global hub agent config")
+
+	// set request name to be used in leafhub controller
+	config.SetMGHNamespacedName(types.NamespacedName{
+		Namespace: mgh.GetNamespace(), Name: mgh.GetName(),
+	})
+
 	// set image overrides
 	if err := config.SetImageOverrides(mgh); err != nil {
 		return err

--- a/operator/pkg/controllers/hubofhubs/globalhub_controller.go
+++ b/operator/pkg/controllers/hubofhubs/globalhub_controller.go
@@ -245,7 +245,7 @@ func (r *MulticlusterGlobalHubReconciler) ReconcileMiddleware(ctx context.Contex
 	mgh *globalhubv1alpha4.MulticlusterGlobalHub,
 ) (ctrl.Result, error) {
 	// support BYO kafka
-	kafkaConnection, err := r.GenerateKafkaConnectionFromGHTransportSecret(ctx)
+	kafkaConnection, err := kafka.GenerateKafkaConnectionFromGHTransportSecret(ctx, r.Client)
 	if err != nil && !errors.IsNotFound(err) {
 		return ctrl.Result{}, err
 	} else if errors.IsNotFound(err) {

--- a/operator/pkg/controllers/hubofhubs/globalhub_controller.go
+++ b/operator/pkg/controllers/hubofhubs/globalhub_controller.go
@@ -35,7 +35,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
@@ -224,7 +223,8 @@ func (r *MulticlusterGlobalHubReconciler) Reconcile(ctx context.Context, req ctr
 }
 
 func AddFailedCondition(ctx context.Context, client client.Client,
-	mgh *globalhubv1alpha4.MulticlusterGlobalHub, msg string) error {
+	mgh *globalhubv1alpha4.MulticlusterGlobalHub, msg string,
+) error {
 	if err := condition.SetCondition(ctx, client, mgh,
 		condition.CONDITION_TYPE_GLOBALHUB_READY,
 		metav1.ConditionFalse,
@@ -372,10 +372,6 @@ func (r *MulticlusterGlobalHubReconciler) reconcileGlobalHub(ctx context.Context
 
 var mghPred = predicate.Funcs{
 	CreateFunc: func(e event.CreateEvent) bool {
-		// set request name to be used in leafhub controller
-		config.SetHoHMGHNamespacedName(types.NamespacedName{
-			Namespace: e.Object.GetNamespace(), Name: e.Object.GetName(),
-		})
 		return true
 	},
 	UpdateFunc: func(e event.UpdateEvent) bool {
@@ -502,10 +498,10 @@ var webhookPred = predicate.Funcs{
 
 var namespacePred = predicate.Funcs{
 	CreateFunc: func(e event.CreateEvent) bool {
-		return e.Object.GetName() == config.GetHoHMGHNamespacedName().Namespace
+		return e.Object.GetName() == config.GetMGHNamespacedName().Namespace
 	},
 	UpdateFunc: func(e event.UpdateEvent) bool {
-		return e.ObjectNew.GetName() == config.GetHoHMGHNamespacedName().Namespace &&
+		return e.ObjectNew.GetName() == config.GetMGHNamespacedName().Namespace &&
 			e.ObjectNew.GetGeneration() != e.ObjectOld.GetGeneration()
 	},
 	DeleteFunc: func(e event.DeleteEvent) bool {
@@ -517,7 +513,7 @@ var globalHubEventHandler = handler.EnqueueRequestsFromMapFunc(
 	func(ctx context.Context, obj client.Object) []reconcile.Request {
 		return []reconcile.Request{
 			// trigger MGH instance reconcile
-			{NamespacedName: config.GetHoHMGHNamespacedName()},
+			{NamespacedName: config.GetMGHNamespacedName()},
 		}
 	},
 )

--- a/operator/pkg/controllers/hubofhubs/globalhub_kafka.go
+++ b/operator/pkg/controllers/hubofhubs/globalhub_kafka.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"path/filepath"
 
 	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
 	subv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -16,7 +15,6 @@ import (
 
 	globalhubv1alpha4 "github.com/stolostron/multicluster-global-hub/operator/apis/v1alpha4"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
-	"github.com/stolostron/multicluster-global-hub/operator/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/kafka"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/utils"
 )
@@ -166,25 +164,4 @@ func (r *MulticlusterGlobalHubReconciler) WaitForKafkaClusterReady(ctx context.C
 		}
 	}
 	return nil, fmt.Errorf("kafka cluster %s is not ready", kafkaCluster.Name)
-}
-
-// GenerateKafkaConnectionFromGHTransportSecret returns a kafka connection object from the BYO kafka secret
-func (r *MulticlusterGlobalHubReconciler) GenerateKafkaConnectionFromGHTransportSecret(ctx context.Context) (
-	*kafka.KafkaConnection, error,
-) {
-	kafkaSecret := &corev1.Secret{}
-	err := r.Client.Get(ctx, types.NamespacedName{
-		Name:      constants.GHTransportSecretName,
-		Namespace: config.GetDefaultNamespace(),
-	}, kafkaSecret)
-	if err != nil {
-		return nil, err
-	}
-
-	return &kafka.KafkaConnection{
-		BootstrapServer: string(kafkaSecret.Data[filepath.Join("bootstrap_server")]),
-		CACert:          base64.StdEncoding.EncodeToString(kafkaSecret.Data[filepath.Join("ca.crt")]),
-		ClientCert:      base64.StdEncoding.EncodeToString(kafkaSecret.Data[filepath.Join("client.crt")]),
-		ClientKey:       base64.StdEncoding.EncodeToString(kafkaSecret.Data[filepath.Join("client.key")]),
-	}, nil
 }

--- a/operator/pkg/controllers/hubofhubs/integration_test.go
+++ b/operator/pkg/controllers/hubofhubs/integration_test.go
@@ -676,7 +676,7 @@ var _ = Describe("MulticlusterGlobalHub controller", Ordered, func() {
 			By("By checking the kafkaBootstrapServer")
 			createdMGH := &globalhubv1alpha4.MulticlusterGlobalHub{}
 			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(mgh), createdMGH)).Should(Succeed())
-			kafkaConnection, err := mghReconciler.GenerateKafkaConnectionFromGHTransportSecret(ctx)
+			kafkaConnection, err := kafka.GenerateKafkaConnectionFromGHTransportSecret(ctx, mghReconciler.Client)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(kafkaConnection.BootstrapServer).To(Equal(kafkaBootstrapServer))
 
@@ -700,7 +700,7 @@ var _ = Describe("MulticlusterGlobalHub controller", Ordered, func() {
 				return fmt.Errorf("should not find the secret")
 			}, timeout, interval).ShouldNot(HaveOccurred())
 			Eventually(func() error {
-				_, err = mghReconciler.GenerateKafkaConnectionFromGHTransportSecret(ctx)
+				_, err = kafka.GenerateKafkaConnectionFromGHTransportSecret(ctx, mghReconciler.Client)
 				return err
 			}, timeout, interval).Should(HaveOccurred())
 		})
@@ -991,7 +991,6 @@ var _ = Describe("MulticlusterGlobalHub controller", Ordered, func() {
 				}
 				return nil
 			}, timeout, interval).ShouldNot(HaveOccurred())
-
 		})
 
 		It("Should create the postgres resources", func() {
@@ -1036,7 +1035,6 @@ var _ = Describe("MulticlusterGlobalHub controller", Ordered, func() {
 				}
 				return nil
 			}, timeout, interval).ShouldNot(HaveOccurred())
-
 		})
 
 		It("Should delete the MGH instance", func() {
@@ -1071,7 +1069,6 @@ var _ = Describe("MulticlusterGlobalHub controller", Ordered, func() {
 			}, timeout, interval).ShouldNot(HaveOccurred())
 		})
 	})
-
 })
 
 func prettyPrint(v interface{}) error {

--- a/operator/pkg/kafka/kafka.go
+++ b/operator/pkg/kafka/kafka.go
@@ -4,13 +4,21 @@
 package kafka
 
 import (
+	"context"
+	"encoding/base64"
+	"path/filepath"
+
 	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
 	subv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	globalhubv1alpha4 "github.com/stolostron/multicluster-global-hub/operator/apis/v1alpha4"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	operatorconstants "github.com/stolostron/multicluster-global-hub/operator/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 )
 
@@ -259,4 +267,25 @@ func NewKafkaUser(username, namespace string) *kafkav1beta2.KafkaUser {
 			},
 		},
 	}
+}
+
+// GenerateKafkaConnectionFromGHTransportSecret returns a kafka connection object from the BYO kafka secret
+func GenerateKafkaConnectionFromGHTransportSecret(ctx context.Context, c client.Client) (
+	*KafkaConnection, error,
+) {
+	kafkaSecret := &corev1.Secret{}
+	err := c.Get(ctx, types.NamespacedName{
+		Name:      operatorconstants.GHTransportSecretName,
+		Namespace: config.GetDefaultNamespace(),
+	}, kafkaSecret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &KafkaConnection{
+		BootstrapServer: string(kafkaSecret.Data[filepath.Join("bootstrap_server")]),
+		CACert:          base64.StdEncoding.EncodeToString(kafkaSecret.Data[filepath.Join("ca.crt")]),
+		ClientCert:      base64.StdEncoding.EncodeToString(kafkaSecret.Data[filepath.Join("client.crt")]),
+		ClientKey:       base64.StdEncoding.EncodeToString(kafkaSecret.Data[filepath.Join("client.key")]),
+	}, nil
 }

--- a/operator/pkg/kafka/kafka.go
+++ b/operator/pkg/kafka/kafka.go
@@ -249,7 +249,8 @@ func NewKafkaUser(username, namespace string) *kafkav1beta2.KafkaUser {
 			Namespace: namespace,
 			Labels: map[string]string{
 				// It is important to set the cluster label otherwise the user will not be ready
-				"strimzi.io/cluster": KafkaClusterName,
+				"strimzi.io/cluster":             KafkaClusterName,
+				constants.GlobalHubOwnerLabelKey: constants.GlobalHubAddonOwnerLabelVal,
 			},
 		},
 		Spec: &kafkav1beta2.KafkaUserSpec{

--- a/operator/pkg/utils/utils.go
+++ b/operator/pkg/utils/utils.go
@@ -260,14 +260,14 @@ func CopyMap(newMap, originalMap map[string]string) {
 
 func WaitGlobalHubReady(ctx context.Context,
 	client client.Client,
-	interval time.Duration) (*globalhubv1alpha4.MulticlusterGlobalHub, error) {
+	interval time.Duration,
+) (*globalhubv1alpha4.MulticlusterGlobalHub, error) {
 	mghInstance := &globalhubv1alpha4.MulticlusterGlobalHub{}
 	klog.Info("Wait MulticlusterGlobalHub ready")
 
 	if err := wait.PollImmediate(interval, 10*time.Minute, func() (bool, error) {
 		mghList := &globalhubv1alpha4.MulticlusterGlobalHubList{}
 		err := client.List(ctx, mghList)
-
 		if err != nil {
 			klog.Error(err, "Failed to list MulticlusterGlobalHub")
 			return false, nil
@@ -292,4 +292,15 @@ func WaitGlobalHubReady(ctx context.Context,
 	}
 	klog.Info("MulticlusterGlobalHub is ready")
 	return mghInstance, nil
+}
+
+func DeleteIfExist(ctx context.Context, c client.Client, obj client.Object) error {
+	err := c.Get(ctx, client.ObjectKeyFromObject(obj), obj)
+	if errors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	return c.Delete(ctx, obj)
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -26,10 +26,11 @@ const (
 
 const (
 	// identify the resource is managed by
-	GlobalHubOwnerLabelKey  = "global-hub.open-cluster-management.io/managed-by"
-	GlobalHubOwnerLabelVal  = "global-hub"
-	GHAgentOwnerLabelValue  = "global-hub-agent"
-	GHOperatorOwnerLabelVal = "global-hub-operator"
+	GlobalHubOwnerLabelKey      = "global-hub.open-cluster-management.io/managed-by"
+	GlobalHubOwnerLabelVal      = "global-hub"
+	GlobalHubAddonOwnerLabelVal = "global-hub-addon"
+	GHAgentOwnerLabelValue      = "global-hub-agent"
+	GHOperatorOwnerLabelVal     = "global-hub-operator"
 	// Deprecated identify the resource is a local-resource
 	// GlobalHubLocalResource = "global-hub.open-cluster-management.io/local-resource"
 	// if the resource with this label, it will be synced to database and then propagated to managed hub

--- a/test/setup/common.sh
+++ b/test/setup/common.sh
@@ -312,17 +312,17 @@ function waitSecretToBeReady() {
 }
 
 function waitKafkaToBeReady() {
-  clusterIsReady=$(kubectl -n kafka get kafka.kafka.strimzi.io/kafka-brokers-cluster -o jsonpath={.status.listeners} --ignore-not-found)
+  clusterIsReady=$(kubectl -n kafka get kafka.kafka.strimzi.io/kafka -o jsonpath={.status.listeners} --ignore-not-found)
   SECOND=0
   while [ -z "$clusterIsReady" ]; do
     if [ $SECOND -gt 600 ]; then
-      echo "Timeout waiting for deploying kafka.kafka.strimzi.io/kafka-brokers-cluster"
+      echo "Timeout waiting for deploying kafka.kafka.strimzi.io/kafka"
       exit 1
     fi
     echo "Waiting for kafka cluster to become available"
     sleep 1
     (( SECOND = SECOND + 1 ))
-    clusterIsReady=$(kubectl -n kafka get kafka.kafka.strimzi.io/kafka-brokers-cluster -o jsonpath={.status.listeners} --ignore-not-found)
+    clusterIsReady=$(kubectl -n kafka get kafka.kafka.strimzi.io/kafka -o jsonpath={.status.listeners} --ignore-not-found)
   done
   echo "Kafka cluster is ready"
   waitSecretToBeReady ${TRANSPORT_SECRET_NAME:-"multicluster-global-hub-transport"} "multicluster-global-hub"

--- a/test/setup/e2e_setup.sh
+++ b/test/setup/e2e_setup.sh
@@ -70,8 +70,8 @@ echo "check connection :$sumTime seconds"
 startTime_s=`date +%s`
 kubectl config use-context $CTX_HUB >> $LOG
 # wait kafka to be ready
-waitAppear "kubectl get pods -n kafka -l name=strimzi-cluster-operator --ignore-not-found | grep Running || true" 1200
-waitAppear "kubectl get kafka kafka-brokers-cluster -n kafka -o jsonpath='{.status.listeners[1].certificates[0]}' --ignore-not-found=true" 1200
+waitAppear "kubectl get pods -n multicluster-global-hub -l name=strimzi-cluster-operator --ignore-not-found | grep Running || true" 1200
+waitAppear "kubectl get kafka kafka-brokers-cluster -n multicluster-global-hub -o jsonpath='{.status.listeners[1].certificates[0]}' --ignore-not-found=true" 1200
 
 # wait postgres to be ready
 waitAppear "kubectl get secret hoh-pguser-postgres -n hoh-postgres --ignore-not-found=true"

--- a/test/setup/e2e_setup.sh
+++ b/test/setup/e2e_setup.sh
@@ -71,7 +71,7 @@ startTime_s=`date +%s`
 kubectl config use-context $CTX_HUB >> $LOG
 # wait kafka to be ready
 waitAppear "kubectl get pods -n multicluster-global-hub -l name=strimzi-cluster-operator --ignore-not-found | grep Running || true" 1200
-waitAppear "kubectl get kafka kafka-brokers-cluster -n multicluster-global-hub -o jsonpath='{.status.listeners[1].certificates[0]}' --ignore-not-found=true" 1200
+waitAppear "kubectl get kafka kafka -n multicluster-global-hub -o jsonpath='{.status.listeners[1].certificates[0]}' --ignore-not-found=true" 1200
 
 # wait postgres to be ready
 waitAppear "kubectl get secret hoh-pguser-postgres -n hoh-postgres --ignore-not-found=true"

--- a/test/setup/hoh/kafka/kafka-cluster/kafka-cluster.yaml
+++ b/test/setup/hoh/kafka/kafka-cluster/kafka-cluster.yaml
@@ -2,7 +2,6 @@ apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: kafka-brokers-cluster
-  namespace: kafka
 spec:
   kafka:
     replicas: 1

--- a/test/setup/hoh/kafka/kafka-cluster/kafka-cluster.yaml
+++ b/test/setup/hoh/kafka/kafka-cluster/kafka-cluster.yaml
@@ -1,7 +1,7 @@
 apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
-  name: kafka-brokers-cluster
+  name: kafka
 spec:
   kafka:
     replicas: 1

--- a/test/setup/hoh/kafka/kafka-cluster/kafka-topics.yaml
+++ b/test/setup/hoh/kafka/kafka-cluster/kafka-topics.yaml
@@ -2,7 +2,6 @@ apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   name: spec
-  namespace: kafka
   labels:
     strimzi.io/cluster: kafka-brokers-cluster
 spec:
@@ -15,7 +14,6 @@ apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   name: status
-  namespace: kafka
   labels:
     strimzi.io/cluster: kafka-brokers-cluster
 spec:
@@ -28,7 +26,6 @@ apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   name: event
-  namespace: kafka
   labels:
     strimzi.io/cluster: kafka-brokers-cluster
 spec:

--- a/test/setup/hoh/kafka/kafka-cluster/kafka-topics.yaml
+++ b/test/setup/hoh/kafka/kafka-cluster/kafka-topics.yaml
@@ -3,7 +3,7 @@ kind: KafkaTopic
 metadata:
   name: spec
   labels:
-    strimzi.io/cluster: kafka-brokers-cluster
+    strimzi.io/cluster: kafka
 spec:
   partitions: 1
   replicas: 1
@@ -15,7 +15,7 @@ kind: KafkaTopic
 metadata:
   name: status
   labels:
-    strimzi.io/cluster: kafka-brokers-cluster
+    strimzi.io/cluster: kafka
 spec:
   partitions: 1
   replicas: 1
@@ -27,7 +27,7 @@ kind: KafkaTopic
 metadata:
   name: event
   labels:
-    strimzi.io/cluster: kafka-brokers-cluster
+    strimzi.io/cluster: kafka
 spec:
   partitions: 1
   replicas: 1

--- a/test/setup/hoh/kafka/kafka-cluster/kafka-user.yaml
+++ b/test/setup/hoh/kafka/kafka-cluster/kafka-user.yaml
@@ -7,3 +7,23 @@ metadata:
 spec:
   authentication:
     type: tls
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: kind-hub1-kafka-user
+  labels:
+    strimzi.io/cluster: kafka
+spec:
+  authentication:
+    type: tls
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: kind-hub2-kafka-user
+  labels:
+    strimzi.io/cluster: kafka
+spec:
+  authentication:
+    type: tls

--- a/test/setup/hoh/kafka/kafka-cluster/kafka-user.yaml
+++ b/test/setup/hoh/kafka/kafka-cluster/kafka-user.yaml
@@ -2,7 +2,6 @@ apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaUser
 metadata:
   name: global-hub-kafka-user
-  namespace: kafka
   labels:
     strimzi.io/cluster: kafka-brokers-cluster
 spec:

--- a/test/setup/hoh/kafka/kafka-cluster/kafka-user.yaml
+++ b/test/setup/hoh/kafka/kafka-cluster/kafka-user.yaml
@@ -3,7 +3,7 @@ kind: KafkaUser
 metadata:
   name: global-hub-kafka-user
   labels:
-    strimzi.io/cluster: kafka-brokers-cluster
+    strimzi.io/cluster: kafka
 spec:
   authentication:
     type: tls

--- a/test/setup/hoh/kafka/kafka-operator/kustomization.yaml
+++ b/test/setup/hoh/kafka/kafka-operator/kustomization.yaml
@@ -1,5 +1,35 @@
 # it is from https://github.com/strimzi/strimzi-kafka-operator/tree/0.33.2/packaging/install/cluster-operator
-bases:
+namespace: multicluster-global-hub
+
+resources:
 - crds
 - manager
 - rbac
+
+replacements:
+- source:
+    fieldPath: metadata.namespace
+    kind: ServiceAccount
+    name: strimzi-cluster-operator
+  targets:
+  - fieldPaths:
+    - subjects.[name=strimzi-cluster-operator].namespace
+    select:
+      group: rbac.authorization.k8s.io
+      kind: ClusterRoleBinding
+      version: v1
+      name: strimzi-cluster-operator
+  - fieldPaths:
+    - subjects.[name=strimzi-cluster-operator].namespace
+    select:
+      group: rbac.authorization.k8s.io
+      kind: ClusterRoleBinding
+      version: v1
+      name: strimzi-cluster-operator-kafka-broker-delegation
+  - fieldPaths:
+    - subjects.[name=strimzi-cluster-operator].namespace
+    select:
+      group: rbac.authorization.k8s.io
+      kind: ClusterRoleBinding
+      version: v1
+      name: strimzi-cluster-operator-kafka-client-delegation

--- a/test/setup/hoh/kafka/kafka-operator/rbac/020-RoleBinding-strimzi-cluster-operator.yaml
+++ b/test/setup/hoh/kafka/kafka-operator/rbac/020-RoleBinding-strimzi-cluster-operator.yaml
@@ -7,7 +7,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: strimzi-cluster-operator
-    namespace: kafka
 roleRef:
   kind: ClusterRole
   name: strimzi-cluster-operator-namespaced

--- a/test/setup/hoh/kafka/kafka-operator/rbac/022-RoleBinding-strimzi-cluster-operator.yaml
+++ b/test/setup/hoh/kafka/kafka-operator/rbac/022-RoleBinding-strimzi-cluster-operator.yaml
@@ -7,7 +7,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: strimzi-cluster-operator
-    namespace: kafka
 roleRef:
   kind: ClusterRole
   name: strimzi-cluster-operator-leader-election

--- a/test/setup/hoh/kafka/kafka-operator/rbac/023-RoleBinding-strimzi-cluster-operator.yaml
+++ b/test/setup/hoh/kafka/kafka-operator/rbac/023-RoleBinding-strimzi-cluster-operator.yaml
@@ -7,7 +7,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: strimzi-cluster-operator
-    namespace: kafka
 roleRef:
   kind: ClusterRole
   name: strimzi-cluster-operator-watched

--- a/test/setup/hoh/kafka/kafka-operator/rbac/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml
+++ b/test/setup/hoh/kafka/kafka-operator/rbac/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml
@@ -9,7 +9,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: strimzi-cluster-operator
-    namespace: kafka
 roleRef:
   kind: ClusterRole
   name: strimzi-entity-operator

--- a/test/setup/hoh/kafka/kafka_setup.sh
+++ b/test/setup/hoh/kafka/kafka_setup.sh
@@ -9,6 +9,8 @@ CTX_HUB=$1
 # check the transport secret
 transportSecret=${TRANSPORT_SECRET_NAME:-"multicluster-global-hub-transport"}
 targetNamespace=${TARGET_NAMESPACE:-"multicluster-global-hub"}
+kubectl --context $CTX_HUB create namespace $targetNamespace --dry-run=client -o yaml | kubectl apply -f -
+
 ready=$(kubectl --context $CTX_HUB get secret $transportSecret -n $targetNamespace --ignore-not-found=true)
 if [ ! -z "$ready" ]; then
   echo "transportSecret $transportSecret already exists in $targetNamespace namespace"
@@ -16,18 +18,17 @@ if [ ! -z "$ready" ]; then
 fi
 
 # deploy kafka operator
-kubectl --context $CTX_HUB create namespace kafka --dry-run=client -o yaml | kubectl apply -f -
-kubectl --context $CTX_HUB apply -k ${currentDir}/kafka-operator -n kafka
+kubectl --context $CTX_HUB apply -k ${currentDir}/kafka-operator -n $targetNamespace
 waitAppear "kubectl --context $CTX_HUB get pods -n kafka -l name=strimzi-cluster-operator --ignore-not-found | grep Running || true" 1200
 echo "Kafka operator is ready"
 
 # deploy kafka cluster
-kubectl --context $CTX_HUB apply -k ${currentDir}/kafka-cluster -n kafka
-waitAppear "kubectl --context $CTX_HUB -n kafka get kafka.kafka.strimzi.io/kafka-brokers-cluster -o jsonpath={.status.listeners} --ignore-not-found" 1200
+kubectl --context $CTX_HUB apply -k ${currentDir}/kafka-cluster -n $targetNamespace
+waitAppear "kubectl --context $CTX_HUB -n $targetNamespace get kafka.kafka.strimzi.io/kafka-brokers-cluster -o jsonpath={.status.listeners} --ignore-not-found" 1200
 echo "Kafka cluster is ready"
 
-waitAppear "kubectl --context $CTX_HUB get kafkatopic spec -n kafka --ignore-not-found | grep spec || true"
-waitAppear "kubectl --context $CTX_HUB get kafkatopic status -n kafka --ignore-not-found | grep status || true"
+waitAppear "kubectl --context $CTX_HUB get kafkatopic spec -n $targetNamespace --ignore-not-found | grep spec || true"
+waitAppear "kubectl --context $CTX_HUB get kafkatopic status -n $targetNamespace --ignore-not-found | grep status || true"
 echo "Kafka topics spec and status are ready!"
 
 # kafkaUser=global-hub-kafka-user
@@ -35,8 +36,8 @@ echo "Kafka topics spec and status are ready!"
 # echo "Kafka user ${kafkaUser} is ready!"
 
 # generate transport secret
-bootstrapServers=$(kubectl --context $CTX_HUB get kafka kafka-brokers-cluster -n kafka -o jsonpath='{.status.listeners[1].bootstrapServers}')
-kubectl --context $CTX_HUB get kafka kafka-brokers-cluster -n kafka -o jsonpath='{.status.listeners[1].certificates[0]}' > $setupDir/config/kafka-ca-cert.pem
+bootstrapServers=$(kubectl --context $CTX_HUB get kafka kafka-brokers-cluster -n $targetNamespace -o jsonpath='{.status.listeners[1].bootstrapServers}')
+kubectl --context $CTX_HUB get kafka kafka-brokers-cluster -n $targetNamespace -o jsonpath='{.status.listeners[1].certificates[0]}' > $setupDir/config/kafka-ca-cert.pem
 # kubectl get secret ${kafkaUser} -n kafka -o jsonpath='{.data.user\.crt}' | base64 -d > $setupDir/config/kafka-client-cert.pem
 # kubectl get secret ${kafkaUser} -n kafka -o jsonpath='{.data.user\.key}' | base64 -d > $setupDir/config/kafka-client-key.pem
 

--- a/test/setup/hoh/kafka/kafka_setup.sh
+++ b/test/setup/hoh/kafka/kafka_setup.sh
@@ -24,7 +24,7 @@ echo "Kafka operator is ready"
 
 # deploy kafka cluster
 kubectl --context $CTX_HUB apply -k ${currentDir}/kafka-cluster -n $targetNamespace
-waitAppear "kubectl --context $CTX_HUB -n $targetNamespace get kafka.kafka.strimzi.io/kafka-brokers-cluster -o jsonpath={.status.listeners} --ignore-not-found" 1200
+waitAppear "kubectl --context $CTX_HUB -n $targetNamespace get kafka.kafka.strimzi.io/kafka -o jsonpath={.status.listeners} --ignore-not-found" 1200
 echo "Kafka cluster is ready"
 
 waitAppear "kubectl --context $CTX_HUB get kafkatopic spec -n $targetNamespace --ignore-not-found | grep spec || true"
@@ -36,8 +36,8 @@ echo "Kafka topics spec and status are ready!"
 # echo "Kafka user ${kafkaUser} is ready!"
 
 # generate transport secret
-bootstrapServers=$(kubectl --context $CTX_HUB get kafka kafka-brokers-cluster -n $targetNamespace -o jsonpath='{.status.listeners[1].bootstrapServers}')
-kubectl --context $CTX_HUB get kafka kafka-brokers-cluster -n $targetNamespace -o jsonpath='{.status.listeners[1].certificates[0]}' > $setupDir/config/kafka-ca-cert.pem
+bootstrapServers=$(kubectl --context $CTX_HUB get kafka kafka -n $targetNamespace -o jsonpath='{.status.listeners[1].bootstrapServers}')
+kubectl --context $CTX_HUB get kafka kafka -n $targetNamespace -o jsonpath='{.status.listeners[1].certificates[0]}' > $setupDir/config/kafka-ca-cert.pem
 # kubectl get secret ${kafkaUser} -n kafka -o jsonpath='{.data.user\.crt}' | base64 -d > $setupDir/config/kafka-client-cert.pem
 # kubectl get secret ${kafkaUser} -n kafka -o jsonpath='{.data.user\.key}' | base64 -d > $setupDir/config/kafka-client-key.pem
 

--- a/test/setup/hoh/kafka/kafka_setup.sh
+++ b/test/setup/hoh/kafka/kafka_setup.sh
@@ -42,7 +42,7 @@ kubectl --context $CTX_HUB get kafka kafka-brokers-cluster -n $targetNamespace -
 # kubectl get secret ${kafkaUser} -n kafka -o jsonpath='{.data.user\.key}' | base64 -d > $setupDir/config/kafka-client-key.pem
 
 # create target namespace
-kubectl --context $CTX_HUB create namespace $targetNamespace || true
+kubectl --context $CTX_HUB create namespace $targetNamespace --dry-run=client -o yaml | kubectl apply -f -
 kubectl --context $CTX_HUB create secret generic $transportSecret -n $targetNamespace \
     --from-literal=bootstrap_server=$bootstrapServers \
     --from-file=ca.crt=$setupDir/config/kafka-ca-cert.pem

--- a/test/setup/hoh/kafka/kafka_setup.sh
+++ b/test/setup/hoh/kafka/kafka_setup.sh
@@ -19,7 +19,7 @@ fi
 
 # deploy kafka operator
 kubectl --context $CTX_HUB apply -k ${currentDir}/kafka-operator -n $targetNamespace
-waitAppear "kubectl --context $CTX_HUB get pods -n kafka -l name=strimzi-cluster-operator --ignore-not-found | grep Running || true" 1200
+waitAppear "kubectl --context $CTX_HUB get pods -n $targetNamespace -l name=strimzi-cluster-operator --ignore-not-found | grep Running || true" 1200
 echo "Kafka operator is ready"
 
 # deploy kafka cluster


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>

Resolved: https://issues.redhat.com/browse/ACM-6179
Reference: https://github.com/strimzi/strimzi-kafka-operator/tree/main/documentation/modules/security

We will disable this feature for the BYO case.  Since we don't know which kind of Kafka cluster the user provisioned, whether cloud we create the connection credential by the `KafkaUser` API under the global hub namespace.

So If the customer provides the transport secret. We will use that as the only source of truth for connecting Kafka, whether from a global hub cluster or managed hub clusters.

Also, we aren't considering renewing the certificates for now. 