### PR TITLE
add backup label for global hub resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ e2e-setup-clean:
 	./test/setup/e2e_clean.sh
 
 e2e-tests-all: tidy vendor
-	./cicd-scripts/run-local-e2e-test.sh -f "e2e-tests-validation,e2e-tests-local-policy,e2e-tests-grafana,e2e-tests-placement,e2e-tests-app,e2e-tests-policy" -v $(VERBOSE)
+	./cicd-scripts/run-local-e2e-test.sh -f "e2e-tests-validation,e2e-tests-local-policy,e2e-tests-grafana,e2e-tests-placement,e2e-tests-app,e2e-tests-policy,e2e-tests-backup" -v $(VERBOSE)
 
 e2e-tests-validation e2e-tests-label e2e-tests-placement e2e-tests-app e2e-tests-policy e2e-tests-local-policy: tidy vendor
 	./cicd-scripts/run-local-e2e-test.sh -f $@ -v $(VERBOSE)

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -138,6 +138,15 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - app.k8s.io
   resources:
   - applications
@@ -292,6 +301,7 @@ rules:
   - create
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - monitoring.coreos.com

--- a/operator/main.go
+++ b/operator/main.go
@@ -43,6 +43,8 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -74,18 +76,26 @@ import (
 	hubofhubsconfig "github.com/stolostron/multicluster-global-hub/operator/pkg/config"
 	operatorconstants "github.com/stolostron/multicluster-global-hub/operator/pkg/constants"
 	hubofhubsaddon "github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/addon"
+	backupcontrollers "github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/backup"
 	hubofhubscontrollers "github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/hubofhubs"
+
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	commonobjects "github.com/stolostron/multicluster-global-hub/pkg/objects"
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
 var (
-	scheme        = runtime.NewScheme()
-	setupLog      = ctrl.Log.WithName("setup")
+	scheme   = runtime.NewScheme()
+	setupLog = ctrl.Log.WithName("setup")
+
 	labelSelector = labels.SelectorFromSet(
 		labels.Set{
 			constants.GlobalHubOwnerLabelKey: constants.GHOperatorOwnerLabelVal,
+		},
+	)
+	kafkaLabelSelector = labels.SelectorFromSet(
+		labels.Set{
+			"app": "strimzi",
 		},
 	)
 )
@@ -111,6 +121,7 @@ func init() {
 	utilruntime.Must(mchv1.AddToScheme(scheme))
 	utilruntime.Must(agentv1.SchemeBuilder.AddToScheme(scheme))
 	utilruntime.Must(promv1.AddToScheme(scheme))
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
 
 	// Add postgres-operator scheme
 	utilruntime.Must(postgresv1beta1.AddToScheme(scheme))
@@ -215,6 +226,16 @@ func doMain(ctx context.Context, cfg *rest.Config) int {
 		LogLevel:             operatorConfig.LogLevel,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create MulticlusterGlobalHubReconciler")
+		return 1
+	}
+
+	backupController := backupcontrollers.NewBackupReconciler(
+		mgr,
+		ctrl.Log.WithName("backup-reconciler"),
+	)
+
+	if err = mgr.Add(backupController); err != nil {
+		setupLog.Error(err, "unable to bakcup controller to manager")
 		return 1
 	}
 
@@ -393,6 +414,12 @@ func initCache(config *rest.Config, cacheOpts cache.Options) (cache.Cache, error
 		&kafkav1beta2.KafkaTopic{}:         {},
 		&kafkav1beta2.KafkaUser{}:          {},
 		&postgresv1beta1.PostgresCluster{}: {},
+		&apiextensionsv1.CustomResourceDefinition{}: {
+			Label: kafkaLabelSelector,
+		},
+		&corev1.PersistentVolumeClaim{}: {
+			Field: fields.OneTermEqualSelector("metadata.namespace", hubofhubsconfig.GetDefaultNamespace()),
+		},
 	}
 	return cache.New(config, cacheOpts)
 }

--- a/operator/pkg/controllers/backup/backup_controller.go
+++ b/operator/pkg/controllers/backup/backup_controller.go
@@ -1,0 +1,291 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backup
+
+import (
+	"context"
+	"reflect"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	// pmcontroller "github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/packagemanifest"
+	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
+	"github.com/go-logr/logr"
+	globalhubv1alpha4 "github.com/stolostron/multicluster-global-hub/operator/apis/v1alpha4"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	operatorconstants "github.com/stolostron/multicluster-global-hub/operator/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/utils"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+)
+
+const (
+	secretType     = "Secret"
+	configmapType  = "ConfigMap"
+	mghType        = "MulticlusterGlobalHub"
+	kafkaType      = "Kafka"
+	kafkaUserType  = "KafkaUser"
+	kafkaTopicType = "KafkaTopic"
+	crdType        = "CustomResourceDefinition"
+	pvcType        = "PersistentVolumeClaim"
+)
+
+var secretList = sets.NewString(
+	operatorconstants.CustomGrafanaIniName,
+	operatorconstants.GHTransportSecretName,
+	operatorconstants.GHStorageSecretName,
+)
+
+var configmapList = sets.NewString(
+	operatorconstants.CustomAlertName,
+)
+
+var crdList = sets.NewString(
+	"kafkas.kafka.strimzi.io",
+	"kafkatopics.kafka.strimzi.io",
+	"kafkausers.kafka.strimzi.io",
+)
+
+// BackupReconciler reconciles a MulticlusterGlobalHub object
+type BackupReconciler struct {
+	manager.Manager
+	client.Client
+	Log logr.Logger
+}
+
+func NewBackupReconciler(mgr manager.Manager, log logr.Logger) *BackupReconciler {
+	return &BackupReconciler{
+		Manager: mgr,
+		Client:  mgr.GetClient(),
+		Log:     log,
+	}
+}
+
+// As we need to watch mgh, secret, configmap. they should be in the same namespace.
+// So for request.Namespace, we set it as request type, like "Secret","Configmap","MulticlusterGlobalHub" and so on.
+// In the reconcile, we identy the request kind and get it by request.Name.
+func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	r.Log.Info("backup reconcile:", "requestType", req.Namespace, "name", req.Name)
+	switch req.Namespace {
+	case mghType:
+		mgh := &globalhubv1alpha4.MulticlusterGlobalHub{}
+		return r.addLabel(ctx, req, mgh, constants.BackupKey, constants.BackupActivationValue)
+	case secretType:
+		secretObj := &corev1.Secret{}
+		return r.addLabel(ctx, req, secretObj, constants.BackupKey, constants.BackupGlobalHubValue)
+	case configmapType:
+		configmapObj := &corev1.ConfigMap{}
+		return r.addLabel(ctx, req, configmapObj, constants.BackupKey, constants.BackupGlobalHubValue)
+	case kafkaType:
+		kafkaObj := &kafkav1beta2.Kafka{}
+		return r.addLabel(ctx, req, kafkaObj, constants.BackupKey, constants.BackupGlobalHubValue)
+	case kafkaUserType:
+		kafkaObj := &kafkav1beta2.KafkaUser{}
+		return r.addLabel(ctx, req, kafkaObj, constants.BackupKey, constants.BackupGlobalHubValue)
+	case kafkaTopicType:
+		kafkaObj := &kafkav1beta2.KafkaTopic{}
+		return r.addLabel(ctx, req, kafkaObj, constants.BackupKey, constants.BackupGlobalHubValue)
+	case crdType:
+		crdObj := &apiextensionsv1.CustomResourceDefinition{}
+		return r.addLabel(ctx, req, crdObj, constants.BackupKey, constants.BackupGlobalHubValue)
+	case pvcType:
+		pvcObj := &corev1.PersistentVolumeClaim{}
+		return r.addLabel(ctx, req, pvcObj, constants.BackupVolumnKey, constants.BackupGlobalHubValue)
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *BackupReconciler) addLabel(
+	ctx context.Context,
+	req ctrl.Request,
+	obj client.Object,
+	labelKey string,
+	labelValue string) (ctrl.Result, error) {
+	if err := r.Get(ctx, types.NamespacedName{
+		Namespace: config.GetMGHNamespacedName().Namespace,
+		Name:      req.Name,
+	}, obj); err != nil {
+		if errors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	objNewLabels := obj.GetLabels()
+	if objNewLabels == nil {
+		objNewLabels = make(map[string]string)
+	}
+	objNewLabels[labelKey] = labelValue
+	obj.SetLabels(objNewLabels)
+
+	if err := r.Update(ctx, obj, &client.UpdateOptions{}); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+var mghPred = predicate.Funcs{
+	CreateFunc: func(e event.CreateEvent) bool {
+		return !utils.HasLabel(e.Object.GetLabels(), constants.BackupKey, constants.BackupActivationValue)
+	},
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		return !utils.HasLabel(e.ObjectNew.GetLabels(), constants.BackupKey, constants.BackupActivationValue)
+	},
+	DeleteFunc: func(e event.DeleteEvent) bool {
+		return false
+	},
+}
+
+var secretPred = predicate.Funcs{
+	CreateFunc: func(e event.CreateEvent) bool {
+		if !secretList.Has(e.Object.GetName()) {
+			return false
+		}
+		return !utils.HasLabel(e.Object.GetLabels(), constants.BackupKey, constants.BackupActivationValue)
+	},
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		if !secretList.Has(e.ObjectNew.GetName()) {
+			return false
+		}
+		return !utils.HasLabel(e.ObjectNew.GetLabels(), constants.BackupKey, constants.BackupActivationValue)
+	},
+	DeleteFunc: func(e event.DeleteEvent) bool {
+		return false
+	},
+}
+
+var configmapPred = predicate.Funcs{
+	CreateFunc: func(e event.CreateEvent) bool {
+		if !configmapList.Has(e.Object.GetName()) {
+			return false
+		}
+		return !utils.HasLabel(e.Object.GetLabels(), constants.BackupKey, constants.BackupActivationValue)
+	},
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		if !configmapList.Has(e.ObjectNew.GetName()) {
+			return false
+		}
+		return !utils.HasLabel(e.ObjectNew.GetLabels(), constants.BackupKey, constants.BackupActivationValue)
+
+	},
+	DeleteFunc: func(e event.DeleteEvent) bool {
+		return false
+	},
+}
+
+var commonPred = predicate.Funcs{
+	CreateFunc: func(e event.CreateEvent) bool {
+		return !utils.HasLabel(e.Object.GetLabels(), constants.BackupKey, constants.BackupActivationValue)
+	},
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		return !utils.HasLabel(e.ObjectNew.GetLabels(), constants.BackupKey, constants.BackupActivationValue)
+	},
+	DeleteFunc: func(e event.DeleteEvent) bool {
+		return false
+	},
+}
+
+var crdPred = predicate.Funcs{
+	CreateFunc: func(e event.CreateEvent) bool {
+		if !crdList.Has(e.Object.GetName()) {
+			return false
+		}
+		return !utils.HasLabel(e.Object.GetLabels(), constants.BackupKey, constants.BackupActivationValue)
+	},
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		if !crdList.Has(e.ObjectNew.GetName()) {
+			return false
+		}
+		return !utils.HasLabel(e.ObjectNew.GetLabels(), constants.BackupKey, constants.BackupActivationValue)
+	},
+	DeleteFunc: func(e event.DeleteEvent) bool {
+		return false
+	},
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *BackupReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).Named("backupController").
+		Watches(&globalhubv1alpha4.MulticlusterGlobalHub{},
+			objEventHandler,
+			builder.WithPredicates(mghPred)).
+		Watches(&corev1.Secret{},
+			objEventHandler,
+			builder.WithPredicates(secretPred)).
+		Watches(&corev1.ConfigMap{},
+			objEventHandler,
+			builder.WithPredicates(configmapPred)).
+		Watches(&kafkav1beta2.Kafka{},
+			objEventHandler,
+			builder.WithPredicates(commonPred)).
+		Watches(&kafkav1beta2.KafkaUser{},
+			objEventHandler,
+			builder.WithPredicates(commonPred)).
+		Watches(&kafkav1beta2.KafkaTopic{},
+			objEventHandler,
+			builder.WithPredicates(commonPred)).
+		Watches(&apiextensionsv1.CustomResourceDefinition{},
+			objEventHandler,
+			builder.WithPredicates(crdPred)).
+		Watches(&corev1.PersistentVolumeClaim{},
+			objEventHandler,
+			builder.WithPredicates(commonPred)).
+		Complete(r)
+}
+
+func (r *BackupReconciler) Start(ctx context.Context) error {
+	//Only when global hub started, then start the backup controller
+	_, err := utils.WaitGlobalHubReady(ctx, r.Client, 5*time.Second)
+	if err != nil {
+		return err
+	}
+
+	if err = r.SetupWithManager(r.Manager); err != nil {
+		return err
+	}
+	return nil
+}
+
+var objEventHandler = handler.EnqueueRequestsFromMapFunc(
+	func(ctx context.Context, obj client.Object) []reconcile.Request {
+		t := reflect.TypeOf(obj)
+		//Only watch the global hub namespace resources or cluster scope resources
+		if len(obj.GetNamespace()) != 0 && (obj.GetNamespace() != config.GetMGHNamespacedName().Namespace) {
+			return []reconcile.Request{}
+		}
+		return []reconcile.Request{
+			{
+				NamespacedName: types.NamespacedName{
+					Namespace: t.Elem().Name(),
+					Name:      obj.GetName(),
+				},
+			},
+		}
+	},
+)

