### PR TITLE
Consume message from the start when the transport(kafkacluster) is changed

### DIFF
--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -127,6 +127,8 @@ func parseFlags() *managerconfig.ManagerConfig {
 		40*time.Second, "The committer interval for transport layer.")
 	pflag.StringVar(&managerConfig.TransportConfig.KafkaConfig.BootstrapServer, "kafka-bootstrap-server",
 		"kafka-kafka-bootstrap.kafka.svc:9092", "The bootstrap server for kafka.")
+	pflag.StringVar(&managerConfig.TransportConfig.KafkaConfig.ClusterIdentity, "kafka-cluster-identity",
+		"", "The identity for kafka cluster.")
 	pflag.StringVar(&managerConfig.TransportConfig.KafkaConfig.CaCertPath, "kafka-ca-cert-path", "",
 		"The path of CA certificate for kafka bootstrap server.")
 	pflag.StringVar(&managerConfig.TransportConfig.KafkaConfig.ClientCertPath, "kafka-client-cert-path", "",

--- a/operator/pkg/controllers/hubofhubs/globalhub_manager.go
+++ b/operator/pkg/controllers/hubofhubs/globalhub_manager.go
@@ -114,6 +114,7 @@ func (r *MulticlusterGlobalHubReconciler) reconcileManager(ctx context.Context,
 			DatabaseURL: base64.StdEncoding.EncodeToString(
 				[]byte(r.MiddlewareConfig.StorageConn.SuperuserDatabaseURI)),
 			PostgresCACert:         base64.StdEncoding.EncodeToString(r.MiddlewareConfig.StorageConn.CACert),
+			KafkaClusterIdentity:   transportConn.Identity,
 			KafkaCACert:            transportConn.CACert,
 			KafkaClientCert:        transportConn.ClientCert,
 			KafkaClientKey:         transportConn.ClientKey,
@@ -233,6 +234,7 @@ type ManagerVariables struct {
 	ProxySessionSecret     string
 	DatabaseURL            string
 	PostgresCACert         string
+	KafkaClusterIdentity   string
 	KafkaCACert            string
 	KafkaConsumerTopic     string
 	KafkaProducerTopic     string

--- a/operator/pkg/controllers/hubofhubs/integration_test.go
+++ b/operator/pkg/controllers/hubofhubs/integration_test.go
@@ -348,6 +348,7 @@ var _ = Describe("MulticlusterGlobalHub controller", Ordered, func() {
 					ProxySessionSecret:     "testing",
 					DatabaseURL:            base64.StdEncoding.EncodeToString([]byte(testPostgres.URI)),
 					PostgresCACert:         base64.StdEncoding.EncodeToString([]byte("")),
+					KafkaClusterIdentity:   transportConn.Identity,
 					KafkaCACert:            transportConn.CACert,
 					KafkaClientCert:        transportConn.ClientCert,
 					KafkaClientKey:         transportConn.ClientKey,

--- a/operator/pkg/controllers/hubofhubs/manifests/manager/deployment.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/manager/deployment.yaml
@@ -39,6 +39,7 @@ spec:
             - --watch-namespace=$(WATCH_NAMESPACE)
             - --transport-type={{.TransportType}}
             - --kafka-bootstrap-server={{.KafkaBootstrapServer}}
+            - --kafka-cluster-identity={{.KafkaClusterIdentity}}
             - --kafka-consumer-topic={{.KafkaConsumerTopic}}
             - --kafka-producer-topic={{.KafkaProducerTopic}}
             - --kafka-event-topic={{.KafkaEventTopic}}

--- a/operator/pkg/transporter/byo_transporter.go
+++ b/operator/pkg/transporter/byo_transporter.go
@@ -85,6 +85,7 @@ func (s *BYOTransporter) GetConnCredential(username string) (*transport.ConnCred
 		return nil, err
 	}
 	return &transport.ConnCredential{
+		Identity:        string(kafkaSecret.Data[filepath.Join("bootstrap_server")]),
 		BootstrapServer: string(kafkaSecret.Data[filepath.Join("bootstrap_server")]),
 		CACert:          base64.StdEncoding.EncodeToString(kafkaSecret.Data[filepath.Join("ca.crt")]),
 		ClientCert:      base64.StdEncoding.EncodeToString(kafkaSecret.Data[filepath.Join("client.crt")]),

--- a/operator/pkg/transporter/strimzi_transporter.go
+++ b/operator/pkg/transporter/strimzi_transporter.go
@@ -448,6 +448,7 @@ func (k *strimziTransporter) GetConnCredential(username string) (*transport.Conn
 	for _, condition := range kafkaCluster.Status.Conditions {
 		if *condition.Type == "Ready" && *condition.Status == "True" {
 			credential := &transport.ConnCredential{
+				Identity:        *kafkaCluster.Status.ClusterId,
 				BootstrapServer: *kafkaCluster.Status.Listeners[1].BootstrapServers,
 				CACert:          base64.StdEncoding.EncodeToString([]byte(kafkaCluster.Status.Listeners[1].Certificates[0])),
 			}

--- a/operator/pkg/transporter/strimzi_transporter.go
+++ b/operator/pkg/transporter/strimzi_transporter.go
@@ -447,8 +447,12 @@ func (k *strimziTransporter) GetConnCredential(username string) (*transport.Conn
 
 	for _, condition := range kafkaCluster.Status.Conditions {
 		if *condition.Type == "Ready" && *condition.Status == "True" {
+			clusterIdentity := string(kafkaCluster.GetUID())
+			if kafkaCluster.Status.ClusterId != nil {
+				clusterIdentity = *kafkaCluster.Status.ClusterId
+			}
 			credential := &transport.ConnCredential{
-				Identity:        *kafkaCluster.Status.ClusterId,
+				Identity:        clusterIdentity,
 				BootstrapServer: *kafkaCluster.Status.Listeners[1].BootstrapServers,
 				CACert:          base64.StdEncoding.EncodeToString([]byte(kafkaCluster.Status.Listeners[1].Certificates[0])),
 			}

--- a/pkg/bundle/metadata/bundle_status.go
+++ b/pkg/bundle/metadata/bundle_status.go
@@ -27,5 +27,5 @@ type TransportPosition struct {
 	// define the kafka cluster identiy:
 	// 1. built in kafka, use the kafka cluster id
 	// 2. byo kafka, use the kafka bootstrapserver as the identity
-	OwnerIdentiy string `json:"ownerIdentity"`
+	OwnerIdentity string `json:"ownerIdentity"`
 }

--- a/pkg/bundle/metadata/bundle_status.go
+++ b/pkg/bundle/metadata/bundle_status.go
@@ -24,4 +24,8 @@ type TransportPosition struct {
 	Topic     string `json:"-"`
 	Partition int32  `json:"partition"`
 	Offset    int64  `json:"offset"`
+	// define the kafka cluster identiy:
+	// 1. built in kafka, use the kafka cluster id
+	// 2. byo kafka, use the kafka bootstrapserver as the identity
+	OwnerIdentiy string `json:"ownerIdentity"`
 }

--- a/pkg/bundle/metadata/status/threshold_bundle_status.go
+++ b/pkg/bundle/metadata/status/threshold_bundle_status.go
@@ -43,8 +43,8 @@ func NewThresholdBundleStatus(clusterIdentity string, max int, evt cloudevents.E
 	}
 
 	offset, err := strconv.ParseInt(offsetStr, 10, 64)
-	if !ok {
-		log.Info("failed to parse offset from event", "offset", offsetStr)
+	if err != nil {
+		log.Info("failed to parse offset into int64 from event", "offset", offsetStr, "error", err)
 	}
 
 	return &ThresholdBundleStatus{
@@ -52,10 +52,10 @@ func NewThresholdBundleStatus(clusterIdentity string, max int, evt cloudevents.E
 		count:    0,
 
 		kafkaPosition: &metadata.TransportPosition{
-			ClusterIdentity: clusterIdentity,
-			Topic:           topic,
-			Partition:       partition,
-			Offset:          offset,
+			OwnerIdentiy: clusterIdentity,
+			Topic:        topic,
+			Partition:    partition,
+			Offset:       offset,
 		},
 	}
 }

--- a/pkg/bundle/metadata/status/threshold_bundle_status.go
+++ b/pkg/bundle/metadata/status/threshold_bundle_status.go
@@ -25,7 +25,7 @@ type ThresholdBundleStatus struct {
 }
 
 // the retry times(max) when the bundle has been failed processed
-func NewThresholdBundleStatus(max int, evt cloudevents.Event) *ThresholdBundleStatus {
+func NewThresholdBundleStatus(clusterIdentity string, max int, evt cloudevents.Event) *ThresholdBundleStatus {
 	log := ctrl.Log.WithName("threshold-bundle-status")
 
 	topic, err := types.ToString(evt.Extensions()[kafka_confluent.KafkaTopicKey])
@@ -52,9 +52,10 @@ func NewThresholdBundleStatus(max int, evt cloudevents.Event) *ThresholdBundleSt
 		count:    0,
 
 		kafkaPosition: &metadata.TransportPosition{
-			Topic:     topic,
-			Partition: partition,
-			Offset:    offset,
+			ClusterIdentity: clusterIdentity,
+			Topic:           topic,
+			Partition:       partition,
+			Offset:          offset,
 		},
 	}
 }

--- a/pkg/bundle/metadata/status/threshold_bundle_status.go
+++ b/pkg/bundle/metadata/status/threshold_bundle_status.go
@@ -52,10 +52,10 @@ func NewThresholdBundleStatus(clusterIdentity string, max int, evt cloudevents.E
 		count:    0,
 
 		kafkaPosition: &metadata.TransportPosition{
-			OwnerIdentiy: clusterIdentity,
-			Topic:        topic,
-			Partition:    partition,
-			Offset:       offset,
+			OwnerIdentity: clusterIdentity,
+			Topic:         topic,
+			Partition:     partition,
+			Offset:        offset,
 		},
 	}
 }

--- a/pkg/conflator/conflation_committer.go
+++ b/pkg/conflator/conflation_committer.go
@@ -74,10 +74,10 @@ func (k *ConflationCommitter) commit() error {
 
 		k.log.V(2).Info("commit offset to database", "topic@partition", key, "offset", transPosition.Offset)
 		payload, err := json.Marshal(metadata.TransportPosition{
-			OwnerIdentiy: transPosition.OwnerIdentiy,
-			Topic:        transPosition.Topic,
-			Partition:    transPosition.Partition,
-			Offset:       int64(transPosition.Offset),
+			OwnerIdentity: transPosition.OwnerIdentity,
+			Topic:         transPosition.Topic,
+			Partition:     transPosition.Partition,
+			Offset:        int64(transPosition.Offset),
 		})
 		if err != nil {
 			return err
@@ -144,10 +144,10 @@ func metadataToCommit(metadataArray []metadata.BundleStatus) map[string]*metadat
 	// increment processed offsets so they are not re-read on kafka consumer restart
 	for key := range processedHighestMetadataMap {
 		processedHighestMetadataMap[key] = &metadata.TransportPosition{
-			OwnerIdentiy: processedHighestMetadataMap[key].OwnerIdentiy,
-			Topic:        processedHighestMetadataMap[key].Topic,
-			Partition:    processedHighestMetadataMap[key].Partition,
-			Offset:       processedHighestMetadataMap[key].Offset + 1,
+			OwnerIdentity: processedHighestMetadataMap[key].OwnerIdentity,
+			Topic:         processedHighestMetadataMap[key].Topic,
+			Partition:     processedHighestMetadataMap[key].Partition,
+			Offset:        processedHighestMetadataMap[key].Offset + 1,
 		}
 	}
 

--- a/pkg/conflator/conflation_committer.go
+++ b/pkg/conflator/conflation_committer.go
@@ -74,9 +74,10 @@ func (k *ConflationCommitter) commit() error {
 
 		k.log.V(2).Info("commit offset to database", "topic@partition", key, "offset", transPosition.Offset)
 		payload, err := json.Marshal(metadata.TransportPosition{
-			Topic:     transPosition.Topic,
-			Partition: transPosition.Partition,
-			Offset:    int64(transPosition.Offset),
+			OwnerIdentiy: transPosition.OwnerIdentiy,
+			Topic:        transPosition.Topic,
+			Partition:    transPosition.Partition,
+			Offset:       int64(transPosition.Offset),
 		})
 		if err != nil {
 			return err
@@ -143,9 +144,10 @@ func metadataToCommit(metadataArray []metadata.BundleStatus) map[string]*metadat
 	// increment processed offsets so they are not re-read on kafka consumer restart
 	for key := range processedHighestMetadataMap {
 		processedHighestMetadataMap[key] = &metadata.TransportPosition{
-			Topic:     processedHighestMetadataMap[key].Topic,
-			Partition: processedHighestMetadataMap[key].Partition,
-			Offset:    processedHighestMetadataMap[key].Offset + 1,
+			OwnerIdentiy: processedHighestMetadataMap[key].OwnerIdentiy,
+			Topic:        processedHighestMetadataMap[key].Topic,
+			Partition:    processedHighestMetadataMap[key].Partition,
+			Offset:       processedHighestMetadataMap[key].Offset + 1,
 		}
 	}
 

--- a/pkg/transport/consumer/generic_consumer.go
+++ b/pkg/transport/consumer/generic_consumer.go
@@ -58,6 +58,7 @@ func NewGenericConsumer(tranConfig *transport.TransportConfig, topics []string,
 	log := ctrl.Log.WithName(fmt.Sprintf("%s-consumer", tranConfig.TransportType))
 	var receiver interface{}
 	var err error
+	var clusterIdentity string
 	switch tranConfig.TransportType {
 	case string(transport.Kafka):
 		log.Info("transport consumer with cloudevents-kafka receiver")
@@ -65,6 +66,7 @@ func NewGenericConsumer(tranConfig *transport.TransportConfig, topics []string,
 		if err != nil {
 			return nil, err
 		}
+		clusterIdentity = tranConfig.KafkaConfig.ClusterIdentity
 	case string(transport.Chan):
 		log.Info("transport consumer with go chan receiver")
 		if tranConfig.Extends == nil {
@@ -74,6 +76,7 @@ func NewGenericConsumer(tranConfig *transport.TransportConfig, topics []string,
 			tranConfig.Extends[string(transport.Chan)] = gochan.New()
 		}
 		receiver = tranConfig.Extends[string(transport.Chan)]
+		clusterIdentity = "kafka-cluster-chan"
 	default:
 		return nil, fmt.Errorf("transport-type - %s is not a valid option", tranConfig.TransportType)
 	}
@@ -85,8 +88,8 @@ func NewGenericConsumer(tranConfig *transport.TransportConfig, topics []string,
 
 	c := &GenericConsumer{
 		log:                  log,
-		clusterIdentity:      tranConfig.KafkaConfig.ClusterIdentity,
 		client:               client,
+		clusterIdentity:      clusterIdentity,
 		messageChan:          make(chan *transport.Message),
 		eventChan:            make(chan cloudevents.Event),
 		assembler:            newMessageAssembler(),

--- a/pkg/transport/consumer/generic_consumer.go
+++ b/pkg/transport/consumer/generic_consumer.go
@@ -183,7 +183,7 @@ func getInitOffset(kafkaClusterIdentity string) ([]kafka.TopicPartition, error) 
 			return nil, err
 		}
 		// the offset is not owned by the current transport instance
-		if kafkaPosition.OwnerIdentiy == "" || kafkaPosition.OwnerIdentiy != kafkaClusterIdentity {
+		if kafkaPosition.OwnerIdentity == "" || kafkaPosition.OwnerIdentity != kafkaClusterIdentity {
 			continue
 		}
 		offsetToStart = append(offsetToStart, kafka.TopicPartition{

--- a/pkg/transport/consumer/generic_consumer_test.go
+++ b/pkg/transport/consumer/generic_consumer_test.go
@@ -46,17 +46,18 @@ func TestGetInitOffset(t *testing.T) {
 
 	databaseTransports := []models.Transport{}
 
-	databaseTransports = append(databaseTransports, generateTransport("status.hub1", 12))
-	databaseTransports = append(databaseTransports, generateTransport("status.hub2", 11))
-	databaseTransports = append(databaseTransports, generateTransport("status", 9))
-	databaseTransports = append(databaseTransports, generateTransport("spec", 9))
+	kafkaClusterIdentity := "clusterID"
+	databaseTransports = append(databaseTransports, generateTransport(kafkaClusterIdentity, "status.hub1", 12))
+	databaseTransports = append(databaseTransports, generateTransport(kafkaClusterIdentity, "status.hub2", 11))
+	databaseTransports = append(databaseTransports, generateTransport(kafkaClusterIdentity, "status", 9))
+	databaseTransports = append(databaseTransports, generateTransport(kafkaClusterIdentity, "spec", 9))
 
 	db := database.GetGorm()
 	err = db.Clauses(clause.OnConflict{
 		UpdateAll: true,
 	}).CreateInBatches(databaseTransports, 100).Error
 	assert.Nil(t, err)
-	offsets, err := getInitOffset("")
+	offsets, err := getInitOffset(kafkaClusterIdentity)
 	assert.Nil(t, err)
 
 	count := 0
@@ -69,11 +70,12 @@ func TestGetInitOffset(t *testing.T) {
 	assert.Equal(t, 3, count)
 }
 
-func generateTransport(topic string, offset int64) models.Transport {
+func generateTransport(ownerIdentity string, topic string, offset int64) models.Transport {
 	payload, _ := json.Marshal(metadata.TransportPosition{
-		Topic:     topic,
-		Partition: 0,
-		Offset:    int64(offset),
+		OwnerIdentiy: ownerIdentity,
+		Topic:        topic,
+		Partition:    0,
+		Offset:       int64(offset),
 	})
 	return models.Transport{
 		Name:    topic,

--- a/pkg/transport/consumer/generic_consumer_test.go
+++ b/pkg/transport/consumer/generic_consumer_test.go
@@ -72,10 +72,10 @@ func TestGetInitOffset(t *testing.T) {
 
 func generateTransport(ownerIdentity string, topic string, offset int64) models.Transport {
 	payload, _ := json.Marshal(metadata.TransportPosition{
-		OwnerIdentiy: ownerIdentity,
-		Topic:        topic,
-		Partition:    0,
-		Offset:       int64(offset),
+		OwnerIdentity: ownerIdentity,
+		Topic:         topic,
+		Partition:     0,
+		Offset:        int64(offset),
 	})
 	return models.Transport{
 		Name:    topic,

--- a/pkg/transport/consumer/generic_consumer_test.go
+++ b/pkg/transport/consumer/generic_consumer_test.go
@@ -56,7 +56,7 @@ func TestGetInitOffset(t *testing.T) {
 		UpdateAll: true,
 	}).CreateInBatches(databaseTransports, 100).Error
 	assert.Nil(t, err)
-	offsets, err := getInitOffset()
+	offsets, err := getInitOffset("")
 	assert.Nil(t, err)
 
 	count := 0

--- a/pkg/transport/consumer/generic_consumer_test.go
+++ b/pkg/transport/consumer/generic_consumer_test.go
@@ -2,6 +2,7 @@ package consumer
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -51,6 +52,8 @@ func TestGetInitOffset(t *testing.T) {
 	databaseTransports = append(databaseTransports, generateTransport(kafkaClusterIdentity, "status.hub2", 11))
 	databaseTransports = append(databaseTransports, generateTransport(kafkaClusterIdentity, "status", 9))
 	databaseTransports = append(databaseTransports, generateTransport(kafkaClusterIdentity, "spec", 9))
+	databaseTransports = append(databaseTransports, generateTransport("", "status.hub3", 8))
+	databaseTransports = append(databaseTransports, generateTransport("another", "status.hub4", 7))
 
 	db := database.GetGorm()
 	err = db.Clauses(clause.OnConflict{
@@ -62,6 +65,7 @@ func TestGetInitOffset(t *testing.T) {
 
 	count := 0
 	for _, offset := range offsets {
+		fmt.Println(*offset.Topic, offset.Partition, offset.Offset)
 		if *offset.Topic == "spec" {
 			t.Fatalf("the topic %s shouldn't be selected", "spec")
 		}

--- a/pkg/transport/type.go
+++ b/pkg/transport/type.go
@@ -42,6 +42,7 @@ type TransportConfig struct {
 
 // Kafka Config
 type KafkaConfig struct {
+	ClusterIdentity string
 	BootstrapServer string
 	CaCertPath      string
 	ClientCertPath  string
@@ -95,6 +96,7 @@ type Message struct {
 
 // ConnCredential is used to connect the transporter instance
 type ConnCredential struct {
+	Identity        string
 	BootstrapServer string
 	CACert          string
 	ClientCert      string

--- a/test/pkg/kafka/strimzi_kafka.go
+++ b/test/pkg/kafka/strimzi_kafka.go
@@ -21,9 +21,10 @@ const (
 )
 
 var (
-	readyCondition = "Ready"
-	trueCondition  = "True"
-	bootServer     = "kafka-kafka-bootstrap.multicluster-global-hub.svc:9092"
+	readyCondition  = "Ready"
+	trueCondition   = "True"
+	bootServer      = "kafka-kafka-bootstrap.multicluster-global-hub.svc:9092"
+	statusClusterId = "MXpoZsJTRD2DDiVUh3Rsqg"
 )
 
 func UpdateKafkaClusterReady(client client.Client, ns string) error {
@@ -59,6 +60,7 @@ func UpdateKafkaClusterReady(client client.Client, ns string) error {
 			},
 		},
 		Status: &kafkav1beta2.KafkaStatus{
+			ClusterId: &statusClusterId,
 			Listeners: []kafkav1beta2.KafkaStatusListenersElem{
 				{
 					BootstrapServers: &bootServer,


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>

This PR is derived from the Kafka backup solution. https://issues.redhat.com/browse/ACM-9703

With the offset cached in the database, we can make sure the unprocessed message won't be lost even if the manager crashes.

But if the original transport is deleted and a new Kafka cluster is created. Then we should also deprecate the cached offset. and the consumer should start receiving messages from the start of the transport.