### PR TITLE
:seedling: Persistent the agent event state to the configmap

### DIFF
--- a/agent/pkg/status/controller/controller.go
+++ b/agent/pkg/status/controller/controller.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/controller/apps"
 	agentstatusconfig "github.com/stolostron/multicluster-global-hub/agent/pkg/status/controller/config"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/controller/event"
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/controller/filter"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/controller/hubcluster"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/controller/managedclusters"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/controller/placement"
@@ -76,6 +77,11 @@ func AddControllers(ctx context.Context, mgr ctrl.Manager, agentConfig *config.A
 	// app
 	if err := apps.LaunchSubscriptionReportSyncer(ctx, mgr, agentConfig, producer); err != nil {
 		return fmt.Errorf("failed to launch subscription report syncer: %w", err)
+	}
+
+	// lunch a time filter, it must be called after filter.RegisterTimeFilter(key)
+	if err := filter.LaunchTimeFilter(ctx, mgr.GetClient(), agentConfig.PodNameSpace); err != nil {
+		return fmt.Errorf("failed to launch time filter: %w", err)
 	}
 	return nil
 }

--- a/agent/pkg/status/controller/event/event_integration_test.go
+++ b/agent/pkg/status/controller/event/event_integration_test.go
@@ -1,0 +1,10 @@
+package event
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("Events emitters", Ordered, func() {
+	Context("with root policy events", Ordered, localRootPolicyEventTestSpecs)
+	Context("with replicated policy events", Ordered, localReplicatedPolicyEventTestSpecs)
+})