--- a/operator/pkg/controllers/backup/backup_suite_test.go
+++ b/operator/pkg/controllers/backup/backup_suite_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2022.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backup_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
+	postgresv1beta1 "github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	routev1 "github.com/openshift/api/route/v1"
+	subv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	operatorsv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
+	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	mchv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
+	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
+	workv1 "open-cluster-management.io/api/work/v1"
+	policyv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	chnv1 "open-cluster-management.io/multicloud-operators-channel/pkg/apis/apps/v1"
+	placementrulesv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/placementrule/v1"
+	appsubv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1"
+	appsubV1alpha1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1alpha1"
+	applicationv1beta1 "sigs.k8s.io/application/api/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	globalhubv1alpha4 "github.com/stolostron/multicluster-global-hub/operator/apis/v1alpha4"
+	backupcontrollers "github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/backup"
+	hubofhubscontroller "github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/hubofhubs"
+	"github.com/stolostron/multicluster-global-hub/test/pkg/testpostgres"
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var (
+	cfg           *rest.Config
+	k8sClient     client.Client // You'll be using this client in your tests.
+	kubeClient    *kubernetes.Clientset
+	testEnv       *envtest.Environment
+	testPostgres  *testpostgres.TestPostgres
+	ctx           context.Context
+	cancel        context.CancelFunc
+	mghReconciler *hubofhubscontroller.MulticlusterGlobalHubReconciler
+	testNamespace = "default"
+)
+
+func TestControllers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Controller Integration Suite")
+}
+
+var _ = BeforeSuite(func() {
+	Expect(os.Setenv("POD_NAMESPACE", testNamespace)).To(Succeed())
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "..", "config", "crd", "bases"),
+			filepath.Join("..", "..", "..", "..", "pkg", "testdata", "crds"),
+		},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	var err error
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	// add scheme
+	Expect(operatorsv1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
+	Expect(routev1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
+	Expect(clusterv1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
+	Expect(clusterv1beta1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
+	Expect(clusterv1beta2.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
+	Expect(workv1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
+	Expect(addonv1alpha1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
+	Expect(appsubv1.SchemeBuilder.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
+	Expect(appsubV1alpha1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
+	Expect(chnv1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
+	Expect(placementrulesv1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
+	Expect(globalhubv1alpha4.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
+	Expect(applicationv1beta1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
+	Expect(policyv1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
+	Expect(mchv1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
+	Expect(promv1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
+	Expect(subv1alpha1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
+	Expect(postgresv1beta1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
+	Expect(kafkav1beta2.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
+
+	//+kubebuilder:scaffold:scheme
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	leaseDuration := 137 * time.Second
+	renewDeadline := 126 * time.Second
+	retryPeriod := 16 * time.Second
+	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
+		MetricsBindAddress:      "0", // disable the metrics serving
+		Scheme:                  scheme.Scheme,
+		LeaderElection:          true,
+		LeaderElectionNamespace: testNamespace,
+		LeaderElectionID:        "549a8919.open-cluster-management.io",
+		LeaseDuration:           &leaseDuration,
+		RenewDeadline:           &renewDeadline,
+		RetryPeriod:             &retryPeriod,
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	kubeClient, err = kubernetes.NewForConfig(k8sManager.GetConfig())
+	Expect(err).ToNot(HaveOccurred())
+
+	backupReconciler := &backupcontrollers.BackupReconciler{
+		Manager: k8sManager,
+		Client:  k8sManager.GetClient(),
+		Log:     ctrl.Log.WithName("backup-reconciler"),
+	}
+	Expect(backupReconciler.SetupWithManager(k8sManager)).ToNot(HaveOccurred())
+
+	go func() {
+		defer GinkgoRecover()
+		err = k8sManager.Start(ctx)
+		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
+	}()
+})
+
+var _ = AfterSuite(func() {
+	cancel()
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	// https://github.com/kubernetes-sigs/controller-runtime/issues/1571
+	// Set 4 with random
+	if err != nil {
+		time.Sleep(4 * time.Second)
+	}
+	err = testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/operator/pkg/controllers/backup/integration_test.go
+++ b/operator/pkg/controllers/backup/integration_test.go
@@ -1,0 +1,258 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backup_test
+
+import (
+	"time"
+
+	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	globalhubv1alpha4 "github.com/stolostron/multicluster-global-hub/operator/apis/v1alpha4"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	operatorconstants "github.com/stolostron/multicluster-global-hub/operator/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/utils"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+)
+
+const (
+	timeout  = time.Second * 15
+	duration = time.Second * 10
+	interval = time.Millisecond * 250
+
+	mghName      = "mgh"
+	mghNamespace = "default"
+)
+
+var _ = Describe("Backup controller", Ordered, func() {
+	BeforeAll(func() {
+		config.SetMGHNamespacedName(types.NamespacedName{
+			Namespace: mghNamespace,
+			Name:      mghName,
+		})
+	})
+	Context("add backup label to mgh instance", Ordered, func() {
+		It("Should create the MGH instance with backup label", func() {
+			mgh := &globalhubv1alpha4.MulticlusterGlobalHub{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      mghName,
+					Namespace: mghNamespace,
+				},
+				Spec: globalhubv1alpha4.MulticlusterGlobalHubSpec{},
+			}
+			Expect(k8sClient.Create(ctx, mgh)).Should(Succeed())
+
+			Eventually(func() bool {
+				Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Namespace: mghNamespace,
+					Name:      mghName,
+				}, mgh, &client.GetOptions{})).Should(Succeed())
+
+				return utils.HasLabel(mgh.Labels, constants.BackupKey, constants.BackupActivationValue)
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		It("update the mgh label, it should be reconciled", func() {
+			mgh := &globalhubv1alpha4.MulticlusterGlobalHub{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Namespace: mghNamespace,
+				Name:      mghName,
+			}, mgh, &client.GetOptions{})).Should(Succeed())
+
+			mgh.Labels = nil
+
+			Expect(k8sClient.Update(ctx, mgh, &client.UpdateOptions{}))
+
+			Eventually(func() bool {
+				Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Namespace: mghNamespace,
+					Name:      mghName,
+				}, mgh, &client.GetOptions{})).Should(Succeed())
+				return utils.HasLabel(mgh.Labels, constants.BackupKey, constants.BackupActivationValue)
+			}, timeout, interval).Should(BeTrue())
+		})
+	})
+
+	Context("add backup label to customize grafana secret", Ordered, func() {
+		It("Should create the customize secret with backup label", func() {
+			cusSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      operatorconstants.CustomGrafanaIniName,
+					Namespace: mghNamespace,
+				},
+			}
+			Expect(k8sClient.Create(ctx, cusSecret)).Should(Succeed())
+
+			Eventually(func() bool {
+				Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Namespace: mghNamespace,
+					Name:      operatorconstants.CustomGrafanaIniName,
+				}, cusSecret, &client.GetOptions{})).Should(Succeed())
+
+				return utils.HasLabel(cusSecret.Labels, constants.BackupKey, constants.BackupGlobalHubValue)
+			}, timeout, interval).Should(BeTrue())
+		})
+	})
+
+	Context("add backup label to customize storage secret", Ordered, func() {
+		It("Should create the customize secret with backup label", func() {
+			cusSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      operatorconstants.GHStorageSecretName,
+					Namespace: mghNamespace,
+				},
+			}
+			Expect(k8sClient.Create(ctx, cusSecret)).Should(Succeed())
+
+			Eventually(func() bool {
+				Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Namespace: mghNamespace,
+					Name:      operatorconstants.GHStorageSecretName,
+				}, cusSecret, &client.GetOptions{})).Should(Succeed())
+
+				return utils.HasLabel(cusSecret.Labels, constants.BackupKey, constants.BackupGlobalHubValue)
+			}, timeout, interval).Should(BeTrue())
+		})
+	})
+
+	Context("add backup label to customize transport secret", Ordered, func() {
+		It("Should create the customize secret with backup label", func() {
+			cusSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      operatorconstants.GHTransportSecretName,
+					Namespace: mghNamespace,
+				},
+			}
+			Expect(k8sClient.Create(ctx, cusSecret)).Should(Succeed())
+
+			Eventually(func() bool {
+				Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Namespace: mghNamespace,
+					Name:      operatorconstants.GHTransportSecretName,
+				}, cusSecret, &client.GetOptions{})).Should(Succeed())
+
+				return utils.HasLabel(cusSecret.Labels, constants.BackupKey, constants.BackupGlobalHubValue)
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		It("update the Secret label, it should be reconciled", func() {
+			cusSecret := &corev1.Secret{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Namespace: mghNamespace,
+				Name:      operatorconstants.GHTransportSecretName,
+			}, cusSecret, &client.GetOptions{})).Should(Succeed())
+
+			cusSecret.Labels = nil
+
+			Expect(k8sClient.Update(ctx, cusSecret, &client.UpdateOptions{}))
+
+			Eventually(func() bool {
+				Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Namespace: mghNamespace,
+					Name:      operatorconstants.GHTransportSecretName,
+				}, cusSecret, &client.GetOptions{})).Should(Succeed())
+				return utils.HasLabel(cusSecret.Labels, constants.BackupKey, constants.BackupGlobalHubValue)
+			}, timeout, interval).Should(BeTrue())
+		})
+	})
+
+	Context("add backup label to customize configmap", Ordered, func() {
+		It("Should create the customize configmap with backup label", func() {
+			cusConfigmap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      operatorconstants.CustomAlertName,
+					Namespace: mghNamespace,
+				},
+			}
+			Expect(k8sClient.Create(ctx, cusConfigmap)).Should(Succeed())
+
+			Eventually(func() bool {
+				Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Namespace: mghNamespace,
+					Name:      operatorconstants.CustomAlertName,
+				}, cusConfigmap, &client.GetOptions{})).Should(Succeed())
+
+				return utils.HasLabel(cusConfigmap.Labels, constants.BackupKey, constants.BackupGlobalHubValue)
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		It("update the configmap backup label, it should be reconciled", func() {
+			cusConfigmap := &corev1.ConfigMap{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Namespace: mghNamespace,
+				Name:      operatorconstants.CustomAlertName,
+			}, cusConfigmap, &client.GetOptions{})).Should(Succeed())
+
+			cusConfigmap.Labels = nil
+
+			Expect(k8sClient.Update(ctx, cusConfigmap, &client.UpdateOptions{}))
+
+			Eventually(func() bool {
+				Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Namespace: mghNamespace,
+					Name:      operatorconstants.CustomAlertName,
+				}, cusConfigmap, &client.GetOptions{})).Should(Succeed())
+				return utils.HasLabel(cusConfigmap.Labels, constants.BackupKey, constants.BackupGlobalHubValue)
+			}, timeout, interval).Should(BeTrue())
+		})
+	})
+	Context("add backup label to kafka", Ordered, func() {
+		It("Should create the kafka with backup label", func() {
+			kafka := &kafkav1beta2.Kafka{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kafka",
+					Namespace: mghNamespace,
+				},
+			}
+			Expect(k8sClient.Create(ctx, kafka)).Should(Succeed())
+
+			Eventually(func() bool {
+				Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Namespace: mghNamespace,
+					Name:      "kafka",
+				}, kafka, &client.GetOptions{})).Should(Succeed())
+
+				return utils.HasLabel(kafka.Labels, constants.BackupKey, constants.BackupGlobalHubValue)
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		It("update the kafka backup label, it should be reconciled", func() {
+			kafka := &kafkav1beta2.Kafka{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Namespace: mghNamespace,
+				Name:      "kafka",
+			}, kafka, &client.GetOptions{})).Should(Succeed())
+
+			kafka.Labels = nil
+
+			Expect(k8sClient.Update(ctx, kafka, &client.UpdateOptions{}))
+
+			Eventually(func() bool {
+				Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Namespace: mghNamespace,
+					Name:      "kafka",
+				}, kafka, &client.GetOptions{})).Should(Succeed())
+				return utils.HasLabel(kafka.Labels, constants.BackupKey, constants.BackupGlobalHubValue)
+			}, timeout, interval).Should(BeTrue())
+		})
+	})
+})

