### PR TITLE
Fix the bug that local compliance history data conflicts

### DIFF
--- a/manager/pkg/cronjob/task/local_compliance_history.go
+++ b/manager/pkg/cronjob/task/local_compliance_history.go
@@ -164,7 +164,7 @@ func insertToLocalComplianceHistoryByLocalStatus(ctx context.Context, tableName 
 					ORDER BY policy_id, cluster_id 
 					LIMIT %d OFFSET %d
 				)
-			ON CONFLICT (policy_id, cluster_id, compliance_date) DO NOTHING
+			ON CONFLICT (leaf_hub_name, policy_id, cluster_id, compliance_date) DO NOTHING
 		`
 			if enableSimulation {
 				selectInsertSQLTemplate = `
@@ -183,7 +183,7 @@ func insertToLocalComplianceHistoryByLocalStatus(ctx context.Context, tableName 
 							ORDER BY policy_id, cluster_id 
 							LIMIT %d OFFSET %d
 						)
-					ON CONFLICT (policy_id, cluster_id, compliance_date) DO NOTHING;
+					ON CONFLICT (leaf_hub_name, policy_id, cluster_id, compliance_date) DO NOTHING;
 				end;
 				$$;
 			`

--- a/manager/pkg/cronjob/task/local_compliance_history.go
+++ b/manager/pkg/cronjob/task/local_compliance_history.go
@@ -270,7 +270,7 @@ func insertToLocalComplianceHistoryByPolicyEvent(ctx context.Context, totalCount
 			FROM compliance_aggregate ca
 			ORDER BY cluster_id, policy_id
 			LIMIT $1 OFFSET $2
-			ON CONFLICT (policy_id, cluster_id, compliance_date)
+			ON CONFLICT (leaf_hub_name, policy_id, cluster_id, compliance_date)
 			DO UPDATE SET
 				compliance = EXCLUDED.compliance,
 				compliance_changed_frequency = EXCLUDED.compliance_changed_frequency;

--- a/operator/pkg/controllers/hubofhubs/database/2.tables.sql
+++ b/operator/pkg/controllers/hubofhubs/database/2.tables.sql
@@ -104,7 +104,7 @@ CREATE TABLE IF NOT EXISTS history.local_compliance (
     compliance_date DATE DEFAULT (CURRENT_DATE - INTERVAL '1 day') NOT NULL, 
     compliance local_status.compliance_type NOT NULL,
     compliance_changed_frequency integer NOT NULL DEFAULT 0,
-    CONSTRAINT local_policies_unique_constraint UNIQUE (policy_id, cluster_id, compliance_date)
+    CONSTRAINT local_policies_unique_constraint UNIQUE (leaf_hub_name, policy_id, cluster_id, compliance_date)
 ) PARTITION BY RANGE (compliance_date);
 
 CREATE TABLE IF NOT EXISTS history.local_compliance_job_log (

--- a/operator/pkg/controllers/hubofhubs/database/3.functions.sql
+++ b/operator/pkg/controllers/hubofhubs/database/3.functions.sql
@@ -34,7 +34,7 @@ BEGIN
             FROM history.local_compliance_view_%1$s
             ORDER BY policy_id, cluster_id
         )
-        ON CONFLICT (policy_id, cluster_id, compliance_date) DO NOTHING',
+        ON CONFLICT (leaf_hub_name, policy_id, cluster_id, compliance_date) DO NOTHING',
         view_date, view_date);
 END;
 $$ LANGUAGE plpgsql;
@@ -61,7 +61,7 @@ BEGIN
             history.local_compliance
         WHERE
             compliance_date = %2$L
-        ON CONFLICT (policy_id, cluster_id, compliance_date) DO NOTHING
+        ON CONFLICT (leaf_hub_name, policy_id, cluster_id, compliance_date) DO NOTHING
     ', curr_date, prev_date);
 END;
 $$;
@@ -94,7 +94,7 @@ BEGIN
             ) AS subquery WHERE compliance <> prev_compliance) AS compliance_changed_frequency
         FROM compliance_aggregate ca
         ORDER BY cluster_id, policy_id
-        ON CONFLICT (policy_id, cluster_id, compliance_date)
+        ON CONFLICT (leaf_hub_name, policy_id, cluster_id, compliance_date)
         DO UPDATE SET
             compliance = EXCLUDED.compliance,
             compliance_changed_frequency = EXCLUDED.compliance_changed_frequency',

--- a/operator/pkg/controllers/hubofhubs/globalhub_database.go
+++ b/operator/pkg/controllers/hubofhubs/globalhub_database.go
@@ -9,11 +9,8 @@ import (
 	"math/big"
 	"net/url"
 	"strings"
-	"sync"
-	"time"
 
 	"github.com/jackc/pgx/v4"
-	"k8s.io/apimachinery/pkg/util/wait"
 
 	globalhubv1alpha4 "github.com/stolostron/multicluster-global-hub/operator/apis/v1alpha4"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/condition"
@@ -33,7 +30,6 @@ var databaseOldFS embed.FS
 //go:embed upgrade
 var upgradeFS embed.FS
 
-var upgradeOnce sync.Once
 var upgraded = false
 
 func (r *MulticlusterGlobalHubReconciler) ReconcileDatabase(ctx context.Context,
@@ -107,21 +103,13 @@ func (r *MulticlusterGlobalHubReconciler) ReconcileDatabase(ctx context.Context,
 		}
 	}
 
-	upgradeOnce.Do(func() {
+	if !upgraded {
+		err := applySQL(ctx, conn, upgradeFS, "upgrade", readonlyUsername)
+		if err != nil {
+			log.Error(err, "failed to exec the upgrade sql files")
+			return err
+		}
 		upgraded = true
-		err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 10*time.Minute, true,
-			func(ctx context.Context) (done bool, err error) {
-				e := applySQL(ctx, conn, upgradeFS, "upgrade", readonlyUsername)
-				if e != nil {
-					r.Log.Info("failed to upgrade database, trying again...", "err", e)
-					return false, nil
-				}
-				return true, nil
-			})
-	})
-	if err != nil {
-		log.Error(err, "failed to upgrade db schema")
-		return err
 	}
 
 	log.V(7).Info("database initialized")

--- a/operator/pkg/controllers/hubofhubs/integration_test.go
+++ b/operator/pkg/controllers/hubofhubs/integration_test.go
@@ -931,9 +931,6 @@ var _ = Describe("MulticlusterGlobalHub controller", Ordered, func() {
 
 		It("Should get the postgres/kafka connection", func() {
 			Eventually(func() error {
-				if mghReconciler.MiddlewareConfig == nil {
-					mghReconciler.MiddlewareConfig = &hubofhubs.MiddlewareConfig{}
-				}
 				mghReconciler.MiddlewareConfig.StorageConn = nil
 				mghReconciler.MiddlewareConfig.TransportConn = nil
 				mghReconciler.ReconcileMiddleware(ctx, mcgh)

--- a/operator/pkg/controllers/hubofhubs/integration_test.go
+++ b/operator/pkg/controllers/hubofhubs/integration_test.go
@@ -931,12 +931,17 @@ var _ = Describe("MulticlusterGlobalHub controller", Ordered, func() {
 
 		It("Should get the postgres/kafka connection", func() {
 			Eventually(func() error {
+				if mghReconciler.MiddlewareConfig == nil {
+					mghReconciler.MiddlewareConfig = &hubofhubs.MiddlewareConfig{}
+				}
 				mghReconciler.MiddlewareConfig.StorageConn = nil
 				mghReconciler.MiddlewareConfig.TransportConn = nil
 				mghReconciler.ReconcileMiddleware(ctx, mcgh)
 
 				err := kafka.UpdateKafkaClusterReady(k8sClient, mcgh.Namespace)
-				Expect(err).NotTo(HaveOccurred())
+				if err != nil {
+					return err
+				}
 
 				// postgres should be ready in envtest
 				// kafka should be ready in envtest

--- a/operator/pkg/controllers/hubofhubs/upgrade/1.upgrade.sql
+++ b/operator/pkg/controllers/hubofhubs/upgrade/1.upgrade.sql
@@ -6,3 +6,6 @@ ALTER TABLE status.leaf_hubs ADD CONSTRAINT leaf_hubs_pkey PRIMARY KEY (cluster_
 
 ALTER TABLE status.leaf_hub_heartbeats ADD COLUMN IF NOT EXISTS status VARCHAR(10) DEFAULT 'active';
 CREATE INDEX IF NOT EXISTS leaf_hub_heartbeats_leaf_hub_status_idx ON status.leaf_hub_heartbeats(status);
+
+ALTER TABLE history.local_compliance DROP CONSTRAINT IF EXISTS local_policies_unique_constraint;
+ALTER TABLE history.local_compliance ADD CONSTRAINT local_policies_unique_constraint UNIQUE (leaf_hub_name, policy_id, cluster_id, compliance_date);


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>

Error message:
```bash
2024/03/05 00:29:55 /remote-source/multicluster-global-hub/app/manager/pkg/cronjob/task/local_compliance_history.go:282 pq: ON CONFLICT DO UPDATE command cannot affect row a second time
[3.439ms] [rows:0]
			INSERT INTO history.local_compliance (policy_id, cluster_id, leaf_hub_name, compliance_date, compliance,
					compliance_changed_frequency)
			WITH compliance_aggregate AS (
					SELECT cluster_id, policy_id, leaf_hub_name,
							CASE
									WHEN bool_or(compliance = 'non_compliant') THEN 'non_compliant'
									WHEN bool_or(compliance = 'unknown') THEN 'unknown'
									ELSE 'compliant'
							END::local_status.compliance_type AS aggregated_compliance
					FROM event.local_policies
					WHERE created_at BETWEEN CURRENT_DATE - INTERVAL '1 days' AND CURRENT_DATE - INTERVAL '0 day'
					GROUP BY cluster_id, policy_id, leaf_hub_name
			)
			SELECT policy_id, cluster_id, leaf_hub_name, (CURRENT_DATE - INTERVAL '1 day'), aggregated_compliance,
					(SELECT COUNT(1) FROM (
							SELECT created_at, compliance,
									LAG(compliance) OVER (PARTITION BY cluster_id, policy_id ORDER BY created_at ASC)
									AS prev_compliance
							FROM event.local_policies lp
							WHERE (lp.created_at BETWEEN CURRENT_DATE - INTERVAL '1 days' AND CURRENT_DATE - INTERVAL '0 day')
									AND lp.cluster_id = ca.cluster_id AND lp.policy_id = ca.policy_id
							ORDER BY created_at ASC
					) AS subquery WHERE compliance <> prev_compliance) AS compliance_changed_frequency
			FROM compliance_aggregate ca
			ORDER BY cluster_id, policy_id
			LIMIT 1000 OFFSET 0
			ON CONFLICT (policy_id, cluster_id, compliance_date)
			DO UPDATE SET
				compliance = EXCLUDED.compliance,
				compliance_changed_frequency = EXCLUDED.compliance_changed_frequency;

