### PR TITLE
Fixed the producer is not set for hub management

### DIFF
--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -259,7 +259,7 @@ func createManager(ctx context.Context, restConfig *rest.Config, managerConfig *
 		return nil, fmt.Errorf("failed to add basic spec syncers: %w", err)
 	}
 
-	if _, err := statussyncer.AddStatusSyncers(mgr, managerConfig); err != nil {
+	if _, err := statussyncer.AddStatusSyncers(mgr, managerConfig, producer); err != nil {
 		return nil, fmt.Errorf("failed to add transport-to-db syncers: %w", err)
 	}
 

--- a/manager/pkg/statussyncer/hubmanagement/hub_management.go
+++ b/manager/pkg/statussyncer/hubmanagement/hub_management.go
@@ -37,10 +37,12 @@ type hubManagement struct {
 	activeTimeout time.Duration
 }
 
-func AddHubManagement(mgr ctrl.Manager) error {
+func AddHubManagement(mgr ctrl.Manager, producer transport.Producer) error {
 	return mgr.Add(&hubManagement{
 		log:           ctrl.Log.WithName("hub-management"),
-		probeDuration: ProbeDuration, activeTimeout: ActiveTimeout,
+		producer:      producer,
+		probeDuration: ProbeDuration,
+		activeTimeout: ActiveTimeout,
 	})
 }
 

--- a/manager/pkg/statussyncer/syncers.go
+++ b/manager/pkg/statussyncer/syncers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/conflator"
 	"github.com/stolostron/multicluster-global-hub/pkg/conflator/workerpool"
 	"github.com/stolostron/multicluster-global-hub/pkg/statistics"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport/consumer"
 )
 
@@ -23,7 +24,9 @@ import (
 // adds controllers and/or runnables to the manager, registers handler functions within the dispatcher
 //
 //	and create bundle functions within the bundle.
-func AddStatusSyncers(mgr ctrl.Manager, managerConfig *config.ManagerConfig) (dbsyncer.BundleRegisterable, error) {
+func AddStatusSyncers(mgr ctrl.Manager, managerConfig *config.ManagerConfig,
+	producer transport.Producer,
+) (dbsyncer.BundleRegisterable, error) {
 	// register statistics within the runtime manager
 	stats, err := addStatisticController(mgr, managerConfig)
 	if err != nil {
@@ -31,7 +34,7 @@ func AddStatusSyncers(mgr ctrl.Manager, managerConfig *config.ManagerConfig) (db
 	}
 
 	// add hub management
-	if err := hubmanagement.AddHubManagement(mgr); err != nil {
+	if err := hubmanagement.AddHubManagement(mgr, producer); err != nil {
 		return nil, fmt.Errorf("failed to add hubmanagement to manager - %w", err)
 	}
 

--- a/manager/pkg/statussyncer/syncers/suite_test.go
+++ b/manager/pkg/statussyncer/syncers/suite_test.go
@@ -114,7 +114,7 @@ var _ = BeforeSuite(func() {
 	Expect(kubeClient).NotTo(BeNil())
 
 	By("Add controllers to manager")
-	transportDispatcher, err = statussyncer.AddStatusSyncers(mgr, managerConfig)
+	transportDispatcher, err = statussyncer.AddStatusSyncers(mgr, managerConfig, nil)
 	Expect(err).ToNot(HaveOccurred())
 
 	By("Start the manager")


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>

The manager will throw a nil pointer error of the transport producer when it is not set in the resync function.