### PR TITLE
:bug:Use the key filter for the replicated policy history event

### DIFF
--- a/agent/pkg/status/controller/policies/status_event_emitter.go
+++ b/agent/pkg/status/controller/policies/status_event_emitter.go
@@ -104,7 +104,7 @@ func (h *statusEventEmitter) Update(obj client.Object) bool {
 		if detail.History != nil {
 			for _, evt := range detail.History {
 
-				// since the replicated policy history(event) is updated by the managed clsuter,
+				// since the replicated policy history(event) is updated by the managed cluster,
 				// using the time filter might cause race condition
 				key := fmt.Sprintf("%s.%s", evt.EventName, evt.LastTimestamp)
 				if h.cache.Contains(key) {

--- a/doc/simulation/local-policies/rotate-policy.sh
+++ b/doc/simulation/local-policies/rotate-policy.sh
@@ -40,11 +40,12 @@ function update_cluster_policies() {
 
     cluster_name=managedcluster-${j}
     event_name=$root_policy_namespace.$root_policy_name.$cluster_name.$random_number
+    last_timestamp=$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")
     if [[ $root_policy_status == "Compliant" ]]; then 
       # patch replicas policy status to compliant
-      kubectl patch policy $root_policy_namespace.$root_policy_name -n $cluster_name --type=merge --subresource status --patch "status: {compliant: Compliant, details: [{compliant: Compliant, history: [{eventName: $event_name, message: Compliant; notification - limitranges container-mem-limit-range found as specified in namespace $root_policy_namespace}], templateMeta: {creationTimestamp: null, name: policy-limitrange-container-mem-limit-range}}]}" &
+      kubectl patch policy $root_policy_namespace.$root_policy_name -n $cluster_name --type=merge --subresource status --patch "status: {compliant: Compliant, details: [{compliant: Compliant, history: [{eventName: $event_name, message: Compliant; notification - limitranges container-mem-limit-range found as specified in namespace $root_policy_namespace, lastTimestamp: "$last_timestamp"}], templateMeta: {creationTimestamp: null, name: policy-limitrange-container-mem-limit-range}}]}" &
     else 
-      kubectl patch policy $root_policy_namespace.$root_policy_name -n $cluster_name --type=merge --subresource status --patch "status: {compliant: NonCompliant, details: [{compliant: NonCompliant, history: [{eventName: $event_name, message: NonCompliant; violation - limitranges container-mem-limit-range not found in namespace $root_policy_namespace}], templateMeta: {creationTimestamp: null, name: policy-limitrange-container-mem-limit-range}}]}" &
+      kubectl patch policy $root_policy_namespace.$root_policy_name -n $cluster_name --type=merge --subresource status --patch "status: {compliant: NonCompliant, details: [{compliant: NonCompliant, history: [{eventName: $event_name, message: NonCompliant; violation - limitranges container-mem-limit-range not found in namespace $root_policy_namespace, lastTimestamp: "$last_timestamp"}], templateMeta: {creationTimestamp: null, name: policy-limitrange-container-mem-limit-range}}]}" &
     fi
 
     if [ $j == 1 ];then


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Rince the replicated policy history(event) is updated by the managed cluster, using the time filter might cause race condition

## Related issue(s)

Fixes #