### PR TITLE
:bug: The operator failed to start without kafka resources

### DIFF
--- a/operator/main.go
+++ b/operator/main.go
@@ -29,7 +29,6 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	subv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	operatorsv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
-
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"

--- a/operator/main.go
+++ b/operator/main.go
@@ -29,6 +29,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	subv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	operatorsv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
+
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -390,15 +391,6 @@ func initCache(config *rest.Config, cacheOpts cache.Options) (cache.Cache, error
 			Label: labelSelector,
 		},
 		&subv1alpha1.Subscription{}: {},
-		&kafkav1beta2.Kafka{}: {
-			Field: fields.OneTermEqualSelector(namespacePath, utils.GetDefaultNamespace()),
-		},
-		&kafkav1beta2.KafkaTopic{}: {
-			Field: fields.OneTermEqualSelector(namespacePath, utils.GetDefaultNamespace()),
-		},
-		&kafkav1beta2.KafkaUser{}: {
-			Field: fields.OneTermEqualSelector(namespacePath, utils.GetDefaultNamespace()),
-		},
 		&corev1.PersistentVolumeClaim{}: {
 			Field: fields.OneTermEqualSelector(namespacePath, utils.GetDefaultNamespace()),
 		},


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

The operator start with the error:
```bash
2024-04-02T02:27:40.868Z	ERROR	setup	unable to start manager	{"error": "failed to determine if *v1beta2.Kafka is namespaced: failed to get restmapping: no matches for kind \"Kafka\" in group \"kafka.strimzi.io\""}
main.doMain
	/workspace/operator/main.go:163
main.main
	/workspace/operator/main.go:132
runtime.main
	/usr/local/go/src/runtime/proc.go:267
```

## Related issue(s)

Reference: https://github.com/kubernetes-sigs/controller-runtime/issues/2456, from here: https://github.com/kubernetes-sigs/controller-runtime/commit/3e35cab1ea29145d8699259b079633a2b8cfc116

Fixes #