### PR TITLE
Remove the deprecated bases for kustomize

### DIFF
--- a/operator/config/default/kustomization.yaml
+++ b/operator/config/default/kustomization.yaml
@@ -12,7 +12,7 @@ namespace: multicluster-global-hub
 #commonLabels:
 #  someName: someValue
 
-bases:
+resources:
 - ../crd
 - ../rbac
 - ../manager

--- a/test/setup/hoh/postgres/postgres-operator/bases/kustomization.yaml
+++ b/test/setup/hoh/postgres/postgres-operator/bases/kustomization.yaml
@@ -3,7 +3,7 @@ namespace: postgres-operator
 commonLabels:
   postgres-operator.crunchydata.com/control-plane: postgres-operator
 
-bases:
+resources:
 - crd
 - rbac/cluster
 - manager

--- a/test/setup/hoh/postgres/postgres-operator/kustomization.yaml
+++ b/test/setup/hoh/postgres/postgres-operator/kustomization.yaml
@@ -1,5 +1,3 @@
 resources:
 - namespace.yaml
-
-bases:
 - bases


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>

When deploying the operator with `make deploy-operator`, It may echo the following warning message:
```bash
.../operator/bin/kustomize build config/default | kubectl apply -f -
# Warning: 'bases' is deprecated. Please use 'resources' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
namespace/multicluster-global-hub unchanged
```