### PR TITLE
set timeout for clusteradmin

### DIFF
--- a/test/script/util.sh
+++ b/test/script/util.sh
@@ -147,7 +147,7 @@ init_managed() {
     fi
     managed_cluster_name+="$managed,"
   done
-  clusteradm accept --clusters "${managed_cluster_name%,*}" --context "${hub}" --wait
+  timeout 5m clusteradm accept --clusters "${managed_cluster_name%,*}" --context "${hub}" --wait
 }
 
 join_cluster() {
@@ -163,7 +163,7 @@ join_cluster() {
     else
       sed -e "s;<cluster_name>;$cluster --context $cluster --wait;" "$join_file" | bash
     fi
-    clusteradm accept --clusters "$2" --context "${hub}" --wait
+    timeout 5m clusteradm accept --clusters "$2" --context "${hub}" --wait
   fi
 }
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
In e2e, if the kind cluster create error, clusteradm command will always waiting , and no timeout. we should set timeout to that.
## Related issue(s)

Fixes #