### PR TITLE
:bug: add entity-operator monitor

### DIFF
--- a/operator/pkg/controllers/hubofhubs/manifests/kafka/podmonitor.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/kafka/podmonitor.yaml
@@ -19,6 +19,24 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
+  name: entity-operator-metrics
+  namespace: {{.Namespace}}
+  labels:
+    app: strimzi
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: entity-operator
+  namespaceSelector:
+    matchNames:
+      - {{.Namespace}}
+  podMetricsEndpoints:
+  - path: /metrics
+    port: healthcheck
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
   name: kafka-resources-metrics
   namespace: {{.Namespace}}
   labels:


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
The kafkauser and kafkatopic metric collected in entyty-operator, and we do not monitor it previously.
<img width="1746" alt="图片" src="https://github.com/stolostron/multicluster-global-hub/assets/56991288/4d9d9c1b-f329-46b7-a056-36e43f398086">
