### PR TITLE
resend hub info bundle when manager start

### DIFF
--- a/agent/pkg/controllers/crd_controller.go
+++ b/agent/pkg/controllers/crd_controller.go
@@ -33,12 +33,10 @@ func (c *crdController) Reconcile(ctx context.Context, request ctrl.Request) (ct
 	reqLogger.V(2).Info("crd controller", "NamespacedName:", request.NamespacedName)
 
 	// add spec controllers
-	if c.agentConfig.EnableGlobalResource {
-		if err := specController.AddToManager(c.mgr, c.agentConfig); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to add spec syncer: %w", err)
-		}
-		reqLogger.V(2).Info("add spec controllers to manager")
+	if err := specController.AddToManager(c.mgr, c.agentConfig); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to add spec syncer: %w", err)
 	}
+	reqLogger.V(2).Info("add spec controllers to manager")
 
 	if err := statusController.AddControllers(ctx, c.mgr, c.agentConfig); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to add status syncer: %w", err)

--- a/agent/pkg/spec/controller/controller.go
+++ b/agent/pkg/spec/controller/controller.go
@@ -35,9 +35,14 @@ func AddToManager(mgr ctrl.Manager, agentConfig *config.AgentConfig) error {
 	}
 
 	// register syncer to the dispatcher
-	dispatcher.RegisterSyncer(syncers.GenericMessageKey,
-		syncers.NewGenericSyncer(workers, agentConfig))
-	dispatcher.RegisterSyncer(constants.ManagedClustersLabelsMsgKey,
-		syncers.NewManagedClusterLabelSyncer(workers))
+	if agentConfig.EnableGlobalResource {
+		dispatcher.RegisterSyncer(syncers.GenericMessageKey,
+			syncers.NewGenericSyncer(workers, agentConfig))
+		dispatcher.RegisterSyncer(constants.ManagedClustersLabelsMsgKey,
+			syncers.NewManagedClusterLabelSyncer(workers))
+	}
+
+	dispatcher.RegisterSyncer(constants.ResyncMsgKey,
+		syncers.NewResyncSyncer())
 	return nil
 }

