### PR TITLE
reset KafkaInit as false

### DIFF
--- a/operator/pkg/controllers/hubofhubs/globalhub_middleware.go
+++ b/operator/pkg/controllers/hubofhubs/globalhub_middleware.go
@@ -34,7 +34,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/stolostron/multicluster-global-hub/operator/apis/v1alpha4"
-	globalhubv1alpha4 "github.com/stolostron/multicluster-global-hub/operator/apis/v1alpha4"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/deployer"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/postgres"
@@ -266,7 +265,7 @@ func detectTransportProtocol(ctx context.Context, runtimeClient client.Client) (
 
 // renderKafkaMetricsResources renders the kafka podmonitor and metrics
 func (r *MulticlusterGlobalHubReconciler) renderKafkaMetricsResources(
-	mgh *globalhubv1alpha4.MulticlusterGlobalHub,
+	mgh *v1alpha4.MulticlusterGlobalHub,
 ) error {
 	if mgh.Spec.EnableMetrics {
 		// render the kafka objects

--- a/operator/pkg/controllers/hubofhubs/integration_test.go
+++ b/operator/pkg/controllers/hubofhubs/integration_test.go
@@ -937,6 +937,7 @@ var _ = Describe("MulticlusterGlobalHub controller", Ordered, func() {
 				if mghReconciler.MiddlewareConfig == nil {
 					mghReconciler.MiddlewareConfig = &hubofhubs.MiddlewareConfig{}
 				}
+				mghReconciler.KafkaInit = false
 				mghReconciler.MiddlewareConfig.StorageConn = nil
 				mghReconciler.MiddlewareConfig.TransportConn = nil
 				mghReconciler.ReconcileMiddleware(ctx, mcgh)

--- a/operator/pkg/controllers/hubofhubs/integration_test.go
+++ b/operator/pkg/controllers/hubofhubs/integration_test.go
@@ -1033,12 +1033,6 @@ var _ = Describe("MulticlusterGlobalHub controller", Ordered, func() {
 
 		It("Should get the postgres connection", func() {
 			Eventually(func() error {
-				if mghReconciler.Manager == nil {
-					mghReconciler.Manager = k8sManager
-				}
-				if mghReconciler.Scheme == nil {
-					mghReconciler.Scheme = k8sManager.GetScheme()
-				}
 				var err error
 				mghReconciler.MiddlewareConfig.StorageConn, err = mghReconciler.InitPostgresByStatefulset(ctx, mcgh)
 				if err != nil {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Most likely the unit test reports the following error:
```
2024-04-03T09:49:58Z    INFO    strimzi-transporter kafka cluster is ready2024-04-03T09:49:59Z    INFO    strimzi-transporter reconcile global hub kafka transport...2024-04-03T09:49:59Z    INFO    strimzi-transporter waiting the kafka cluster instance to be ready...2024-04-03T09:49:59Z    INFO    strimzi-transporter kafka cluster is ready[FAILED] in [It] - /go/src/github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/hubofhubs/integration_test.go:958 @ 04/03/24 09:49:59.274
<< Timeline
[FAILED] Timed out after 30.001s.
Unexpected error:    <*errors.errorString | 0xc003033900>:     mghReconciler.TransportConn.PgConnection should not be nil    
{        
s: "mghReconciler.TransportConn.PgConnection should not be nil",    
}
occurred
In [It] at: /go/src/github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/hubofhubs/integration_test.go:958 @ 04/03/24 09:49:59.274 
```

## Related issue(s)

ref: https://issues.redhat.com/browse/ACM-10852