### PR TITLE
Reset scrape interval to 1m

### DIFF
--- a/operator/pkg/config/multiclusterglobalhub_config.go
+++ b/operator/pkg/config/multiclusterglobalhub_config.go
@@ -77,7 +77,7 @@ var (
 		PostgresImageKey:         "quay.io/stolostron/postgresql-13:1-101",
 	}
 	statisticLogInterval  = "1m"
-	metricsScrapeInterval = "12h"
+	metricsScrapeInterval = "1m"
 	imagePullSecretName   = ""
 	transporter           transport.Transporter
 )


### PR DESCRIPTION
reset scrape interval to 1m. set to 12h has some problems due to:
1. If no sample is found (by default) 5 minutes before a sampling timestamp,
no value is returned for that time series at this point in time. This
effectively means that time series "disappear" from graphs at times where their
latest collected sample is older than 5 minutes or after they are marked stale.

2. refer to https://groups.google.com/g/prometheus-users/c/_HxPK5nI3dw

It is safe to set to 1m even if we do not have data until 24h.