--- a/agent/pkg/spec/controller/syncers/resend_syncer.go
+++ b/agent/pkg/spec/controller/syncers/resend_syncer.go
@@ -1,0 +1,44 @@
+package syncers
+
+import (
+	"encoding/json"
+
+	"github.com/go-logr/logr"
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/controller/cache"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// resyncSyncer resync the bundle info.
+type resyncSyncer struct {
+	log logr.Logger
+}
+
+func NewResyncSyncer() *resyncSyncer {
+	return &resyncSyncer{
+		log: ctrl.Log.WithName("Resync status syncer"),
+	}
+}
+
+func (syncer *resyncSyncer) Sync(payload []byte) error {
+	syncer.log.Info("Resync bundle info")
+	bundleKeys := []string{}
+	if err := json.Unmarshal(payload, &bundleKeys); err != nil {
+		syncer.log.Error(err, "Failed to unmarshal bundle keys")
+		return err
+	}
+
+	for _, bundleKey := range bundleKeys {
+		syncer.log.Info("Resync bundle", "key", bundleKey)
+		if cache.Cache == nil {
+			syncer.log.Info("Cache is nil, do not need to resync info")
+			return nil
+		}
+		_, ok := cache.Cache[bundleKey]
+		if !ok {
+			syncer.log.Info("Cache is nil, do not need to resync info", "bundle key", bundleKey)
+			return nil
+		}
+		cache.Cache[bundleKey].GetVersion().Incr()
+	}
+	return nil
+}

--- a/agent/pkg/spec/controller/syncers/resend_syncer_test.go
+++ b/agent/pkg/spec/controller/syncers/resend_syncer_test.go
@@ -1,0 +1,56 @@
+package syncers_test
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/controller/cache"
+	"github.com/stolostron/multicluster-global-hub/pkg/bundle/cluster"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport"
+)
+
+var _ = Describe("Test resync Bundle", func() {
+	It("sync resync bundle with no cache", func() {
+		resyncMsgKeys := []string{constants.HubClusterInfoMsgKey}
+		payloadBytes, err := json.Marshal(resyncMsgKeys)
+		Expect(err).NotTo(HaveOccurred())
+		err = producer.Send(ctx, &transport.Message{
+			Key:         constants.ResyncMsgKey,
+			Destination: transport.Broadcast,
+			MsgType:     constants.SpecBundle,
+			Payload:     payloadBytes,
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	clusterInfoBundle := cluster.NewAgentHubClusterInfoBundle("leafhub0")
+	cache.RegistToCache(constants.HubClusterInfoMsgKey, clusterInfoBundle)
+	It("sync resync bundle with cache", func() {
+		resyncMsgKeys := []string{constants.HubClusterInfoMsgKey}
+		payloadBytes, err := json.Marshal(resyncMsgKeys)
+		Expect(err).NotTo(HaveOccurred())
+		err = producer.Send(ctx, &transport.Message{
+			Key:         constants.ResyncMsgKey,
+			Destination: transport.Broadcast,
+			MsgType:     constants.SpecBundle,
+			Payload:     payloadBytes,
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("sync resync bundle with unknown message", func() {
+		resyncMsgKeys := "unknownMsg"
+		payloadBytes, err := json.Marshal(resyncMsgKeys)
+		Expect(err).NotTo(HaveOccurred())
+		err = producer.Send(ctx, &transport.Message{
+			Key:         constants.ResyncMsgKey,
+			Destination: transport.Broadcast,
+			MsgType:     constants.SpecBundle,
+			Payload:     payloadBytes,
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/agent/pkg/spec/controller/syncers/syncers_suite_test.go
+++ b/agent/pkg/spec/controller/syncers/syncers_suite_test.go
@@ -66,9 +66,10 @@ var _ = BeforeSuite(func() {
 		TransportConfig: &transport.TransportConfig{
 			TransportType: string(transport.Chan),
 		},
-		SpecWorkPoolSize:   2,
-		LeafHubName:        "leaf-hub1",
-		SpecEnforceHohRbac: true,
+		SpecWorkPoolSize:     2,
+		LeafHubName:          "leaf-hub1",
+		SpecEnforceHohRbac:   true,
+		EnableGlobalResource: true,
 	}
 
 	err = speccontroller.AddToManager(mgr, agentConfig)

--- a/agent/pkg/status/controller/cache/cache.go
+++ b/agent/pkg/status/controller/cache/cache.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2024 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package cache
+
+import (
+	"github.com/stolostron/multicluster-global-hub/pkg/bundle"
+)
+
+var Cache map[string]bundle.BaseAgentBundle
+
+func RegistToCache(key string, value bundle.BaseAgentBundle) {
+	if Cache == nil {
+		Cache = make(map[string]bundle.BaseAgentBundle)
+	}
+	Cache[key] = value
+}

--- a/agent/pkg/status/controller/hubcluster/clusters_status_syncer.go
+++ b/agent/pkg/status/controller/hubcluster/clusters_status_syncer.go
@@ -5,6 +5,7 @@ import (
 
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/controller/cache"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/controller/config"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/controller/generic"
 	"github.com/stolostron/multicluster-global-hub/pkg/bundle"
@@ -18,16 +19,17 @@ import (
 // right now, it only syncs the openshift console url.
 func AddHubClusterInfoSyncer(mgr ctrl.Manager, producer transport.Producer) error {
 	leafHubName := config.GetLeafHubName()
-
 	clusterInfoBundle := cluster.NewAgentHubClusterInfoBundle(leafHubName)
+
 	transportKey := fmt.Sprintf("%s.%s", leafHubName, constants.HubClusterInfoMsgKey)
 	bundlePredicate := func() bool { return true }
 	bundleEntry := generic.NewSharedBundleEntry(transportKey, clusterInfoBundle, bundlePredicate)
-
 	objectCollection := []bundle.SharedBundleObject{
 		cluster.NewHubClusterInfoClaimObject(),
 		cluster.NewHubClusterInfoRouteObject(),
 	}
+
+	cache.RegistToCache(constants.HubClusterInfoMsgKey, clusterInfoBundle)
 	return generic.NewGenericSharedBundleSyncer(mgr, producer, bundleEntry, objectCollection,
 		config.GetHubClusterInfoDuration)
 }

--- a/manager/pkg/specsyncer/db2transport/syncer/dbsyncer/syncers_intergration_test.go
+++ b/manager/pkg/specsyncer/db2transport/syncer/dbsyncer/syncers_intergration_test.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 	"gorm.io/gorm"
 
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/database"
 	"github.com/stolostron/multicluster-global-hub/pkg/database/models"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
@@ -48,6 +49,9 @@ var _ = Describe("Database to Transport Syncer", Ordered, func() {
 			Version:            0,
 		}).Error
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Resend hubinfo")
+		ExpectedMessageIDs["Resync"] = constants.HubClusterInfoMsgKey
 
 		By("ManagedClusterSet")
 		ExpectedMessageIDs["ManagedClusterSets"] = managedclustersetUID
@@ -114,7 +118,7 @@ var _ = Describe("Database to Transport Syncer", Ordered, func() {
 				return fmt.Errorf("missing the message: %s", ExpectedMessageIDs)
 			}
 			return nil
-		}, 10*time.Second, 1*time.Second).Should(Succeed())
+		}, 15*time.Second, 1*time.Second).Should(Succeed())
 	})
 
 	// It("Test managed cluster labels syncer", func() {

--- a/manager/pkg/specsyncer/db2transport/syncer/syncers.go
+++ b/manager/pkg/specsyncer/db2transport/syncer/syncers.go
@@ -11,15 +11,11 @@ import (
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/specsyncer/db2transport/db/gorm"
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/specsyncer/db2transport/syncer/dbsyncer"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
-	"github.com/stolostron/multicluster-global-hub/pkg/transport/producer"
 )
 
 // AddDB2TransportSyncers adds the controllers that send info from DB to transport layer to the Manager.
-func AddDB2TransportSyncers(mgr ctrl.Manager, managerConfig *config.ManagerConfig) error {
-	producer, err := producer.NewGenericProducer(managerConfig.TransportConfig)
-	if err != nil {
-		return fmt.Errorf("failed to init spec transport bridge: %w", err)
-	}
+func AddDB2TransportSyncers(mgr ctrl.Manager, managerConfig *config.ManagerConfig, producer transport.Producer) error {
+
 	specSyncInterval := managerConfig.SyncerConfig.SpecSyncInterval
 
 	addDBSyncerFunctions := []func(ctrl.Manager, db.SpecDB, transport.Producer, time.Duration) error{
@@ -41,7 +37,6 @@ func AddDB2TransportSyncers(mgr ctrl.Manager, managerConfig *config.ManagerConfi
 			return fmt.Errorf("failed to add DB Syncer: %w", err)
 		}
 	}
-
 	return nil
 }
 

--- a/manager/pkg/specsyncer/syncers.go
+++ b/manager/pkg/specsyncer/syncers.go
@@ -1,6 +1,8 @@
 package specsyncer
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -9,14 +11,18 @@ import (
 	specsyncer "github.com/stolostron/multicluster-global-hub/manager/pkg/specsyncer/db2transport/syncer"
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/specsyncer/spec2db"
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/specsyncer/spec2db/controller"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 )
 
-func AddGlobalResourceSpecSyncers(mgr ctrl.Manager, managerConfig *config.ManagerConfig) error {
+func AddGlobalResourceSpecSyncers(mgr ctrl.Manager,
+	managerConfig *config.ManagerConfig,
+	producer transport.Producer) error {
 	if err := spec2db.AddSpec2DBControllers(mgr); err != nil {
 		return fmt.Errorf("failed to add spec-to-db controllers: %w", err)
 	}
 
-	if err := specsyncer.AddDB2TransportSyncers(mgr, managerConfig); err != nil {
+	if err := specsyncer.AddDB2TransportSyncers(mgr, managerConfig, producer); err != nil {
 		return fmt.Errorf("failed to add db-to-transport syncers: %w", err)
 	}
 
@@ -24,9 +30,31 @@ func AddGlobalResourceSpecSyncers(mgr ctrl.Manager, managerConfig *config.Manage
 		managerConfig.SyncerConfig.DeletedLabelsTrimmingInterval); err != nil {
 		return fmt.Errorf("failed to add status db watchers: %w", err)
 	}
+
 	return nil
 }
 
 func AddBasicSpecSyncers(mgr ctrl.Manager) error {
 	return controller.AddManagedHubController(mgr)
+}
+
+// SendSyncAllMsgInfo send a constants.ResyncMsgKey bundle in manager start.
+// When agent get the bundle, it will resend the "resendMsgKeys" bundles to transport
+// It is mainly used to handle data lost in upgade scenario.
+func SendSyncAllMsgInfo(producer transport.Producer) error {
+	ctx := context.Background()
+	resendMsgKeys := []string{constants.HubClusterInfoMsgKey}
+	payloadBytes, err := json.Marshal(resendMsgKeys)
+	if err != nil {
+		return err
+	}
+	if err := producer.Send(ctx, &transport.Message{
+		Key:         constants.ResyncMsgKey,
+		Destination: transport.Broadcast,
+		MsgType:     constants.SpecBundle,
+		Payload:     payloadBytes,
+	}); err != nil {
+		return fmt.Errorf("Failed to resend resendbundle")
+	}
+	return nil
 }

--- a/operator/pkg/controllers/hubofhubs/integration_test.go
+++ b/operator/pkg/controllers/hubofhubs/integration_test.go
@@ -113,6 +113,7 @@ const (
 var _ = Describe("MulticlusterGlobalHub controller", Ordered, func() {
 	var storageSecret *corev1.Secret
 	BeforeAll(func() {
+
 		storageSecret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      StorageSecretName,
@@ -162,6 +163,11 @@ var _ = Describe("MulticlusterGlobalHub controller", Ordered, func() {
 			// delete the testing MGH instance with invalid large scale data layer setting
 			By("By deleting the testing MGH instance with invalid large scale data layer setting")
 			Expect(k8sClient.Delete(ctx, mgh)).Should(Succeed())
+			// check MGH instance is deleted
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, mghLookupKey, createdMGH)
+				return errors.IsNotFound(err)
+			}, timeout, interval).Should(BeTrue())
 		})
 	})
 

--- a/pkg/bundle/cluster/hub_cluster_info_bundle.go
+++ b/pkg/bundle/cluster/hub_cluster_info_bundle.go
@@ -20,7 +20,7 @@ type HubClusterInfoBundle struct {
 }
 
 // LeafHubClusterInfoStatusBundle creates a new instance of LeafHubClusterInfoStatusBundle.
-func NewAgentHubClusterInfoBundle(leafHubName string) bundle.BaseAgentBundle {
+func NewAgentHubClusterInfoBundle(leafHubName string) *HubClusterInfoBundle {
 	return &HubClusterInfoBundle{
 		BaseHubClusterInfoBundle: base.BaseHubClusterInfoBundle{
 			Objects:       make([]*base.HubClusterInfo, 0),

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -102,6 +102,8 @@ const (
 	// HubClusterInfoMsgKey - hub cluster info message key.
 	HubClusterInfoMsgKey = "HubClusterInfo"
 
+	ResyncMsgKey = "Resync"
+
 	// ManagedClustersMsgKey - managed clusters message key.
 	ManagedClustersMsgKey = "ManagedClusters"
 	// ManagedClustersLabelsMsgKey - managed clusters labels message key.


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-9179
In upgrade case, there is a middle status that agent upgrade to new version, but manager do not. 
When agent start, agent will send the managed hubinfo(we add clusterid in this release) to manager, but manager can not handle it now and will discard it. 
After manager upgrade to new version, agent will not send the hubinfo any more, so the hubinfo in database could not be updated. So we need to ask agent to resend hubinfo after manager started.

