### PR TITLE
:bug: fix postgres pod can not start in upgrade case

### DIFF
--- a/operator/pkg/controllers/hubofhubs/manifests/postgres/secret.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/postgres/secret.yaml
@@ -5,8 +5,6 @@ metadata:
   namespace: {{.Namespace}}
   labels:
     name: multicluster-global-hub-postgres
-  annotations:
-    skip-creation-if-exist: "true"
 type: Opaque
 stringData:
   database-admin_user: "{{.PostgresAdminUser}}"


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
postgres pod can not start in upgrade case:
```
Normal   Started         <invalid>                      kubelet            Started container multicluster-global-hub-postgres
  Normal   Pulled          <invalid> (x8 over <invalid>)  kubelet            Container image "quay.io/prometheuscommunity/postgres-exporter:v0.15.0" already present on machine
  Warning  Failed          <invalid> (x8 over <invalid>)  kubelet            Error: couldn't find key database-uri in Secret multicluster-global-hub/multicluster-global-hub-postgres
```
## Related issue(s)
https://issues.redhat.com/browse/ACM-11537
Fixes #