--- a/operator/pkg/controllers/hubofhubs/globalhub_controller.go
+++ b/operator/pkg/controllers/hubofhubs/globalhub_controller.go
@@ -121,7 +121,8 @@ type MiddlewareConfig struct {
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;create;delete;update;list;watch
 // +kubebuilder:rbac:groups=operators.coreos.com,resources=subscriptions,verbs=get;create;delete;update;list;watch
 // +kubebuilder:rbac:groups=postgres-operator.crunchydata.com,resources=postgresclusters,verbs=get;create;list;watch
-// +kubebuilder:rbac:groups=kafka.strimzi.io,resources=kafkas;kafkatopics;kafkausers,verbs=get;create;list;watch
+// +kubebuilder:rbac:groups=kafka.strimzi.io,resources=kafkas;kafkatopics;kafkausers,verbs=get;create;list;watch;update
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/operator/pkg/controllers/hubofhubs/manifests/postgres/statefulset.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/postgres/statefulset.yaml
@@ -105,7 +105,6 @@ spec:
         app: multicluster-global-hub
         component: multicluster-global-hub-operator
         name: multicluster-global-hub-postgres
-        cluster.open-cluster-management.io/volsync: globalhub
       name: postgresdb
     spec:
       accessModes:

--- a/operator/pkg/controllers/hubofhubs/manifests/postgres/statefulset.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/postgres/statefulset.yaml
@@ -105,6 +105,7 @@ spec:
         app: multicluster-global-hub
         component: multicluster-global-hub-operator
         name: multicluster-global-hub-postgres
+        cluster.open-cluster-management.io/volsync: globalhub
       name: postgresdb
     spec:
       accessModes:

--- a/operator/pkg/kafka/kafka.go
+++ b/operator/pkg/kafka/kafka.go
@@ -159,6 +159,9 @@ func NewKafka(mgh *globalhubv1alpha4.MulticlusterGlobalHub, name, namespace stri
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			Labels: map[string]string{
+				constants.BackupKey: constants.BackupGlobalHubValue,
+			},
 		},
 		Spec: &kafkav1beta2.KafkaSpec{
 			Kafka: kafkav1beta2.KafkaSpecKafka{
@@ -203,6 +206,16 @@ func NewKafka(mgh *globalhubv1alpha4.MulticlusterGlobalHub, name, namespace stri
 						kafkaSpecKafkaStorageVolumesElem,
 					},
 				},
+				Template: &kafkav1beta2.KafkaSpecKafkaTemplate{
+					PersistentVolumeClaim: &kafkav1beta2.KafkaSpecKafkaTemplatePersistentVolumeClaim{
+						Metadata: &kafkav1beta2.KafkaSpecKafkaTemplatePersistentVolumeClaimMetadata{
+							Labels: &apiextensions.JSON{Raw: []byte(`{
+								"cluster.open-cluster-management.io/volsync": "globalhub"
+								}`),
+							},
+						},
+					},
+				},
 				Version: &kafkaVersion,
 			},
 			Zookeeper: kafkav1beta2.KafkaSpecZookeeper{
@@ -216,6 +229,16 @@ func NewKafka(mgh *globalhubv1alpha4.MulticlusterGlobalHub, name, namespace stri
 					Limits: &apiextensions.JSON{Raw: []byte(`{
 "memory": "3Gi"
 }`)},
+				},
+				Template: &kafkav1beta2.KafkaSpecZookeeperTemplate{
+					PersistentVolumeClaim: &kafkav1beta2.KafkaSpecZookeeperTemplatePersistentVolumeClaim{
+						Metadata: &kafkav1beta2.KafkaSpecZookeeperTemplatePersistentVolumeClaimMetadata{
+							Labels: &apiextensions.JSON{Raw: []byte(`{
+								"cluster.open-cluster-management.io/volsync": "globalhub"
+								}`),
+							},
+						},
+					},
 				},
 			},
 			EntityOperator: &kafkav1beta2.KafkaSpecEntityOperator{
@@ -236,6 +259,7 @@ func NewKafkaTopic(topicName, namespace string) *kafkav1beta2.KafkaTopic {
 			Labels: map[string]string{
 				// It is important to set the cluster label otherwise the topic will not be ready
 				"strimzi.io/cluster": KafkaClusterName,
+				constants.BackupKey:  constants.BackupGlobalHubValue,
 			},
 		},
 		Spec: &kafkav1beta2.KafkaTopicSpec{
@@ -259,6 +283,7 @@ func NewKafkaUser(username, namespace string) *kafkav1beta2.KafkaUser {
 				// It is important to set the cluster label otherwise the user will not be ready
 				"strimzi.io/cluster":             KafkaClusterName,
 				constants.GlobalHubOwnerLabelKey: constants.GlobalHubAddonOwnerLabelVal,
+				constants.BackupKey:              constants.BackupGlobalHubValue,
 			},
 		},
 		Spec: &kafkav1beta2.KafkaUserSpec{

--- a/operator/pkg/utils/utils.go
+++ b/operator/pkg/utils/utils.go
@@ -71,6 +71,19 @@ func GetAnnotation(annotations map[string]string, key string) string {
 	return annotations[key]
 }
 
+// HasLabel check if the labels has key=value label
+func HasLabel(labels map[string]string, key, value string) bool {
+	if len(labels) == 0 {
+		return false
+	}
+	for k, v := range labels {
+		if k == key && v == value {
+			return true
+		}
+	}
+	return false
+}
+
 func RemoveDuplicates(elements []string) []string {
 	// Use map to record duplicates as we find them.
 	encountered := map[string]struct{}{}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -24,6 +24,11 @@ const (
 	DefaultAgentBurst = 300
 
 	DefaultClusterId = "00000000-0000-0000-0000-000000000000"
+
+	BackupKey             = "cluster.open-cluster-management.io/backup"
+	BackupVolumnKey       = "cluster.open-cluster-management.io/volsync"
+	BackupActivationValue = "cluster-activation"
+	BackupGlobalHubValue  = "globalhub"
 )
 
 const (

--- a/test/pkg/e2e/backup_test.go
+++ b/test/pkg/e2e/backup_test.go
@@ -1,0 +1,193 @@
+package tests
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
+	globalhubv1alpha4 "github.com/stolostron/multicluster-global-hub/operator/apis/v1alpha4"
+	operatorconstants "github.com/stolostron/multicluster-global-hub/operator/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/utils"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+var crdList = sets.NewString(
+	"kafkas.kafka.strimzi.io",
+	"kafkatopics.kafka.strimzi.io",
+	"kafkausers.kafka.strimzi.io",
+)
+var runtimeClient client.Client
+var scheme = runtime.NewScheme()
+var ctx = context.Background()
+
+var _ = Describe("The resources should have backup label", Ordered, Label("e2e-tests-backup"), func() {
+	BeforeAll(func() {
+		By("Get the runtimeClient client")
+		globalhubv1alpha4.AddToScheme(scheme)
+		kafkav1beta2.AddToScheme(scheme)
+		apiextensionsv1.AddToScheme(scheme)
+		corev1.AddToScheme(scheme)
+		var err error
+		runtimeClient, err = testClients.ControllerRuntimeClient(testOptions.GlobalHub.Name, scheme)
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+	It("The kafka resources should have backup label", func() {
+		Eventually(func() bool {
+			kafka := &kafkav1beta2.Kafka{}
+			Expect(runtimeClient.Get(ctx, types.NamespacedName{
+				Namespace: Namespace,
+				Name:      "kafka",
+			}, kafka)).Should(Succeed())
+			klog.Errorf("crrent label: %v", kafka.Labels)
+			return utils.HasLabel(kafka.Labels, constants.BackupKey, constants.BackupGlobalHubValue)
+		}, 2*time.Minute, 1*time.Second).Should(BeTrue())
+
+		Eventually(func() bool {
+			kafkaUserList := &kafkav1beta2.KafkaUserList{}
+			Expect(runtimeClient.List(ctx, kafkaUserList)).Should(Succeed())
+			for _, v := range kafkaUserList.Items {
+				if v.Namespace != Namespace {
+					continue
+				}
+				klog.Errorf("kafka user:%v crrent label: %v", v.Name, v.Labels)
+				if !utils.HasLabel(v.Labels, constants.BackupKey, constants.BackupGlobalHubValue) {
+					return false
+				}
+			}
+			return true
+		}, 2*time.Minute, 1*time.Second).Should(BeTrue())
+
+		Eventually(func() bool {
+			kafkaTopicList := &kafkav1beta2.KafkaTopicList{}
+			Expect(runtimeClient.List(ctx, kafkaTopicList)).Should(Succeed())
+			for _, v := range kafkaTopicList.Items {
+				if v.Namespace != Namespace {
+					continue
+				}
+				klog.Errorf("kafka topic:%v crrent label: %v", v.Name, v.Labels)
+				if !utils.HasLabel(v.Labels, constants.BackupKey, constants.BackupGlobalHubValue) {
+					return false
+				}
+			}
+			return true
+		}, 2*time.Minute, 1*time.Second).Should(BeTrue())
+
+		Eventually(func() bool {
+			kafkaCRDList := &apiextensionsv1.CustomResourceDefinitionList{}
+			Expect(runtimeClient.List(ctx, kafkaCRDList, &client.ListOptions{
+				LabelSelector: labels.SelectorFromSet(
+					labels.Set{
+						"app": "strimzi",
+					},
+				),
+			})).Should(Succeed())
+			for _, v := range kafkaCRDList.Items {
+				klog.Errorf("%v crrent label: %v", v.Name, v.Labels)
+				if !crdList.Has(v.Name) {
+					continue
+				}
+				if !utils.HasLabel(v.Labels, constants.BackupKey, constants.BackupGlobalHubValue) {
+					return false
+				}
+			}
+			return true
+		}, 2*time.Minute, 1*time.Second).Should(BeTrue())
+	})
+
+	It("The pvc should have backup label", func() {
+		Eventually(func() bool {
+			pvcList := &corev1.PersistentVolumeClaimList{}
+			Expect(runtimeClient.List(ctx, pvcList)).Should(Succeed())
+			for _, v := range pvcList.Items {
+				if v.Namespace != Namespace {
+					continue
+				}
+				klog.Errorf("pvc:%v, label:%v", v.Name, v.Labels)
+				if !utils.HasLabel(v.Labels, constants.BackupVolumnKey, constants.BackupGlobalHubValue) {
+					return false
+				}
+			}
+			return true
+		}, 2*time.Minute, 1*time.Second).Should(BeTrue())
+	})
+
+	It("The mgh should have backup label", func() {
+		Eventually(func() bool {
+			mgh := &globalhubv1alpha4.MulticlusterGlobalHub{}
+			Expect(runtimeClient.Get(ctx, types.NamespacedName{
+				Namespace: Namespace,
+				Name:      "multiclusterglobalhub",
+			}, mgh)).Should(Succeed())
+			return utils.HasLabel(mgh.Labels, constants.BackupKey, constants.BackupActivationValue)
+		}, 2*time.Minute, 1*time.Second).Should(BeTrue())
+	})
+
+	It("The secret should have backup label", func() {
+		customSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: Namespace,
+				Name:      operatorconstants.CustomGrafanaIniName,
+			},
+			Data: map[string][]byte{
+				grafanaIniKey: []byte(`
+	[smtp]
+	user = true
+	pass = true
+	[auth]
+	enabled = false
+	[dataproxy]
+	timeout = 300
+	dial_timeout = 30
+	keep_alive_seconds = 300
+	`),
+			},
+		}
+		_, err := testClients.KubeClient().CoreV1().Secrets(Namespace).Create(ctx, customSecret, metav1.CreateOptions{})
+		Expect(err).ShouldNot(HaveOccurred())
+
+		Eventually(func() bool {
+			cusSecret, err := testClients.KubeClient().CoreV1().Secrets(Namespace).Get(ctx, customSecret.Name, metav1.GetOptions{})
+			Expect(err).ShouldNot(HaveOccurred())
+			return utils.HasLabel(cusSecret.Labels, constants.BackupKey, constants.BackupGlobalHubValue)
+		}, 2*time.Minute, 1*time.Second).Should(BeTrue())
+	})
+
+	It("The configmap should have backup label", func() {
+		customConfig := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: Namespace,
+				Name:      operatorconstants.CustomAlertName,
+			},
+			Data: map[string]string{
+				alertConfigMapKey: `
+- name: alerts-cu-webhook
+	orgId: 1
+  receivers:
+  - disableResolveMessage: false
+	type: email
+	uid: 4e3bfe25-00cf-4173-b02b-16f077e539da`,
+			},
+		}
+
+		_, err := testClients.KubeClient().CoreV1().ConfigMaps(Namespace).Create(ctx, customConfig, metav1.CreateOptions{})
+		Expect(err).ShouldNot(HaveOccurred())
+		Eventually(func() bool {
+			cusConfigmap, err := testClients.KubeClient().CoreV1().ConfigMaps(Namespace).Get(ctx, customConfig.Name, metav1.GetOptions{})
+			Expect(err).ShouldNot(HaveOccurred())
+			return utils.HasLabel(cusConfigmap.Labels, constants.BackupKey, constants.BackupGlobalHubValue)
+		}, 2*time.Minute, 1*time.Second).Should(BeTrue())
+	})
+})

--- a/test/pkg/e2e/backup_test.go
+++ b/test/pkg/e2e/backup_test.go
@@ -163,6 +163,8 @@ var _ = Describe("The resources should have backup label", Ordered, Label("e2e-t
 			Expect(err).ShouldNot(HaveOccurred())
 			return utils.HasLabel(cusSecret.Labels, constants.BackupKey, constants.BackupGlobalHubValue)
 		}, 2*time.Minute, 1*time.Second).Should(BeTrue())
+		err = testClients.KubeClient().CoreV1().Secrets(Namespace).Delete(ctx, customSecret.Name, metav1.DeleteOptions{})
+		Expect(err).ShouldNot(HaveOccurred())
 	})
 
 	It("The configmap should have backup label", func() {
@@ -189,5 +191,7 @@ var _ = Describe("The resources should have backup label", Ordered, Label("e2e-t
 			Expect(err).ShouldNot(HaveOccurred())
 			return utils.HasLabel(cusConfigmap.Labels, constants.BackupKey, constants.BackupGlobalHubValue)
 		}, 2*time.Minute, 1*time.Second).Should(BeTrue())
+		err = testClients.KubeClient().CoreV1().ConfigMaps(Namespace).Delete(ctx, customConfig.Name, metav1.DeleteOptions{})
+		Expect(err).ShouldNot(HaveOccurred())
 	})
 })

