### PR TITLE
fix watch no spec resources

### DIFF
--- a/operator/pkg/controllers/addon/addon_installer.go
+++ b/operator/pkg/controllers/addon/addon_installer.go
@@ -274,7 +274,7 @@ func (r *HoHAddonInstaller) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 			return secretCond(e.Object)
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return secretCond(e.ObjectNew) && e.ObjectNew.GetGeneration() != e.ObjectOld.GetGeneration()
+			return secretCond(e.ObjectNew)
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			return false


### PR DESCRIPTION
The generation field is always 0 for no spec resources.
So we should update the watch logic for these kind of resources.