2024-03-05T00:29:55.051Z	INFO	local-compliance-history	insert failed, retrying	{"history": "2024-03-04", "error": "pq: ON CONFLICT DO UPDATE command cannot affect row a second time"}
```

Generate the data that needs to be inserted into `history.local_compliance`:
```bash
hoh=# WITH compliance_aggregate AS (
    SELECT
        cluster_id,
        policy_id,
        leaf_hub_name,
        CASE
            WHEN bool_or(compliance = 'non_compliant') THEN 'non_compliant'
            WHEN bool_or(compliance = 'unknown') THEN 'unknown'
            ELSE 'compliant'
        END::local_status.compliance_type AS aggregated_compliance
    FROM
        event.local_policies
    WHERE
        created_at BETWEEN CURRENT_DATE - INTERVAL '1 day' AND CURRENT_DATE - INTERVAL '0 day'
    GROUP BY
        cluster_id, policy_id, leaf_hub_name
)
SELECT
    policy_id,
    cluster_id,
    leaf_hub_name,
    (CURRENT_DATE - INTERVAL '2 day') AS compliance_date,
    aggregated_compliance,
    (
        SELECT COUNT(1) FROM (
            SELECT
                created_at,
                compliance,
                LAG(compliance) OVER (PARTITION BY cluster_id, policy_id ORDER BY created_at ASC) AS prev_compliance
            FROM
                event.local_policies lp
            WHERE
                (lp.created_at BETWEEN CURRENT_DATE - INTERVAL '1 day' AND CURRENT_DATE - INTERVAL '0 day')
                AND lp.cluster_id = ca.cluster_id AND lp.policy_id = ca.policy_id
            ORDER BY
                created_at ASC
        ) AS subquery
        WHERE compliance <> prev_compliance
    ) AS compliance_changed_frequency