--- a/test/pkg/e2e/suite_test.go
+++ b/test/pkg/e2e/suite_test.go
@@ -28,6 +28,7 @@ import (
 	globalhubv1alpha4 "github.com/stolostron/multicluster-global-hub/operator/apis/v1alpha4"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/constants"
+	operatorutils "github.com/stolostron/multicluster-global-hub/operator/pkg/utils"
 	"github.com/stolostron/multicluster-global-hub/test/pkg/kustomize"
 	"github.com/stolostron/multicluster-global-hub/test/pkg/utils"
 )
@@ -78,6 +79,7 @@ var _ = BeforeSuite(func() {
 	By("Get the managed clusters")
 	Eventually(func() (err error) {
 		managedClusters, err = getManagedCluster(httpClient)
+		klog.Errorf("Faild to get managedclusters: %v", err)
 		return err
 	}, 1*time.Minute, 1*time.Second).ShouldNot(HaveOccurred())
 	Expect(len(managedClusters)).Should(Equal(ExpectedManagedClusterNum))
@@ -224,6 +226,10 @@ func deployGlobalHub() {
 		}
 		return checkDeployAvailable(runtimeClient, Namespace, "multicluster-global-hub-grafana")
 	}, 3*time.Minute, 1*time.Second).Should(Succeed())
