### PR TITLE
keep the order of the events on the partitions

### DIFF
--- a/pkg/transport/consumer/generic_consumer.go
+++ b/pkg/transport/consumer/generic_consumer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Shopify/sarama"
 	"github.com/cloudevents/sdk-go/protocol/kafka_sarama/v2"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/cloudevents/sdk-go/v2/client"
 	ceprotocol "github.com/cloudevents/sdk-go/v2/protocol"
 	"github.com/cloudevents/sdk-go/v2/protocol/gochan"
 	"github.com/go-logr/logr"
@@ -59,7 +60,7 @@ func NewGenericConsumer(transportConfig *transport.TransportConfig) (*GenericCon
 		return nil, fmt.Errorf("transport-type - %s is not a valid option", transportConfig.TransportType)
 	}
 
-	client, err := cloudevents.NewClient(receiver)
+	client, err := cloudevents.NewClient(receiver, client.WithPollGoroutines(1))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com> 

To make events more efficient, the cloudevents use the multi-goroutine to fetch the messages. That will break the order of the messages on the partition.

Since Kafka already natively utilizes consumer groups to enhance consumption efficiency, there is no need to use multiple goroutines to boost consumption speed.