FROM
    compliance_aggregate ca
ORDER BY
    cluster_id, policy_id;
              policy_id               |              cluster_id              |     leaf_hub_name     |   compliance_date   | aggregated_compliance | compliance_changed_frequency
--------------------------------------+--------------------------------------+-----------------------+---------------------+-----------------------+------------------------------
 0eab5e0a-1e2c-4bda-8ac2-4376320a869b | e81c17b6-ca32-45dd-8b16-52f93f67747e | acmqe-hoh-auto-pzphpk | 2024-03-03 00:00:00 | non_compliant         |                            0
 13768a7e-5e64-40ed-94cf-704cba9852dd | e81c17b6-ca32-45dd-8b16-52f93f67747e | acmqe-hoh-auto-j9rb75 | 2024-03-03 00:00:00 | non_compliant         |                            1
 13d7e3fe-aa6f-4bb0-898b-3cfdbd011682 | e81c17b6-ca32-45dd-8b16-52f93f67747e | acmqe-hoh-auto-pzphpk | 2024-03-03 00:00:00 | non_compliant         |                            2
 3688ad7d-8604-4eb2-aee5-c8035b9dd2a6 | e81c17b6-ca32-45dd-8b16-52f93f67747e | acmqe-hoh-auto-fbvdd6 | 2024-03-03 00:00:00 | non_compliant         |                            0
 4614e98e-5e98-4b63-a6c3-427608e8743d | e81c17b6-ca32-45dd-8b16-52f93f67747e | acmqe-hoh-auto-fbvdd6 | 2024-03-03 00:00:00 | non_compliant         |                            2
 52ef4d5f-5ba8-4351-9b1b-7065b9f90e12 | e81c17b6-ca32-45dd-8b16-52f93f67747e | acmqe-hoh-auto-j9rb75 | 2024-03-03 00:00:00 | non_compliant         |                            0
 54683d5b-7639-4308-a102-0446abc4b3b0 | e81c17b6-ca32-45dd-8b16-52f93f67747e | acmqe-hoh-auto-fbvdd6 | 2024-03-03 00:00:00 | non_compliant         |                            0
 7d8b6055-2c53-4158-8a2f-f08bbfb8861d | e81c17b6-ca32-45dd-8b16-52f93f67747e | acmqe-hoh-auto-fbvdd6 | 2024-03-03 00:00:00 | non_compliant         |                            0
 7d8b6055-2c53-4158-8a2f-f08bbfb8861d | e81c17b6-ca32-45dd-8b16-52f93f67747e | acmqe-hoh-auto-pzphpk | 2024-03-03 00:00:00 | non_compliant         |                            0
 8c912fb9-cc86-4229-8fef-1fff344d6ab1 | e81c17b6-ca32-45dd-8b16-52f93f67747e | acmqe-hoh-auto-j9rb75 | 2024-03-03 00:00:00 | non_compliant         |                            0
 8d518a4f-d3a7-4443-9e41-beb530d8f945 | e81c17b6-ca32-45dd-8b16-52f93f67747e | acmqe-hoh-auto-pzphpk | 2024-03-03 00:00:00 | non_compliant         |                            0
 96f83ed3-674c-4e6a-b7ab-ad57b71e537e | e81c17b6-ca32-45dd-8b16-52f93f67747e | acmqe-hoh-auto-fbvdd6 | 2024-03-03 00:00:00 | non_compliant         |                            0
 9e5dfdf5-bb34-49b9-a8a3-0356b9c9ac7a | e81c17b6-ca32-45dd-8b16-52f93f67747e | acmqe-hoh-auto-fbvdd6 | 2024-03-03 00:00:00 | non_compliant         |                            0
 a6b76950-77b9-4f83-8e34-eb0f0b49480d | e81c17b6-ca32-45dd-8b16-52f93f67747e | acmqe-hoh-auto-fbvdd6 | 2024-03-03 00:00:00 | non_compliant         |                            2
 b1dedcff-8007-4d2a-a832-51306b2cb7f5 | e81c17b6-ca32-45dd-8b16-52f93f67747e | acmqe-hoh-auto-fbvdd6 | 2024-03-03 00:00:00 | non_compliant         |                            0
 b41c83b6-06dd-4a10-b798-d9921a6e3cd0 | e81c17b6-ca32-45dd-8b16-52f93f67747e | acmqe-hoh-auto-fbvdd6 | 2024-03-03 00:00:00 | non_compliant         |                            0
 cb2cc696-a563-4d36-8d3d-d0303638d894 | e81c17b6-ca32-45dd-8b16-52f93f67747e | acmqe-hoh-auto-fbvdd6 | 2024-03-03 00:00:00 | non_compliant         |                            0
 d5d165b7-042e-4894-857f-1593e6d80dff | e81c17b6-ca32-45dd-8b16-52f93f67747e | acmqe-hoh-auto-fbvdd6 | 2024-03-03 00:00:00 | non_compliant         |                           10
 d5d165b7-042e-4894-857f-1593e6d80dff | e81c17b6-ca32-45dd-8b16-52f93f67747e | acmqe-hoh-auto-pzphpk | 2024-03-03 00:00:00 | non_compliant         |                           10
 f557383b-924a-4184-872d-3f92f06ab88f | e81c17b6-ca32-45dd-8b16-52f93f67747e | acmqe-hoh-auto-fbvdd6 | 2024-03-03 00:00:00 | non_compliant         |                            2
(20 rows)
```
We can see that the unique key for the table should be `leaf_hub_name, policy_id, cluster_id, compliance_date`. This means that we can record the history policy even if then managed hub cluster is detached and then rejoin to the global hub with another name.