### PR TITLE
Add default producer event handler for kafka protocol

### DIFF
--- a/pkg/transport/producer/generic_producer.go
+++ b/pkg/transport/producer/generic_producer.go
@@ -174,7 +174,7 @@ func handleProducerEvents(log logr.Logger, eventChan chan kafka.Event) {
 				// as the underlying client will automatically try to
 				// recover from any errors encountered, the application
 				// does not need to take action on them.
-				log.Info("Transport producer client error", "error", ev)
+				log.Info("Transport producer client error, ignore it for most cases", "error", ev)
 			}
 		}
 	}()


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

After this https://github.com/cloudevents/sdk-go/pull/1031 patch to the sdk, we must add the producer event handler, otherwise, it may cause a memory leak for the event channel.

## Related issue(s)

Fixes #