--- a/agent/pkg/status/controller/event/event_suite_test.go
+++ b/agent/pkg/status/controller/event/event_suite_test.go
@@ -3,7 +3,6 @@ package event
 import (
 	"context"
 	"path/filepath"
-	"sync"
 	"testing"
 	"time"
 
@@ -41,7 +40,6 @@ var (
 	consumer    transport.Consumer
 	producer    transport.Producer
 	kubeClient  client.Client
-	lock        sync.Mutex
 )
 
 func TestControllers(t *testing.T) {

--- a/agent/pkg/status/controller/event/event_suite_test.go
+++ b/agent/pkg/status/controller/event/event_suite_test.go
@@ -3,6 +3,7 @@ package event
 import (
 	"context"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -40,6 +41,7 @@ var (
 	consumer    transport.Consumer
 	producer    transport.Producer
 	kubeClient  client.Client
+	lock        sync.Mutex
 )
 
 func TestControllers(t *testing.T) {

--- a/agent/pkg/status/controller/event/local_replicated_policy_emitter.go
+++ b/agent/pkg/status/controller/event/local_replicated_policy_emitter.go
@@ -140,7 +140,7 @@ func (h *localReplicatedPolicyEmitter) Update(obj client.Object) bool {
 			Reason:         evt.Reason,
 			Count:          evt.Count,
 			Source:         evt.Source,
-			CreatedAt:      evt.LastTimestamp,
+			CreatedAt:      evt.CreationTimestamp,
 		},
 		PolicyID:   string(rootPolicy.GetUID()),
 		ClusterID:  clusterID,

--- a/agent/pkg/status/controller/event/local_replicated_policy_emitter.go
+++ b/agent/pkg/status/controller/event/local_replicated_policy_emitter.go
@@ -98,7 +98,7 @@ func (h *localReplicatedPolicyEmitter) ShouldUpdate(obj client.Object) bool {
 	if config.GetEnableLocalPolicy() != config.EnableLocalPolicyTrue {
 		return false
 	}
-	policy, ok := policyEventPredicate(h.ctx, obj, h.runtimeClient, h.log)
+	policy, ok := policyEventPredicate(h.ctx, h.name, obj, h.runtimeClient, h.log)
 
 	return ok && !utils.HasAnnotation(policy, constants.OriginOwnerReferenceAnnotation) &&
 		utils.HasItemKey(policy.GetLabels(), constants.PolicyEventRootPolicyNameLabelKey)
@@ -115,10 +115,6 @@ func (h *localReplicatedPolicyEmitter) Topic() string {
 func (h *localReplicatedPolicyEmitter) Update(obj client.Object) bool {
 	evt, ok := obj.(*corev1.Event)
 	if !ok {
-		return false
-	}
-	// if it's a older event, then return false
-	if !filter.Newer(h.name, evt.LastTimestamp.Time) {
 		return false
 	}
 

--- a/agent/pkg/status/controller/event/local_replicated_policy_emitter_test.go
+++ b/agent/pkg/status/controller/event/local_replicated_policy_emitter_test.go
@@ -1,0 +1,93 @@
+package event
+
+import (
+	"encoding/json"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	policyv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/bundle/event"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/enum"
+)
+
+var _ = Describe("test the replicated policy emitter", Ordered, func() {
+	It("should pass the replicated policy event", func() {
+		By("Create namespace and cluster for the replicated policy")
+		err := kubeClient.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cluster1",
+			},
+		}, &client.CreateOptions{})
+		Expect(err).Should(Succeed())
+
+		By("Create the cluster")
+		cluster := &clusterv1.ManagedCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cluster1",
+			},
+		}
+		Expect(kubeClient.Create(ctx, cluster, &client.CreateOptions{})).Should(Succeed())
+		cluster.Status = clusterv1.ManagedClusterStatus{
+			ClusterClaims: []clusterv1.ManagedClusterClaim{
+				{
+					Name:  "id.k8s.io",
+					Value: "3f406177-34b2-4852-88dd-ff2809680336",
+				},
+			},
+		}
+		Expect(kubeClient.Status().Update(ctx, cluster)).Should(Succeed())
+
+		By("Create the replicated policy")
+		replicatedPolicy := &policyv1.Policy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "default.policy1",
+				Namespace: "cluster1",
+				Labels: map[string]string{
+					constants.PolicyEventRootPolicyNameLabelKey: fmt.Sprintf("%s.%s", "default", "policy1"),
+					constants.PolicyEventClusterNameLabelKey:    "cluster1",
+				},
+			},
+			Spec: policyv1.PolicySpec{
+				Disabled:        false,
+				PolicyTemplates: []*policyv1.PolicyTemplate{},
+			},
+		}
+		Expect(kubeClient.Create(ctx, replicatedPolicy)).ToNot(HaveOccurred())
+
+		By("Create the replicated policy event")
+		evt := &corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "default.policy1.17af98f19c06811e",
+				Namespace: "cluster1",
+			},
+			InvolvedObject: v1.ObjectReference{
+				Kind:      string(policyv1.Kind),
+				Namespace: "cluster1",
+				Name:      "default.policy1",
+			},
+			Reason:  "PolicyStatusSync",
+			Message: "Policy default.policy1 status was updated in cluster",
+			Source: corev1.EventSource{
+				Component: "policy-status-sync",
+			},
+		}
+		Expect(kubeClient.Create(ctx, evt)).NotTo(HaveOccurred())
+
+		receivedEvent := <-consumer.EventChan()
+		fmt.Sprintln(receivedEvent)
+		Expect(string(enum.LocalReplicatedPolicyEventType)).To(Equal(receivedEvent.Type()))
+
+		replicatedPolicyEvents := []event.ReplicatedPolicyEvent{}
+		err = json.Unmarshal(receivedEvent.Data(), &replicatedPolicyEvents)
+		Expect(err).Should(Succeed())
+		Expect(replicatedPolicyEvents[0].EventName).To(Equal(evt.Name))
+	})
+})

--- a/agent/pkg/status/controller/event/local_replicated_policy_emitter_test.go
+++ b/agent/pkg/status/controller/event/local_replicated_policy_emitter_test.go
@@ -3,6 +3,7 @@ package event
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -18,7 +19,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/enum"
 )
 
