### PR TITLE
Split topics for each regional hub

### DIFF
--- a/agent/cmd/agent/main.go
+++ b/agent/cmd/agent/main.go
@@ -45,9 +45,7 @@ const (
 	leaderElectionLockID       = "multicluster-global-hub-agent-lock"
 )
 
-var (
-	setupLog = ctrl.Log.WithName("setup")
-)
+var setupLog = ctrl.Log.WithName("setup")
 
 func init() {
 	agentscheme.AddToScheme(scheme.Scheme)
@@ -72,7 +70,6 @@ func main() {
 }
 
 func doTermination(ctx context.Context, restConfig *rest.Config) int {
-
 	client, err := client.New(restConfig, client.Options{})
 	if err != nil {
 		setupLog.Error(err, "failed to int controller runtime client")

--- a/agent/pkg/controllers/crd_controller.go
+++ b/agent/pkg/controllers/crd_controller.go
@@ -8,16 +8,17 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	"github.com/stolostron/multicluster-global-hub/agent/pkg/config"
-	"github.com/stolostron/multicluster-global-hub/agent/pkg/lease"
-	specController "github.com/stolostron/multicluster-global-hub/agent/pkg/spec/controller"
-	statusController "github.com/stolostron/multicluster-global-hub/agent/pkg/status/controller"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/lease"
+	specController "github.com/stolostron/multicluster-global-hub/agent/pkg/spec/controller"
+	statusController "github.com/stolostron/multicluster-global-hub/agent/pkg/status/controller"
 )
 
 type crdController struct {

--- a/agent/pkg/event/event_exporter.go
+++ b/agent/pkg/event/event_exporter.go
@@ -115,7 +115,9 @@ func validateEventConfig(eventConfig *exporter.Config, log logr.Logger) {
 	}
 
 	kafkaConfig := eventConfig.Receivers[0].Kafka
-	if utils.Validate(kafkaConfig.TLS.CertFile) && utils.Validate(kafkaConfig.TLS.KeyFile) {
+	_, validCert := utils.Validate(kafkaConfig.TLS.CertFile)
+	_, validKey := utils.Validate(kafkaConfig.TLS.KeyFile)
+	if validCert && validKey {
 		kafkaConfig.TLS.InsecureSkipVerify = false
 	} else {
 		kafkaConfig.TLS.InsecureSkipVerify = true

--- a/go.mod
+++ b/go.mod
@@ -62,11 +62,6 @@ require (
 )
 
 require (
-	github.com/jackc/pgconn v1.12.1 // indirect
-	sigs.k8s.io/kube-storage-version-migrator v0.0.6-0.20230721195810-5c8923c5ff96 // indirect
-)
-
-require (
 	cloud.google.com/go v0.110.0 // indirect
 	cloud.google.com/go/bigquery v1.50.0 // indirect
 	cloud.google.com/go/compute v1.19.0 // indirect
@@ -146,6 +141,7 @@ require (
 	github.com/huandu/xstrings v1.4.0 // indirect
 	github.com/imdario/mergo v0.3.15 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
+	github.com/jackc/pgconn v1.12.1 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgproto3/v2 v2.3.0 // indirect
@@ -249,10 +245,12 @@ require (
 	k8s.io/klog/v2 v2.100.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
+	sigs.k8s.io/kube-storage-version-migrator v0.0.6-0.20230721195810-5c8923c5ff96 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
 
 replace (
+	github.com/cloudevents/sdk-go => github.com/yanmxa/cloudevents-sdk-go v0.0.0-20231219014825-195a55e2d6b9
 	k8s.io/api => k8s.io/api v0.26.7
 	k8s.io/apiserver => k8s.io/apiserver v0.26.7
 	k8s.io/client-go => k8s.io/client-go v0.26.7

--- a/go.mod
+++ b/go.mod
@@ -250,7 +250,6 @@ require (
 )
 
 replace (
-	github.com/cloudevents/sdk-go => github.com/yanmxa/cloudevents-sdk-go v0.0.0-20231219014825-195a55e2d6b9
 	k8s.io/api => k8s.io/api v0.26.7
 	k8s.io/apiserver => k8s.io/apiserver v0.26.7
 	k8s.io/client-go => k8s.io/client-go v0.26.7

--- a/go.sum
+++ b/go.sum
@@ -473,6 +473,7 @@ github.com/flowstack/go-jsonschema v0.1.1/go.mod h1:yL7fNggx1o8rm9RlgXv7hTBWxdBM
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
+github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/frankban/quicktest v1.2.2/go.mod h1:Qh/WofXFeiAFII1aEBu529AtJo6Zg2VHscnEsbBnJ20=
 github.com/frankban/quicktest v1.7.2/go.mod h1:jaStnuzAqU1AJdCO0l53JDCJrVDKcS03DbaAcR7Ks/o=
 github.com/frankban/quicktest v1.10.0/go.mod h1:ui7WezCLWMWxVWr1GETZY3smRy0G4KWq9vcPtJmFl7Y=
@@ -778,6 +779,7 @@ github.com/googleapis/gnostic v0.1.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTV
 github.com/googleapis/gnostic v0.3.1/go.mod h1:on+2t9HRStVgn95RSsFWFz+6Q0Snyqv1awfrALZdbtU=
 github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3ir6b65WBswg=
 github.com/googleapis/gnostic v0.5.1/go.mod h1:6U4PtQXGIEt/Z3h5MAT7FNofLnw9vXk2cUuW7uA/OeU=
+github.com/googleapis/gnostic v0.5.5/go.mod h1:7+EbHbldMins07ALC74bsA81Ovc97DwqyJO1AENw9kA=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/handlers v0.0.0-20150720190736-60c7bfde3e33/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
@@ -926,6 +928,7 @@ github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0f
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.2.1 h1:gI8os0wpRXFd4FiAY2dWiqRK037tjj3t7rKFeO4X5iw=
 github.com/jackc/puddle v1.2.1/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
+github.com/jackc/puddle/v2 v2.2.0/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jcmturner/aescts/v2 v2.0.0 h1:9YKLH6ey7H4eDBXW8khjYslgyqG2xZikXP0EQFKrle8=
@@ -1105,6 +1108,7 @@ github.com/mitchellh/hashstructure v1.1.0/go.mod h1:xUDAozZz0Wmdiufv0uyhnHkUTN6/
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
@@ -1481,6 +1485,8 @@ github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q
 github.com/xlab/treeprint v1.1.0 h1:G/1DjNkPpfZCFt9CSh6b5/nY4VimlbHF3Rh4obvtzDk=
 github.com/xlab/treeprint v1.1.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+github.com/yanmxa/cloudevents-sdk-go v0.1.0 h1:ot7rj1XiPtsfNzqnJUqdzetongqbKPGq5wK21CX/6n8=
+github.com/yanmxa/cloudevents-sdk-go v0.1.0/go.mod h1:uaHHRtId4xhRBvmaGwFxFnfd0OUFf0+rHHe2ei4Gezk=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -2240,6 +2246,10 @@ gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
+gopkg.in/jcmturner/aescts.v1 v1.0.1/go.mod h1:nsR8qBOg+OucoIW+WMhB3GspUQXq9XorLnQb9XtvcOo=
+gopkg.in/jcmturner/dnsutils.v1 v1.0.1/go.mod h1:m3v+5svpVOhtFAP/wSz+yzh4Mc0Fg7eRhxkJMWSIz9Q=
+gopkg.in/jcmturner/gokrb5.v7 v7.2.3/go.mod h1:l8VISx+WGYp+Fp7KRbsiUuXTTOnxIc3Tuvyavf11/WM=
+gopkg.in/jcmturner/rpc.v1 v1.1.0/go.mod h1:YIdkC4XfD6GXbzje11McwsDuOlZQSb9W4vfLvuNnlv8=
 gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22/go.mod h1:yeKp02qBN3iKW1OzL3MGk2IdtZzaj7SFntXj72NppTA=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=

--- a/manager/pkg/webhook/admission_suite_test.go
+++ b/manager/pkg/webhook/admission_suite_test.go
@@ -21,13 +21,14 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to

--- a/operator/pkg/controllers/hubofhubs/globalhub_manager.go
+++ b/operator/pkg/controllers/hubofhubs/globalhub_manager.go
@@ -81,7 +81,7 @@ func (r *MulticlusterGlobalHubReconciler) reconcileManager(ctx context.Context,
 
 	trans := config.GetTransporter()
 
-	transportTopic := trans.GenerateClusterTopic("")
+	transportTopic := trans.GenerateClusterTopic(transportprotocol.GlobalHubClusterName)
 	transportConn, err := trans.GetConnCredential(transportprotocol.DefaultGlobalHubKafkaUser)
 	if err != nil {
 		return fmt.Errorf("failed to get global hub transport connection: %v", err)

--- a/operator/pkg/controllers/hubofhubs/globalhub_middleware.go
+++ b/operator/pkg/controllers/hubofhubs/globalhub_middleware.go
@@ -117,8 +117,9 @@ func (r *MulticlusterGlobalHubReconciler) ReconcileTransport(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	// create global hub topics
-	topics := trans.GenerateClusterTopic("")
+	// create global hub topics, create the globalhub.status.global, global.spec and event topics
+	// it's a placeholder for the manager to subscribe the `^globalhub.status.*`
+	topics := trans.GenerateClusterTopic("global")
 	err = trans.CreateTopic(topics)
 	if err != nil {
 		return nil, err

--- a/operator/pkg/controllers/hubofhubs/globalhub_middleware.go
+++ b/operator/pkg/controllers/hubofhubs/globalhub_middleware.go
@@ -117,9 +117,9 @@ func (r *MulticlusterGlobalHubReconciler) ReconcileTransport(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	// create global hub topics, create the globalhub.status.global, global.spec and event topics
-	// it's a placeholder for the manager to subscribe the `^globalhub.status.*`
-	topics := trans.GenerateClusterTopic("global")
+	// create global hub topics, create the status.global, spec and event topics
+	// it's a placeholder for the manager to subscribe the `^status.*`
+	topics := trans.GenerateClusterTopic(transportprotocol.GlobalHubClusterName)
 	err = trans.CreateTopic(topics)
 	if err != nil {
 		return nil, err

--- a/operator/pkg/transporter/byo_transporter.go
+++ b/operator/pkg/transporter/byo_transporter.go
@@ -6,11 +6,12 @@ import (
 	"path/filepath"
 
 	"github.com/go-logr/logr"
-	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 )
 
 type BYOTransporter struct {

--- a/operator/pkg/transporter/strimzi_transporter.go
+++ b/operator/pkg/transporter/strimzi_transporter.go
@@ -313,6 +313,13 @@ func (k *strimziTransporter) GetConnCredential(username string) (*transport.Conn
 }
 
 func (k *strimziTransporter) newKafkaTopic(topicName string) *kafkav1beta2.KafkaTopic {
+	replicas := DefaultReplicas
+	// if tls is not enabled(that means its the dev environment), the replicas must be 1
+	// of it may occur such error 'Replication factor: 2 larger than available brokers: 1.'
+	if !k.enableTLS {
+		replicas = 1
+	}
+
 	return &kafkav1beta2.KafkaTopic{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      topicName,
@@ -325,7 +332,7 @@ func (k *strimziTransporter) newKafkaTopic(topicName string) *kafkav1beta2.Kafka
 		},
 		Spec: &kafkav1beta2.KafkaTopicSpec{
 			Partitions: &DefaultPartition,
-			Replicas:   &DefaultReplicas,
+			Replicas:   &replicas,
 			Config: &apiextensions.JSON{Raw: []byte(`{
 				"cleanup.policy": "compact"
 			}`)},

--- a/operator/pkg/transporter/strimzi_transporter.go
+++ b/operator/pkg/transporter/strimzi_transporter.go
@@ -52,8 +52,6 @@ const (
 	// topic names
 	StatusTopicTemplate    = "globalhub.status.%s"
 	GlobalRegexStatusTopic = "^globalhub.status.*"
-
-	GlobalSpecTopic = "globalhub.spec"
 )
 
 var (
@@ -227,7 +225,6 @@ func (k *strimziTransporter) GenerateClusterTopic(clusterIdentity string) *trans
 		EventTopic:  "event",
 	}
 	if k.multiTopic {
-		topic.SpecTopic = GlobalSpecTopic
 		topic.StatusTopic = fmt.Sprintf(StatusTopicTemplate, clusterIdentity)
 		if len(clusterIdentity) == 0 {
 			topic.StatusTopic = GlobalRegexStatusTopic

--- a/operator/pkg/transporter/strimzi_transporter.go
+++ b/operator/pkg/transporter/strimzi_transporter.go
@@ -9,9 +9,6 @@ import (
 	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
 	"github.com/go-logr/logr"
 	subv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
-	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
-	"github.com/stolostron/multicluster-global-hub/pkg/constants"
-	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 	corev1 "k8s.io/api/core/v1"
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -23,6 +20,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	operatorv1alpha4 "github.com/stolostron/multicluster-global-hub/operator/apis/v1alpha4"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 )
 
 const (
@@ -366,7 +366,7 @@ func (k *strimziTransporter) kafkaClusterReady() error {
 				return false, nil
 			}
 			if kafkaCluster.Status == nil || kafkaCluster.Status.Conditions == nil {
-				k.log.Info("kafka cluster status is not ready", "message", err.Error())
+				k.log.Info("kafka cluster status is not ready")
 				return false, nil
 			}
 

--- a/operator/pkg/transporter/strimzi_transporter_test.go
+++ b/operator/pkg/transporter/strimzi_transporter_test.go
@@ -139,9 +139,9 @@ func TestStrimziTransporter(t *testing.T) {
 
 	// topic
 	clusterTopic := trans.GenerateClusterTopic(clusterName)
-	assert.Equal(t, "globalhub.spec", clusterTopic.SpecTopic)
+	assert.Equal(t, "spec", clusterTopic.SpecTopic)
 	assert.Equal(t, "event", clusterTopic.EventTopic)
-	assert.Equal(t, fmt.Sprintf("globalhub.status.%s", clusterName), clusterTopic.StatusTopic)
+	assert.Equal(t, fmt.Sprintf(StatusTopicTemplate, clusterName), clusterTopic.StatusTopic)
 
 	err = trans.CreateTopic(clusterTopic)
 	assert.Nil(t, err)

--- a/operator/pkg/transporter/strimzi_transporter_test.go
+++ b/operator/pkg/transporter/strimzi_transporter_test.go
@@ -139,9 +139,9 @@ func TestStrimziTransporter(t *testing.T) {
 
 	// topic
 	clusterTopic := trans.GenerateClusterTopic(clusterName)
-	assert.Equal(t, "spec", clusterTopic.SpecTopic)
+	assert.Equal(t, "globalhub.spec", clusterTopic.SpecTopic)
 	assert.Equal(t, "event", clusterTopic.EventTopic)
-	assert.Equal(t, "status", clusterTopic.StatusTopic)
+	assert.Equal(t, fmt.Sprintf("globalhub.status.%s", clusterName), clusterTopic.StatusTopic)
 
 	err = trans.CreateTopic(clusterTopic)
 	assert.Nil(t, err)

--- a/operator/pkg/transporter/strimzi_transporter_test.go
+++ b/operator/pkg/transporter/strimzi_transporter_test.go
@@ -13,8 +13,6 @@ import (
 
 	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
 	subv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
-	"github.com/stolostron/multicluster-global-hub/operator/apis/v1alpha4"
-	"github.com/stolostron/multicluster-global-hub/test/pkg/kafka"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -24,6 +22,9 @@ import (
 	chnv1 "open-cluster-management.io/multicloud-operators-channel/pkg/apis/apps/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	"github.com/stolostron/multicluster-global-hub/operator/apis/v1alpha4"
+	"github.com/stolostron/multicluster-global-hub/test/pkg/kafka"
 )
 
 var (

--- a/pkg/database/gorm_conn.go
+++ b/pkg/database/gorm_conn.go
@@ -97,7 +97,8 @@ func completePostgres(postgresUri string, caCertPath string) (*url.URL, error) {
 	}
 	// only support verify-ca or disable(for test)
 	query := urlObj.Query()
-	if query.Get("sslmode") == "verify-ca" && utils.Validate(caCertPath) {
+	_, ok := utils.Validate(caCertPath)
+	if query.Get("sslmode") == "verify-ca" && ok {
 		query.Set("sslrootcert", caCertPath)
 	} else {
 		query.Add("sslmode", "disable")

--- a/pkg/transport/config/confluent_config.go
+++ b/pkg/transport/config/confluent_config.go
@@ -1,6 +1,11 @@
 package config
 
 import (
+	"crypto/x509"
+	"errors"
+	"os"
+	"path/filepath"
+
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
@@ -13,6 +18,8 @@ func GetConfluentConfigMap(kafkaConfig *transport.KafkaConfig, producer bool) (*
 		"socket.keepalive.enable": "true",
 		// silence spontaneous disconnection logs, kafka recovers by itself.
 		"log.connection.close": "false",
+		// https://github.com/confluentinc/librdkafka/issues/4349
+		"ssl.endpoint.identification.algorithm": "none",
 	}
 	if producer {
 		_ = kafkaConfigMap.SetKey("acks", "1")
@@ -21,47 +28,47 @@ func GetConfluentConfigMap(kafkaConfig *transport.KafkaConfig, producer bool) (*
 		_ = kafkaConfigMap.SetKey("enable.auto.commit", "true")
 		_ = kafkaConfigMap.SetKey("auto.offset.reset", "earliest")
 		_ = kafkaConfigMap.SetKey("group.id", kafkaConfig.ConsumerConfig.ConsumerID)
+		_ = kafkaConfigMap.SetKey("client.id", kafkaConfig.ConsumerConfig.ConsumerID)
 	}
 
-	caPEM, validCA := utils.Validate(kafkaConfig.CaCertPath)
+	_, validCA := utils.Validate(kafkaConfig.CaCertPath)
 	if kafkaConfig.EnableTLS && validCA {
+		if err := setCertificate(kafkaConfig.CaCertPath); err != nil {
+			return nil, err
+		}
+
 		if err := kafkaConfigMap.SetKey("security.protocol", "ssl"); err != nil {
 			return nil, err
 		}
-		// if err := kafkaConfigMap.SetKey("ssl.ca.location", kafkaConfig.CaCertPath); err != nil {
-		// 	return nil, err
-		// }
-		if err := kafkaConfigMap.SetKey("ssl.ca.pem", caPEM); err != nil {
+		if err := kafkaConfigMap.SetKey("ssl.ca.location", kafkaConfig.CaCertPath); err != nil {
 			return nil, err
 		}
 
-		certPEM, validCert := utils.Validate(kafkaConfig.ClientCertPath)
-		keyPEM, validKey := utils.Validate(kafkaConfig.ClientKeyPath)
+		_, validCert := utils.Validate(kafkaConfig.ClientCertPath)
+		_, validKey := utils.Validate(kafkaConfig.ClientKeyPath)
 		if validCert && validKey {
-			// _ = kafkaConfigMap.SetKey("ssl.certificate.location", kafkaConfig.ClientCertPath)
-			// _ = kafkaConfigMap.SetKey("ssl.key.location", kafkaConfig.ClientKeyPath)
-			_ = kafkaConfigMap.SetKey("ssl.certificate.pem", certPEM)
-			_ = kafkaConfigMap.SetKey("ssl.key.pem", keyPEM)
+			_ = kafkaConfigMap.SetKey("ssl.certificate.location", kafkaConfig.ClientCertPath)
+			_ = kafkaConfigMap.SetKey("ssl.key.location", kafkaConfig.ClientKeyPath)
 		}
 	}
 	return kafkaConfigMap, nil
 }
 
-// // registers the ca in root certification authority.
-// func setCertificate(caCertPath string) error {
-// 	certBytes, err := os.ReadFile(filepath.Clean(caCertPath))
-// 	if err != nil {
-// 		return err
-// 	}
-// 	// Get the SystemCertPool, continue with an empty pool on error
-// 	rootCertAuth, _ := x509.SystemCertPool()
-// 	if rootCertAuth == nil {
-// 		rootCertAuth = x509.NewCertPool()
-// 	}
+// registers the ca in root certification authority.
+func setCertificate(caCertPath string) error {
+	certBytes, err := os.ReadFile(filepath.Clean(caCertPath))
+	if err != nil {
+		return err
+	}
+	// Get the SystemCertPool, continue with an empty pool on error
+	rootCertAuth, _ := x509.SystemCertPool()
+	if rootCertAuth == nil {
+		rootCertAuth = x509.NewCertPool()
+	}
 
-// 	// Append our cert to the system pool
-// 	if ok := rootCertAuth.AppendCertsFromPEM(certBytes); !ok {
-// 		return errors.New("kafka-certificate-manager: failed to append certificate")
-// 	}
-// 	return nil
-// }
+	// Append our cert to the system pool
+	if ok := rootCertAuth.AppendCertsFromPEM(certBytes); !ok {
+		return errors.New("kafka-certificate-manager: failed to append certificate")
+	}
+	return nil
+}

--- a/pkg/transport/config/confluent_config.go
+++ b/pkg/transport/config/confluent_config.go
@@ -1,6 +1,11 @@
 package config
 
 import (
+	"crypto/x509"
+	"errors"
+	"os"
+	"path/filepath"
+
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
@@ -24,17 +29,38 @@ func GetConfluentConfigMap(kafkaConfig *transport.KafkaConfig, producer bool) (*
 	}
 
 	if kafkaConfig.EnableTLS && utils.Validate(kafkaConfig.CaCertPath) {
+		if err := setCertificate(kafkaConfig.CaCertPath); err != nil {
+			return nil, err
+		}
 		if err := kafkaConfigMap.SetKey("security.protocol", "ssl"); err != nil {
 			return nil, err
 		}
 		if err := kafkaConfigMap.SetKey("ssl.ca.location", kafkaConfig.CaCertPath); err != nil {
 			return nil, err
 		}
-
 		if utils.Validate(kafkaConfig.ClientCertPath) && utils.Validate(kafkaConfig.ClientKeyPath) {
 			_ = kafkaConfigMap.SetKey("ssl.certificate.location", kafkaConfig.ClientCertPath)
 			_ = kafkaConfigMap.SetKey("ssl.key.location", kafkaConfig.ClientKeyPath)
 		}
 	}
 	return kafkaConfigMap, nil
+}
+
+// registers the ca in root certification authority.
+func setCertificate(caCertPath string) error {
+	certBytes, err := os.ReadFile(filepath.Clean(caCertPath))
+	if err != nil {
+		return err
+	}
+	// Get the SystemCertPool, continue with an empty pool on error
+	rootCertAuth, _ := x509.SystemCertPool()
+	if rootCertAuth == nil {
+		rootCertAuth = x509.NewCertPool()
+	}
+
+	// Append our cert to the system pool
+	if ok := rootCertAuth.AppendCertsFromPEM(certBytes); !ok {
+		return errors.New("kafka-certificate-manager: failed to append certificate")
+	}
+	return nil
 }

--- a/pkg/transport/config/confluent_config.go
+++ b/pkg/transport/config/confluent_config.go
@@ -17,7 +17,7 @@ func GetConfluentConfigMap(kafkaConfig *transport.KafkaConfig, producer bool) (*
 		"bootstrap.servers":       kafkaConfig.BootstrapServer,
 		"socket.keepalive.enable": "true",
 		// silence spontaneous disconnection logs, kafka recovers by itself.
-		"log.connection.close": "true",
+		"log.connection.close": "false",
 	}
 	if producer {
 		_ = kafkaConfigMap.SetKey("acks", "1")

--- a/pkg/transport/config/confluent_config.go
+++ b/pkg/transport/config/confluent_config.go
@@ -18,8 +18,9 @@ func GetConfluentConfigMap(kafkaConfig *transport.KafkaConfig, producer bool) (*
 		_ = kafkaConfigMap.SetKey("acks", "1")
 		_ = kafkaConfigMap.SetKey("retries", "0")
 	} else {
-		_ = kafkaConfigMap.SetKey("enable.auto.commit", "false")
+		_ = kafkaConfigMap.SetKey("enable.auto.commit", "true")
 		_ = kafkaConfigMap.SetKey("auto.offset.reset", "earliest")
+		_ = kafkaConfigMap.SetKey("group.id", kafkaConfig.ConsumerConfig.ConsumerID)
 	}
 
 	if kafkaConfig.EnableTLS && utils.Validate(kafkaConfig.CaCertPath) {

--- a/pkg/transport/config/confluent_config.go
+++ b/pkg/transport/config/confluent_config.go
@@ -1,11 +1,6 @@
 package config
 
 import (
-	"crypto/x509"
-	"errors"
-	"os"
-	"path/filepath"
-
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
@@ -28,39 +23,45 @@ func GetConfluentConfigMap(kafkaConfig *transport.KafkaConfig, producer bool) (*
 		_ = kafkaConfigMap.SetKey("group.id", kafkaConfig.ConsumerConfig.ConsumerID)
 	}
 
-	if kafkaConfig.EnableTLS && utils.Validate(kafkaConfig.CaCertPath) {
-		if err := setCertificate(kafkaConfig.CaCertPath); err != nil {
-			return nil, err
-		}
+	caPEM, validCA := utils.Validate(kafkaConfig.CaCertPath)
+	if kafkaConfig.EnableTLS && validCA {
 		if err := kafkaConfigMap.SetKey("security.protocol", "ssl"); err != nil {
 			return nil, err
 		}
-		if err := kafkaConfigMap.SetKey("ssl.ca.location", kafkaConfig.CaCertPath); err != nil {
+		// if err := kafkaConfigMap.SetKey("ssl.ca.location", kafkaConfig.CaCertPath); err != nil {
+		// 	return nil, err
+		// }
+		if err := kafkaConfigMap.SetKey("ssl.ca.pem", caPEM); err != nil {
 			return nil, err
 		}
-		if utils.Validate(kafkaConfig.ClientCertPath) && utils.Validate(kafkaConfig.ClientKeyPath) {
-			_ = kafkaConfigMap.SetKey("ssl.certificate.location", kafkaConfig.ClientCertPath)
-			_ = kafkaConfigMap.SetKey("ssl.key.location", kafkaConfig.ClientKeyPath)
+
+		certPEM, validCert := utils.Validate(kafkaConfig.ClientCertPath)
+		keyPEM, validKey := utils.Validate(kafkaConfig.ClientKeyPath)
+		if validCert && validKey {
+			// _ = kafkaConfigMap.SetKey("ssl.certificate.location", kafkaConfig.ClientCertPath)
+			// _ = kafkaConfigMap.SetKey("ssl.key.location", kafkaConfig.ClientKeyPath)
+			_ = kafkaConfigMap.SetKey("ssl.certificate.pem", certPEM)
+			_ = kafkaConfigMap.SetKey("ssl.key.pem", keyPEM)
 		}
 	}
 	return kafkaConfigMap, nil
 }
 
-// registers the ca in root certification authority.
-func setCertificate(caCertPath string) error {
-	certBytes, err := os.ReadFile(filepath.Clean(caCertPath))
-	if err != nil {
-		return err
-	}
-	// Get the SystemCertPool, continue with an empty pool on error
-	rootCertAuth, _ := x509.SystemCertPool()
-	if rootCertAuth == nil {
-		rootCertAuth = x509.NewCertPool()
-	}
+// // registers the ca in root certification authority.
+// func setCertificate(caCertPath string) error {
+// 	certBytes, err := os.ReadFile(filepath.Clean(caCertPath))
+// 	if err != nil {
+// 		return err
+// 	}
+// 	// Get the SystemCertPool, continue with an empty pool on error
+// 	rootCertAuth, _ := x509.SystemCertPool()
+// 	if rootCertAuth == nil {
+// 		rootCertAuth = x509.NewCertPool()
+// 	}
 
-	// Append our cert to the system pool
-	if ok := rootCertAuth.AppendCertsFromPEM(certBytes); !ok {
-		return errors.New("kafka-certificate-manager: failed to append certificate")
-	}
-	return nil
-}
+// 	// Append our cert to the system pool
+// 	if ok := rootCertAuth.AppendCertsFromPEM(certBytes); !ok {
+// 		return errors.New("kafka-certificate-manager: failed to append certificate")
+// 	}
+// 	return nil
+// }

--- a/pkg/transport/config/saram_config.go
+++ b/pkg/transport/config/saram_config.go
@@ -16,7 +16,8 @@ func GetSaramaConfig(kafkaConfig *transport.KafkaConfig) (*sarama.Config, error)
 	saramaConfig := sarama.NewConfig()
 	saramaConfig.Version = sarama.V2_0_0_0
 
-	if kafkaConfig.EnableTLS && utils.Validate(kafkaConfig.CaCertPath) {
+	_, validCa := utils.Validate(kafkaConfig.CaCertPath)
+	if kafkaConfig.EnableTLS && validCa {
 		var err error
 		saramaConfig.Net.TLS.Enable = true
 		saramaConfig.Net.TLS.Config, err = NewTLSConfig(kafkaConfig.ClientCertPath, kafkaConfig.ClientKeyPath,
@@ -33,7 +34,9 @@ func NewTLSConfig(clientCertFile, clientKeyFile, caCertFile string) (*tls.Config
 	tlsConfig := tls.Config{}
 
 	// Load client cert
-	if utils.Validate(clientCertFile) && utils.Validate(clientKeyFile) {
+	_, validCert := utils.Validate(clientCertFile)
+	_, validKey := utils.Validate(clientKeyFile)
+	if validCert && validKey {
 		cert, err := tls.LoadX509KeyPair(clientCertFile, clientKeyFile)
 		if err != nil {
 			return &tlsConfig, err

--- a/pkg/transport/kafka_confluent/message.go
+++ b/pkg/transport/kafka_confluent/message.go
@@ -1,0 +1,138 @@
+package kafka_confluent
+
+import (
+	"bytes"
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/cloudevents/sdk-go/v2/binding"
+	"github.com/cloudevents/sdk-go/v2/binding/format"
+	"github.com/cloudevents/sdk-go/v2/binding/spec"
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
+)
+
+const (
+	prefix         = "ce-"
+	contentTypeKey = "Content-Type"
+)
+
+const (
+	KafkaOffsetKey    = "kafkaoffset"
+	KafkaPartitionKey = "kafkapartition"
+	KafkaTopicKey     = "kafkatopic"
+	KafkaMessageKey   = "kafkamessagekey"
+)
+
+var specs = spec.WithPrefix(prefix)
+
+// Message represents a Kafka message.
+// This message *can* be read several times safely
+type Message struct {
+	internal   *kafka.Message
+	properties map[string][]byte
+	format     format.Format
+	version    spec.Version
+}
+
+// Check if Message implements binding.Message
+var (
+	_ binding.Message               = (*Message)(nil)
+	_ binding.MessageMetadataReader = (*Message)(nil)
+)
+
+func NewMessage(msg *kafka.Message) *Message {
+	var contentType, contentVersion string
+	properties := make(map[string][]byte, len(msg.Headers)+3)
+	for _, header := range msg.Headers {
+		k := strings.ToLower(string(header.Key))
+		if k == strings.ToLower(contentTypeKey) {
+			contentType = string(header.Value)
+		}
+		if k == specs.PrefixedSpecVersionName() {
+			contentVersion = string(header.Value)
+		}
+		properties[k] = header.Value
+	}
+
+	// add the kafka message key, topic, partition and partition key to the properties
+	properties[prefix+KafkaOffsetKey] = []byte(strconv.FormatInt(int64(msg.TopicPartition.Offset), 10))
+	properties[prefix+KafkaPartitionKey] = []byte(strconv.FormatInt(int64(msg.TopicPartition.Partition), 10))
+	properties[prefix+KafkaTopicKey] = []byte(*msg.TopicPartition.Topic)
+	if msg.Key != nil {
+		properties[prefix+KafkaMessageKey] = msg.Key
+	}
+
+	message := &Message{
+		internal:   msg,
+		properties: properties,
+	}
+	if ft := format.Lookup(contentType); ft != nil {
+		message.format = ft
+	} else if v := specs.Version(contentVersion); v != nil {
+		message.version = v
+	}
+
+	return message
+}
+
+func (m *Message) ReadEncoding() binding.Encoding {
+	if m.version != nil {
+		return binding.EncodingBinary
+	}
+	if m.format != nil {
+		return binding.EncodingStructured
+	}
+	return binding.EncodingUnknown
+}
+
+func (m *Message) ReadStructured(ctx context.Context, encoder binding.StructuredWriter) error {
+	if m.format != nil {
+		return encoder.SetStructuredEvent(ctx, m.format, bytes.NewReader(m.internal.Value))
+	}
+	return binding.ErrNotStructured
+}
+
+func (m *Message) ReadBinary(ctx context.Context, encoder binding.BinaryWriter) error {
+	if m.version == nil {
+		return binding.ErrNotBinary
+	}
+
+	var err error
+	for k, v := range m.properties {
+		if strings.HasPrefix(k, prefix) {
+			attr := m.version.Attribute(k)
+			if attr != nil {
+				err = encoder.SetAttribute(attr, string(v))
+			} else {
+				err = encoder.SetExtension(strings.TrimPrefix(k, prefix), string(v))
+			}
+		} else if k == strings.ToLower(contentTypeKey) {
+			err = encoder.SetAttribute(m.version.AttributeFromKind(spec.DataContentType), string(v))
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	if m.internal.Value != nil {
+		err = encoder.SetData(bytes.NewBuffer(m.internal.Value))
+	}
+	return err
+}
+
+func (m *Message) Finish(error) error {
+	return nil
+}
+
+func (m *Message) GetAttribute(k spec.Kind) (spec.Attribute, interface{}) {
+	attr := m.version.AttributeFromKind(k)
+	if attr == nil {
+		return nil, nil
+	}
+	return attr, m.properties[attr.PrefixedName()]
+}
+
+func (m *Message) GetExtension(name string) interface{} {
+	return m.properties[prefix+name]
+}

--- a/pkg/transport/kafka_confluent/option.go
+++ b/pkg/transport/kafka_confluent/option.go
@@ -1,0 +1,167 @@
+package kafka_confluent
+
+import (
+	"context"
+	"fmt"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
+)
+
+// Option is the function signature required to be considered an kafka_confluent.Option.
+type Option func(*Protocol) error
+
+func WithConfigMap(config *kafka.ConfigMap) Option {
+	return func(p *Protocol) error {
+		if config == nil {
+			return fmt.Errorf("the kafka.ConfigMap option must not be nil")
+		}
+		p.kafkaConfigMap = config
+		return nil
+	}
+}
+
+// WithSenderTopic sets the defaultTopic for the kafka.Producer. This option is not required.
+func WithSenderTopic(defaultTopic string) Option {
+	return func(p *Protocol) error {
+		if defaultTopic == "" {
+			return fmt.Errorf("the producer topic option must not be nil")
+		}
+		p.producerDefaultTopic = defaultTopic
+		return nil
+	}
+}
+
+// WithDeliveryChan sets the deliveryChan for the kafka.Producer. This option is not required.
+func WithDeliveryChan(deliveryChan chan kafka.Event) Option {
+	return func(p *Protocol) error {
+		if deliveryChan == nil {
+			return fmt.Errorf("the producer deliveryChan option must not be nil")
+		}
+		p.producerDeliveryChan = deliveryChan
+		return nil
+	}
+}
+
+func WithReceiverTopics(topics []string) Option {
+	return func(p *Protocol) error {
+		if topics == nil {
+			return fmt.Errorf("the consumer topics option must not be nil")
+		}
+		p.consumerTopics = topics
+		return nil
+	}
+}
+
+func WithRebalanceCallBack(rebalanceCb kafka.RebalanceCb) Option {
+	return func(p *Protocol) error {
+		if rebalanceCb == nil {
+			return fmt.Errorf("the consumer group rebalance callback must not be nil")
+		}
+		p.consumerRebalanceCb = rebalanceCb
+		return nil
+	}
+}
+
+func WithPollTimeout(timeoutMs int) Option {
+	return func(p *Protocol) error {
+		p.consumerPollTimeout = timeoutMs
+		return nil
+	}
+}
+
+func WithSender(producer *kafka.Producer) Option {
+	return func(p *Protocol) error {
+		if producer == nil {
+			return fmt.Errorf("the producer option must not be nil")
+		}
+		p.producer = producer
+		return nil
+	}
+}
+
+func WithReceiver(consumer *kafka.Consumer) Option {
+	return func(p *Protocol) error {
+		if consumer == nil {
+			return fmt.Errorf("the consumer option must not be nil")
+		}
+		p.consumer = consumer
+		return nil
+	}
+}
+
+// Opaque key type used to store offsets: assgin offset from ctx, commit offset from context
+type commitOffsetType struct{}
+
+var offsetKey = commitOffsetType{}
+
+// CommitOffsetCtx will return the topic partitions to commit offsets for.
+func CommitOffsetCtx(ctx context.Context, topicPartitions []kafka.TopicPartition) context.Context {
+	return context.WithValue(ctx, offsetKey, topicPartitions)
+}
+
+// CommitOffsetCtx looks in the given context and returns `[]kafka.TopicPartition` if found and valid, otherwise nil.
+func CommitOffsetFrom(ctx context.Context) []kafka.TopicPartition {
+	c := ctx.Value(offsetKey)
+	if c != nil {
+		if s, ok := c.([]kafka.TopicPartition); ok {
+			return s
+		}
+	}
+	return nil
+}
+
+const (
+	OffsetEventSource = "io.cloudevents.kafka.confluent.consumer"
+	OffsetEventType   = "io.cloudevents.kafka.confluent.consumer.offsets"
+)
+
+func NewOffsetEvent() cloudevents.Event {
+	e := cloudevents.NewEvent()
+	e.SetSource(OffsetEventSource)
+	e.SetType(OffsetEventType)
+	return e
+}
+
+// Opaque key type used to store topic partition
+type topicPartitionKeyType struct{}
+
+var topicPartitionKey = topicPartitionKeyType{}
+
+// WithTopicPartition returns back a new context with the given partition.
+func WithTopicPartition(ctx context.Context, partition int32) context.Context {
+	return context.WithValue(ctx, topicPartitionKey, partition)
+}
+
+// TopicPartitionFrom looks in the given context and returns `partition` as a int64 if found and valid, otherwise -1.
+func TopicPartitionFrom(ctx context.Context) int32 {
+	c := ctx.Value(topicPartitionKey)
+	if c != nil {
+		if s, ok := c.(int32); ok {
+			return s
+		}
+	}
+	return -1
+}
+
+// Opaque key type used to store message key
+type messageKeyType struct{}
+
+var keyForMessageKey = messageKeyType{}
+
+// WithMessageKey returns back a new context with the given messageKey.
+func WithMessageKey(ctx context.Context, messageKey string) context.Context {
+	return context.WithValue(ctx, keyForMessageKey, messageKey)
+}
+
+// MessageKeyFrom looks in the given context and returns `messageKey` as a string if found and valid, otherwise "".
+func MessageKeyFrom(ctx context.Context) string {
+	c := ctx.Value(keyForMessageKey)
+	if c != nil {
+		if s, ok := c.(string); ok {
+			return s
+		}
+	}
+	return ""
+}

--- a/pkg/transport/kafka_confluent/protocol.go
+++ b/pkg/transport/kafka_confluent/protocol.go
@@ -172,7 +172,7 @@ func (p *Protocol) OpenInbound(ctx context.Context) error {
 			case kafka.Error:
 				// Errors should generally be considered informational, the client
 				// will try to automatically recover.
-				logger.Warnf("Consumer get a kafka error %v: %v\n", e.Code(), e)
+				// logger.Warnf("Consumer get a kafka error %v: %v\n", e.Code(), e)
 			default:
 				// logger.Infof("Ignored %v\n", e)
 			}

--- a/pkg/transport/kafka_confluent/protocol.go
+++ b/pkg/transport/kafka_confluent/protocol.go
@@ -1,0 +1,210 @@
+package kafka_confluent
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/cloudevents/sdk-go/v2/binding"
+	"github.com/cloudevents/sdk-go/v2/protocol"
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
+
+	cecontext "github.com/cloudevents/sdk-go/v2/context"
+)
+
+var (
+	_ protocol.Sender   = (*Protocol)(nil)
+	_ protocol.Opener   = (*Protocol)(nil)
+	_ protocol.Receiver = (*Protocol)(nil)
+	_ protocol.Closer   = (*Protocol)(nil)
+)
+
+type Protocol struct {
+	kafkaConfigMap *kafka.ConfigMap
+
+	consumer            *kafka.Consumer
+	consumerTopics      []string
+	consumerRebalanceCb kafka.RebalanceCb // optional
+	consumerPollTimeout int               // optional
+	consumerMux         sync.Mutex
+
+	producer                 *kafka.Producer
+	producerDeliveryChan     chan kafka.Event // optional
+	producerDefaultTopic     string           // optional
+	producerDefaultPartition int32            // optional
+
+	// receiver
+	incoming chan *kafka.Message
+}
+
+func New(opts ...Option) (*Protocol, error) {
+	p := &Protocol{
+		producerDefaultPartition: kafka.PartitionAny,
+		consumerPollTimeout:      100,
+		incoming:                 make(chan *kafka.Message),
+	}
+	if err := p.applyOptions(opts...); err != nil {
+		return nil, err
+	}
+
+	if p.consumerTopics != nil && p.consumer == nil && p.kafkaConfigMap != nil {
+		consumer, err := kafka.NewConsumer(p.kafkaConfigMap)
+		if err != nil {
+			return nil, err
+		}
+		p.consumer = consumer
+	} else if p.producer == nil && p.kafkaConfigMap != nil {
+		producer, err := kafka.NewProducer(p.kafkaConfigMap)
+		if err != nil {
+			return nil, err
+		}
+		p.producer = producer
+		p.producerDeliveryChan = make(chan kafka.Event)
+	}
+
+	if p.kafkaConfigMap == nil && p.producer == nil && p.consumer == nil {
+		return nil, fmt.Errorf("At least one of the following to initialize the protocol: config, producer, or consumer.")
+	}
+
+	return p, nil
+}
+
+func (p *Protocol) applyOptions(opts ...Option) error {
+	for _, fn := range opts {
+		if err := fn(p); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *Protocol) Send(ctx context.Context, in binding.Message, transformers ...binding.Transformer) (err error) {
+	// support the commit offset from the context
+	offsets := CommitOffsetFrom(ctx)
+	if offsets != nil {
+		if p.consumer == nil {
+			return fmt.Errorf("the consumer client must not be nil")
+		}
+		_, err = p.consumer.CommitOffsets(offsets)
+		return err
+	}
+
+	if p.producer == nil {
+		return fmt.Errorf("the producer client must not be nil")
+	}
+	defer in.Finish(err)
+
+	kafkaMsg := &kafka.Message{
+		TopicPartition: kafka.TopicPartition{
+			Topic:     &p.producerDefaultTopic,
+			Partition: p.producerDefaultPartition,
+		},
+	}
+
+	if topic := cecontext.TopicFrom(ctx); topic != "" {
+		kafkaMsg.TopicPartition.Topic = &topic
+	}
+
+	if partition := TopicPartitionFrom(ctx); partition != -1 {
+		kafkaMsg.TopicPartition.Partition = partition
+	}
+
+	if messageKey := MessageKeyFrom(ctx); messageKey != "" {
+		kafkaMsg.Key = []byte(messageKey)
+	}
+
+	err = WriteProducerMessage(ctx, in, kafkaMsg, transformers...)
+	if err != nil {
+		return err
+	}
+
+	err = p.producer.Produce(kafkaMsg, p.producerDeliveryChan)
+	if err != nil {
+		return err
+	}
+	e := <-p.producerDeliveryChan
+	m := e.(*kafka.Message)
+	if m.TopicPartition.Error != nil {
+		return m.TopicPartition.Error
+	}
+	return nil
+}
+
+func (p *Protocol) OpenInbound(ctx context.Context) error {
+	if p.consumer == nil {
+		return fmt.Errorf("the consumer client must not be nil")
+	}
+	if p.consumerTopics == nil {
+		return fmt.Errorf("the consumer topics must not be nil")
+	}
+
+	p.consumerMux.Lock()
+	defer p.consumerMux.Unlock()
+	logger := cecontext.LoggerFrom(ctx)
+
+	// Query committed offsets for each partition
+	if positions := CommitOffsetFrom(ctx); positions != nil {
+		if err := p.consumer.Assign(positions); err != nil {
+			return err
+		}
+	}
+
+	logger.Infof("Subscribing to topics: %v", p.consumerTopics)
+	err := p.consumer.SubscribeTopics(p.consumerTopics, p.consumerRebalanceCb)
+	if err != nil {
+		return err
+	}
+
+	run := true
+	for run {
+		select {
+		case <-ctx.Done():
+			run = false
+		default:
+			ev := p.consumer.Poll(p.consumerPollTimeout)
+			if ev == nil {
+				continue
+			}
+			switch e := ev.(type) {
+			case *kafka.Message:
+				p.incoming <- e
+			case kafka.Error:
+				// Errors should generally be considered informational, the client
+				// will try to automatically recover.
+				logger.Warnf("Consumer get a kafka error %v: %v\n", e.Code(), e)
+			default:
+				logger.Infof("Ignored %v\n", e)
+			}
+		}
+	}
+
+	logger.Infof("Closing consumer %v", p.consumerTopics)
+	return p.consumer.Close()
+}
+
+// Receive implements Receiver.Receive
+func (p *Protocol) Receive(ctx context.Context) (binding.Message, error) {
+	select {
+	case m, ok := <-p.incoming:
+		if !ok {
+			return nil, io.EOF
+		}
+		msg := NewMessage(m)
+		return msg, nil
+	case <-ctx.Done():
+		return nil, io.EOF
+	}
+}
+
+func (p *Protocol) Close(ctx context.Context) error {
+	if p.consumer != nil {
+		return p.consumer.Close()
+	}
+	if p.producer != nil {
+		p.producer.Close()
+	}
+	close(p.producerDeliveryChan)
+	close(p.incoming)
+	return nil
+}

--- a/pkg/transport/kafka_confluent/protocol.go
+++ b/pkg/transport/kafka_confluent/protocol.go
@@ -174,7 +174,7 @@ func (p *Protocol) OpenInbound(ctx context.Context) error {
 				// will try to automatically recover.
 				logger.Warnf("Consumer get a kafka error %v: %v\n", e.Code(), e)
 			default:
-				logger.Infof("Ignored %v\n", e)
+				// logger.Infof("Ignored %v\n", e)
 			}
 		}
 	}

--- a/pkg/transport/kafka_confluent/write_producer_message.go
+++ b/pkg/transport/kafka_confluent/write_producer_message.go
@@ -1,0 +1,120 @@
+package kafka_confluent
+
+import (
+	"bytes"
+	"context"
+	"io"
+
+	"github.com/cloudevents/sdk-go/v2/binding"
+	"github.com/cloudevents/sdk-go/v2/binding/format"
+	"github.com/cloudevents/sdk-go/v2/binding/spec"
+	"github.com/cloudevents/sdk-go/v2/types"
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
+)
+
+// extends the kafka.Message to support the interfaces for the converting it to binding.Message
+type kafkaMessageWriter kafka.Message
+
+var (
+	_ binding.StructuredWriter = (*kafkaMessageWriter)(nil)
+	_ binding.BinaryWriter     = (*kafkaMessageWriter)(nil)
+)
+
+// WriteProducerMessage fills the provided pubMessage with the message m.
+// Using context you can tweak the encoding processing (more details on binding.Write documentation).
+func WriteProducerMessage(ctx context.Context, in binding.Message, kafkaMsg *kafka.Message,
+	transformers ...binding.Transformer,
+) error {
+	structuredWriter := (*kafkaMessageWriter)(kafkaMsg)
+	binaryWriter := (*kafkaMessageWriter)(kafkaMsg)
+
+	_, err := binding.Write(
+		ctx,
+		in,
+		structuredWriter,
+		binaryWriter,
+		transformers...,
+	)
+	return err
+}
+
+func (b *kafkaMessageWriter) SetStructuredEvent(ctx context.Context, f format.Format, event io.Reader) error {
+	b.Headers = []kafka.Header{{
+		Key:   contentTypeKey,
+		Value: []byte(f.MediaType()),
+	}}
+
+	var buf bytes.Buffer
+	_, err := io.Copy(&buf, event)
+	if err != nil {
+		return err
+	}
+
+	b.Value = buf.Bytes()
+	return nil
+}
+
+func (b *kafkaMessageWriter) Start(ctx context.Context) error {
+	b.Headers = []kafka.Header{}
+	return nil
+}
+
+func (b *kafkaMessageWriter) End(ctx context.Context) error {
+	return nil
+}
+
+func (b *kafkaMessageWriter) SetData(reader io.Reader) error {
+	buf, ok := reader.(*bytes.Buffer)
+	if !ok {
+		buf = new(bytes.Buffer)
+		_, err := io.Copy(buf, reader)
+		if err != nil {
+			return err
+		}
+	}
+	b.Value = buf.Bytes()
+	return nil
+}
+
+func (b *kafkaMessageWriter) SetAttribute(attribute spec.Attribute, value interface{}) error {
+	if attribute.Kind() == spec.DataContentType {
+		if value == nil {
+			b.removeProperty(contentTypeKey)
+			return nil
+		}
+		b.addProperty(contentTypeKey, value)
+	} else {
+		key := prefix + attribute.Name()
+		if value == nil {
+			b.removeProperty(key)
+			return nil
+		}
+		b.addProperty(key, value)
+	}
+	return nil
+}
+
+func (b *kafkaMessageWriter) SetExtension(name string, value interface{}) error {
+	if value == nil {
+		b.removeProperty(prefix + name)
+	}
+	return b.addProperty(prefix+name, value)
+}
+
+func (b *kafkaMessageWriter) removeProperty(key string) {
+	for i, v := range b.Headers {
+		if v.Key == key {
+			b.Headers = append(b.Headers[:i], b.Headers[i+1:]...)
+			break
+		}
+	}
+}
+
+func (b *kafkaMessageWriter) addProperty(key string, value interface{}) error {
+	s, err := types.Format(value)
+	if err != nil {
+		return err
+	}
+	b.Headers = append(b.Headers, kafka.Header{Key: key, Value: []byte(s)})
+	return nil
+}

--- a/pkg/transport/producer/generic_producer.go
+++ b/pkg/transport/producer/generic_producer.go
@@ -35,12 +35,12 @@ func NewGenericProducer(transportConfig *transport.TransportConfig) (transport.P
 	var sender interface{}
 	var err error
 	messageSize := DefaultMessageKBSize * 1000
-	if transportConfig.KafkaConfig.ProducerConfig.MessageSizeLimitKB > 0 {
-		messageSize = transportConfig.KafkaConfig.ProducerConfig.MessageSizeLimitKB * 1000
-	}
 
 	switch transportConfig.TransportType {
 	case string(transport.Kafka):
+		if transportConfig.KafkaConfig.ProducerConfig.MessageSizeLimitKB > 0 {
+			messageSize = transportConfig.KafkaConfig.ProducerConfig.MessageSizeLimitKB * 1000
+		}
 		sender, err = getConfluentSenderProtocol(transportConfig)
 		if err != nil {
 			return nil, err

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -34,17 +34,17 @@ func CtrlZapOptions() zap.Options {
 }
 
 // Validate return true if the file exists and the content is not empty
-func Validate(filePath string) bool {
+func Validate(filePath string) (string, bool) {
 	if len(filePath) == 0 {
-		return false
+		return "", false
 	}
 	content, err := os.ReadFile(filePath) // #nosec G304
 	if err != nil {
 		log.Printf("failed to read file %s - %v", filePath, err)
-		return false
+		return "", false
 	}
 	trimmedContent := strings.TrimSpace(string(content))
-	return len(trimmedContent) > 0
+	return trimmedContent, len(trimmedContent) > 0
 }
 
 // GetDefaultNamespace returns default installation namespace

--- a/samples/cloudevent/confluent-receiver/main.go
+++ b/samples/cloudevent/confluent-receiver/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport/kafka_confluent"
+	"github.com/stolostron/multicluster-global-hub/samples/config"
+)
+
+const (
+	count = 10
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Please provide at least one topic command-line argument.")
+		os.Exit(1)
+	}
+	topic := os.Args[1]
+
+	configmap, err := config.GetConfluentConfigMapByKafkaUser(false)
+	if err != nil {
+		log.Fatalf("failed to create protocol: %s", err.Error())
+	}
+
+	receiver, err := kafka_confluent.New(kafka_confluent.WithConfigMap(configmap),
+		kafka_confluent.WithReceiverTopics([]string{topic}))
+
+	defer receiver.Close(context.Background())
+
+	c, err := cloudevents.NewClient(receiver, cloudevents.WithTimeNow(), cloudevents.WithUUIDs())
+	if err != nil {
+		log.Fatalf("failed to create client, %v", err)
+	}
+
+	log.Printf("will listen consuming topic: %s\n", topic)
+	err = c.StartReceiver(context.Background(), receive)
+	if err != nil {
+		log.Fatalf("failed to start receiver: %s", err)
+	} else {
+		log.Printf("receiver stopped\n")
+	}
+}
+
+func receive(ctx context.Context, event cloudevents.Event) {
+	fmt.Printf("%s \n", event.Data())
+}

--- a/samples/cloudevent/confluent-sender/main.go
+++ b/samples/cloudevent/confluent-sender/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/google/uuid"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport/kafka_confluent"
+	"github.com/stolostron/multicluster-global-hub/samples/config"
+)
+
+const (
+	count = 10
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Please provide at least one topic command-line argument.")
+		os.Exit(1)
+	}
+	topic := os.Args[1]
+
+	configmap, err := config.GetConfluentConfigMapByKafkaUser(true)
+	if err != nil {
+		log.Fatalf("failed to create protocol: %s", err.Error())
+	}
+
+	sender, err := kafka_confluent.New(kafka_confluent.WithConfigMap(configmap),
+		kafka_confluent.WithSenderTopic(topic))
+
+	defer sender.Close(context.Background())
+
+	c, err := cloudevents.NewClient(sender, cloudevents.WithTimeNow(), cloudevents.WithUUIDs())
+	if err != nil {
+		log.Fatalf("failed to create client, %v", err)
+	}
+
+	for i := 0; i < count; i++ {
+		e := cloudevents.NewEvent()
+		e.SetID(uuid.New().String())
+		e.SetType("com.cloudevents.sample.sent")
+		e.SetSource("https://github.com/cloudevents/sdk-go/samples/kafka/sender")
+		e.SetExtension("test", "foo")
+		_ = e.SetData(cloudevents.ApplicationJSON, map[string]interface{}{
+			"id":      i,
+			"message": fmt.Sprintf("Hello, %s!", topic),
+		})
+
+		if result := c.Send(
+			kafka_confluent.WithMessageKey(context.Background(), e.ID()),
+			e,
+		); cloudevents.IsUndelivered(result) {
+			log.Printf("failed to send: %v", result)
+		} else {
+			log.Printf("sent: %d, accepted: %t", i, cloudevents.IsACK(result))
+		}
+	}
+}

--- a/samples/config/confluent_config.go
+++ b/samples/config/confluent_config.go
@@ -125,6 +125,9 @@ func GetConfluentConfigMapByKafkaUser(isProducer bool) (*kafka.ConfigMap, error)
 		CaCertPath:      caCrtPath,
 		ClientCertPath:  clientCrtPath,
 		ClientKeyPath:   clientKeyPath,
+		ConsumerConfig: &transport.KafkaConsumerConfig{
+			ConsumerID: KAFkA_USER,
+		},
 	}
 	configMap, err := config.GetConfluentConfigMap(kafkaConfig, isProducer)
 	if err != nil {

--- a/samples/kafka/confluent_consumer/main.go
+++ b/samples/kafka/confluent_consumer/main.go
@@ -35,7 +35,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to get kafka config map: %v", err)
 	}
-	_ = kafkaConfigMap.SetKey("client.id", consumerId)
+	// _ = kafkaConfigMap.SetKey("client.id", consumerId)
 	_ = kafkaConfigMap.SetKey("group.id", consumerId)
 	_ = kafkaConfigMap.SetKey("auto.offset.reset", "earliest")
 	_ = kafkaConfigMap.SetKey("enable.auto.commit", "true")


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>
Ref: https://issues.redhat.com/browse/ACM-8793


<img width="902" alt="image" src="https://github.com/stolostron/multicluster-global-hub/assets/19286664/9e369be2-026a-477b-8a73-5f172f725d84">


If we split the spec, then the manager must get which cluster it needs to send the message. That means it has to hold the cluster information

Note:
- e2e certificate error reference: https://github.com/confluentinc/librdkafka/issues/4349
	- resolved by setting: "ssl.endpoint.identification.algorithm": "none",
```bash
%3|1703161332.046|FAIL|multicluster-global-hub-manager#consumer-2| [thrd:ssl://172.20.0.2:30095/bootstrap]: ssl://172.20.0.2:30095/bootstrap: SSL handshake failed: error:0A000086:SSL routines::certificate verify failed: broker certificate could not be verified, verify that ssl.ca.location is correctly configured or root CA certificates are installed (install ca-certificates package) (after 7ms in state SSL_HANDSHAKE, 30 identical error(s) suppressed)
```
- override the UT test coverage, cause the codes mostly is about the cloudevents implementations