### PR TITLE
Fixed the event persist error

### DIFF
--- a/agent/pkg/status/controller/event/local_replicated_policy_emitter.go
+++ b/agent/pkg/status/controller/event/local_replicated_policy_emitter.go
@@ -139,13 +139,6 @@ func (h *localReplicatedPolicyEmitter) Update(obj client.Object) {
 		ClusterID:  clusterID,
 		Compliance: policyCompliance(rootPolicy, evt),
 	}
-
-	if replicatedPolicyEvent.PolicyID == "" {
-		h.log.Error(err, "the policyID of the replicated policy event is not retrieved", "event",
-			evt.Namespace+"/"+evt.Name)
-		return
-	}
-
 	// cache to events and update version
 	h.events = append(h.events, replicatedPolicyEvent)
 	h.cache.Add(evtKey, nil)

--- a/agent/pkg/status/controller/event/local_replicated_policy_emitter.go
+++ b/agent/pkg/status/controller/event/local_replicated_policy_emitter.go
@@ -108,7 +108,9 @@ func (h *localReplicatedPolicyEmitter) Update(obj client.Object) {
 	// get policy
 	policy, err := getInvolvePolicy(h.ctx, h.runtimeClient, evt)
 	if err != nil {
-		h.log.Error(err, "failed to get involved policy", "event", evt.Namespace+"/"+evt.Name)
+		h.log.Error(err, "failed to get involved policy", "event", evt.Namespace+"/"+evt.Name,
+			"policy", evt.InvolvedObject.Namespace+"/"+evt.InvolvedObject.Name)
+		return
 	}
 
 	// global resource || root policy
@@ -137,6 +139,13 @@ func (h *localReplicatedPolicyEmitter) Update(obj client.Object) {
 		ClusterID:  clusterID,
 		Compliance: policyCompliance(rootPolicy, evt),
 	}
+
+	if replicatedPolicyEvent.PolicyID == "" {
+		h.log.Error(err, "the policyID of the replicated policy event is not retrieved", "event",
+			evt.Namespace+"/"+evt.Name)
+		return
+	}
+
 	// cache to events and update version
 	h.events = append(h.events, replicatedPolicyEvent)
 	h.cache.Add(evtKey, nil)

--- a/agent/pkg/status/controller/event/local_root_policy_emitter.go
+++ b/agent/pkg/status/controller/event/local_root_policy_emitter.go
@@ -66,7 +66,9 @@ func (h *localRootPolicyEmitter) Update(obj client.Object) {
 	// get policy
 	policy, err := getInvolvePolicy(h.ctx, h.runtimeClient, evt)
 	if err != nil {
-		h.log.Error(err, "failed to get involved policy", "event", evt.Namespace+"/"+evt.Name)
+		h.log.Error(err, "failed to get involved policy", "event", evt.Namespace+"/"+evt.Name,
+			"policy", evt.InvolvedObject.Namespace+"/"+evt.InvolvedObject.Name)
+		return
 	}
 
 	// global resource || replicated policy
@@ -89,6 +91,7 @@ func (h *localRootPolicyEmitter) Update(obj client.Object) {
 		PolicyID:   string(policy.GetUID()),
 		Compliance: policyCompliance(policy, evt),
 	}
+
 	// cache to events and update version
 	h.events = append(h.events, rootPolicyEvent)
 	h.cache.Add(evtKey, nil)

--- a/agent/pkg/status/controller/event/local_root_policy_emitter.go
+++ b/agent/pkg/status/controller/event/local_root_policy_emitter.go
@@ -91,7 +91,6 @@ func (h *localRootPolicyEmitter) Update(obj client.Object) {
 		PolicyID:   string(policy.GetUID()),
 		Compliance: policyCompliance(policy, evt),
 	}
-
 	// cache to events and update version
 	h.events = append(h.events, rootPolicyEvent)
 	h.cache.Add(evtKey, nil)

--- a/manager/pkg/statussyncer/handler/local_policies/root_policy_event_handler.go
+++ b/manager/pkg/statussyncer/handler/local_policies/root_policy_event_handler.go
@@ -63,6 +63,9 @@ func (h *localRootPolicyEventHandler) ToDatabase(evt cloudevents.Event) error {
 
 	upsertEvents := []models.LocalRootPolicyEvent{}
 	for _, element := range rootPolicyEvents {
+		if element.PolicyID == "" {
+			continue
+		}
 		upsertEvents = append(upsertEvents, models.LocalRootPolicyEvent{
 			BaseLocalPolicyEvent: models.BaseLocalPolicyEvent{
 				LeafHubName: evt.Source(),


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>

Reference: https://issues.redhat.com/browse/ACM-10145

Error message:

```bash
2024/02/26 04:07:35 /remote-source/multicluster-global-hub/app/manager/pkg/statussyncer/handler/local_policies/root_policy_event_handler.go:84 pq: invalid input syntax for type uuid: ""
[7.320ms] [rows:0] INSERT INTO "event"."local_root_policies" ("event_name","policy_id","message","leaf_hub_name","reason","count","source","compliance","created_at") VALUES ('acmqe-policy-38732.17b74d718fde269b','aed9bbb1-f47a-4a1b-ba78-62d3db3ccb93','Policy acmqe-policy-38732/acmqe-policy-38732 was propagated to cluster clc-iks-609-9bxmp-iks','acmqe-hoh-auto-hskp4x','PolicyPropagation',1,NULL,'non_compliant','2024-02-26 03:55:33'),('acmqe-policy-43020.17b74de84e9ad09c','b8e3a1ca-79f8-47f6-89f8-38a7766a2019','Policy acmqe-policy-43020/acmqe-policy-43020 was propagated to cluster clc-iks-609-9bxmp-iks','acmqe-hoh-auto-hskp4x','PolicyPropagation',1,NULL,'non_compliant','2024-02-26 04:04:03'),('acmqe-policy-rs7pmm.17b74d3a02d6db7f','','Policy acmqe-policy-rs7pmm/acmqe-policy-rs7pmm was propagated to cluster clc-iks-609-9bxmp-iks','acmqe-hoh-auto-hskp4x','PolicyPropagation',1,NULL,'unknown','2024-02-26 03:51:35'),('acmqe-policy-k6qqdh.acmqe-policy-k6qqdh.17b74d5ae21dcc75','','Policy acmqe-policy-k6qqdh.acmqe-policy-k6qqdh status was updated to NonCompliant in cluster namespace clc-iks-609-9bxmp-iks','acmqe-hoh-auto-hskp4x','PolicyStatusSync',2,NULL,'non_compliant','2024-02-26 03:53:56'),('acmqe-policy-rs7pmm.acmqe-policy-rs7pmm.17b74d3a09f0dd74','','Policy acmqe-policy-rs7pmm.acmqe-policy-rs7pmm status was updated to  in cluster namespace clc-iks-609-9bxmp-iks','acmqe-hoh-auto-hskp4x','PolicyStatusSync',1,NULL,'unknown','2024-02-26 03:51:35'),('local-compliance-job-policy.local-compliance-job-policy.17b74cf83e2e0b3b','','Policy local-compliance-job-policy.local-compliance-job-policy status was updated to NonCompliant in cluster namespace clc-iks-609-9bxmp-iks','acmqe-hoh-auto-hskp4x','PolicyStatusSync',1,NULL,'non_compliant','2024-02-26 03:46:52'),('acmqe-policy-k6qqdh.acmqe-policy-k6qqdh.17b74d5968e4902a','','Policy acmqe-policy-k6qqdh.acmqe-policy-k6qqdh status was updated to NonCompliant in cluster namespace clc-iks-609-9bxmp-iks','acmqe-hoh-auto-hskp4x','PolicyStatusSync',1,NULL,'non_compliant','2024-02-26 03:53:50'),('local-compliance-job-policy.local-compliance-job-policy.17b74cf61e0c9d32','','Policy local-compliance-job-policy.local-compliance-job-policy status was updated to  in cluster namespace clc-iks-609-9bxmp-iks','acmqe-hoh-auto-hskp4x','PolicyStatusSync',1,NULL,'unknown','2024-02-26 03:46:43'),('local-compliance-job-policy.17b74cf6173dad4c','','Policy local-compliance-job-policy/local-compliance-job-policy was propagated to cluster clc-iks-609-9bxmp-iks','acmqe-hoh-auto-hskp4x','PolicyPropagation',1,NULL,'unknown','2024-02-26 03:46:43'),('acmqe-policy-k6qqdh.acmqe-policy-k6qqdh.17b74d5872d8a369','','Policy acmqe-policy-k6qqdh.acmqe-policy-k6qqdh status was updated to  in cluster namespace clc-iks-609-9bxmp-iks','acmqe-hoh-auto-hskp4x','PolicyStatusSync',1,NULL,'unknown','2024-02-26 03:53:45'),('acmqe-policy-k6qqdh.acmqe-policy-k6qqdh.17b74d5da9ac2be7','','Policy acmqe-policy-k6qqdh.acmqe-policy-k6qqdh status was updated to Compliant in cluster namespace clc-iks-609-9bxmp-iks','acmqe-hoh-auto-hskp4x','PolicyStatusSync',1,NULL,'compliant','2024-02-26 03:54:08'),('acmqe-policy-rs7pmm.acmqe-policy-rs7pmm.17b74d3bddc3be28','','Policy acmqe-policy-rs7pmm.acmqe-policy-rs7pmm status was updated to NonCompliant in cluster namespace clc-iks-609-9bxmp-iks','acmqe-hoh-auto-hskp4x','PolicyStatusSync',1,NULL,'non_compliant','2024-02-26 03:51:43'),('test-enforce-pod-1708918683.17b74c7e85a375d7','4c8b9519-b1ed-463d-a564-bf5c9794136d','Policy default/test-enforce-pod-1708918683 was propagated to cluster clc-iks-609-9bxmp-iks','acmqe-hoh-auto-hskp4x','PolicyPropagation',1,NULL,'compliant','2024-02-26 03:38:09'),('test-role-policy-1708918683.17b74c7ec9ce0165','baeb8064-3ba8-4767-a290-08fb1d3dd482','Policy kube-system/test-role-policy-1708918683 was propagated to cluster clc-iks-609-9bxmp-iks','acmqe-hoh-auto-hskp4x','PolicyPropagation',1,NULL,'non_compliant','2024-02-26 03:38:11') ON CONFLICT ("event_name","count","created_at") DO UPDATE SET "event_name"="excluded"."event_name","policy_id"="excluded"."policy_id","message"="excluded"."message","leaf_hub_name"="excluded"."leaf_hub_name","reason"="excluded"."reason","count"="excluded"."count","source"="excluded"."source","compliance"="excluded"."compliance" RETURNING "created_at"
```