### PR TITLE
Add authorization for managed hub topics

### DIFF
--- a/agent/pkg/spec/controller/syncers/managed_cluster_label_syncer.go
+++ b/agent/pkg/spec/controller/syncers/managed_cluster_label_syncer.go
@@ -107,6 +107,10 @@ func (syncer *managedClusterLabelsBundleSyncer) updateManagedClusterAsync(
 			return
 		}
 
+		if managedCluster.Labels == nil {
+			managedCluster.Labels = make(map[string]string)
+		}
+
 		// enforce received labels state (overwrite if exists)
 		for key, value := range labelsSpec.Labels {
 			managedCluster.Labels[key] = value
@@ -123,8 +127,7 @@ func (syncer *managedClusterLabelsBundleSyncer) updateManagedClusterAsync(
 		}
 
 		// update CR with replace API: fails if CR was modified since client.get
-		if err := k8sClient.Update(ctx, managedCluster,
-			&client.UpdateOptions{FieldManager: hohFieldManager}); err != nil {
+		if err := k8sClient.Update(ctx, managedCluster, &client.UpdateOptions{FieldManager: hohFieldManager}); err != nil {
 			syncer.log.Error(err, "failed to update managed cluster", "name", labelsSpec.ClusterName)
 			return
 		}

--- a/operator/main.go
+++ b/operator/main.go
@@ -31,7 +31,6 @@ import (
 	routeV1Client "github.com/openshift/client-go/route/clientset/versioned"
 	subv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	operatorsv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
-
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -44,7 +43,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -77,7 +75,6 @@ import (
 	hubofhubsaddon "github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/addon"
 	backupcontrollers "github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/backup"
 	hubofhubscontrollers "github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/hubofhubs"
-
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	commonobjects "github.com/stolostron/multicluster-global-hub/pkg/objects"
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"

--- a/operator/pkg/controllers/addon/addon_installer.go
+++ b/operator/pkg/controllers/addon/addon_installer.go
@@ -116,7 +116,7 @@ func (r *HoHAddonInstaller) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	err = transporter.GrantRead(userName, clusterTopic.EventTopic)
+	err = transporter.GrantWrite(userName, clusterTopic.EventTopic)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/operator/pkg/controllers/addon/addon_installer.go
+++ b/operator/pkg/controllers/addon/addon_installer.go
@@ -111,6 +111,20 @@ func (r *HoHAddonInstaller) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 
+	// grant spec/event with readable, status with writable
+	err = transporter.GrantRead(userName, clusterTopic.SpecTopic)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	err = transporter.GrantRead(userName, clusterTopic.EventTopic)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	err = transporter.GrantWrite(userName, clusterTopic.StatusTopic)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	addon := &v1alpha1.ManagedClusterAddOn{}
 	err = r.Get(ctx, types.NamespacedName{
 		Namespace: cluster.Name,

--- a/operator/pkg/controllers/backup/backup.go
+++ b/operator/pkg/controllers/backup/backup.go
@@ -23,12 +23,12 @@ import (
 )
 
 type Backup interface {
-	//Add label to one object
+	// Add label to one object
 	AddLabelToOneObj(ctx context.Context, client client.Client, namespace, name string) error
 
-	//Add label to all objects which in one namespace
+	// Add label to all objects which in one namespace
 	AddLabelToAllObjs(ctx context.Context, client client.Client, namespace string) error
 
-	//Delete the label of all objects which in one namespace
+	// Delete the label of all objects which in one namespace
 	DeleteLabelOfAllObjs(ctx context.Context, client client.Client, namespace string) error
 }

--- a/operator/pkg/controllers/backup/backup_reconcile.go
+++ b/operator/pkg/controllers/backup/backup_reconcile.go
@@ -61,7 +61,7 @@ var allResourcesBackup = map[string]Backup{
 // So for request.Namespace, we set it as request type, like "Secret","Configmap","MulticlusterGlobalHub" and so on.
 // In the reconcile, we identy the request kind and get it by request.Name.
 func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	//mgh is used to update backup condition
+	// mgh is used to update backup condition
 	mghList := &globalhubv1alpha4.MulticlusterGlobalHubList{}
 	err := r.Client.List(ctx, mghList)
 	if err != nil {
@@ -72,15 +72,15 @@ func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, nil
 	}
 	mgh := mghList.Items[0].DeepCopy()
-	//Backup condition means added backup label to all resources already
+	// Backup condition means added backup label to all resources already
 	backuped := meta.IsStatusConditionTrue(mgh.Status.Conditions, condition.CONDITION_TYPE_BACKUP)
 
-	//Check if backup is enabled
+	// Check if backup is enabled
 	backupEnabled, err := isBackupEnabled(ctx, r.Client)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	//If backup is not enable, need to clean up the backup labels
+	// If backup is not enable, need to clean up the backup labels
 	if !backupEnabled {
 		if !backuped {
 			return addDisableCondition(ctx, r.Client, mgh, nil)
@@ -92,7 +92,7 @@ func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return addDisableCondition(ctx, r.Client, mgh, err)
 	}
 
-	//If backup is enable, need to add backup label to all resources
+	// If backup is enable, need to add backup label to all resources
 	if !backuped {
 		err := r.addLableToAllResources(ctx)
 		if err != nil {
@@ -101,7 +101,7 @@ func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return addBackupCondition(ctx, r.Client, mgh, err)
 	}
 
-	//Watch the changed resources, then update the backuplabel
+	// Watch the changed resources, then update the backuplabel
 	r.Log.Info("backup reconcile:", "requestType", req.Namespace, "name", req.Name)
 	_, found := allResourcesBackup[req.Namespace]
 	if !found {
@@ -152,7 +152,8 @@ func addBackupCondition(ctx context.Context, client client.Client,
 func addLabel(
 	ctx context.Context, client client.Client, obj client.Object,
 	namespace, name string,
-	labelKey string, labelValue string) error {
+	labelKey string, labelValue string,
+) error {
 	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		err := client.Get(ctx, types.NamespacedName{
 			Namespace: namespace,
@@ -188,7 +189,8 @@ func addLabel(
 func deleteLabel(
 	ctx context.Context, client client.Client, obj client.Object,
 	namespace, name string,
-	labelKey string) error {
+	labelKey string,
+) error {
 	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		err := client.Get(ctx, types.NamespacedName{
 			Namespace: namespace,

--- a/operator/pkg/controllers/backup/backup_start.go
+++ b/operator/pkg/controllers/backup/backup_start.go
@@ -21,6 +21,9 @@ import (
 	"reflect"
 	"time"
 
+	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
+	"github.com/go-logr/logr"
+	mchv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -33,15 +36,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
-	"github.com/go-logr/logr"
 	globalhubv1alpha4 "github.com/stolostron/multicluster-global-hub/operator/apis/v1alpha4"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
 	operatorutils "github.com/stolostron/multicluster-global-hub/operator/pkg/utils"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
-
-	mchv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
 )
 
 var (
@@ -67,7 +66,7 @@ func NewBackupReconciler(mgr manager.Manager, log logr.Logger) *BackupReconciler
 }
 
 func (r *BackupReconciler) Start(ctx context.Context) error {
-	//Only when global hub started, then start the backup controller
+	// Only when global hub started, then start the backup controller
 	_, err := operatorutils.WaitGlobalHubReady(ctx, r.Client, 5*time.Second)
 	if err != nil {
 		return err
@@ -167,7 +166,6 @@ var configmapPred = predicate.Funcs{
 			return false
 		}
 		return !utils.HasLabel(e.ObjectNew.GetLabels(), constants.BackupKey, constants.BackupActivationValue)
-
 	},
 	DeleteFunc: func(e event.DeleteEvent) bool {
 		return false
@@ -227,7 +225,7 @@ var crdPred = predicate.Funcs{
 var objEventHandler = handler.EnqueueRequestsFromMapFunc(
 	func(ctx context.Context, obj client.Object) []reconcile.Request {
 		t := reflect.TypeOf(obj)
-		//Only watch the global hub namespace resources or cluster scope resources
+		// Only watch the global hub namespace resources or cluster scope resources
 		if len(obj.GetNamespace()) != 0 && (obj.GetNamespace() != config.GetMGHNamespacedName().Namespace) {
 			return []reconcile.Request{}
 		}

--- a/operator/pkg/controllers/backup/integration_test.go
+++ b/operator/pkg/controllers/backup/integration_test.go
@@ -22,6 +22,7 @@ import (
 	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	mchv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -36,7 +37,6 @@ import (
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
-	mchv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
 )
 
 const (
@@ -84,11 +84,12 @@ var _ = Describe("Backup controller", Ordered, func() {
 		Expect(k8sClient.Create(ctx, &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: mchNamespace,
-			}})).Should(Succeed())
+			},
+		})).Should(Succeed())
 		Expect(k8sClient.Create(ctx, mchObj)).Should(Succeed())
 	})
 	BeforeEach(func() {
-		//enable backup before each case
+		// enable backup before each case
 		Eventually(func() error {
 			existingMch := &mchv1.MultiClusterHub{}
 			err := k8sClient.Get(ctx, types.NamespacedName{
@@ -146,7 +147,7 @@ var _ = Describe("Backup controller", Ordered, func() {
 		})
 
 		It("disable backup, mgh should remove backup label and have disable condition", func() {
-			//Disable backup
+			// Disable backup
 			disableBackup()
 			Eventually(func() bool {
 				mgh := &globalhubv1alpha4.MulticlusterGlobalHub{}
@@ -471,7 +472,6 @@ var _ = Describe("Backup controller", Ordered, func() {
 				return !utils.HasLabel(kafkaTopic.Labels, constants.BackupKey, constants.BackupGlobalHubValue)
 			}, timeout, interval).Should(BeTrue())
 		})
-
 	})
 
 	Context("add backup label to kafka PVC", Ordered, func() {
@@ -537,7 +537,6 @@ var _ = Describe("Backup controller", Ordered, func() {
 				return !utils.HasLabel(pvc.Labels, constants.BackupVolumnKey, constants.BackupGlobalHubValue)
 			}, timeout, interval).Should(BeTrue())
 		})
-
 	})
 
 	Context("add backup label to postgres PVC", Ordered, func() {
@@ -603,7 +602,6 @@ var _ = Describe("Backup controller", Ordered, func() {
 				return !utils.HasLabel(pvc.Labels, constants.BackupVolumnKey, constants.BackupGlobalHubValue)
 			}, timeout, interval).Should(BeTrue())
 		})
-
 	})
 
 	Context("add backup label to crd", Ordered, func() {
@@ -687,9 +685,7 @@ var _ = Describe("Backup controller", Ordered, func() {
 				return !utils.HasLabel(crd.Labels, constants.BackupKey, constants.BackupGlobalHubValue)
 			}, timeout, interval).Should(BeTrue())
 		})
-
 	})
-
 })
 
 func disableBackup() {

--- a/operator/pkg/controllers/backup/kafka.go
+++ b/operator/pkg/controllers/backup/kafka.go
@@ -19,10 +19,10 @@ package backup
 import (
 	"context"
 
+	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )

--- a/operator/pkg/controllers/backup/kafkatopic.go
+++ b/operator/pkg/controllers/backup/kafkatopic.go
@@ -19,10 +19,10 @@ package backup
 import (
 	"context"
 
+	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )

--- a/operator/pkg/controllers/backup/kafkauser.go
+++ b/operator/pkg/controllers/backup/kafkauser.go
@@ -19,10 +19,10 @@ package backup
 import (
 	"context"
 
+	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )

--- a/operator/pkg/controllers/hubofhubs/globalhub_middleware.go
+++ b/operator/pkg/controllers/hubofhubs/globalhub_middleware.go
@@ -124,6 +124,19 @@ func (r *MulticlusterGlobalHubReconciler) ReconcileTransport(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
+	// grant permission: read - status,event, write - spec;
+	err = trans.GrantRead(transportprotocol.DefaultGlobalHubKafkaUser, topics.EventTopic)
+	if err != nil {
+		return nil, err
+	}
+	err = trans.GrantRead(transportprotocol.DefaultGlobalHubKafkaUser, topics.StatusTopic)
+	if err != nil {
+		return nil, err
+	}
+	err = trans.GrantWrite(transportprotocol.DefaultGlobalHubKafkaUser, topics.SpecTopic)
+	if err != nil {
+		return nil, err
+	}
 
 	var conn *transport.ConnCredential
 	err = wait.PollUntilContextTimeout(ctx, 2*time.Second, 10*time.Minute, true,

--- a/operator/pkg/controllers/hubofhubs/integration_test.go
+++ b/operator/pkg/controllers/hubofhubs/integration_test.go
@@ -385,7 +385,6 @@ var _ = Describe("MulticlusterGlobalHub controller", Ordered, func() {
 				fmt.Printf("all manager resources(%d) are created as expected \n", len(managerObjects))
 				return nil
 			}, timeout, interval).Should(Succeed())
-
 		})
 
 		It("Should create grafana resources when MGH instance is created", func() {

--- a/operator/pkg/transporter/byo_transporter.go
+++ b/operator/pkg/transporter/byo_transporter.go
@@ -58,6 +58,15 @@ func (k *BYOTransporter) DeleteTopic(topic *transport.ClusterTopic) error {
 	return nil
 }
 
+// authorize
+func (k *BYOTransporter) GrantRead(userName string, topicName string) error {
+	return nil
+}
+
+func (k *BYOTransporter) GrantWrite(userName string, topicName string) error {
+	return nil
+}
+
 func (k *BYOTransporter) GenerateClusterTopic(clusterIdentity string) *transport.ClusterTopic {
 	return &transport.ClusterTopic{
 		SpecTopic:   "spec",

--- a/operator/pkg/transporter/strimzi_transporter.go
+++ b/operator/pkg/transporter/strimzi_transporter.go
@@ -55,6 +55,7 @@ const (
 	// topic names
 	StatusTopicTemplate  = "status.%s"
 	StatusTopicRegex     = "^status.*"
+	StatusTopicPrefix    = "status"
 	GlobalHubClusterName = "global"
 )
 
@@ -311,6 +312,7 @@ func topicReadAcl(topicName string) kafkav1beta2.KafkaUserSpecAuthorizationAclsE
 	if topicName == StatusTopicRegex {
 		// give the topic permission for the manager user
 		patternType = kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypePrefix
+		topicName = StatusTopicPrefix
 	}
 	return kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
 		Host: &host,
@@ -408,7 +410,6 @@ func topicWriteAcl(topicName string) kafkav1beta2.KafkaUserSpecAuthorizationAcls
 			PatternType: &patternType,
 		},
 		Operations: []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
-			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
 			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite,
 		},
 	}

--- a/operator/pkg/transporter/strimzi_transporter.go
+++ b/operator/pkg/transporter/strimzi_transporter.go
@@ -53,6 +53,7 @@ const (
 	DefaultGlobalHubKafkaUser = "global-hub-kafka-user"
 
 	// topic names
+	StatusPrefix           = "status"
 	StatusTopicTemplate    = "status.%s"
 	GlobalRegexStatusTopic = "^status.*"
 	GlobalHubClusterName   = "global"
@@ -300,6 +301,11 @@ func (k *strimziTransporter) GrantRead(userName string, topicName string) error 
 	// expected ACL
 	host := "*"
 	patternType := kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypeLiteral
+	if userName == DefaultGlobalHubKafkaUser {
+		// give the topic permission for the manager user
+		topicName = StatusPrefix
+		patternType = kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypePrefix
+	}
 	readAcl := kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
 		Host: &host,
 		Resource: kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResource{

--- a/operator/pkg/transporter/strimzi_transporter.go
+++ b/operator/pkg/transporter/strimzi_transporter.go
@@ -53,7 +53,6 @@ const (
 	DefaultGlobalHubKafkaUser = "global-hub-kafka-user"
 
 	// topic names
-	StatusTopicPrefix    = "status"
 	StatusTopicTemplate  = "status.%s"
 	StatusTopicRegex     = "^status.*"
 	GlobalHubClusterName = "global"

--- a/operator/pkg/transporter/strimzi_transporter.go
+++ b/operator/pkg/transporter/strimzi_transporter.go
@@ -363,8 +363,8 @@ func (k *strimziTransporter) GrantWrite(userName string, topicName string) error
 }
 
 func (k *strimziTransporter) addPermissions(kafkaUser *kafkav1beta2.KafkaUser,
-	expectedAcls []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem) error {
-
+	expectedAcls []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem,
+) error {
 	authorization := kafkaUser.Spec.Authorization
 	if authorization == nil {
 		authorization = &kafkav1beta2.KafkaUserSpecAuthorization{
@@ -588,7 +588,8 @@ func (k *strimziTransporter) createKafkaCluster(mgh *operatorv1alpha4.Multiclust
 }
 
 func (k *strimziTransporter) getKafkaResources(
-	mgh *operatorv1alpha4.MulticlusterGlobalHub) *kafkav1beta2.KafkaSpecKafkaResources {
+	mgh *operatorv1alpha4.MulticlusterGlobalHub,
+) *kafkav1beta2.KafkaSpecKafkaResources {
 	kafkaRes := utils.GetResources(operatorconstants.Kafka, mgh.Spec.AdvancedConfig)
 	kafkaSpecRes := &kafkav1beta2.KafkaSpecKafkaResources{}
 	jsonData, err := json.Marshal(kafkaRes)
@@ -604,7 +605,8 @@ func (k *strimziTransporter) getKafkaResources(
 }
 
 func (k *strimziTransporter) getZookeeperResources(
-	mgh *operatorv1alpha4.MulticlusterGlobalHub) *kafkav1beta2.KafkaSpecZookeeperResources {
+	mgh *operatorv1alpha4.MulticlusterGlobalHub,
+) *kafkav1beta2.KafkaSpecZookeeperResources {
 	zookeeperRes := utils.GetResources(operatorconstants.Zookeeper, mgh.Spec.AdvancedConfig)
 
 	zookeeperSpecRes := &kafkav1beta2.KafkaSpecZookeeperResources{}

--- a/operator/pkg/transporter/strimzi_transporter.go
+++ b/operator/pkg/transporter/strimzi_transporter.go
@@ -458,23 +458,27 @@ func containAcl(acls []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem,
 		if *targetAcl.Host == *acl.Host &&
 			targetAcl.Resource.Type == acl.Resource.Type &&
 			*targetAcl.Resource.Name == *acl.Resource.Name &&
-			*targetAcl.Resource.PatternType == *acl.Resource.PatternType {
-			// operation
-			matchedOp := 0
-			for _, targetOp := range targetAcl.Operations {
-				for _, op := range acl.Operations {
-					if string(op) == string(targetOp) {
-						matchedOp += 1
-						break
-					}
-				}
-			}
-			if matchedOp == len(targetAcl.Operations) {
-				return true
-			}
+			*targetAcl.Resource.PatternType == *acl.Resource.PatternType &&
+			containOps(acl.Operations, targetAcl.Operations) { // operation
+			return true
 		}
 	}
 	return false
+}
+
+func containOps(operations []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem,
+	subOpertions []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem,
+) bool {
+	matchedOp := 0
+	for _, targetOp := range subOpertions {
+		for _, op := range operations {
+			if string(op) == string(targetOp) {
+				matchedOp += 1
+				break
+			}
+		}
+	}
+	return len(subOpertions) == matchedOp
 }
 
 func (k *strimziTransporter) newKafkaTopic(topicName string) *kafkav1beta2.KafkaTopic {

--- a/operator/pkg/transporter/strimzi_transporter.go
+++ b/operator/pkg/transporter/strimzi_transporter.go
@@ -331,6 +331,7 @@ func (k *strimziTransporter) GrantRead(userName string, topicName string) error 
 	}
 
 	// add the read acl
+	k.log.Info("add read permission", "user", kafkaUser, "topic", topicName)
 	authorization.Acls = append(authorization.Acls, readAcl)
 	kafkaUser.Spec.Authorization = authorization
 	return k.runtimeClient.Update(k.ctx, kafkaUser)
@@ -375,6 +376,7 @@ func (k *strimziTransporter) GrantWrite(userName string, topicName string) error
 	}
 
 	// add the read acl
+	k.log.Info("add write permission", "user", kafkaUser, "topic", topicName)
 	authorization.Acls = append(authorization.Acls, writeAcl)
 	kafkaUser.Spec.Authorization = authorization
 	return k.runtimeClient.Update(k.ctx, kafkaUser)
@@ -427,15 +429,15 @@ func containAcl(acls []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem,
 ) bool {
 	for _, acl := range acls {
 		// resource
-		if targetAcl.Host == acl.Host &&
+		if *targetAcl.Host == *acl.Host &&
 			targetAcl.Resource.Type == acl.Resource.Type &&
-			targetAcl.Resource.Name == acl.Resource.Name &&
-			targetAcl.Resource.PatternType == acl.Resource.PatternType {
+			*targetAcl.Resource.Name == *acl.Resource.Name &&
+			*targetAcl.Resource.PatternType == *acl.Resource.PatternType {
 			// operation
 			matchedOp := 0
 			for _, targetOp := range targetAcl.Operations {
 				for _, op := range acl.Operations {
-					if op == targetOp {
+					if string(op) == string(targetOp) {
 						matchedOp += 1
 						break
 					}

--- a/operator/pkg/transporter/strimzi_transporter_test.go
+++ b/operator/pkg/transporter/strimzi_transporter_test.go
@@ -5,6 +5,7 @@ package transporter
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -174,6 +175,8 @@ func TestStrimziTransporter(t *testing.T) {
 	}, kafkaUser)
 	assert.Nil(t, err)
 	assert.Equal(t, 3, len(kafkaUser.Spec.Authorization.Acls))
+	p, _ := json.MarshalIndent(kafkaUser, "", " ")
+	fmt.Println(string(p))
 
 	// delete user and topic
 	err = trans.DeleteUser(userName)

--- a/operator/pkg/transporter/strimzi_transporter_test.go
+++ b/operator/pkg/transporter/strimzi_transporter_test.go
@@ -156,13 +156,15 @@ func TestStrimziTransporter(t *testing.T) {
 		Namespace: "default",
 	}, kafkaUser)
 	assert.Nil(t, err)
-	assert.Equal(t, len(kafkaUser.Spec.Authorization.Acls), 1)
+	assert.Equal(t, 2, len(kafkaUser.Spec.Authorization.Acls))
+	// p, _ := json.MarshalIndent(kafkaUser, "", " ")
+	// fmt.Println(string(p))
 
 	// grant writable permission
-	err = trans.GrantWrite(userName, "spec")
+	err = trans.GrantWrite(userName, "event")
 	assert.Nil(t, err)
 
-	err = trans.GrantWrite(userName, "spec")
+	err = trans.GrantWrite(userName, "event")
 	assert.Nil(t, err)
 
 	kafkaUser = &kafkav1beta2.KafkaUser{}
@@ -171,7 +173,7 @@ func TestStrimziTransporter(t *testing.T) {
 		Namespace: "default",
 	}, kafkaUser)
 	assert.Nil(t, err)
-	assert.Equal(t, len(kafkaUser.Spec.Authorization.Acls), 2)
+	assert.Equal(t, 3, len(kafkaUser.Spec.Authorization.Acls))
 
 	// delete user and topic
 	err = trans.DeleteUser(userName)

--- a/operator/pkg/transporter/strimzi_transporter_test.go
+++ b/operator/pkg/transporter/strimzi_transporter_test.go
@@ -168,13 +168,16 @@ func TestStrimziTransporter(t *testing.T) {
 	err = trans.GrantWrite(userName, "event")
 	assert.Nil(t, err)
 
+	err = trans.GrantRead(userName, StatusTopicRegex)
+	assert.Nil(t, err)
+
 	kafkaUser = &kafkav1beta2.KafkaUser{}
 	err = runtimeClient.Get(context.TODO(), types.NamespacedName{
 		Name:      userName,
 		Namespace: "default",
 	}, kafkaUser)
 	assert.Nil(t, err)
-	assert.Equal(t, 3, len(kafkaUser.Spec.Authorization.Acls))
+	assert.Equal(t, 4, len(kafkaUser.Spec.Authorization.Acls))
 	p, _ := json.MarshalIndent(kafkaUser, "", " ")
 	fmt.Println(string(p))
 

--- a/operator/pkg/transporter/strimzi_transporter_test.go
+++ b/operator/pkg/transporter/strimzi_transporter_test.go
@@ -5,7 +5,6 @@ package transporter
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -178,8 +177,8 @@ func TestStrimziTransporter(t *testing.T) {
 	}, kafkaUser)
 	assert.Nil(t, err)
 	assert.Equal(t, 4, len(kafkaUser.Spec.Authorization.Acls))
-	p, _ := json.MarshalIndent(kafkaUser, "", " ")
-	fmt.Println(string(p))
+	// p, _ := json.MarshalIndent(kafkaUser, "", " ")
+	// fmt.Println(string(p))
 
 	// delete user and topic
 	err = trans.DeleteUser(userName)

--- a/operator/pkg/utils/utils.go
+++ b/operator/pkg/utils/utils.go
@@ -297,7 +297,6 @@ func WaitGlobalHubReady(ctx context.Context,
 }
 
 func GetResources(component string, advanced *globalhubv1alpha4.AdvancedConfig) *corev1.ResourceRequirements {
-
 	resourceReq := corev1.ResourceRequirements{}
 	requests := corev1.ResourceList{}
 	limits := corev1.ResourceList{}

--- a/operator/pkg/utils/utils_test.go
+++ b/operator/pkg/utils/utils_test.go
@@ -501,7 +501,6 @@ func Test_GetResources(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-
 		t.Run(tt.name, func(t *testing.T) {
 			var advanced *globalhubv1alpha4.AdvancedConfig
 			if tt.custom {
@@ -525,7 +524,5 @@ func Test_GetResources(t *testing.T) {
 				t.Errorf("expect cpu: %v, actual cpu: %v", tt.cpuRequest, res.Requests.Cpu().String())
 			}
 		})
-
 	}
-
 }

--- a/pkg/transport/consumer/sarama_consumer.go
+++ b/pkg/transport/consumer/sarama_consumer.go
@@ -76,7 +76,7 @@ func (c *saramaConsumer) Start(ctx context.Context) error {
 			processedChan: c.processedChan,
 		})
 		if err != nil {
-			c.log.Error(err, "Error from sarama consumer")
+			c.log.Error(err, "Error from sarama consumer", "topic", c.kafkaConfig.ConsumerConfig.ConsumerTopic)
 		}
 		// check if context was cancelled, signaling that the consumer should stop
 		if ctx.Err() != nil {

--- a/pkg/transport/transport.go
+++ b/pkg/transport/transport.go
@@ -19,6 +19,10 @@ type Transporter interface {
 	CreateTopic(topic *ClusterTopic) error
 	DeleteTopic(topic *ClusterTopic) error
 
+	// authorize
+	GrantRead(userName string, topicName string) error
+	GrantWrite(userName string, topicName string) error
+
 	// get the connection credential by user
 	GetConnCredential(userName string) (*ConnCredential, error)
 }

--- a/samples/config/confluent_config.go
+++ b/samples/config/confluent_config.go
@@ -72,6 +72,12 @@ func GetConfluentConfigMapByKafkaUser(isProducer bool) (*kafka.ConfigMap, error)
 		return nil, fmt.Errorf("failed to get kubeconfig")
 	}
 
+	userName := KAFkA_USER
+	name := os.Getenv("KAFkA_USER")
+	if name != "" {
+		userName = name
+	}
+
 	kafkav1beta2.AddToScheme(scheme.Scheme)
 	c, err := client.New(kubeconfig, client.Options{Scheme: scheme.Scheme})
 	if err != nil {
@@ -91,7 +97,7 @@ func GetConfluentConfigMapByKafkaUser(isProducer bool) (*kafka.ConfigMap, error)
 
 	kafkaUserSecret := &corev1.Secret{}
 	err = c.Get(context.TODO(), types.NamespacedName{
-		Name:      KAFkA_USER,
+		Name:      userName,
 		Namespace: KAFKA_NAMESPACE,
 	}, kafkaUserSecret)
 	if err != nil {
@@ -126,7 +132,7 @@ func GetConfluentConfigMapByKafkaUser(isProducer bool) (*kafka.ConfigMap, error)
 		ClientCertPath:  clientCrtPath,
 		ClientKeyPath:   clientKeyPath,
 		ConsumerConfig: &transport.KafkaConsumerConfig{
-			ConsumerID: KAFkA_USER,
+			ConsumerID: userName,
 		},
 	}
 	configMap, err := config.GetConfluentConfigMap(kafkaConfig, isProducer)

--- a/test/setup/hoh/kafka/kafka-cluster/kafka-cluster.yaml
+++ b/test/setup/hoh/kafka/kafka-cluster/kafka-cluster.yaml
@@ -35,6 +35,8 @@ spec:
         configuration:
           bootstrap:
             nodePort: 30095
+    authorization:
+      type: simple
     config:
       auto.create.topics.enable: "false"
       offsets.topic.replication.factor: 1


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>

Ref: https://issues.redhat.com/browse/ACM-8508

- Global Hub Manager Authorization
```yaml
authorization:
    # ACL rules for consuming from event/^status* using consumer group  '*'
    acls:
    - host: '*'
      operations:
      - Describe
      - Read
      resource:
        name: event
        patternType: literal
        type: topic
    - host: '*'
      operations:
      - Read
      resource:
        name: '*'
        patternType: literal
        type: group
    - host: '*'
      operations:
      - Describe
      - Read
      resource:
        name: status
        patternType: prefix
        type: topic
   # ACL rules for producing to topic spec
    - host: '*'
      operations:
      - Write
      resource:
        name: spec
        patternType: literal
        type: topic
    type: simple

```
- Global Hub Agent Authorization for Each Managed Hub
```yaml
authorization:
    acls:
    - host: '*'
      operations:
      - Describe
      - Read
      resource:
        name: spec
        patternType: literal
        type: topic
    - host: '*'
      operations:
      - Read
      resource:
        name: '*'
        patternType: literal
        type: group
    - host: '*'
      operations:
      - Describe
      - Read
      resource:
        name: event
        patternType: literal
        type: topic
    - host: '*'
      operations:
      - Write
      resource:
        name: status.kind-hub1
        patternType: literal
        type: topic
    type: simple
```