-var _ = Describe("test the replicated policy emitter", Ordered, func() {
+var _ = Describe("Replicated Policy event emitter", Ordered, func() {
 	It("should pass the replicated policy event", func() {
 		By("Create namespace and cluster for the replicated policy")
 		err := kubeClient.Create(ctx, &corev1.Namespace{
@@ -78,11 +79,12 @@ var _ = Describe("test the replicated policy emitter", Ordered, func() {
 			Source: corev1.EventSource{
 				Component: "policy-status-sync",
 			},
+			LastTimestamp: metav1.Time{Time: time.Now()},
 		}
 		Expect(kubeClient.Create(ctx, evt)).NotTo(HaveOccurred())
 
 		receivedEvent := <-consumer.EventChan()
-		fmt.Sprintln(receivedEvent)
+		fmt.Println(">>>>>>>>>>>>>>>>>>> replicated policy event", receivedEvent)
 		Expect(string(enum.LocalReplicatedPolicyEventType)).To(Equal(receivedEvent.Type()))
 
 		replicatedPolicyEvents := []event.ReplicatedPolicyEvent{}

--- a/agent/pkg/status/controller/event/local_replicated_policy_emitter_test.go
+++ b/agent/pkg/status/controller/event/local_replicated_policy_emitter_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/enum"
 )
 
-var _ = Describe("Replicated Policy event emitter", Ordered, func() {
+func localReplicatedPolicyEventTestSpecs() {
 	It("should pass the replicated policy event", func() {
 		By("Create namespace and cluster for the replicated policy")
 		err := kubeClient.Create(ctx, &corev1.Namespace{
@@ -92,4 +92,4 @@ var _ = Describe("Replicated Policy event emitter", Ordered, func() {
 		Expect(err).Should(Succeed())
 		Expect(replicatedPolicyEvents[0].EventName).To(Equal(evt.Name))
 	})
-})
+}

--- a/agent/pkg/status/controller/event/local_root_policy_emitter.go
+++ b/agent/pkg/status/controller/event/local_root_policy_emitter.go
@@ -3,10 +3,10 @@ package event
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/go-logr/logr"
-	lru "github.com/hashicorp/golang-lru"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/controller/config"
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/controller/filter"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/controller/generic"
 	"github.com/stolostron/multicluster-global-hub/pkg/bundle/event"
 	"github.com/stolostron/multicluster-global-hub/pkg/bundle/version"
@@ -27,27 +28,28 @@ var _ generic.ObjectEmitter = &localRootPolicyEmitter{}
 
 type localRootPolicyEmitter struct {
 	ctx             context.Context
+	name            string
 	log             logr.Logger
 	runtimeClient   client.Client
 	eventType       string
 	topic           string
 	currentVersion  *version.Version
 	lastSentVersion version.Version
-	cache           *lru.Cache
 	payload         event.RootPolicyEventBundle
 }
 
 func NewLocalRootPolicyEmitter(ctx context.Context, c client.Client, topic string) *localRootPolicyEmitter {
-	cache, _ := lru.New(20)
+	name := strings.Replace(string(enum.LocalRootPolicyEventType), enum.EventTypePrefix, "", -1)
+	filter.RegisterTimeFilter(name)
 	return &localRootPolicyEmitter{
 		ctx:             ctx,
-		log:             ctrl.Log.WithName("policy-event-sycner/local-root-policy"),
+		name:            name,
+		log:             ctrl.Log.WithName(name),
 		eventType:       string(enum.LocalRootPolicyEventType),
 		topic:           transport.GenericEventTopic,
 		runtimeClient:   c,
 		currentVersion:  version.NewVersion(),
 		lastSentVersion: *version.NewVersion(),
-		cache:           cache,
 		payload:         make([]event.RootPolicyEvent, 0),
 	}
 }
@@ -93,9 +95,8 @@ func (h *localRootPolicyEmitter) Update(obj client.Object) bool {
 	if !ok {
 		return false
 	}
-	// if exist, then return
-	evtKey := getEventKey(evt)
-	if ok = h.cache.Contains(evtKey); ok {
+	// if it's a older event, then return false
+	if !filter.Newer(h.name, evt.LastTimestamp.Time) {
 		return false
 	}
 
@@ -116,14 +117,12 @@ func (h *localRootPolicyEmitter) Update(obj client.Object) bool {
 			Reason:         evt.Reason,
 			Count:          evt.Count,
 			Source:         evt.Source,
-			CreatedAt:      evt.CreationTimestamp,
+			CreatedAt:      evt.LastTimestamp,
 		},
 		PolicyID:   string(policy.GetUID()),
 		Compliance: policyCompliance(policy, evt),
 	}
-	// cache to events and update version
 	h.payload = append(h.payload, rootPolicyEvent)
-	h.cache.Add(evtKey, nil)
 	return true
 }
 
@@ -154,6 +153,10 @@ func (h *localRootPolicyEmitter) Topic() string {
 }
 
 func (h *localRootPolicyEmitter) PostSend() {
+	// update the time filter: with latest event
+	for _, evt := range h.payload {
+		filter.CacheTime(h.name, evt.CreatedAt.Time)
+	}
 	// update version and clean the cache
 	h.payload = make([]event.RootPolicyEvent, 0)
 	// 1. the version get into the next generation

--- a/agent/pkg/status/controller/event/local_root_policy_emitter.go
+++ b/agent/pkg/status/controller/event/local_root_policy_emitter.go
@@ -118,7 +118,7 @@ func (h *localRootPolicyEmitter) Update(obj client.Object) bool {
 			Reason:         evt.Reason,
 			Count:          evt.Count,
 			Source:         evt.Source,
-			CreatedAt:      evt.LastTimestamp,
+			CreatedAt:      evt.CreationTimestamp,
 		},
 		PolicyID:   string(policy.GetUID()),
 		Compliance: policyCompliance(policy, evt),

--- a/agent/pkg/status/controller/event/local_root_policy_emitter_test.go
+++ b/agent/pkg/status/controller/event/local_root_policy_emitter_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/enum"
 )
 
-var _ = Describe("Policy event emitters", Ordered, func() {
+func localRootPolicyEventTestSpecs() {
 	eventTime := time.Now()
 	It("should pass the root policy event", func() {
 		By("Creating a root policy")
@@ -120,4 +120,4 @@ var _ = Describe("Policy event emitters", Ordered, func() {
 		Expect(rootPolicyEvents[0].EventName).NotTo(Equal(expiredEventName))
 		Expect(rootPolicyEvents[0].EventName).To(Equal(newerEventName))
 	})
-})
+}

--- a/agent/pkg/status/controller/event/local_root_policy_emitter_test.go
+++ b/agent/pkg/status/controller/event/local_root_policy_emitter_test.go
@@ -17,8 +17,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/enum"
 )
 
-// go test ./agent/pkg/status/controller/event -v -ginkgo.focus "LocalRootPolicyEventEmitter"
-var _ = Describe("LocalRootPolicyEventEmitter", Ordered, func() {
+var _ = Describe("Policy event emitters", Ordered, func() {
 	eventTime := time.Now()
 	It("should pass the root policy event", func() {
 		By("Creating a root policy")

--- a/agent/pkg/status/controller/filter/time_filter.go
+++ b/agent/pkg/status/controller/filter/time_filter.go
@@ -8,7 +8,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/agent/pkg/status/controller/filter/time_filter.go
+++ b/agent/pkg/status/controller/filter/time_filter.go
@@ -1,0 +1,96 @@
+package filter
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	CacheConfigMapName = "multicluster-global-hub-agent-sync-state"
+	CacheInterval      = 5 * time.Second
+	CacheTimeFormat    = "2006-01-02 15:04:05.000"
+)
+
+var (
+	eventTimeCache     = make(map[string]time.Time)
+	lastEventTimeCache = make(map[string]time.Time)
+)
+
+type timeFilter struct {
+	lastSentTime map[string]time.Time
+}
+
+// CacheTime cache the latest time
+func CacheTime(key string, new time.Time) {
+	old, ok := eventTimeCache[key]
+	if !ok || old.Before(new) {
+		eventTimeCache[key] = new
+	}
+}
+
+// Newer compares the val time with cached the time, if not exist, then return true
+func Newer(key string, val time.Time) bool {
+	old, ok := eventTimeCache[key]
+	if !ok {
+		return true
+	}
+	return val.After(old)
+}
+
+// LaunchTimeFilter start a goroutine periodically sync the time filter cache to configMap
+// and also init the event time cache with configmap
+func LaunchTimeFilter(ctx context.Context, c client.Client, namespace string) error {
+	agentStateConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      CacheConfigMapName,
+			Namespace: namespace,
+		},
+	}
+	err := c.Get(ctx, client.ObjectKeyFromObject(agentStateConfigMap), agentStateConfigMap)
+	if err != nil && errors.IsNotFound(err) {
+		if e := c.Create(ctx, agentStateConfigMap); e != nil {
+			return e
+		}
+	} else if err != nil {
+		return err
+	}
+
+	for key := range lastEventTimeCache {
+		err = loadTimeCacheFromConfigMap(agentStateConfigMap, key)
+		if err != nil {
+			return err
+		}
+	}
+
+	// TODO: start a goroutine to sync the event sync state periodically, update the lastEventTimeCache
+
+	return nil
+}
+
+// RegisterTimeFilter call before the LaunchTimeFilter, it will get the init time from the configMap
+func RegisterTimeFilter(key string) {
+	eventTimeCache[key] = time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC)
+	lastEventTimeCache[key] = time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC)
+}
+
+func loadTimeCacheFromConfigMap(cm *corev1.ConfigMap, key string) error {
+	val, found := cm.Data[key]
+	if !found {
+		klog.Info("the time cache isn't found in the ConfigMap", "key", key, "configMap", cm.Name)
+		return nil
+	}
+
+	timeVal, err := time.Parse(CacheTimeFormat, val)
+	if err != nil {
+		return err
+	}
+	eventTimeCache[key] = timeVal
+	return nil
+}

--- a/agent/pkg/status/controller/filter/time_filter.go
+++ b/agent/pkg/status/controller/filter/time_filter.go
@@ -58,7 +58,7 @@ func LaunchTimeFilter(ctx context.Context, c client.Client, namespace string) er
 	}
 
 	for key := range lastEventTimeCache {
-		err = loadTimeCacheFromConfigMap(agentStateConfigMap, key)
+		err = loadEventTimeCacheFromConfigMap(agentStateConfigMap, key)
 		if err != nil {
 			return err
 		}
@@ -128,7 +128,7 @@ func RegisterTimeFilter(key string) {
 	lastEventTimeCache[key] = time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC)
 }
 
-func loadTimeCacheFromConfigMap(cm *corev1.ConfigMap, key string) error {
+func loadEventTimeCacheFromConfigMap(cm *corev1.ConfigMap, key string) error {
 	val, found := cm.Data[key]
 	if !found {
 		klog.Info("the time cache isn't found in the ConfigMap", "key", key, "configMap", cm.Name)

--- a/agent/pkg/status/controller/filter/time_filter_test.go
+++ b/agent/pkg/status/controller/filter/time_filter_test.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2024 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package filter
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+var (
+	cfg           *rest.Config
+	kubeClient    kubernetes.Interface
+	runtimeClient client.Client
+)
+
+func TestMain(m *testing.M) {
+	err := os.Setenv("POD_NAMESPACE", "default")
+	if err != nil {
+		panic(err)
+	}
+	err = os.Setenv("MANAGER_TESTING", "true")
+	if err != nil {
+		panic(err)
+	}
+
+	// start testenv
+	testenv := &envtest.Environment{}
+
+	cfg, err = testenv.Start()
+	if err != nil {
+		panic(err)
+	}
+
+	if cfg == nil {
+		panic(fmt.Errorf("empty kubeconfig!"))
+	}
+
+	kubeClient, err = kubernetes.NewForConfig(cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	runtimeClient, err = client.New(cfg, client.Options{})
+	if err != nil {
+		panic(err)
+	}
+
+	// run testings
+	code := m.Run()
+
+	// stop testenv
+	if err := testenv.Stop(); err != nil {
+		panic(err)
+	}
+	os.Exit(code)
+}
+
+func TestTimeFilter(t *testing.T) {
+	// init the time cache to configMap
+	initCtx, initCancel := context.WithCancel(context.Background())
+
+	eventTimeCacheInterval = 1 * time.Second
+	err := LaunchTimeFilter(initCtx, runtimeClient, "default")
+	assert.Nil(t, err)
+
+	// the configMap can be created
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: CACHE_CONFIG_NAME, Namespace: "default"}}
+	err = runtimeClient.Get(initCtx, client.ObjectKeyFromObject(cm), cm)
+	assert.Nil(t, err)
+	utils.PrettyPrint(cm)
+
+	// update the cache time
+	testTime := time.Now()
+	fmt.Println("test time", testTime)
+	CacheTime("test", testTime)
+
+	time.Sleep(2 * time.Second)
+
+	// check the cache time is synced to the configMap
+	err = runtimeClient.Get(initCtx, client.ObjectKeyFromObject(cm), cm)
+	assert.Nil(t, err)
+	cachedTimeStr := cm.Data["test"]
+	cachedTime, err := time.Parse(CACHE_TIME_FORMAT, cachedTimeStr)
+	assert.Nil(t, err)
+	fmt.Println("cached time", cachedTime)
+	assert.True(t, cachedTime.Equal(testTime))
+	initCancel()
+
+	// reload the time from configMap
+	RegisterTimeFilter("test")
+	reloadCtx, reloadCancel := context.WithCancel(context.Background())
+	defer reloadCancel()
+
+	// update the configmap
+	updateTime := testTime.Add(5 * time.Second)
+	cm.Data["test"] = updateTime.Format(CACHE_TIME_FORMAT)
+	err = runtimeClient.Update(reloadCtx, cm)
+	assert.Nil(t, err)
+
+	err = LaunchTimeFilter(reloadCtx, runtimeClient, "default")
+	assert.Nil(t, err)
+
+	err = runtimeClient.Get(reloadCtx, client.ObjectKeyFromObject(cm), cm)
+	assert.Nil(t, err)
+	cachedTimeStr = cm.Data["test"]
+	cachedTime, err = time.Parse(CACHE_TIME_FORMAT, cachedTimeStr)
+	assert.Nil(t, err)
+	fmt.Println("updated time1", cachedTime)
+	assert.True(t, cachedTime.Equal(updateTime))
+
+	// update the cache with a expired time, verify the cached time isn't changed
+	CacheTime("test", updateTime.Add(-10*time.Second))
+	time.Sleep(2 * time.Second)
+
+	err = runtimeClient.Get(reloadCtx, client.ObjectKeyFromObject(cm), cm)
+	assert.Nil(t, err)
+	cachedTimeStr = cm.Data["test"]
+	cachedTime, err = time.Parse(CACHE_TIME_FORMAT, cachedTimeStr)
+	assert.Nil(t, err)
+	fmt.Println("updated time2", cachedTime)
+	assert.True(t, cachedTime.Equal(updateTime))
+}

--- a/agent/pkg/status/controller/filter/time_filter_test.go
+++ b/agent/pkg/status/controller/filter/time_filter_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,6 +17,8 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
 var (

--- a/agent/pkg/status/controller/generic/generic_event_syncer.go
+++ b/agent/pkg/status/controller/generic/generic_event_syncer.go
@@ -64,6 +64,7 @@ func (s *genericEventSyncer) periodicSync() {
 	currentSyncInterval := s.syncIntervalFunc()
 	s.log.Info(fmt.Sprintf("sync interval has been reset to %s", currentSyncInterval.String()))
 	ticker := time.NewTicker(currentSyncInterval)
+	defer ticker.Stop()
 
 	for {
 		<-ticker.C // wait for next time interval

--- a/agent/pkg/status/controller/generic/generic_object_syncer.go
+++ b/agent/pkg/status/controller/generic/generic_object_syncer.go
@@ -124,6 +124,7 @@ func (c *genericObjectSyncer) deleteObject(object client.Object) {
 func (c *genericObjectSyncer) periodicSync() {
 	currentSyncInterval := c.syncIntervalFunc()
 	ticker := time.NewTicker(currentSyncInterval)
+	defer ticker.Stop()
 
 	for {
 		<-ticker.C // wait for next time interval


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Add the configMap to save the agent event state, so as to deduplicate the event in the message queue(event topics)

## Related issue(s)

Fixes #https://issues.redhat.com/browse/ACM-11243