### PR TITLE
:seedling: Define the Kafka's data rentention policy explicity

### DIFF
--- a/operator/pkg/transporter/strimzi_transporter.go
+++ b/operator/pkg/transporter/strimzi_transporter.go
@@ -736,7 +736,10 @@ func (k *strimziTransporter) newKafkaCluster(mgh *operatorv1alpha4.MulticlusterG
 "min.insync.replicas": 2,
 "offsets.topic.replication.factor": 3,
 "transaction.state.log.min.isr": 2,
-"transaction.state.log.replication.factor": 3
+"transaction.state.log.replication.factor": 3,
+"log.retention.ms": 604800000,
+"log.retention.bytes": 1073741824,
+"log.segment.bytes": 107374182
 }`)},
 				Listeners: []kafkav1beta2.KafkaSpecKafkaListenersElem{
 					{


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

`"log.retention.ms": 604800000`: the logs in each partition older than 7 days will be deleted
`"log.retention.bytes": 1073741824`: make sure each partition size is below 1 GB
`"log.segment.bytes": 107374182 `: each segment log in a partition will make sure the file size is 100 MB, this a not a deletion policy.

Either the "log.retention.ms" and "log.retention.bytes" condition is met. It will apply the deletion policy on the related partitions

## Related issue(s)

Fixes #