### PR TITLE
Sync policy object only policy spec is changed

### DIFF
--- a/agent/pkg/status/controller/apps/subscription_report_sync.go
+++ b/agent/pkg/status/controller/apps/subscription_report_sync.go
@@ -23,7 +23,7 @@ func LaunchSubscriptionReportSyncer(ctx context.Context, mgr ctrl.Manager, agent
 	predicate := predicate.NewPredicateFuncs(func(object client.Object) bool { return true })
 
 	// emitter config
-	emitter := generic.ObjectEmitterWrapper(enum.SubscriptionReportType, nil, nil)
+	emitter := generic.ObjectEmitterWrapper(enum.SubscriptionReportType, nil, nil, false)
 
 	// syncer
 	name := "status.subscription_report"

--- a/agent/pkg/status/controller/apps/subscription_status_sync.go
+++ b/agent/pkg/status/controller/apps/subscription_status_sync.go
@@ -23,7 +23,7 @@ func LaunchSubscriptionStatusSyncer(ctx context.Context, mgr ctrl.Manager, agent
 	predicate := predicate.NewPredicateFuncs(func(object client.Object) bool { return true })
 
 	// emitter config
-	emitter := generic.ObjectEmitterWrapper(enum.SubscriptionStatusType, nil, nil)
+	emitter := generic.ObjectEmitterWrapper(enum.SubscriptionStatusType, nil, nil, false)
 
 	// syncer
 	name := "status.subscription_status"

--- a/agent/pkg/status/controller/generic/generic_object_emitter.go
+++ b/agent/pkg/status/controller/generic/generic_object_emitter.go
@@ -34,13 +34,13 @@ func (e *genericObjectEmitter) Delete(object client.Object) bool {
 func ObjectEmitterWrapper(eventType enum.EventType,
 	shouldUpdate func(client.Object) bool,
 	tweakFunc func(client.Object),
-	specUpdate bool,
+	isSpecHandler bool,
 ) ObjectEmitter {
 	eventData := genericpayload.GenericObjectBundle{}
 	return NewGenericObjectEmitter(
 		eventType,
 		&eventData,
-		NewGenericObjectHandler(&eventData, specUpdate),
+		NewGenericObjectHandler(&eventData, isSpecHandler),
 		WithShouldUpdate(shouldUpdate),
 		WithTweakFunc(tweakFunc),
 	)

--- a/agent/pkg/status/controller/generic/generic_object_emitter.go
+++ b/agent/pkg/status/controller/generic/generic_object_emitter.go
@@ -34,12 +34,13 @@ func (e *genericObjectEmitter) Delete(object client.Object) bool {
 func ObjectEmitterWrapper(eventType enum.EventType,
 	shouldUpdate func(client.Object) bool,
 	tweakFunc func(client.Object),
+	specUpdate bool,
 ) ObjectEmitter {
 	eventData := genericpayload.GenericObjectBundle{}
 	return NewGenericObjectEmitter(
 		eventType,
 		&eventData,
-		NewGenericObjectHandler(&eventData),
+		NewGenericObjectHandler(&eventData, specUpdate),
 		WithShouldUpdate(shouldUpdate),
 		WithTweakFunc(tweakFunc),
 	)

--- a/agent/pkg/status/controller/generic/generic_object_handler.go
+++ b/agent/pkg/status/controller/generic/generic_object_handler.go
@@ -9,13 +9,15 @@ import (
 
 type genericObjectHandler struct {
 	eventData *genericpayload.GenericObjectBundle
-	onlySpec  bool
+	// isSpec is to let the handler only update the event when spec is changed, that means whether it is a specHandler.
+	isSpec bool
 }
 
-func NewGenericObjectHandler(eventData *genericpayload.GenericObjectBundle, onlySpec bool) Handler {
+// TODO: isSpec is true for policy, haven't handle the other object spec like placement, appsub...
+func NewGenericObjectHandler(eventData *genericpayload.GenericObjectBundle, isSpec bool) Handler {
 	return &genericObjectHandler{
 		eventData: eventData,
-		onlySpec:  onlySpec,
+		isSpec:    isSpec,
 	}
 }
 
@@ -27,7 +29,7 @@ func (h *genericObjectHandler) Update(obj client.Object) bool {
 	}
 
 	old := (*h.eventData)[index]
-	if h.onlySpec && old.GetGeneration() == obj.GetGeneration() {
+	if h.isSpec && old.GetGeneration() == obj.GetGeneration() {
 		return false
 	}
 

--- a/agent/pkg/status/controller/generic/generic_object_handler.go
+++ b/agent/pkg/status/controller/generic/generic_object_handler.go
@@ -9,11 +9,13 @@ import (
 
 type genericObjectHandler struct {
 	eventData *genericpayload.GenericObjectBundle
+	onlySpec  bool
 }
 
-func NewGenericObjectHandler(eventData *genericpayload.GenericObjectBundle) Handler {
+func NewGenericObjectHandler(eventData *genericpayload.GenericObjectBundle, onlySpec bool) Handler {
 	return &genericObjectHandler{
 		eventData: eventData,
+		onlySpec:  onlySpec,
 	}
 }
 
@@ -22,6 +24,11 @@ func (h *genericObjectHandler) Update(obj client.Object) bool {
 	if index == -1 { // object not found, need to add it to the bundle
 		(*h.eventData) = append((*h.eventData), obj)
 		return true
+	}
+
+	old := (*h.eventData)[index]
+	if h.onlySpec && old.GetGeneration() == obj.GetGeneration() {
+		return false
 	}
 
 	// if we reached here, object already exists in the bundle. check if we need to update the object

--- a/agent/pkg/status/controller/managedclusters/managed_cluster_syncer.go
+++ b/agent/pkg/status/controller/managedclusters/managed_cluster_syncer.go
@@ -30,7 +30,7 @@ func LaunchManagedClusterSyncer(ctx context.Context, mgr ctrl.Manager, agentConf
 			constants.ManagedClusterManagedByAnnotation: statusconfig.GetLeafHubName(),
 		})
 	}
-	emitter := generic.ObjectEmitterWrapper(enum.ManagedClusterType, nil, tweakFunc)
+	emitter := generic.ObjectEmitterWrapper(enum.ManagedClusterType, nil, tweakFunc, false)
 
 	return generic.LaunchGenericObjectSyncer(
 		"status.managed_cluster",

--- a/agent/pkg/status/controller/placement/placement_decision_syncer.go
+++ b/agent/pkg/status/controller/placement/placement_decision_syncer.go
@@ -28,7 +28,7 @@ func LaunchPlacementDecisionSyncer(ctx context.Context, mgr ctrl.Manager, agentC
 			return true // resource
 		}, func(obj client.Object) {
 			obj.SetManagedFields(nil)
-		})
+		}, false)
 
 	// syncer
 	name := "status.placement_decision"

--- a/agent/pkg/status/controller/placement/placement_rule_syncer.go
+++ b/agent/pkg/status/controller/placement/placement_rule_syncer.go
@@ -33,14 +33,14 @@ func LaunchPlacementRuleSyncer(ctx context.Context, mgr ctrl.Manager, agentConfi
 		func(obj client.Object) bool {
 			return agentConfig.EnableGlobalResource &&
 				utils.HasAnnotation(obj, constants.OriginOwnerReferenceAnnotation)
-		}, tweakFunc)
+		}, tweakFunc, false)
 
 	localPlacementRuleEmitter := generic.ObjectEmitterWrapper(enum.LocalPlacementRuleSpecType,
 		func(obj client.Object) bool {
 			// return statusconfig.GetEnableLocalPolicy() == statusconfig.EnableLocalPolicyTrue &&
 			// 	!utils.HasAnnotation(obj, constants.OriginOwnerReferenceAnnotation) // local resource
 			return false // disable the placementrule now
-		}, tweakFunc)
+		}, tweakFunc, false)
 
 	// syncer
 	name := "status.placement_decision"

--- a/agent/pkg/status/controller/placement/placement_syncer.go
+++ b/agent/pkg/status/controller/placement/placement_syncer.go
@@ -32,7 +32,7 @@ func LaunchPlacementSyncer(ctx context.Context, mgr ctrl.Manager, agentConfig *c
 		},
 		func(obj client.Object) {
 			obj.SetManagedFields(nil)
-		},
+		}, false,
 	)
 
 	// syncer

--- a/agent/pkg/status/controller/policies/policy_syncer.go
+++ b/agent/pkg/status/controller/policies/policy_syncer.go
@@ -67,6 +67,7 @@ func LaunchPolicySyncer(ctx context.Context, mgr ctrl.Manager, agentConfig *conf
 				!utils.HasLabel(obj, constants.PolicyEventRootPolicyNameLabelKey) // root policy
 		},
 		cleanPolicy,
+		true,
 	)
 
 	// global policy emitters


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>

Reference: https://issues.redhat.com/browse/ACM-10797

For the policy spec event, we only need to report the object when the generation(spec) is changed. And ignore the status updates.