### PR TITLE
Remove simulation for e2e

### DIFF
--- a/test/pkg/e2e/suite_test.go
+++ b/test/pkg/e2e/suite_test.go
@@ -189,7 +189,6 @@ func deployGlobalHub() {
 			Namespace: "multicluster-global-hub",
 			Annotations: map[string]string{
 				constants.AnnotationMGHSkipAuth: "true",
-				"mgh-scheduler-interval":        "minute",
 			},
 		},
 		Spec: globalhubv1alpha4.MulticlusterGlobalHubSpec{


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>

It will show the following error message in the manager when enabling the simulation 
```bash
2024/03/13 03:39:13 /workspace/manager/pkg/cronjob/task/local_compliance_history.go:194 pq: no partition of relation "local_compliance" found for row
[0.826ms] [rows:0]
                                do
                                $$
                                declare
                                        all_compliances local_status.compliance_type[] := '{"compliant","non_compliant"}';
                                        compliance_random_index int;
                                begin
                                        SELECT floor(random() * 2 + 1)::int into compliance_random_index;
                                        INSERT INTO history.local_compliance (policy_id, cluster_id, leaf_hub_name, compliance, compliance_date)
                                                (
                                                        SELECT policy_id,cluster_id,leaf_hub_name,all_compliances[compliance_random_index],
                                                        (CURRENT_DATE - INTERVAL '44 day')
                                                        FROM history.local_compliance_view_2024_01_29
                                                        ORDER BY policy_id, cluster_id
                                                        LIMIT 1000 OFFSET 0
                                                )
                                        ON CONFLICT (leaf_hub_name, policy_id, cluster_id, compliance_date) DO NOTHING;
                                end;
                                $$;
```