### PR TITLE
handle ca updated

### DIFF
--- a/agent/pkg/controllers/cert_controller.go
+++ b/agent/pkg/controllers/cert_controller.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2024 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package controllers
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
+)
+
+// certController is used to watch if the kafka cert(constants.KafkaCertSecretName) changed,
+// if changed, restart agent pod
+type certController struct {
+	kubeClient kubernetes.Interface
+	log        logr.Logger
+}
+
+// Restart the agent pod when secret data changed
+func (c *certController) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
+	reqLogger := c.log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	reqLogger.V(2).Info("cert controller", "NamespacedName:", request.NamespacedName)
+	err := utils.RestartPod(ctx, c.kubeClient, constants.GHAgentNamespace, constants.AgentDeploymentName)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+func AddCertController(mgr ctrl.Manager, kubeClient kubernetes.Interface) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Secret{}, builder.WithPredicates(predicate.Funcs{
+			CreateFunc: func(e event.CreateEvent) bool {
+				return false
+			},
+			UpdateFunc: func(e event.UpdateEvent) bool {
+				if e.ObjectNew.GetName() != constants.KafkaCertSecretName {
+					return false
+				}
+				newSecret := e.ObjectNew.(*corev1.Secret)
+				oldSecret := e.ObjectOld.(*corev1.Secret)
+				//only enqueue the obj when secret data changed
+				if !reflect.DeepEqual(newSecret.Data, oldSecret.Data) {
+					return true
+				}
+				return false
+			},
+			DeleteFunc: func(e event.DeleteEvent) bool {
+				return true
+			},
+		})).
+		Complete(&certController{
+			kubeClient: kubeClient,
+			log:        ctrl.Log.WithName("cert-controller"),
+		})
+}

