### PR TITLE
:seedling: Add `cluster_name` and `cluster_id` for the managed cluster events

### DIFF
--- a/agent/pkg/status/controller/event/managedcluster_emitter.go
+++ b/agent/pkg/status/controller/event/managedcluster_emitter.go
@@ -94,6 +94,7 @@ func (h *managedClusterEmitter) Update(obj client.Object) bool {
 		EventNamespace: evt.Namespace,
 		Message:        evt.Message,
 		Reason:         evt.Reason,
+		ClusterName:    cluster.Name,
 		// ClusterID:           clusterId,
 		LeafHubName:         config.GetLeafHubName(),
 		ReportingController: evt.ReportingController,
@@ -106,25 +107,26 @@ func (h *managedClusterEmitter) Update(obj client.Object) bool {
 		h.log.Error(err, "failed to get involved clusterId", "event", evt.Namespace+"/"+evt.Name)
 		return false
 	}
-	// if the clusterId isn't ready, cache it
-	if clusterId == "" {
-		_, ok := h.cachedEvents[cluster.Name]
-		if !ok {
-			h.cachedEvents[cluster.Name] = make([]*models.ManagedClusterEvent, 0)
-		}
-		h.cachedEvents[cluster.Name] = append(h.cachedEvents[cluster.Name], &clusterEvent)
-		return false
-	}
+	// TODO: We can open the following codes to patch the claimed clusterId for the event table.
+	// // if the clusterId isn't ready, cache it
+	// if clusterId == "" {
+	// 	_, ok := h.cachedEvents[cluster.Name]
+	// 	if !ok {
+	// 		h.cachedEvents[cluster.Name] = make([]*models.ManagedClusterEvent, 0)
+	// 	}
+	// 	h.cachedEvents[cluster.Name] = append(h.cachedEvents[cluster.Name], &clusterEvent)
+	// 	return false
+	// }
 
-	// load the cache events to payload if the clusterId is ready
-	cachedEvents, ok := h.cachedEvents[cluster.Name]
-	if ok {
-		for _, cacheEvent := range cachedEvents {
-			cacheEvent.ClusterID = clusterId
-			h.payload = append(h.payload, *cacheEvent)
-		}
-		delete(h.cachedEvents, cluster.Name)
-	}
+	// // load the cache events to payload if the clusterId is ready
+	// cachedEvents, ok := h.cachedEvents[cluster.Name]
+	// if ok {
+	// 	for _, cacheEvent := range cachedEvents {
+	// 		cacheEvent.ClusterID = clusterId
+	// 		h.payload = append(h.payload, *cacheEvent)
+	// 	}
+	// 	delete(h.cachedEvents, cluster.Name)
+	// }
 
 	// load the current event to payload
 	clusterEvent.ClusterID = clusterId

--- a/agent/pkg/status/controller/event/managedcluster_emitter_test.go
+++ b/agent/pkg/status/controller/event/managedcluster_emitter_test.go
@@ -37,27 +37,26 @@ var _ = Describe("ManagedClusterEventEmitter", Ordered, func() {
 		}
 		Expect(kubeClient.Create(ctx, cluster, &client.CreateOptions{})).Should(Succeed())
 
-		By("Create a event before the clusterId is ready")
-		evt1 := &corev1.Event{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "cluster2.event.cache.17cd34e8c8b27fcc",
-				Namespace: "cluster2",
-			},
-			InvolvedObject: v1.ObjectReference{
-				Kind: constants.ManagedClusterKind,
-				// TODO: the cluster namespace should be empty! but if not set the namespace,
-				// it will throw the error: involvedObject.namespace: Invalid value: "": does not match event.namespace
-				Namespace: "cluster2",
-				Name:      cluster.Name,
-			},
-			Reason:              "WaitForImporting",
-			Message:             "The cluster2 is waiting for importing",
-			ReportingController: "managedcluster-import-controller",
-			ReportingInstance:   "managedcluster-import-controller-managedcluster-import-controller-v2-7c76cf646f-rb5ws",
-			Type:                "Normal",
-		}
-		Expect(kubeClient.Create(ctx, evt1)).NotTo(HaveOccurred())
-		time.Sleep(2 * time.Second)
+		// By("Create a event before the clusterId is ready")
+		// evt1 := &corev1.Event{
+		// 	ObjectMeta: metav1.ObjectMeta{
+		// 		Name:      "cluster2.event.cache.17cd34e8c8b27fcc",
+		// 		Namespace: "cluster2",
+		// 	},
+		// 	InvolvedObject: v1.ObjectReference{
+		// 		Kind: constants.ManagedClusterKind,
+		// 		// TODO: the cluster namespace should be empty! but if not set the namespace,
+		// 		// it will throw the error: involvedObject.namespace: Invalid value: "": does not match event.namespace
+		// 		Namespace: "cluster2",
+		// 		Name:      cluster.Name,
+		// 	},
+		// 	Reason:              "WaitForImporting",
+		// 	Message:             "The cluster2 is waiting for importing",
+		// 	ReportingController: "managedcluster-import-controller",
+		// 	ReportingInstance:   "managedcluster-import-controller-managedcluster-import-controller-v2-7c76cf646f-rb5ws",
+		// 	Type:                "Normal",
+		// }
+		// Expect(kubeClient.Create(ctx, evt1)).NotTo(HaveOccurred())
 
 		By("Claim the clusterId")
 		cluster.Status = clusterv1.ManagedClusterStatus{
@@ -107,15 +106,15 @@ var _ = Describe("ManagedClusterEventEmitter", Ordered, func() {
 				return fmt.Errorf("got an empty event payload %s", key)
 			}
 
-			if len(outEvents) != 2 {
-				return fmt.Errorf("should send the 2 events in 1 bundle")
-			}
+			// if len(outEvents) != 2 {
+			// 	return fmt.Errorf("should send the 2 events in 1 bundle")
+			// }
 
-			if outEvents[0].EventName != evt1.Name {
-				return fmt.Errorf("want %v, but got %v", evt1, outEvents[0])
-			}
-			if outEvents[1].EventName != evt2.Name {
-				return fmt.Errorf("want %v, but got %v", evt2, outEvents[1])
+			// if outEvents[0].EventName != evt1.Name {
+			// 	return fmt.Errorf("want %v, but got %v", evt1, outEvents[0])
+			// }
+			if outEvents[0].EventName != evt2.Name {
+				return fmt.Errorf("want %v, but got %v", evt2, outEvents[0])
 			}
 			return nil
 		}, 10*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())

--- a/agent/pkg/status/controller/event/managedcluster_emitter_test.go
+++ b/agent/pkg/status/controller/event/managedcluster_emitter_test.go
@@ -37,27 +37,6 @@ var _ = Describe("ManagedClusterEventEmitter", Ordered, func() {
 		}
 		Expect(kubeClient.Create(ctx, cluster, &client.CreateOptions{})).Should(Succeed())
 
-		// By("Create a event before the clusterId is ready")
-		// evt1 := &corev1.Event{
-		// 	ObjectMeta: metav1.ObjectMeta{
-		// 		Name:      "cluster2.event.cache.17cd34e8c8b27fcc",
-		// 		Namespace: "cluster2",
-		// 	},
-		// 	InvolvedObject: v1.ObjectReference{
-		// 		Kind: constants.ManagedClusterKind,
-		// 		// TODO: the cluster namespace should be empty! but if not set the namespace,
-		// 		// it will throw the error: involvedObject.namespace: Invalid value: "": does not match event.namespace
-		// 		Namespace: "cluster2",
-		// 		Name:      cluster.Name,
-		// 	},
-		// 	Reason:              "WaitForImporting",
-		// 	Message:             "The cluster2 is waiting for importing",
-		// 	ReportingController: "managedcluster-import-controller",
-		// 	ReportingInstance:   "managedcluster-import-controller-managedcluster-import-controller-v2-7c76cf646f-rb5ws",
-		// 	Type:                "Normal",
-		// }
-		// Expect(kubeClient.Create(ctx, evt1)).NotTo(HaveOccurred())
-
 		By("Claim the clusterId")
 		cluster.Status = clusterv1.ManagedClusterStatus{
 			ClusterClaims: []clusterv1.ManagedClusterClaim{
@@ -70,7 +49,7 @@ var _ = Describe("ManagedClusterEventEmitter", Ordered, func() {
 		Expect(kubeClient.Status().Update(ctx, cluster)).Should(Succeed())
 
 		By("Create the cluster event after the clusterId is ready")
-		evt2 := &corev1.Event{
+		evt := &corev1.Event{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "cluster2.event.17cd34e8c8b27fdd",
 				Namespace: "cluster2",
@@ -88,7 +67,7 @@ var _ = Describe("ManagedClusterEventEmitter", Ordered, func() {
 			ReportingInstance:   "registration-controller-cluster-manager-registration-controller-6794cf54d9-j7lgm",
 			Type:                "Warning",
 		}
-		Expect(kubeClient.Create(ctx, evt2)).NotTo(HaveOccurred())
+		Expect(kubeClient.Create(ctx, evt)).NotTo(HaveOccurred())
 
 		Eventually(func() error {
 			key := string(enum.ManagedClusterEventType)
@@ -106,15 +85,8 @@ var _ = Describe("ManagedClusterEventEmitter", Ordered, func() {
 				return fmt.Errorf("got an empty event payload %s", key)
 			}
 
-			// if len(outEvents) != 2 {
-			// 	return fmt.Errorf("should send the 2 events in 1 bundle")
-			// }
-
-			// if outEvents[0].EventName != evt1.Name {
-			// 	return fmt.Errorf("want %v, but got %v", evt1, outEvents[0])
-			// }
-			if outEvents[0].EventName != evt2.Name {
-				return fmt.Errorf("want %v, but got %v", evt2, outEvents[0])
+			if outEvents[0].EventName != evt.Name {
+				return fmt.Errorf("want %v, but got %v", evt, outEvents[0])
 			}
 			return nil
 		}, 10*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())

--- a/manager/pkg/statussyncer/syncers/managedcluster_event_handler_test.go
+++ b/manager/pkg/statussyncer/syncers/managedcluster_event_handler_test.go
@@ -27,8 +27,9 @@ var _ = Describe("ManagedClusterEventHandler", Ordered, func() {
 		data = append(data, models.ManagedClusterEvent{
 			EventNamespace:      "managed-cluster1",
 			EventName:           "managed-cluster1.17cd5c3642c43a8a",
-			ClusterID:           "13b2e003-2bdf-4c82-9bdf-f1aa7ccf608d",
+			ClusterID:           "",
 			LeafHubName:         "hub1",
+			ClusterName:         "managed-cluster1",
 			Message:             "The managed cluster (managed-cluster1) cannot connect to the hub cluster.",
 			Reason:              "AvailableUnknown",
 			ReportingController: "registration-controller",
@@ -53,7 +54,7 @@ var _ = Describe("ManagedClusterEventHandler", Ordered, func() {
 
 			count := 0
 			for _, item := range items {
-				fmt.Println(">>>>>>>>>>>>>>>>>> ", item.LeafHubName, item.EventName, item.Message, item.CreatedAt)
+				fmt.Println(">> ", item.LeafHubName, item.ClusterName, item.EventName, item.Message, item.CreatedAt)
 				count++
 			}
 			if count > 0 {

--- a/manager/pkg/statussyncer/syncers/managedcluster_event_handler_test.go
+++ b/manager/pkg/statussyncer/syncers/managedcluster_event_handler_test.go
@@ -53,7 +53,7 @@ var _ = Describe("ManagedClusterEventHandler", Ordered, func() {
 
 			count := 0
 			for _, item := range items {
-				fmt.Println(item.LeafHubName, item.EventName, item.Message, item.CreatedAt)
+				fmt.Println(">>>>>>>>>>>>>>>>>> ", item.LeafHubName, item.EventName, item.Message, item.CreatedAt)
 				count++
 			}
 			if count > 0 {

--- a/operator/pkg/controllers/hubofhubs/database/2.tables.sql
+++ b/operator/pkg/controllers/hubofhubs/database/2.tables.sql
@@ -62,7 +62,8 @@ CREATE INDEX IF NOT EXISTS leafhub_deleted_at_idx ON status.leaf_hubs (deleted_a
 CREATE TABLE IF NOT EXISTS event.managed_clusters (
     event_namespace text NOT NULL,
     event_name text NOT NULL,
-    cluster_id uuid NOT NULL,
+    cluster_name text NOT NULL,
+    cluster_id text,
     leaf_hub_name character varying(256) NOT NULL,
     message text,
     reason text,

--- a/operator/pkg/controllers/hubofhubs/database/2.tables.sql
+++ b/operator/pkg/controllers/hubofhubs/database/2.tables.sql
@@ -63,7 +63,7 @@ CREATE TABLE IF NOT EXISTS event.managed_clusters (
     event_namespace text NOT NULL,
     event_name text NOT NULL,
     cluster_name text NOT NULL,
-    cluster_id text,
+    cluster_id uuid NOT NULL,
     leaf_hub_name character varying(256) NOT NULL,
     message text,
     reason text,

--- a/operator/pkg/controllers/hubofhubs/database/3.functions.sql
+++ b/operator/pkg/controllers/hubofhubs/database/3.functions.sql
@@ -20,6 +20,20 @@ BEGIN
 END;
 $$;
 
+CREATE OR REPLACE FUNCTION public.update_cluster_event_cluster_id()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+AS $$
+BEGIN
+    UPDATE event.managed_clusters
+    SET cluster_id = NEW.cluster_id
+    WHERE leaf_hub_name = NEW.leaf_hub_name
+        AND cluster_name = (NEW.payload -> 'metadata' ->> 'name')
+        AND cluster_id = (New.payload -> 'metadata' ->> 'uid')::uuid;
+    RETURN NEW;
+END;
+$$;
+
 -- manually exec local compliance cronjob func
 -- insert compliance view records to history.local_compliance: SELECT history.insert_local_compliance_job('2023_07_06');
 CREATE OR REPLACE FUNCTION history.insert_local_compliance_job(

--- a/operator/pkg/controllers/hubofhubs/database/4.trigger.sql
+++ b/operator/pkg/controllers/hubofhubs/database/4.trigger.sql
@@ -12,6 +12,12 @@ AFTER INSERT OR UPDATE ON status.managed_clusters
 FOR EACH ROW
 EXECUTE FUNCTION public.update_local_compliance_cluster_id();
 
+DROP TRIGGER IF EXISTS update_cluster_event_cluster_id_trigger ON status.managed_clusters;
+CREATE TRIGGER update_cluster_event_cluster_id_trigger
+AFTER INSERT OR UPDATE ON status.managed_clusters
+FOR EACH ROW
+EXECUTE FUNCTION public.update_cluster_event_cluster_id();
+
 --- create the current month partitioned tables for local_policies and local_root_policies
 SELECT create_monthly_range_partitioned_table('event.local_root_policies', to_char(current_date, 'YYYY-MM-DD'));
 SELECT create_monthly_range_partitioned_table('event.local_policies', to_char(current_date, 'YYYY-MM-DD'));

--- a/pkg/database/models/event.go
+++ b/pkg/database/models/event.go
@@ -53,12 +53,12 @@ type ManagedClusterEvent struct {
 	EventNamespace      string    `gorm:"column:event_namespace;type:varchar(63);not null" json:"eventNamespace"`
 	EventName           string    `gorm:"column:event_name;type:varchar(63);not null" json:"eventName"`
 	ClusterID           string    `gorm:"column:cluster_id;type:uuid;not null" json:"clusterId"`
-	LeafHubName         string    `gorm:"size:256;not null" json:"-"`
+	LeafHubName         string    `gorm:"column:leaf_hub_name;type:varchar(256);not null" json:"leaf_hub_name"`
 	Message             string    `gorm:"column:message;type:text" json:"message"`
 	Reason              string    `gorm:"column:reason;type:text" json:"reason"`
 	ReportingController string    `gorm:"column:reporting_controller;type:text" json:"reportingController"`
 	ReportingInstance   string    `gorm:"column:reporting_instance;type:text" json:"reportingInstance"`
-	EventType           string    `gorm:"size:256;not null" json:"type"`
+	EventType           string    `gorm:"column:event_type;type:varchar(63);not null" json:"type"`
 	CreatedAt           time.Time `gorm:"column:created_at;default:now();not null" json:"createdAt"`
 }
 

--- a/pkg/database/models/event.go
+++ b/pkg/database/models/event.go
@@ -52,8 +52,9 @@ func (DataRetentionJobLog) TableName() string {
 type ManagedClusterEvent struct {
 	EventNamespace      string    `gorm:"column:event_namespace;type:varchar(63);not null" json:"eventNamespace"`
 	EventName           string    `gorm:"column:event_name;type:varchar(63);not null" json:"eventName"`
-	ClusterID           string    `gorm:"column:cluster_id;type:uuid;not null" json:"clusterId"`
-	LeafHubName         string    `gorm:"column:leaf_hub_name;type:varchar(256);not null" json:"leaf_hub_name"`
+	ClusterName         string    `gorm:"column:cluster_name;type:varchar(63);not null" json:"clusterName"`
+	ClusterID           string    `gorm:"column:cluster_id;type:text" json:"clusterId"`
+	LeafHubName         string    `gorm:"column:leaf_hub_name;type:varchar(256);not null" json:"leafHubName"`
 	Message             string    `gorm:"column:message;type:text" json:"message"`
 	Reason              string    `gorm:"column:reason;type:text" json:"reason"`
 	ReportingController string    `gorm:"column:reporting_controller;type:text" json:"reportingController"`

--- a/pkg/utils/object.go
+++ b/pkg/utils/object.go
@@ -71,6 +71,7 @@ func GetRootPolicy(ctx context.Context, runtimeClient client.Client, namespacedN
 	return &rootPolicy, nil
 }
 
+// GetClusterId retrieve the claimId("id.k8s.io") first, if not exist, then get the cluster.UID()
 func GetClusterId(ctx context.Context, runtimeClient client.Client, clusterName string) (string, error) {
 	cluster := clusterv1.ManagedCluster{}
 	if err := runtimeClient.Get(ctx, client.ObjectKey{Name: clusterName}, &cluster); err != nil {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Note:
1. add cluster_name in the cluster event table
2. patch the cluster_id in the event table when managed_clusters is created/updated

## Related issue(s)

Fixes #