### PR TITLE
Enable TLS for e2e

### DIFF
--- a/operator/pkg/transporter/strimzi_transporter.go
+++ b/operator/pkg/transporter/strimzi_transporter.go
@@ -307,9 +307,10 @@ func (k *strimziTransporter) GetConnCredential(username string) (*transport.Conn
 				CACert:          base64.StdEncoding.EncodeToString([]byte(kafkaCluster.Status.Listeners[1].Certificates[0])),
 			}
 			if k.enableTLS {
-				k.log.Info("enable TLS for kafka user", "username", username)
 				credential.ClientCert = base64.StdEncoding.EncodeToString(kafkaUserSecret.Data["user.crt"])
 				credential.ClientKey = base64.StdEncoding.EncodeToString(kafkaUserSecret.Data["user.key"])
+			} else {
+				k.log.Info("the kafka cluster hasn't enable tls for user", "username", username)
 			}
 			return credential, nil
 		}
@@ -387,7 +388,7 @@ func (k *strimziTransporter) kafkaClusterReady() error {
 				// if the kafka cluster is already created, check if the tls is enabled
 				enableTLS := false
 				for _, listener := range kafkaCluster.Spec.Kafka.Listeners {
-					if listener.Tls && listener.Type != kafkav1beta2.KafkaSpecKafkaListenersElemTypeNodeport {
+					if listener.Tls {
 						enableTLS = true
 						break
 					}

--- a/operator/pkg/transporter/strimzi_transporter.go
+++ b/operator/pkg/transporter/strimzi_transporter.go
@@ -85,7 +85,7 @@ type strimziTransporter struct {
 	waitReady              bool
 	enableTLS              bool
 	multiTopic             bool
-	TopicPartitionReplicas int32
+	topicPartitionReplicas int32
 }
 
 type KafkaOption func(*strimziTransporter)
@@ -108,7 +108,7 @@ func NewStrimziTransporter(c client.Client, mgh *operatorv1alpha4.MulticlusterGl
 		waitReady:              true,
 		enableTLS:              true,
 		multiTopic:             true,
-		TopicPartitionReplicas: DefaultPartitionReplicas,
+		topicPartitionReplicas: DefaultPartitionReplicas,
 
 		runtimeClient: c,
 		mgh:           mgh,
@@ -125,7 +125,7 @@ func NewStrimziTransporter(c client.Client, mgh *operatorv1alpha4.MulticlusterGl
 	}
 
 	if mgh.Spec.AvailabilityConfig == operatorv1alpha4.HABasic {
-		k.TopicPartitionReplicas = 1
+		k.topicPartitionReplicas = 1
 	}
 
 	err := k.initialize(k.mgh)
@@ -338,7 +338,7 @@ func (k *strimziTransporter) newKafkaTopic(topicName string) *kafkav1beta2.Kafka
 		},
 		Spec: &kafkav1beta2.KafkaTopicSpec{
 			Partitions: &DefaultPartition,
-			Replicas:   &k.TopicPartitionReplicas,
+			Replicas:   &k.topicPartitionReplicas,
 			Config: &apiextensions.JSON{Raw: []byte(`{
 				"cleanup.policy": "compact"
 			}`)},

--- a/operator/pkg/transporter/strimzi_transporter.go
+++ b/operator/pkg/transporter/strimzi_transporter.go
@@ -56,11 +56,11 @@ const (
 )
 
 var (
-	KafkaStorageIdentifier  int32 = 0
-	KafkaStorageDeleteClaim       = false
-	KafkaVersion                  = "3.5.0"
-	DefaultPartition        int32 = 1
-	DefaultReplicas         int32 = 2
+	KafkaStorageIdentifier   int32 = 0
+	KafkaStorageDeleteClaim        = false
+	KafkaVersion                   = "3.5.0"
+	DefaultPartition         int32 = 1
+	DefaultPartitionReplicas int32 = 2
 )
 
 // install the strimzi kafka cluster by operator
@@ -82,9 +82,10 @@ type strimziTransporter struct {
 	runtimeClient client.Client
 
 	// wait until kafka cluster status is ready when initialize
-	waitReady  bool
-	enableTLS  bool
-	multiTopic bool
+	waitReady              bool
+	enableTLS              bool
+	multiTopic             bool
+	TopicPartitionReplicas int32
 }
 
 type KafkaOption func(*strimziTransporter)
@@ -104,9 +105,10 @@ func NewStrimziTransporter(c client.Client, mgh *operatorv1alpha4.MulticlusterGl
 		subPackageName:       DefaultAMQPackageName,
 		subCatalogSourceName: DefaultCatalogSourceName,
 
-		waitReady:  true,
-		enableTLS:  true,
-		multiTopic: true,
+		waitReady:              true,
+		enableTLS:              true,
+		multiTopic:             true,
+		TopicPartitionReplicas: DefaultPartitionReplicas,
 
 		runtimeClient: c,
 		mgh:           mgh,
@@ -120,6 +122,10 @@ func NewStrimziTransporter(c client.Client, mgh *operatorv1alpha4.MulticlusterGl
 		k.subChannel = CommunityChannel
 		k.subPackageName = CommunityPackageName
 		k.subCatalogSourceName = CommunityCatalogSourceName
+	}
+
+	if mgh.Spec.AvailabilityConfig == operatorv1alpha4.HABasic {
+		k.TopicPartitionReplicas = 1
 	}
 
 	err := k.initialize(k.mgh)
@@ -320,13 +326,6 @@ func (k *strimziTransporter) GetConnCredential(username string) (*transport.Conn
 }
 
 func (k *strimziTransporter) newKafkaTopic(topicName string) *kafkav1beta2.KafkaTopic {
-	replicas := DefaultReplicas
-	// if tls is not enabled(that means its the dev environment), the replicas must be 1
-	// of it may occur such error 'Replication factor: 2 larger than available brokers: 1.'
-	if !k.enableTLS {
-		replicas = 1
-	}
-
 	return &kafkav1beta2.KafkaTopic{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      topicName,
@@ -339,7 +338,7 @@ func (k *strimziTransporter) newKafkaTopic(topicName string) *kafkav1beta2.Kafka
 		},
 		Spec: &kafkav1beta2.KafkaTopicSpec{
 			Partitions: &DefaultPartition,
-			Replicas:   &replicas,
+			Replicas:   &k.TopicPartitionReplicas,
 			Config: &apiextensions.JSON{Raw: []byte(`{
 				"cleanup.policy": "compact"
 			}`)},

--- a/test/pkg/e2e/suite_test.go
+++ b/test/pkg/e2e/suite_test.go
@@ -193,6 +193,8 @@ func deployGlobalHub() {
 			},
 		},
 		Spec: globalhubv1alpha4.MulticlusterGlobalHubSpec{
+			// the topic partition replicas(depend on the HA) should less than broker replicas
+			AvailabilityConfig: globalhubv1alpha4.HABasic,
 			DataLayer: globalhubv1alpha4.DataLayerConfig{
 				Kafka: globalhubv1alpha4.KafkaConfig{},
 				Postgres: globalhubv1alpha4.PostgresConfig{
@@ -228,7 +230,7 @@ func deployGlobalHub() {
 		return checkDeployAvailable(runtimeClient, Namespace, "multicluster-global-hub-grafana")
 	}, 3*time.Minute, 1*time.Second).Should(Succeed())
 
-	//Before run test, the mgh should be ready
+	// Before run test, the mgh should be ready
 	_, err = operatorutils.WaitGlobalHubReady(ctx, runtimeClient, 5*time.Second)
 	Expect(err).ShouldNot(HaveOccurred())
 }

--- a/test/setup/hoh/kafka/kafka-cluster/kafka-cluster.yaml
+++ b/test/setup/hoh/kafka/kafka-cluster/kafka-cluster.yaml
@@ -30,8 +30,8 @@ spec:
         port: 9095
         type: nodeport
         tls: true 
-        # authentication: # the hostname of nodeport is not fixed, so we can't use tls, 
-        #   type: tls     # https://strimzi.io/blog/2019/04/23/accessing-kafka-part-2/
+        authentication: 
+          type: tls     
         configuration:
           bootstrap:
             nodePort: 30095

--- a/test/setup/hoh/kafka/kafka_setup.sh
+++ b/test/setup/hoh/kafka/kafka_setup.sh
@@ -27,28 +27,49 @@ kubectl --context $CTX_HUB apply -k ${currentDir}/kafka-cluster -n $targetNamesp
 waitAppear "kubectl --context $CTX_HUB -n $targetNamespace get kafka.kafka.strimzi.io/kafka -o jsonpath={.status.listeners} --ignore-not-found" 1200
 echo "Kafka cluster is ready"
 
-waitAppear "kubectl --context $CTX_HUB get kafkatopic spec -n $targetNamespace --ignore-not-found | grep spec || true"
-waitAppear "kubectl --context $CTX_HUB get kafkatopic status -n $targetNamespace --ignore-not-found | grep status || true"
-echo "Kafka topics spec and status are ready!"
+# patch the nodeport IP to the broker certificate Subject Alternative Name(SAN)
+nodePortHost=$(kubectl --context $CTX_HUB -n $targetNamespace get kafka.kafka.strimzi.io/kafka -o jsonpath='{.status.listeners[1].addresses[0].host}')
+kubectl --context $CTX_HUB -n $targetNamespace patch kafka.kafka.strimzi.io/kafka --type json -p '[
+  {
+    "op": "replace",
+    "path": "/spec/kafka/listeners/1/configuration",
+    "value": {
+      "bootstrap": {
+        "nodePort": 30095
+      },
+      "brokers": [
+        {
+          "broker": 0,
+          "advertisedHost": "'"$nodePortHost"'", 
+        }
+      ]
+    }
+  }
+]'
+
+# BYO: 1. create the topics; 2. create the user; 3. create the transport secret 
+# waitAppear "kubectl --context $CTX_HUB get kafkatopic spec -n $targetNamespace --ignore-not-found | grep spec || true"
+# waitAppear "kubectl --context $CTX_HUB get kafkatopic status -n $targetNamespace --ignore-not-found | grep status || true"
+# echo "Kafka topics spec and status are ready!"
 
 # kafkaUser=global-hub-kafka-user
 # waitAppear "kubectl get secret ${kafkaUser} -n kafka --ignore-not-found"
 # echo "Kafka user ${kafkaUser} is ready!"
 
-# generate transport secret
-bootstrapServers=$(kubectl --context $CTX_HUB get kafka kafka -n $targetNamespace -o jsonpath='{.status.listeners[1].bootstrapServers}')
-kubectl --context $CTX_HUB get kafka kafka -n $targetNamespace -o jsonpath='{.status.listeners[1].certificates[0]}' > $setupDir/config/kafka-ca-cert.pem
+## generate transport secret
+# bootstrapServers=$(kubectl --context $CTX_HUB get kafka kafka -n $targetNamespace -o jsonpath='{.status.listeners[1].bootstrapServers}')
+# kubectl --context $CTX_HUB get kafka kafka -n $targetNamespace -o jsonpath='{.status.listeners[1].certificates[0]}' > $setupDir/config/kafka-ca-cert.pem
 # kubectl get secret ${kafkaUser} -n kafka -o jsonpath='{.data.user\.crt}' | base64 -d > $setupDir/config/kafka-client-cert.pem
 # kubectl get secret ${kafkaUser} -n kafka -o jsonpath='{.data.user\.key}' | base64 -d > $setupDir/config/kafka-client-key.pem
 
-# create target namespace
-kubectl --context $CTX_HUB create namespace $targetNamespace --dry-run=client -o yaml | kubectl apply -f -
+## create target namespace
+# kubectl --context $CTX_HUB create namespace $targetNamespace --dry-run=client -o yaml | kubectl apply -f -
 # Note: skip to create the transport secret, trying to use the the internal multi users and topics for managed hubs 
 # kubectl --context $CTX_HUB create secret generic $transportSecret -n $targetNamespace \
 #     --from-literal=bootstrap_server=$bootstrapServers \
 #     --from-file=ca.crt=$setupDir/config/kafka-ca-cert.pem
 #     # --from-file=client.crt=$setupDir/config/kafka-client-cert.pem \
 #     # --from-file=client.key=$setupDir/config/kafka-client-key.pem 
-echo "transport secret is ready!"
+# echo "transport secret is ready!"
 
 


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>

Add the `nodeport` IP to the broker/server certificate SAN

ref: https://strimzi.io/blog/2019/04/23/accessing-kafka-part-2/