### PR TITLE
:bug: Enable spec syncer for agent

### DIFF
--- a/agent/pkg/status/controller/generic/generic_event_controller.go
+++ b/agent/pkg/status/controller/generic/generic_event_controller.go
@@ -119,7 +119,6 @@ func enableCleanUpFinalizer(obj client.Object) bool {
 func cleanObject(object client.Object) {
 	object.SetManagedFields(nil)
 	object.SetFinalizers(nil)
-	object.SetGeneration(0)
 	object.SetOwnerReferences(nil)
 	object.SetSelfLink("")
 	// object.SetClusterName("")

--- a/agent/pkg/status/controller/policies/local_policies_test.go
+++ b/agent/pkg/status/controller/policies/local_policies_test.go
@@ -81,7 +81,6 @@ var _ = Describe("LocalPolicyEmitters", Ordered, func() {
 			fmt.Println("============================ update policy -> policy spec event")
 			return nil
 		}, 5*time.Second, 100*time.Millisecond).Should(Succeed())
-
 	})
 
 	It("be able to sync local policy compliance", func() {

--- a/agent/pkg/status/controller/policies/local_policies_test.go
+++ b/agent/pkg/status/controller/policies/local_policies_test.go
@@ -41,10 +41,47 @@ var _ = Describe("LocalPolicyEmitters", Ordered, func() {
 			evt := <-consumer.EventChan()
 			fmt.Println(evt)
 			if evt.Type() != string(enum.LocalPolicySpecType) {
+				policy := &policyv1.Policy{}
+				err := evt.DataAs(policy)
+				if err != nil {
+					return err
+				}
+				if !policy.Spec.Disabled {
+					return fmt.Errorf("policy should be disabled")
+				}
 				return fmt.Errorf("want %v, got %v", string(enum.LocalPolicySpecType), evt.Type())
 			}
+			fmt.Println("============================ create policy -> policy spec event")
 			return nil
 		}, 5*time.Second, 100*time.Millisecond).Should(Succeed())
+
+		By("Update the root policy")
+		err := kubeClient.Get(ctx, client.ObjectKeyFromObject(localRootPolicy), localRootPolicy)
+		Expect(err).Should(Succeed())
+
+		localRootPolicy.Spec.Disabled = false
+		err = kubeClient.Update(ctx, localRootPolicy)
+		Expect(err).Should(Succeed())
+
+		By("Check the local policy spec can be read from cloudevents consumer")
+		Eventually(func() error {
+			evt := <-consumer.EventChan()
+			fmt.Println(evt)
+			if evt.Type() != string(enum.LocalPolicySpecType) {
+				policy := &policyv1.Policy{}
+				err := evt.DataAs(policy)
+				if err != nil {
+					return err
+				}
+				if policy.Spec.Disabled {
+					return fmt.Errorf("policy should be enabled")
+				}
+				return fmt.Errorf("want %v, got %v", string(enum.LocalPolicySpecType), evt.Type())
+			}
+			fmt.Println("============================ update policy -> policy spec event")
+			return nil
+		}, 5*time.Second, 100*time.Millisecond).Should(Succeed())
+
 	})
 
 	It("be able to sync local policy compliance", func() {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Fix the bug that the policy payload isn't synced to database when update its spec

## Related issue(s)

Fixes # https://issues.redhat.com/browse/ACM-10943