### PR TITLE
:bug: Fix the event format incompatible when upgrading

### DIFF
--- a/agent/pkg/spec/controller/syncers/dispatcher.go
+++ b/agent/pkg/spec/controller/syncers/dispatcher.go
@@ -58,6 +58,10 @@ func (d *genericDispatcher) dispatch(ctx context.Context) {
 				d.log.V(2).Info("dispatching to the default generic syncer", "eventType", evt.Type())
 				syncer = d.syncers[GenericMessageKey]
 			}
+			if syncer == nil || evt == nil {
+				d.log.Info("nil syncer or evt", "syncer", syncer, "event", evt)
+				continue
+			}
 			if err := syncer.Sync(evt.Data()); err != nil {
 				d.log.Error(err, "submit to syncer error", "eventType", evt.Type())
 			}

--- a/agent/pkg/spec/controller/syncers/dispatcher.go
+++ b/agent/pkg/spec/controller/syncers/dispatcher.go
@@ -59,7 +59,8 @@ func (d *genericDispatcher) dispatch(ctx context.Context) {
 				syncer = d.syncers[GenericMessageKey]
 			}
 			if syncer == nil || evt == nil {
-				d.log.Info("nil syncer or evt", "syncer", syncer, "event", evt)
+				d.log.Info("the incompatible event will disappear once the upgrade is completed: nil syncer or evt",
+					"syncer", syncer, "event", evt)
 				continue
 			}
 			if err := syncer.Sync(evt.Data()); err != nil {


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Upgrade from `release-2.10` to `release-2.11`
Error message
```bash
 nil syncer or evt       {"syncer": null, "event": "Context Attributes,\n  specversion: 1.0\n  type: SpecBundle\n  source: broadcast\n  id: Resync\n  time: 2024-05-06T08:34:03.018187888Z\n  datacontenttype: application/json\nExtensions,\n  extoffset: 0\n  extsize: 18\n  kafkamessagekey: Resync\n  kafkaoffset: 1\n  kafkapartition: 0\n  kafkatopic: spec\nData (binary),\n  [\n    \"HubClusterInfo\"\n  ]\n"}
```

## Related issue(s)

Fixes # https://issues.redhat.com/browse/ACM-11490