### PR TITLE
:sparkles: Add the cache filter with topic prefix

### DIFF
--- a/agent/pkg/status/controller/controller.go
+++ b/agent/pkg/status/controller/controller.go
@@ -80,7 +80,8 @@ func AddControllers(ctx context.Context, mgr ctrl.Manager, agentConfig *config.A
 	}
 
 	// lunch a time filter, it must be called after filter.RegisterTimeFilter(key)
-	if err := filter.LaunchTimeFilter(ctx, mgr.GetClient(), agentConfig.PodNameSpace); err != nil {
+	if err := filter.LaunchTimeFilter(ctx, mgr.GetClient(), agentConfig.PodNameSpace,
+		agentConfig.TransportConfig.KafkaConfig.Topics.StatusTopic); err != nil {
 		return fmt.Errorf("failed to launch time filter: %w", err)
 	}
 	return nil

--- a/test/Makefile
+++ b/test/Makefile
@@ -29,6 +29,9 @@ e2e-log/manager:
 e2e-log/grafana:
 	@COMPONENT=multicluster-global-hub-grafana ./test/script/e2e_log.sh
 
+e2e-log/agent:
+	@export CLUSTER_NAME=hub1 COMPONENT=multicluster-global-hub-agent NAMESPACE=multicluster-global-hub-agent && ./test/script/e2e_log.sh
+
 integration-test: setup_envtest
 	KUBEBUILDER_ASSETS="$(shell ${TMP_BIN}/setup-envtest use --use-env -p path)" ${GO_TEST} `go list ./test/integration/...`
 

--- a/test/script/e2e_prow.sh
+++ b/test/script/e2e_prow.sh
@@ -38,6 +38,7 @@ log_component_logs() {
     ssh "${OPT[@]}" "$HOST" "cd $HOST_DIR && . test/script/env.list && make e2e-log/operator" > >(tee "$ARTIFACT_DIR/e2e-operator.log")
     ssh "${OPT[@]}" "$HOST" "cd $HOST_DIR && . test/script/env.list && make e2e-log/manager" > >(tee "$ARTIFACT_DIR/e2e-manager.log")
     ssh "${OPT[@]}" "$HOST" "cd $HOST_DIR && . test/script/env.list && make e2e-log/grafana" > >(tee "$ARTIFACT_DIR/e2e-grafana.log")
+    ssh "${OPT[@]}" "$HOST" "cd $HOST_DIR && . test/script/env.list && make e2e-log/agent" > >(tee "$ARTIFACT_DIR/e2e-agent.log")
 }
 
 echo "runn e2e tests"


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

The previous cache key is based on the `eventType`. But if we support renaming the topic, we need the agent to send the event to the new topic again after the topic is changed. Otherwise, it might lose data when renaming the topics

## Related issue(s)

Reference: https://github.com/stolostron/multicluster-global-hub/pull/1032