+
+	//Before run test, the mgh should be ready
+	_, err = operatorutils.WaitGlobalHubReady(ctx, runtimeClient, 5*time.Second)
+	Expect(err).ShouldNot(HaveOccurred())
 }
 
 func checkDeployAvailable(runtimeClient client.Client, namespace, name string) error {

--- a/test/pkg/utils/client.go
+++ b/test/pkg/utils/client.go
@@ -104,10 +104,14 @@ func (c *testClient) KubeDynamicClient() dynamic.Interface {
 
 func (c *testClient) Kubectl(clusterName string, args ...string) (string, error) {
 	if c.options.GlobalHub.Name == clusterName {
-		// insert to the first
 		args = append([]string{"--context", c.options.GlobalHub.KubeContext}, args...)
 		args = append([]string{"--kubeconfig", c.options.GlobalHub.KubeConfig}, args...)
+		klog.Infof("args: %v", args)
 		output, err := exec.Command("kubectl", args...).Output()
+		if err != nil {
+			combinedOutput, curErr := exec.Command("kubectl", args...).CombinedOutput()
+			klog.Errorf("Output:%v, err:%v", string(combinedOutput), curErr)
+		}
 		return string(output), err
 	}
 	for _, cluster := range c.options.GlobalHub.ManagedHubs {
@@ -115,7 +119,11 @@ func (c *testClient) Kubectl(clusterName string, args ...string) (string, error)
 			args = append([]string{"--context", cluster.KubeContext}, args...)
 			args = append([]string{"--kubeconfig", cluster.KubeConfig}, args...)
 			fmt.Println(args)
-			output, err := exec.Command("kubectl", args...).Output()
+			output, err := exec.Command("kubectl", args...).CombinedOutput()
+			if err != nil {
+				combinedOutput, curErr := exec.Command("kubectl", args...).CombinedOutput()
+				klog.Errorf("Output:%v, err:%v", string(combinedOutput), curErr)
+			}
 			return string(output), err
 		}
 	}

--- a/test/setup/hoh/kafka/kafka-cluster/kafka-cluster.yaml
+++ b/test/setup/hoh/kafka/kafka-cluster/kafka-cluster.yaml
@@ -43,6 +43,11 @@ spec:
       ssl.protocol: "TLSv1.2"
     storage:
       type: ephemeral
+    template:
+      persistentVolumeClaim:
+        metadata:
+          labels:
+            cluster.open-cluster-management.io/volsync: globalhub
   zookeeper:
     replicas: 1
     logging:
@@ -51,6 +56,11 @@ spec:
         zookeeper.root.logger: "INFO"
     storage:
       type: ephemeral
+    template:
+      persistentVolumeClaim:
+        metadata:
+          labels:
+            cluster.open-cluster-management.io/volsync: globalhub
   entityOperator:
     topicOperator: {}
     userOperator: {}

--- a/test/setup/hoh/kafka/kafka-cluster/kafka-cluster.yaml
+++ b/test/setup/hoh/kafka/kafka-cluster/kafka-cluster.yaml
@@ -2,6 +2,8 @@ apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: kafka
+  labels:
+    cluster.open-cluster-management.io/backup: globalhub
 spec:
   kafka:
     replicas: 1


### PR DESCRIPTION
Add `cluster.open-cluster-management.io/backup:globalhub` label for the following resources in **Global hub** namespace:
1. Customize secrets
    - "multicluster-global-hub-custom-grafana-config"
    - "multicluster-global-hub-transport"
    - "multicluster-global-hub-storage"
2. Customize configmap
    - multicluster-global-hub-custom-alerting
4. kafka cluster
5. all kafka users
6. All kafka topic
7. kafka crds
    - "kafkas.kafka.strimzi.io"
    -  "kafkatopics.kafka.strimzi.io"
    - "kafkausers.kafka.strimzi.io"


Add `cluster.open-cluster-management.io/backup:cluster-activation` label for **mgh** instance in **Global hub** namespace

Add `cluster.open-cluster-management.io/volsync:globalhub` label for all PVC in **Global hub** namespace



