### PR TITLE
:seedling:Extend the manager/agent memory limitation

### DIFF
--- a/operator/pkg/constants/constants.go
+++ b/operator/pkg/constants/constants.go
@@ -144,13 +144,13 @@ const (
 
 	// default resources for manager
 	Manager              = "manager"
-	ManagerMemoryLimit   = "300Mi"
+	ManagerMemoryLimit   = "600Mi"
 	ManagerMemoryRequest = "100Mi"
 	ManagerCPURequest    = "100m"
 
 	// default resources for agent
 	Agent              = "agent"
-	AgentMemoryLimit   = "1000Mi"
+	AgentMemoryLimit   = "1200Mi"
 	AgentMemoryRequest = "200Mi"
 	AgentCPURequest    = "10m"
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Avoid the pods being evicted by the resource limitation. 

## Related issue(s)

Reference: [Scenario 3](https://github.com/stolostron/multicluster-global-hub/blob/main/doc/simulation/scenario/Scenario3%3A%203000_clusters_500_policies.md)