### PR TITLE
fix backup log always show

### DIFF
--- a/operator/pkg/controllers/backup/kafka.go
+++ b/operator/pkg/controllers/backup/kafka.go
@@ -18,13 +18,25 @@ package backup
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 
 	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
+)
+
+const (
+	BackupVolumnLabelRaw = `{
+		"cluster.open-cluster-management.io/volsync": "globalhub"
+	}`
 )
 
 type kafkaBackup struct {
@@ -47,7 +59,287 @@ func (r *kafkaBackup) AddLabelToOneObj(ctx context.Context,
 	namespace, name string,
 ) error {
 	obj := &kafkav1beta2.Kafka{}
-	return addLabel(ctx, client, obj, namespace, name, r.labelKey, r.labelValue)
+	err := addLabel(ctx, client, obj, namespace, name, r.labelKey, r.labelValue)
+	if err != nil {
+		return err
+	}
+	err = AddBackupLabelToTemplate(ctx, client, namespace, name)
+	return err
+}
+
+// AddTemplateBackupLabels add backup label to kafka pvc template
+func AddBackupLabelToTemplate(ctx context.Context,
+	client client.Client,
+	namespace, name string) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+
+		existingKafka := &kafkav1beta2.Kafka{}
+		err := client.Get(ctx, types.NamespacedName{
+			Name:      name,
+			Namespace: namespace,
+		}, existingKafka)
+		if err != nil {
+			return err
+		}
+
+		updatedKafka, updateBackupLabelInKafkaPVC, err := AddBackupLabelToKafkaTemplate(existingKafka)
+		if err != nil {
+			return err
+		}
+
+		updatedKafka, updateBackupLabelInZookeeperPVC, err := AddBackupLabelToZookeeperTemplate(updatedKafka)
+		if err != nil {
+			return err
+		}
+
+		if !updateBackupLabelInZookeeperPVC && !updateBackupLabelInKafkaPVC {
+			return nil
+		}
+
+		err = client.Update(ctx, updatedKafka)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+func AddBackupLabelToKafkaTemplate(existingKafka *kafkav1beta2.Kafka) (*kafkav1beta2.Kafka, bool, error) {
+	var kafkaPVCLabels map[string]string
+	updatedKafka := existingKafka.DeepCopy()
+	if existingKafka == nil || existingKafka.Spec == nil {
+		return nil, false, fmt.Errorf("kafka spec should not be nil, name: %s}", existingKafka.Name)
+	}
+
+	var desiredTemplate = &kafkav1beta2.KafkaSpecKafkaTemplate{
+		PersistentVolumeClaim: &kafkav1beta2.KafkaSpecKafkaTemplatePersistentVolumeClaim{
+			Metadata: &kafkav1beta2.KafkaSpecKafkaTemplatePersistentVolumeClaimMetadata{
+				Labels: &apiextensions.JSON{
+					Raw: []byte(BackupVolumnLabelRaw),
+				},
+			},
+		},
+	}
+	if existingKafka.Spec.Kafka.Template == nil {
+		updatedKafka.Spec.Kafka.Template = desiredTemplate
+		return updatedKafka, true, nil
+	}
+
+	if existingKafka.Spec.Kafka.Template.PersistentVolumeClaim == nil {
+		updatedKafka.Spec.Kafka.Template.PersistentVolumeClaim = desiredTemplate.PersistentVolumeClaim
+		return updatedKafka, true, nil
+	}
+
+	if existingKafka.Spec.Kafka.Template.PersistentVolumeClaim.Metadata == nil {
+		updatedKafka.Spec.Kafka.Template.PersistentVolumeClaim.Metadata =
+			desiredTemplate.PersistentVolumeClaim.Metadata
+		return updatedKafka, true, nil
+	}
+
+	if existingKafka.Spec.Kafka.Template.PersistentVolumeClaim.Metadata.Labels == nil {
+		updatedKafka.Spec.Kafka.Template.PersistentVolumeClaim.Metadata.Labels =
+			desiredTemplate.PersistentVolumeClaim.Metadata.Labels
+		return updatedKafka, true, nil
+	}
+
+	kafkaPVCLabelsJson := existingKafka.Spec.Kafka.Template.PersistentVolumeClaim.Metadata.Labels
+
+	err := json.Unmarshal(kafkaPVCLabelsJson.Raw, &kafkaPVCLabels)
+	if err != nil {
+		return nil, true, err
+	}
+	if utils.HasLabel(kafkaPVCLabels, constants.BackupVolumnKey, constants.BackupGlobalHubValue) {
+		return updatedKafka, false, nil
+	}
+
+	if kafkaPVCLabels == nil {
+		kafkaPVCLabels = make(map[string]string)
+	}
+
+	kafkaPVCLabels[constants.BackupVolumnKey] = constants.BackupGlobalHubValue
+
+	kafkaLabelJSON, err := json.Marshal(kafkaPVCLabels)
+	if err != nil {
+		return nil, true, err
+	}
+	updatedKafka.Spec.Kafka.Template.PersistentVolumeClaim.Metadata.Labels = &apiextensions.JSON{
+		Raw: kafkaLabelJSON,
+	}
+	return updatedKafka, true, nil
+}
+
+func AddBackupLabelToZookeeperTemplate(existingKafka *kafkav1beta2.Kafka) (*kafkav1beta2.Kafka, bool, error) {
+	var zookeeperPVCLabels map[string]string
+	if existingKafka == nil || existingKafka.Spec == nil {
+		return nil, false, fmt.Errorf("kafka spec should not be nil")
+	}
+	var desiredTemplate = &kafkav1beta2.KafkaSpecZookeeperTemplate{
+		PersistentVolumeClaim: &kafkav1beta2.KafkaSpecZookeeperTemplatePersistentVolumeClaim{
+			Metadata: &kafkav1beta2.KafkaSpecZookeeperTemplatePersistentVolumeClaimMetadata{
+				Labels: &apiextensions.JSON{
+					Raw: []byte(BackupVolumnLabelRaw),
+				},
+			},
+		},
+	}
+
+	updatedKafka := existingKafka.DeepCopy()
+
+	if existingKafka.Spec.Zookeeper.Template == nil {
+		updatedKafka.Spec.Zookeeper.Template = desiredTemplate
+		return updatedKafka, true, nil
+	}
+
+	if existingKafka.Spec.Zookeeper.Template.PersistentVolumeClaim == nil {
+		updatedKafka.Spec.Zookeeper.Template.PersistentVolumeClaim =
+			desiredTemplate.PersistentVolumeClaim
+		return updatedKafka, true, nil
+	}
+
+	if existingKafka.Spec.Zookeeper.Template.PersistentVolumeClaim.Metadata == nil {
+		updatedKafka.Spec.Zookeeper.Template.PersistentVolumeClaim.Metadata =
+			desiredTemplate.PersistentVolumeClaim.Metadata
+		return updatedKafka, true, nil
+	}
+
+	if existingKafka.Spec.Zookeeper.Template.PersistentVolumeClaim.Metadata.Labels == nil {
+		updatedKafka.Spec.Zookeeper.Template.PersistentVolumeClaim.Metadata.Labels =
+			desiredTemplate.PersistentVolumeClaim.Metadata.Labels
+		return updatedKafka, true, nil
+	}
+
+	zookeeperPVCLabelsJson := existingKafka.Spec.Zookeeper.Template.PersistentVolumeClaim.Metadata.Labels
+
+	err := json.Unmarshal(zookeeperPVCLabelsJson.Raw, &zookeeperPVCLabels)
+	if err != nil {
+		return nil, true, err
+	}
+	if utils.HasLabel(zookeeperPVCLabels, constants.BackupVolumnKey, constants.BackupGlobalHubValue) {
+		return updatedKafka, false, nil
+	}
+
+	if zookeeperPVCLabels == nil {
+		zookeeperPVCLabels = make(map[string]string)
+	}
+
+	zookeeperPVCLabels[constants.BackupVolumnKey] = constants.BackupGlobalHubValue
+
+	zookeeperLabelJSON, err := json.Marshal(zookeeperPVCLabels)
+	if err != nil {
+		return nil, true, err
+	}
+	updatedKafka.Spec.Zookeeper.Template.PersistentVolumeClaim.Metadata.Labels = &apiextensions.JSON{
+		Raw: zookeeperLabelJSON,
+	}
+	return updatedKafka, true, nil
+}
+
+func DeleteBackupLabelToKafkaTemplate(existingKafka *kafkav1beta2.Kafka) (*kafkav1beta2.Kafka, bool, error) {
+	var kafkaPVCLabels map[string]string
+
+	updatedKafka := existingKafka.DeepCopy()
+	if existingKafka.Spec == nil {
+		return updatedKafka, false, nil
+	}
+
+	if existingKafka.Spec.Kafka.Template == nil ||
+		existingKafka.Spec.Kafka.Template.PersistentVolumeClaim == nil ||
+		existingKafka.Spec.Kafka.Template.PersistentVolumeClaim.Metadata == nil ||
+		existingKafka.Spec.Kafka.Template.PersistentVolumeClaim.Metadata.Labels == nil {
+		return updatedKafka, false, nil
+	}
+
+	kafkaPVCLabelsJson := existingKafka.Spec.Kafka.Template.PersistentVolumeClaim.Metadata.Labels
+	err := json.Unmarshal(kafkaPVCLabelsJson.Raw, &kafkaPVCLabels)
+	if err != nil {
+		return updatedKafka, false, err
+	}
+	if !utils.HasLabel(kafkaPVCLabels, constants.BackupVolumnKey, constants.BackupGlobalHubValue) {
+		return updatedKafka, false, nil
+	}
+
+	delete(kafkaPVCLabels, constants.BackupVolumnKey)
+	kafkaLabelJSON, err := json.Marshal(kafkaPVCLabels)
+	if err != nil {
+		return updatedKafka, false, err
+	}
+	updatedKafka.Spec.Kafka.Template.PersistentVolumeClaim.Metadata.Labels = &apiextensions.JSON{
+		Raw: kafkaLabelJSON,
+	}
+	return updatedKafka, true, err
+}
+
+func DeleteBackupLabelToZookeeperTemplate(existingKafka *kafkav1beta2.Kafka) (*kafkav1beta2.Kafka, bool, error) {
+	var zookeeperPVCLabels map[string]string
+
+	updatedKafka := existingKafka.DeepCopy()
+	if existingKafka.Spec == nil {
+		return updatedKafka, false, nil
+	}
+
+	if existingKafka.Spec.Zookeeper.Template == nil ||
+		existingKafka.Spec.Zookeeper.Template.PersistentVolumeClaim == nil ||
+		existingKafka.Spec.Zookeeper.Template.PersistentVolumeClaim.Metadata == nil ||
+		existingKafka.Spec.Zookeeper.Template.PersistentVolumeClaim.Metadata.Labels == nil {
+		return updatedKafka, false, nil
+	}
+
+	zookeeperPVCLabelsJson := existingKafka.Spec.Zookeeper.Template.PersistentVolumeClaim.Metadata.Labels
+	err := json.Unmarshal(zookeeperPVCLabelsJson.Raw, &zookeeperPVCLabels)
+	if err != nil {
+		return updatedKafka, false, err
+	}
+	if !utils.HasLabel(zookeeperPVCLabels, constants.BackupVolumnKey, constants.BackupGlobalHubValue) {
+		return updatedKafka, false, nil
+	}
+
+	delete(zookeeperPVCLabels, constants.BackupVolumnKey)
+	zookeeperLabelJSON, err := json.Marshal(zookeeperPVCLabels)
+	if err != nil {
+		return updatedKafka, false, err
+	}
+	updatedKafka.Spec.Zookeeper.Template.PersistentVolumeClaim.Metadata.Labels = &apiextensions.JSON{
+		Raw: zookeeperLabelJSON,
+	}
+	return updatedKafka, true, err
+}
+
+// DeleteTemplateBackupLabels delete backup label to kafka pvc template
+func DeleteTemplateBackupLabels(ctx context.Context,
+	client client.Client,
+	namespace, name string) error {
+
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		existingKafka := &kafkav1beta2.Kafka{}
+
+		err := client.Get(ctx, types.NamespacedName{
+			Name:      name,
+			Namespace: namespace,
+		}, existingKafka)
+		if err != nil {
+			return err
+		}
+
+		updatedKafka, updateBackupLabelInKafkaPVC, err := DeleteBackupLabelToKafkaTemplate(existingKafka)
+		if err != nil {
+			return err
+		}
+
+		updatedKafka, updateBackupLabelInZookeeperPVC, err := DeleteBackupLabelToZookeeperTemplate(updatedKafka)
+		if err != nil {
+			return err
+		}
+
+		if !updateBackupLabelInZookeeperPVC && !updateBackupLabelInKafkaPVC {
+			return nil
+		}
+
+		err = client.Update(ctx, updatedKafka)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
 }
 
 func (r *kafkaBackup) AddLabelToAllObjs(ctx context.Context, c client.Client, namespace string) error {
@@ -67,6 +359,8 @@ func (r *kafkaBackup) AddLabelToAllObjs(ctx context.Context, c client.Client, na
 		if err != nil {
 			return err
 		}
+		err = AddBackupLabelToTemplate(ctx, c, namespace, obj.Name)
+		return err
 	}
 	return nil
 }
@@ -88,6 +382,8 @@ func (r *kafkaBackup) DeleteLabelOfAllObjs(ctx context.Context, c client.Client,
 		if err != nil {
 			return err
 		}
+		err = DeleteTemplateBackupLabels(ctx, c, namespace, obj.Name)
+		return err
 	}
 	return nil
 }

