### PR TITLE
:bug: Fix the topic isn't ready for the detach case

### DIFF
--- a/operator/pkg/transporter/strimzi_transporter.go
+++ b/operator/pkg/transporter/strimzi_transporter.go
@@ -271,24 +271,23 @@ func (k *strimziTransporter) CreateTopic(topic *transport.ClusterTopic) error {
 }
 
 func (k *strimziTransporter) DeleteTopic(topic *transport.ClusterTopic) error {
-	for _, topicName := range []string{topic.SpecTopic, topic.StatusTopic, topic.EventTopic} {
-		kafkaTopic := &kafkav1beta2.KafkaTopic{}
-		err := k.runtimeClient.Get(k.ctx, types.NamespacedName{
-			Name:      topicName,
-			Namespace: k.namespace,
-		}, kafkaTopic)
-		if errors.IsNotFound(err) {
-			continue
-		}
-		if err != nil {
-			return err
-		}
-		err = k.runtimeClient.Delete(k.ctx, kafkaTopic)
-		if err != nil {
-			return err
-		}
+	// This topic is shared between different managed hub clusters
+	if StatusTopicPrefix == topic.StatusTopic {
+		return nil
 	}
-	return nil
+
+	// Only delete the specific cluster topic
+	kafkaTopic := &kafkav1beta2.KafkaTopic{}
+	err := k.runtimeClient.Get(k.ctx, types.NamespacedName{
+		Name:      topic.StatusTopic,
+		Namespace: k.namespace,
+	}, kafkaTopic)
+	if err != nil && errors.IsNotFound(err) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+	return k.runtimeClient.Delete(k.ctx, kafkaTopic)
 }
 
 // authorize


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

When detaching a managed hub cluster or disable the agent, should delete the shared topic like `event` or `spec`.

## Related issue(s)

Fixes # https://issues.redhat.com/browse/ACM-11284