### PR TITLE
disable the replicated policy event

### DIFF
--- a/agent/pkg/status/controller/event/event_syncer.go
+++ b/agent/pkg/status/controller/event/event_syncer.go
@@ -51,7 +51,7 @@ func LaunchEventSyncer(ctx context.Context, mgr ctrl.Manager,
 		statusconfig.GetEventDuration,
 		[]generic.ObjectEmitter{
 			NewLocalRootPolicyEmitter(ctx, mgr.GetClient(), eventTopic),
-			NewLocalReplicatedPolicyEmitter(ctx, mgr.GetClient(), eventTopic),
+			// NewLocalReplicatedPolicyEmitter(ctx, mgr.GetClient(), eventTopic),
 			NewManagedClusterEventEmitter(ctx, mgr.GetClient(), eventTopic),
 		})
 }

--- a/test/integration/agent/status/localpolicy_event_test.go
+++ b/test/integration/agent/status/localpolicy_event_test.go
@@ -162,6 +162,7 @@ var _ = Describe("LocalPolicyEventEmitter", Ordered, func() {
 	})
 
 	It("should pass the replicated policy event", func() {
+		Skip("the event is duplicated with event from replicated policy history, so skip...")
 		By("Create namespace and cluster for the replicated policy")
 		err := runtimeClient.Create(ctx, &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

The replicated policy events are duplicated and do not consist of the ACM dashboard.

## Related issue(s)

Fixes #