--- a/operator/pkg/controllers/backup/kafka_test.go
+++ b/operator/pkg/controllers/backup/kafka_test.go
@@ -1,0 +1,381 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backup
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestAddBackupLabelToKafkaTemplate(t *testing.T) {
+	namespace := "default"
+	tests := []struct {
+		name          string
+		existingKafka *kafkav1beta2.Kafka
+		wantUpdate    bool
+		wantErr       bool
+	}{
+		{
+			name:          "kafka is nil",
+			existingKafka: &kafkav1beta2.Kafka{},
+			wantUpdate:    false,
+			wantErr:       true,
+		},
+		{
+			name:          "kafka spec is nil",
+			existingKafka: &kafkav1beta2.Kafka{},
+			wantUpdate:    false,
+			wantErr:       true,
+		},
+		{
+			name: "kafka do not have backup label",
+			existingKafka: &kafkav1beta2.Kafka{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kafka",
+					Namespace: namespace,
+				},
+				Spec: &kafkav1beta2.KafkaSpec{
+					Kafka: kafkav1beta2.KafkaSpecKafka{
+						Replicas: 1,
+					},
+				},
+			},
+			wantUpdate: true,
+			wantErr:    false,
+		},
+		{
+			name: "kafka do not have backup label with template",
+			existingKafka: &kafkav1beta2.Kafka{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kafka",
+					Namespace: namespace,
+				},
+				Spec: &kafkav1beta2.KafkaSpec{
+					Kafka: kafkav1beta2.KafkaSpecKafka{
+						Replicas: 1,
+						Template: &kafkav1beta2.KafkaSpecKafkaTemplate{},
+					},
+				},
+			},
+			wantUpdate: true,
+			wantErr:    false,
+		},
+		{
+			name: "kafka do not have backup label with template",
+			existingKafka: &kafkav1beta2.Kafka{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kafka",
+					Namespace: namespace,
+				},
+				Spec: &kafkav1beta2.KafkaSpec{
+					Kafka: kafkav1beta2.KafkaSpecKafka{
+						Replicas: 1,
+						Template: &kafkav1beta2.KafkaSpecKafkaTemplate{
+							PersistentVolumeClaim: &kafkav1beta2.KafkaSpecKafkaTemplatePersistentVolumeClaim{},
+						},
+					},
+				},
+			},
+			wantUpdate: true,
+			wantErr:    false,
+		},
+		{
+			name: "kafka do not have backup label with metadata template",
+			existingKafka: &kafkav1beta2.Kafka{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kafka",
+					Namespace: namespace,
+				},
+				Spec: &kafkav1beta2.KafkaSpec{
+					Kafka: kafkav1beta2.KafkaSpecKafka{
+						Replicas: 1,
+						Template: &kafkav1beta2.KafkaSpecKafkaTemplate{
+							PersistentVolumeClaim: &kafkav1beta2.KafkaSpecKafkaTemplatePersistentVolumeClaim{
+								Metadata: &kafkav1beta2.KafkaSpecKafkaTemplatePersistentVolumeClaimMetadata{},
+							},
+						},
+					},
+				},
+			},
+			wantUpdate: true,
+			wantErr:    false,
+		},
+		{
+			name: "kafka have other label in template",
+			existingKafka: &kafkav1beta2.Kafka{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kafka",
+					Namespace: namespace,
+				},
+				Spec: &kafkav1beta2.KafkaSpec{
+					Kafka: kafkav1beta2.KafkaSpecKafka{
+						Replicas: 1,
+						Template: &kafkav1beta2.KafkaSpecKafkaTemplate{
+							PersistentVolumeClaim: &kafkav1beta2.KafkaSpecKafkaTemplatePersistentVolumeClaim{
+								Metadata: &kafkav1beta2.KafkaSpecKafkaTemplatePersistentVolumeClaimMetadata{
+									Labels: &apiextensions.JSON{
+										Raw: []byte(`{
+											"existlabel": "value"
+										}`),
+									},
+								},
+							},
+						},
+					},
+					Zookeeper: kafkav1beta2.KafkaSpecZookeeper{
+						Replicas: 1,
+					},
+				},
+			},
+			wantUpdate: true,
+			wantErr:    false,
+		},
+		{
+			name: "kafka have other label in template",
+			existingKafka: &kafkav1beta2.Kafka{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kafka",
+					Namespace: namespace,
+				},
+				Spec: &kafkav1beta2.KafkaSpec{
+					Kafka: kafkav1beta2.KafkaSpecKafka{
+						Replicas: 1,
+						Template: &kafkav1beta2.KafkaSpecKafkaTemplate{
+							PersistentVolumeClaim: &kafkav1beta2.KafkaSpecKafkaTemplatePersistentVolumeClaim{
+								Metadata: &kafkav1beta2.KafkaSpecKafkaTemplatePersistentVolumeClaimMetadata{
+									Labels: &apiextensions.JSON{
+										Raw: []byte(BackupVolumnLabelRaw),
+									},
+								},
+							},
+						},
+					},
+					Zookeeper: kafkav1beta2.KafkaSpecZookeeper{
+						Replicas: 1,
+					},
+				},
+			},
+			wantUpdate: false,
+			wantErr:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var kafkaPVCLabels map[string]string
+			returnedKafka, updated, err := AddBackupLabelToKafkaTemplate(tt.existingKafka)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Should have error, err: %v", err)
+				}
+				return
+			}
+
+			if !reflect.DeepEqual(updated, tt.wantUpdate) {
+				t.Errorf("AddBackupLabelToKafkaTemplate() got = %v, want %v", updated, tt.wantUpdate)
+			}
+			kafkaPVCLabelsJson := returnedKafka.Spec.Kafka.Template.PersistentVolumeClaim.Metadata.Labels
+
+			err = json.Unmarshal(kafkaPVCLabelsJson.Raw, &kafkaPVCLabels)
+			if err != nil {
+				t.Errorf("Should not have error, err: %v", err)
+			}
+			if !utils.HasLabel(kafkaPVCLabels, constants.BackupVolumnKey, constants.BackupGlobalHubValue) {
+				t.Errorf("Should not have error, err: %v", err)
+			}
+		})
+	}
+}
+
+func TestAddBackupLabelToZookeeperTemplate(t *testing.T) {
+	namespace := "default"
+	tests := []struct {
+		name          string
+		existingKafka *kafkav1beta2.Kafka
+		wantUpdate    bool
+		wantErr       bool
+	}{
+		{
+			name:          "kafka is nil",
+			existingKafka: &kafkav1beta2.Kafka{},
+			wantUpdate:    false,
+			wantErr:       true,
+		},
+		{
+			name:          "kafka spec is nil",
+			existingKafka: &kafkav1beta2.Kafka{},
+			wantUpdate:    false,
+			wantErr:       true,
+		},
+		{
+			name: "kafka do not have backup label",
+			existingKafka: &kafkav1beta2.Kafka{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kafka",
+					Namespace: namespace,
+				},
+				Spec: &kafkav1beta2.KafkaSpec{
+					Zookeeper: kafkav1beta2.KafkaSpecZookeeper{
+						Replicas: 1,
+					},
+				},
+			},
+			wantUpdate: true,
+			wantErr:    false,
+		},
+		{
+			name: "kafka do not have backup label with template",
+			existingKafka: &kafkav1beta2.Kafka{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kafka",
+					Namespace: namespace,
+				},
+				Spec: &kafkav1beta2.KafkaSpec{
+					Zookeeper: kafkav1beta2.KafkaSpecZookeeper{
+						Replicas: 1,
+						Template: &kafkav1beta2.KafkaSpecZookeeperTemplate{},
+					},
+				},
+			},
+			wantUpdate: true,
+			wantErr:    false,
+		},
+		{
+			name: "kafka do not have backup label with template",
+			existingKafka: &kafkav1beta2.Kafka{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kafka",
+					Namespace: namespace,
+				},
+				Spec: &kafkav1beta2.KafkaSpec{
+					Zookeeper: kafkav1beta2.KafkaSpecZookeeper{
+						Replicas: 1,
+						Template: &kafkav1beta2.KafkaSpecZookeeperTemplate{
+							PersistentVolumeClaim: &kafkav1beta2.KafkaSpecZookeeperTemplatePersistentVolumeClaim{},
+						},
+					},
+				},
+			},
+			wantUpdate: true,
+			wantErr:    false,
+		},
+		{
+			name: "kafka do not have backup label with metadata template",
+			existingKafka: &kafkav1beta2.Kafka{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kafka",
+					Namespace: namespace,
+				},
+				Spec: &kafkav1beta2.KafkaSpec{
+					Zookeeper: kafkav1beta2.KafkaSpecZookeeper{
+						Replicas: 1,
+						Template: &kafkav1beta2.KafkaSpecZookeeperTemplate{
+							PersistentVolumeClaim: &kafkav1beta2.KafkaSpecZookeeperTemplatePersistentVolumeClaim{
+								Metadata: &kafkav1beta2.KafkaSpecZookeeperTemplatePersistentVolumeClaimMetadata{},
+							},
+						},
+					},
+				},
+			},
+			wantUpdate: true,
+			wantErr:    false,
+		},
+		{
+			name: "kafka have other label in template",
+			existingKafka: &kafkav1beta2.Kafka{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kafka",
+					Namespace: namespace,
+				},
+				Spec: &kafkav1beta2.KafkaSpec{
+					Zookeeper: kafkav1beta2.KafkaSpecZookeeper{
+						Replicas: 1,
+						Template: &kafkav1beta2.KafkaSpecZookeeperTemplate{
+							PersistentVolumeClaim: &kafkav1beta2.KafkaSpecZookeeperTemplatePersistentVolumeClaim{
+								Metadata: &kafkav1beta2.KafkaSpecZookeeperTemplatePersistentVolumeClaimMetadata{
+									Labels: &apiextensions.JSON{
+										Raw: []byte(`{
+											"existlabel": "value"
+										}`),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantUpdate: true,
+			wantErr:    false,
+		},
+		{
+			name: "kafka have other label in template",
+			existingKafka: &kafkav1beta2.Kafka{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kafka",
+					Namespace: namespace,
+				},
+				Spec: &kafkav1beta2.KafkaSpec{
+					Zookeeper: kafkav1beta2.KafkaSpecZookeeper{
+						Replicas: 1,
+						Template: &kafkav1beta2.KafkaSpecZookeeperTemplate{
+							PersistentVolumeClaim: &kafkav1beta2.KafkaSpecZookeeperTemplatePersistentVolumeClaim{
+								Metadata: &kafkav1beta2.KafkaSpecZookeeperTemplatePersistentVolumeClaimMetadata{
+									Labels: &apiextensions.JSON{
+										Raw: []byte(BackupVolumnLabelRaw),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantUpdate: false,
+			wantErr:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var kafkaPVCLabels map[string]string
+			returnedKafka, updated, err := AddBackupLabelToZookeeperTemplate(tt.existingKafka)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Should have error, err: %v", err)
+				}
+				return
+			}
+
+			if !reflect.DeepEqual(updated, tt.wantUpdate) {
+				t.Errorf("AddBackupLabelToZookeeperTemplate() got = %v, want %v", updated, tt.wantUpdate)
+			}
+			kafkaPVCLabelsJson := returnedKafka.Spec.Zookeeper.Template.PersistentVolumeClaim.Metadata.Labels
+
+			err = json.Unmarshal(kafkaPVCLabelsJson.Raw, &kafkaPVCLabels)
+			if err != nil {
+				t.Errorf("Should not have error, err: %v", err)
+			}
+			if !utils.HasLabel(kafkaPVCLabels, constants.BackupVolumnKey, constants.BackupGlobalHubValue) {
+				t.Errorf("Should not have error, err: %v", err)
+			}
+		})
+	}
+}

--- a/operator/pkg/controllers/backup/suite_test.go
+++ b/operator/pkg/controllers/backup/suite_test.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/klog"
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
@@ -77,7 +76,6 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
-	klog.Errorf("####")
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
@@ -120,7 +118,6 @@ var _ = BeforeSuite(func() {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
-	klog.Errorf("####")
 
 	leaseDuration := 137 * time.Second
 	renewDeadline := 126 * time.Second
@@ -136,7 +133,6 @@ var _ = BeforeSuite(func() {
 		RetryPeriod:             &retryPeriod,
 	})
 	Expect(err).ToNot(HaveOccurred())
-	klog.Errorf("####")
 
 	kubeClient, err = kubernetes.NewForConfig(k8sManager.GetConfig())
 	Expect(err).ToNot(HaveOccurred())
@@ -147,11 +143,9 @@ var _ = BeforeSuite(func() {
 		Log:     ctrl.Log.WithName("backup-reconciler"),
 	}
 	Expect(backupReconciler.SetupWithManager(k8sManager)).ToNot(HaveOccurred())
-	klog.Errorf("####")
 
 	go func() {
 		defer GinkgoRecover()
-		klog.Errorf("####")
 
 		err = k8sManager.Start(ctx)
 		Expect(err).ToNot(HaveOccurred(), "failed to run manager")


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-9293
The kafka always sync the pvc label based on kafka cr pvc template, so we also need to update the template in kafka cr.