### PR TITLE
Trigger `cleanup/resync` when status is updated

### DIFF
--- a/manager/pkg/statussyncer/hubmanagement/hub_management.go
+++ b/manager/pkg/statussyncer/hubmanagement/hub_management.go
@@ -5,14 +5,19 @@ package hubmanagement
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
-	"gorm.io/gorm/clause"
+	"gorm.io/gorm"
+	"k8s.io/apimachinery/pkg/util/wait"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/database"
 	"github.com/stolostron/multicluster-global-hub/pkg/database/models"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 )
 
 const (
@@ -27,6 +32,7 @@ const (
 // manage the leaf hub lifecycle based on the heartbeat
 type hubManagement struct {
 	log           logr.Logger
+	producer      transport.Producer
 	probeDuration time.Duration
 	activeTimeout time.Duration
 }
@@ -62,40 +68,121 @@ func (h *hubManagement) update(ctx context.Context) error {
 	db := database.GetGorm()
 
 	var expiredHubs []models.LeafHubHeartbeat
-	err := db.Model(&expiredHubs).
-		Clauses(clause.Returning{Columns: []clause.Column{{Name: "leaf_hub_name"}}}).
-		Where("last_timestamp < ? AND status = ?", thresholdTime, HubActive).
-		Update("status", HubInactive).Error
-	if err != nil {
+	if err := db.Where("last_timestamp < ? AND status = ?", thresholdTime, HubActive).
+		Find(&expiredHubs).Error; err != nil {
 		return err
 	}
-	if err := h.inactive(ctx, expiredHubs); err != nil {
-		return err
+	if err := h.inactive(ctx, expiredHubs, thresholdTime); err != nil {
+		return fmt.Errorf("failed to inactive hubs %v", err)
 	}
 
 	var reactiveHubs []models.LeafHubHeartbeat
-	err = db.Model(&reactiveHubs).
-		Clauses(clause.Returning{Columns: []clause.Column{{Name: "leaf_hub_name"}}}).
-		Where("last_timestamp > ? AND status = ?", thresholdTime, HubInactive).
-		Update("status", HubActive).Error
+	if err := db.Where("last_timestamp > ? AND status = ?", thresholdTime, HubInactive).
+		Find(&reactiveHubs).Error; err != nil {
+		return err
+	}
+	if err := h.reactive(ctx, reactiveHubs, thresholdTime); err != nil {
+		return fmt.Errorf("failed to reactive hubs %v", err)
+	}
+	return nil
+}
+
+func (h *hubManagement) inactive(ctx context.Context, hubs []models.LeafHubHeartbeat, thresholdTime time.Time) error {
+	for _, hub := range hubs {
+		err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 5*time.Minute, true,
+			func(ctx context.Context) (bool, error) {
+				if e := h.cleanup(hub.Name); e != nil {
+					h.log.Info("cleanup the hub resource failed, retrying...", "name", hub.Name, "err", e.Error())
+					return false, nil
+				}
+				return true, nil
+			})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (h *hubManagement) cleanup(hubName string) error {
+	db := database.GetGorm()
+	return db.Transaction(func(tx *gorm.DB) error {
+		// soft delete the cluster
+		e := tx.Where(&models.ManagedCluster{
+			LeafHubName: hubName,
+		}).Delete(&models.ManagedCluster{}).Error
+		if e != nil {
+			return e
+		}
+
+		// soft delete the hub info
+		e = tx.Where(&models.LeafHub{
+			LeafHubName: hubName,
+		}).Delete(&models.LeafHub{}).Error
+		if e != nil {
+			return e
+		}
+		// soft delete the policy from the hub
+		e = tx.Where(&models.LocalSpecPolicy{
+			LeafHubName: hubName,
+		}).Delete(&models.LocalSpecPolicy{}).Error
+		if e != nil {
+			return e
+		}
+		// delete the compliance
+		e = tx.Where(&models.LocalStatusCompliance{
+			LeafHubName: hubName,
+		}).Delete(&models.LocalStatusCompliance{}).Error
+		if e != nil {
+			return e
+		}
+
+		// inactive the hub status
+		return tx.Model(&models.LeafHubHeartbeat{}).Where("leaf_hub_name = ?", hubName).Update("status", HubInactive).Error
+	})
+}
+
+func (h *hubManagement) reactive(ctx context.Context, hubs []models.LeafHubHeartbeat, thresholdTime time.Time) error {
+	// resync hub resources
+	db := database.GetGorm()
+	for _, hub := range hubs {
+		err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 5*time.Minute, true,
+			func(ctx context.Context) (bool, error) {
+				if e := h.resync(ctx, hub.Name); e != nil {
+					h.log.Info("resync the hub resources failed, retrying...", "name", hub.Name, "err", e.Error())
+					return false, nil
+				}
+				// reactive the batch hub status
+				e := db.Model(&models.LeafHubHeartbeat{}).Where("leaf_hub_name = ?", hub.Name).Update("status", HubActive).Error
+				if e != nil {
+					h.log.Info("fail to reactive the hub, retrying...", "name", hub.Name, "err", e.Error())
+					return false, nil
+				}
+				return true, nil
+			})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (h *hubManagement) resync(ctx context.Context, hubName string) error {
+	resyncResources := []string{
+		constants.ManagedClustersMsgKey,
+		constants.HubClusterInfoMsgKey,
+		constants.LocalPolicySpecMsgKey,
+		constants.LocalComplianceMsgKey,
+	}
+	payloadBytes, err := json.Marshal(resyncResources)
 	if err != nil {
 		return err
 	}
-	if err := h.reactive(ctx, reactiveHubs); err != nil {
-		return err
-	}
 
-	return nil
-}
-
-func (h *hubManagement) inactive(ctx context.Context, hubs []models.LeafHubHeartbeat) error {
-	// TODO: cleanup the database resources
-
-	return nil
-}
-
-func (h *hubManagement) reactive(ctx context.Context, hubs []models.LeafHubHeartbeat) error {
-	// TODO: resync the resources has been cleanup
-
-	return nil
+	return h.producer.Send(ctx, &transport.Message{
+		Key:         constants.ResyncMsgKey,
+		Destination: hubName,
+		MsgType:     constants.SpecBundle,
+		Payload:     payloadBytes,
+	})
 }

--- a/manager/pkg/statussyncer/hubmanagement/hub_management_test.go
+++ b/manager/pkg/statussyncer/hubmanagement/hub_management_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/stolostron/multicluster-global-hub/pkg/database"
 	"github.com/stolostron/multicluster-global-hub/pkg/database/models"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 	"github.com/stolostron/multicluster-global-hub/test/pkg/testpostgres"
 )
 
@@ -87,7 +88,8 @@ func TestHubManagement(t *testing.T) {
 	// update
 	hubManagement := &hubManagement{
 		log:           ctrl.Log.WithName("hub-management"),
-		probeDuration: 2 * time.Second,
+		producer:      &tmpProducer{},
+		probeDuration: 1 * time.Second,
 		activeTimeout: 90 * time.Second,
 	}
 	assert.Nil(t, hubManagement.Start(ctx))
@@ -111,4 +113,10 @@ func TestHubManagement(t *testing.T) {
 	cancel()
 	err = testPostgres.Stop()
 	assert.Nil(t, err)
+}
+
+type tmpProducer struct{}
+
+func (*tmpProducer) Send(ctx context.Context, msg *transport.Message) error {
+	return nil
 }

--- a/pkg/bundle/grc/compliance_bundle.go
+++ b/pkg/bundle/grc/compliance_bundle.go
@@ -186,9 +186,9 @@ func (b *ComplianceBundle) updateObjectIfChanged(objectIndex int, policy *polici
 	// check if any cluster was added or removed
 	if len(oldPolicyStatus.CompliantClusters)+len(oldPolicyStatus.NonCompliantClusters)+
 		len(oldPolicyStatus.UnknownComplianceClusters) != len(allClusters) ||
-		!b.clusterListContains(oldPolicyStatus.CompliantClusters, allClusters) ||
-		!b.clusterListContains(oldPolicyStatus.NonCompliantClusters, allClusters) ||
-		!b.clusterListContains(oldPolicyStatus.UnknownComplianceClusters, allClusters) {
+		!b.containClusters(allClusters, oldPolicyStatus.CompliantClusters) ||
+		!b.containClusters(allClusters, oldPolicyStatus.NonCompliantClusters) ||
+		!b.containClusters(allClusters, oldPolicyStatus.UnknownComplianceClusters) {
 		clusterListChanged = true // at least one cluster was added/removed
 	}
 
@@ -200,7 +200,7 @@ func (b *ComplianceBundle) updateObjectIfChanged(objectIndex int, policy *polici
 	return clusterListChanged
 }
 
-func (b *ComplianceBundle) clusterListContains(subsetClusters []string, allClusters []string) bool {
+func (b *ComplianceBundle) containClusters(allClusters []string, subsetClusters []string) bool {
 	for _, clusterName := range subsetClusters {
 		if !utils.ContainsString(allClusters, clusterName) {
 			return false


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>



When the managed hub status switches to inactive:
- soft delete the managed cluster(`status.managed_clusters`)
- soft delete the spec policy(`local_spec.polcies`)
- soft delete the hub info(`status.leaf_hubs`)
- delete the compliance(`local_status.compliance`)
- mark the status of the hub as inactive(`status.leaf_hub_heartbeats`)

Otherwise, when the status switches to active:
- resync the managed cluster
- resync the spec policy
- resync the hub info
- resync the compliance
- mark the hub status as active