### PR TITLE
:bug: fix kafka cluster error when enable metric by default

### DIFF
--- a/operator/pkg/controllers/hubofhubs/integration_test.go
+++ b/operator/pkg/controllers/hubofhubs/integration_test.go
@@ -924,7 +924,9 @@ var _ = Describe("MulticlusterGlobalHub controller", Ordered, func() {
 						operatorconstants.AnnotationMGHInstallCrunchyOperator: "true",
 					},
 				},
-				Spec: globalhubv1alpha4.MulticlusterGlobalHubSpec{},
+				Spec: globalhubv1alpha4.MulticlusterGlobalHubSpec{
+					EnableMetrics: true,
+				},
 			}
 			Expect(k8sClient.Create(ctx, mcgh)).Should(Succeed())
 		})


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Globalhub can not install successfully when enable metric in mgh.
## Related issue(s)

Fixes #
When enable metric in mgh, kafka cluster depend on a kafka-metric configmap, but it's created after kafka operator and it depend on kafka cluster ready in current code logic, so we should create the configmap first.