--- a/agent/pkg/controllers/cert_controller_test.go
+++ b/agent/pkg/controllers/cert_controller_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2022 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package controllers_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var certSecret = &corev1.Secret{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      constants.KafkaCertSecretName,
+		Namespace: constants.GHAgentNamespace,
+	},
+	Data: map[string][]byte{
+		"service.crt": []byte("testcert"),
+	},
+}
+var _ = Describe("cert controllers", Ordered, func() {
+	It("create cert secret when cache is null", func() {
+		Eventually(func() error {
+			return mgr.GetClient().Create(ctx, certSecret)
+		}, 1*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
+	})
+
+	It("update cert secret", func() {
+		Eventually(func() error {
+			existingCertSecret := &corev1.Secret{}
+			err := mgr.GetClient().Get(ctx, types.NamespacedName{
+				Namespace: constants.GHAgentNamespace,
+				Name:      constants.KafkaCertSecretName,
+			}, existingCertSecret)
+			if err != nil {
+				return err
+			}
+			updateCertSecret := existingCertSecret.DeepCopy()
+			updateCertSecret.Data = map[string][]byte{
+				"service.crt": []byte("updatecert"),
+			}
+			err = mgr.GetClient().Update(ctx, updateCertSecret)
+			return err
+		}, 1*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
+	})
+})

--- a/agent/pkg/controllers/controllers_suite_test.go
+++ b/agent/pkg/controllers/controllers_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Red Hat, Inc.
+// Copyright (c) 2024 Red Hat, Inc.
 // Copyright Contributors to the Open Cluster Management project
 
 package controllers_test
@@ -12,7 +12,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	mchv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	clustersv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
@@ -23,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/controllers"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 )
 
 func TestControllers(t *testing.T) {
@@ -51,9 +55,15 @@ var _ = BeforeSuite(func() {
 	var err error
 	cfg, err = testenv.Start()
 	Expect(err).NotTo(HaveOccurred())
+	kubeClient, err := kubernetes.NewForConfig(cfg)
+	Expect(err).NotTo(HaveOccurred())
 
 	By("Creating the Manager")
 	// add scheme
+	mghSystemNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: constants.GHAgentNamespace}}
+	_, err = kubeClient.CoreV1().Namespaces().Create(ctx, mghSystemNamespace, metav1.CreateOptions{})
+	Expect(err).Should(Succeed())
+
 	Expect(mchv1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
 	Expect(clustersv1alpha1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
 	Expect(apiextensionsv1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
@@ -67,8 +77,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	By("Adding the controllers to the manager")
-	Expect(controllers.StartHubClusterClaimController(mgr)).NotTo(HaveOccurred())
-	Expect(controllers.StartVersionClusterClaimController(mgr)).NotTo(HaveOccurred())
+	Expect(controllers.AddHubClusterClaimController(mgr)).NotTo(HaveOccurred())
+	Expect(controllers.AddVersionClusterClaimController(mgr)).NotTo(HaveOccurred())
+	Expect(controllers.AddCertController(mgr, kubeClient)).NotTo(HaveOccurred())
 
 	go func() {
 		Expect(mgr.Start(ctx)).NotTo(HaveOccurred())

--- a/agent/pkg/controllers/crd_controller.go
+++ b/agent/pkg/controllers/crd_controller.go
@@ -43,7 +43,7 @@ func (c *crdController) Reconcile(ctx context.Context, request ctrl.Request) (ct
 	}
 
 	// Need this controller to update the value of clusterclaim version.open-cluster-management.io
-	if err := StartVersionClusterClaimController(c.mgr); err != nil {
+	if err := AddVersionClusterClaimController(c.mgr); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to add controllers: %w", err)
 	}
 
@@ -57,7 +57,7 @@ func (c *crdController) Reconcile(ctx context.Context, request ctrl.Request) (ct
 
 // this controller is used to watch the multiclusterhub crd or clustermanager crd
 // if the crd exists, then add controllers to the manager dynamically
-func StartCRDController(mgr ctrl.Manager, restConfig *rest.Config, agentConfig *config.AgentConfig) error {
+func AddCRDController(mgr ctrl.Manager, restConfig *rest.Config, agentConfig *config.AgentConfig) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&apiextensionsv1.CustomResourceDefinition{}, builder.WithPredicates(predicate.Funcs{
 			// trigger the reconciler only if the crd is created

--- a/agent/pkg/controllers/hub_clusterclaim_controller.go
+++ b/agent/pkg/controllers/hub_clusterclaim_controller.go
@@ -29,7 +29,7 @@ func (c *hubClusterClaimController) Reconcile(ctx context.Context, request ctrl.
 	return ctrl.Result{}, err
 }
 
-func StartHubClusterClaimController(mgr ctrl.Manager) error {
+func AddHubClusterClaimController(mgr ctrl.Manager) error {
 	// the controller is only to trigger create hub clusterClaim at the beginning
 	// do nothing if the hub clusterClaim existed
 	clusterClaimPredicate := predicate.NewPredicateFuncs(func(object client.Object) bool {

--- a/agent/pkg/controllers/version_clusterclaim_controller.go
+++ b/agent/pkg/controllers/version_clusterclaim_controller.go
@@ -44,7 +44,7 @@ func (c *versionClusterClaimController) Reconcile(ctx context.Context, request c
 	return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 5}, nil
 }
 
-func StartVersionClusterClaimController(mgr ctrl.Manager) error {
+func AddVersionClusterClaimController(mgr ctrl.Manager) error {
 	clusterClaimPredicate, _ := predicate.LabelSelectorPredicate(metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			constants.GlobalHubOwnerLabelKey: constants.GHAgentOwnerLabelValue,

--- a/operator/pkg/controllers/addon/manifests/templates/agent/multicluster-global-hub-agent-clusterrole.yaml
+++ b/operator/pkg/controllers/addon/manifests/templates/agent/multicluster-global-hub-agent-clusterrole.yaml
@@ -96,6 +96,7 @@ rules:
   - pods
   - configmaps
   - events
+  - secrets
   verbs:
   - create
   - delete

--- a/operator/pkg/controllers/addon/manifests/templates/hostedagent/multicluster-global-hub-hosting-agent-role.yaml
+++ b/operator/pkg/controllers/addon/manifests/templates/hostedagent/multicluster-global-hub-hosting-agent-role.yaml
@@ -12,6 +12,7 @@ rules:
   resources:
   - pods
   - events
+  - secrets
   verbs:
   - create
   - delete

--- a/operator/pkg/controllers/backup/suite_test.go
+++ b/operator/pkg/controllers/backup/suite_test.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/klog"
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
@@ -77,7 +76,6 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
-	klog.Errorf("####")
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
@@ -120,7 +118,6 @@ var _ = BeforeSuite(func() {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
-	klog.Errorf("####")
 
 	leaseDuration := 137 * time.Second
 	renewDeadline := 126 * time.Second
@@ -136,7 +133,6 @@ var _ = BeforeSuite(func() {
 		RetryPeriod:             &retryPeriod,
 	})
 	Expect(err).ToNot(HaveOccurred())
-	klog.Errorf("####")
 
 	kubeClient, err = kubernetes.NewForConfig(k8sManager.GetConfig())
 	Expect(err).ToNot(HaveOccurred())
@@ -147,11 +143,9 @@ var _ = BeforeSuite(func() {
 		Log:     ctrl.Log.WithName("backup-reconciler"),
 	}
 	Expect(backupReconciler.SetupWithManager(k8sManager)).ToNot(HaveOccurred())
-	klog.Errorf("####")
 
 	go func() {
 		defer GinkgoRecover()
-		klog.Errorf("####")
 
 		err = k8sManager.Start(ctx)
 		Expect(err).ToNot(HaveOccurred(), "failed to run manager")

--- a/operator/pkg/controllers/hubofhubs/globalhub_grafana_test.go
+++ b/operator/pkg/controllers/hubofhubs/globalhub_grafana_test.go
@@ -336,46 +336,6 @@ policies:
 	}
 }
 
-func TestRestartGrafanaPod(t *testing.T) {
-	ctx := context.Background()
-	configNamespace := utils.GetDefaultNamespace()
-
-	tests := []struct {
-		name        string
-		initObjects []runtime.Object
-		wantErr     bool
-	}{
-		{
-			name:        "no grafana pods",
-			initObjects: []runtime.Object{},
-			wantErr:     false,
-		},
-		{
-			name: "has grafana pods",
-			initObjects: []runtime.Object{
-				&corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: configNamespace,
-						Name:      grafanaDeploymentName + "xxx",
-						Labels: map[string]string{
-							"name": grafanaDeploymentName,
-						},
-					},
-				},
-			},
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		kubeClient := fakekube.NewSimpleClientset(tt.initObjects...)
-		t.Run(tt.name, func(t *testing.T) {
-			if err := restartGrafanaPod(ctx, kubeClient); (err != nil) != tt.wantErr {
-				t.Errorf("RestartGrafanaPod() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
-}
-
 func Test_generateGranafaIni(t *testing.T) {
 	configNamespace := utils.GetDefaultNamespace()
 	mgh := &globalhubv1alpha4.MulticlusterGlobalHub{

--- a/operator/pkg/controllers/hubofhubs/globalhub_middleware.go
+++ b/operator/pkg/controllers/hubofhubs/globalhub_middleware.go
@@ -64,6 +64,7 @@ func (r *MulticlusterGlobalHubReconciler) ReconcileMiddleware(ctx context.Contex
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+
 		conn, e := r.ReconcileStorage(ctx, mgh)
 		if e != nil {
 			errorChan <- e
@@ -157,7 +158,7 @@ func (r *MulticlusterGlobalHubReconciler) ReconcileTransport(ctx context.Context
 func (r *MulticlusterGlobalHubReconciler) ReconcileStorage(ctx context.Context, mgh *v1alpha4.MulticlusterGlobalHub,
 ) (*postgres.PostgresConnection, error) {
 	// support BYO postgres
-	pgConnection, err := r.GeneratePGConnectionFromGHStorageSecret(ctx)
+	pgConnection, err := config.GetPGConnectionFromGHStorageSecret(ctx, r.Client)
 	if err == nil {
 		return pgConnection, nil
 	} else if err != nil && !errors.IsNotFound(err) {
@@ -193,7 +194,7 @@ func (r *MulticlusterGlobalHubReconciler) ReconcileStorage(ctx context.Context, 
 					return false, nil
 				}
 
-				pgConnection, err = r.WaitForPostgresReady(ctx)
+				pgConnection, err = config.GetPGConnectionFromBuildInPostgres(ctx, r.Client)
 				if err != nil {
 					r.Log.Info("waiting the postgres connection credential to be ready...", "message", err.Error())
 					return false, nil

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -6,6 +6,11 @@ const (
 	GHDefaultNamespace = "multicluster-global-hub"
 	// GHAgentNamespace defines global hub agent namespace
 	GHAgentNamespace = "multicluster-global-hub-agent"
+	// ManagerDeploymentName define the global hub manager deployment name
+	ManagerDeploymentName = "multicluster-global-hub-manager"
+	// AgentDeploymentName define the global hub agent deployment name
+	AgentDeploymentName = "multicluster-global-hub-agent"
+
 	// GHAgentConfigCMName is the name of configmap that stores important global hub settings
 	// eg. aggregationLevel and enableLocalPolicy.
 	GHAgentConfigCMName = "multicluster-global-hub-agent-config"
@@ -31,12 +36,14 @@ const (
 	BackupGlobalHubValue  = "globalhub"
 )
 
-// global hub transport and storage secret names
+// global hub transport and storage secret and configmap names
 const (
 	GHTransportSecretName      = "multicluster-global-hub-transport" // #nosec G101
 	GHStorageSecretName        = "multicluster-global-hub-storage"   // #nosec G101
 	GHBuiltInStorageSecretName = "multicluster-global-hub-postgres"  // #nosec G101
+	KafkaCertSecretName        = "kafka-certs-secret"                // #nosec G101
 	GHDefaultStorageRetention  = "18m"                               // 18 months
+	PostgresCAConfigMap        = "multicluster-global-hub-postgres-ca"
 )
 
 // global hub console secret/configmap names


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-7489

We need to rebuild the database and transport connection if transport/database connection info changed.
1. The the database/transport secret changed(url/ca/cert...)
2. The database/transport ca is expired.

And for kafka, it's difficult to rebuild the consumer connection when CA changed. I tried openshift/kafka, they all restart the related pods when rotate the CA, So I also restart the manager/agent pod when CA changed. 