### PR TITLE
Fixed the history compliance conflicts with exist condition

### DIFF
--- a/manager/pkg/cronjob/task/local_compliance_history.go
+++ b/manager/pkg/cronjob/task/local_compliance_history.go
@@ -233,7 +233,7 @@ func syncToLocalComplianceHistoryByPolicyEvent(ctx context.Context, batchSize in
 func insertToLocalComplianceHistoryByPolicyEvent(ctx context.Context, totalCount, batchSize, offset int64,
 ) (int64, error) {
 	insertCount := int64(0)
-	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 30*time.Minute, true,
+	err := wait.PollUntilContextTimeout(ctx, 1*time.Minute, 30*time.Minute, true,
 		func(ctx context.Context) (done bool, err error) {
 			var insertError error
 			defer func() {

--- a/manager/pkg/cronjob/task/local_compliance_history.go
+++ b/manager/pkg/cronjob/task/local_compliance_history.go
@@ -253,8 +253,15 @@ func insertToLocalComplianceHistoryByPolicyEvent(ctx context.Context, totalCount
 									WHEN bool_or(compliance = 'unknown') THEN 'unknown'
 									ELSE 'compliant'
 							END::local_status.compliance_type AS aggregated_compliance
-					FROM event.local_policies
-					WHERE created_at BETWEEN CURRENT_DATE - INTERVAL '%d days' AND CURRENT_DATE - INTERVAL '%d day'
+					FROM 
+						event.local_policies lp
+					WHERE 
+						created_at BETWEEN CURRENT_DATE - INTERVAL '%d days' AND CURRENT_DATE - INTERVAL '%d day'
+						AND EXISTS (
+							SELECT 1
+							FROM status.leaf_hubs lh
+							WHERE lh.leaf_hub_name = lp.leaf_hub_name
+						)
 					GROUP BY cluster_id, policy_id, leaf_hub_name
 			)
 			SELECT policy_id, cluster_id, leaf_hub_name, (CURRENT_DATE - INTERVAL '%d day'), aggregated_compliance,

--- a/manager/pkg/cronjob/task/local_compliance_history.go
+++ b/manager/pkg/cronjob/task/local_compliance_history.go
@@ -260,7 +260,7 @@ func insertToLocalComplianceHistoryByPolicyEvent(ctx context.Context, totalCount
 						AND EXISTS (
 							SELECT 1
 							FROM status.leaf_hubs lh
-							WHERE lh.leaf_hub_name = lp.leaf_hub_name
+							WHERE lh.leaf_hub_name = lp.leaf_hub_name AND deleted_at IS NULL
 						)
 					GROUP BY cluster_id, policy_id, leaf_hub_name
 			)

--- a/operator/pkg/controllers/hubofhubs/database/3.functions.sql
+++ b/operator/pkg/controllers/hubofhubs/database/3.functions.sql
@@ -79,8 +79,13 @@ BEGIN
                     WHEN bool_and(compliance = ''compliant'') THEN ''compliant''
                     ELSE ''non_compliant''
                 END::local_status.compliance_type AS aggregated_compliance
-            FROM event.local_policies
-            WHERE created_at BETWEEN %1$L::date AND %2$L::date
+            FROM event.local_policies lp
+            WHERE created_at BETWEEN %1$L::date AND %2$L::date 
+              AND EXISTS (
+                SELECT 1
+                FROM status.leaf_hubs lh
+                WHERE lh.leaf_hub_name = lp.leaf_hub_name
+              )
             GROUP BY cluster_id, policy_id, leaf_hub_name
         )
         SELECT policy_id, cluster_id, leaf_hub_name, %1$L, aggregated_compliance,

--- a/operator/pkg/controllers/hubofhubs/database/3.functions.sql
+++ b/operator/pkg/controllers/hubofhubs/database/3.functions.sql
@@ -84,7 +84,7 @@ BEGIN
               AND EXISTS (
                 SELECT 1
                 FROM status.leaf_hubs lh
-                WHERE lh.leaf_hub_name = lp.leaf_hub_name
+                WHERE lh.leaf_hub_name = lp.leaf_hub_name AND deleted_at IS NULL
               )
             GROUP BY cluster_id, policy_id, leaf_hub_name
         )


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>
Reference: https://issues.redhat.com/browse/ACM-10255

It also needs to be noted this change will lose the history data in the following cases:

If a managed hub cluster was detached yesterday, then the history compliance of yesterday will not persist on the database.

