### PR TITLE
[WIP] the e2e issue

### DIFF
--- a/test/script/e2e_kafka.sh
+++ b/test/script/e2e_kafka.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 
-CURRENT_DIR=$(cd "$(dirname "$0")" || exit; pwd)
+CURRENT_DIR=$(
+  cd "$(dirname "$0")" || exit
+  pwd
+)
 # shellcheck source=/dev/null
 source "$CURRENT_DIR/util.sh"
 
-KUBECONFIG=${1:-$KUBECONFIG}               # install the kafka 
-SECRET_KUBECONFIG=${2:-$KUBECONFIG}        # generate the crenditial secret 
+KUBECONFIG=${1:-$KUBECONFIG}        # install the kafka
+SECRET_KUBECONFIG=${2:-$KUBECONFIG} # generate the crenditial secret
 
 start_time=$(date +%s)
 echo -e "\r${BOLD_GREEN}[ START - $(date +"%T") ] Install Kafka $NC"
@@ -54,17 +57,21 @@ kubectl -n "$target_namespace" patch kafka.kafka.strimzi.io/kafka --type json -p
 wait_cmd "kubectl get kafka kafka -n $target_namespace -o jsonpath='{.status.listeners[1]}' | grep bootstrapServers"
 
 # kafka
+kubectl get kafkatopic -n multicluster-global-hub -oyaml
+
 wait_cmd "kubectl get kafkatopic gh-spec -n multicluster-global-hub | grep -C 1 True"
 wait_cmd "kubectl get kafkatopic gh-event.hub1 -n multicluster-global-hub | grep -C 1 True"
 wait_cmd "kubectl get kafkatopic gh-event.hub2 -n multicluster-global-hub | grep -C 1 True"
+
+kubectl get kafkauser -n multicluster-global-hub -oyaml
 wait_cmd "kubectl get kafkauser global-hub-kafka-user -n multicluster-global-hub | grep -C 1 True"
 wait_cmd "kubectl get kafkauser hub1-kafka-user -n multicluster-global-hub | grep -C 1 True"
 wait_cmd "kubectl get kafkauser hub2-kafka-user -n multicluster-global-hub | grep -C 1 True"
 echo "Kafka topic/user are ready"
 
-# Note: skip to create the transport secret, trying to use the the internal multi users and topics for managed hubs 
+# Note: skip to create the transport secret, trying to use the the internal multi users and topics for managed hubs
 
-# # BYO: 1. create the topics; 2. create the user; 3. create the transport secret 
+# # BYO: 1. create the topics; 2. create the user; 3. create the transport secret
 # byo_user=global-hub-byo-user
 # wait_cmd "kubectl get kafkauser $byo_user -n $target_namespace | grep -C 1 True"
 
@@ -81,7 +88,7 @@ echo "Kafka topic/user are ready"
 #     --from-literal=bootstrap_server="$bootstrap_server" \
 #     --from-file=ca.crt="$CURRENT_DIR"/config/kafka-ca-cert.pem \
 #     --from-file=client.crt="$CURRENT_DIR"/config/kafka-client-cert.pem \
-#     --from-file=client.key="$CURRENT_DIR"/config/kafka-client-key.pem 
+#     --from-file=client.key="$CURRENT_DIR"/config/kafka-client-key.pem
 # echo "transport secret is ready!"
 
 echo -e "\r${BOLD_GREEN}[ END - $(date +"%T") ] Install Kafka ${NC} $(($(date +%s) - start_time)) seconds"


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This PR will remain open to trace the errors in the e2e and integration tests

https://github.com/stolostron/multicluster-global-hub/pull/1054#issuecomment-2287860986
```bash
Context "kind-hub2" renamed to "hub2".
kubectl config rename-context kind-hub2 hub2: Success.  
kubectl config set-cluster kind-hub2 --server=https://172.21.0.2:6443/  
 Attempt 1...  
Set kubectl context to "kind-global-hub"
You can now use your cluster with:
kubectl cluster-info --context kind-global-hub
Not sure what to do next? 😅  Check out https://kind.sigs.k8s.io/docs/user/quick-start/
kind create cluster --name global-hub --wait 5m: Success.  
kubectl config rename-context kind-global-hub global-hub  
 Attempt 1...  
error: open /tmp/multicluster-global-hub/test/script/config/clusters.lock: file exists
Context "kind-global-hub" renamed to "global-hub".
```

## Related issue(s)

Fixes https://github.com/stolostron/multicluster-global-hub/issues/1031

