### PR TITLE
:bug: Disable the the topic deletion when removing the global hub agent

### DIFF
--- a/operator/pkg/controllers/addon/addon_installer.go
+++ b/operator/pkg/controllers/addon/addon_installer.go
@@ -134,11 +134,11 @@ func (r *AddonInstaller) reconclieAddonAndResources(ctx context.Context, cluster
 		}
 	}
 
-	// reconcile kafka resources
-	return ensureKafkaResource(cluster.Name)
+	// reconcile transport resources
+	return ensureTransportResource(cluster.Name)
 }
 
-func ensureKafkaResource(clusterName string) error {
+func ensureTransportResource(clusterName string) error {
 	// create kafka resource: user and topic
 	trans := config.GetTransporter()
 	if trans == nil {

--- a/operator/pkg/controllers/hubofhubs/transporter/protocol/strimzi_transporter.go
+++ b/operator/pkg/controllers/hubofhubs/transporter/protocol/strimzi_transporter.go
@@ -380,26 +380,26 @@ func (k *strimziTransporter) Prune(clusterName string) error {
 		return err
 	}
 
-	// cleanup kafkaTopic
-	if k.sharedTopics || !strings.Contains(config.GetRawStatusTopic(), "*") {
-		return nil
-	}
+	// only delete the topic when removing the CR, otherwise the manager throws error like "Unknown topic or partition"
+	// if k.sharedTopics || !strings.Contains(config.GetRawStatusTopic(), "*") {
+	// 	return nil
+	// }
 
-	clusterTopic := k.getClusterTopic(clusterName)
-	kafkaTopic := &kafkav1beta2.KafkaTopic{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      clusterTopic.StatusTopic,
-			Namespace: k.kafkaClusterNamespace,
-		},
-	}
-	err = k.runtimeClient.Get(k.ctx, client.ObjectKeyFromObject(kafkaTopic), kafkaTopic)
-	if err == nil {
-		if err := k.runtimeClient.Delete(k.ctx, kafkaTopic); err != nil {
-			return err
-		}
-	} else if !errors.IsNotFound(err) {
-		return err
-	}
+	// clusterTopic := k.getClusterTopic(clusterName)
+	// kafkaTopic := &kafkav1beta2.KafkaTopic{
+	// 	ObjectMeta: metav1.ObjectMeta{
+	// 		Name:      clusterTopic.StatusTopic,
+	// 		Namespace: k.kafkaClusterNamespace,
+	// 	},
+	// }
+	// err = k.runtimeClient.Get(k.ctx, client.ObjectKeyFromObject(kafkaTopic), kafkaTopic)
+	// if err == nil {
+	// 	if err := k.runtimeClient.Delete(k.ctx, kafkaTopic); err != nil {
+	// 		return err
+	// 	}
+	// } else if !errors.IsNotFound(err) {
+	// 	return err
+	// }
 
 	return nil
 }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

### Kafka topic deletion:
1. Consumer Impact: The consumer typically detects the deletion during its polling process. The default polling interval (max.poll.interval.ms) is 5 minutes, meaning the consumer may not notice the deletion until the next poll.

2. Metadata Refresh: Kafka clients periodically refresh their metadata, which includes topic information. The frequency of this refresh (`metadata.max.age.ms`) can also affect how quickly the consumer becomes aware of the topic deletion. The default value is 5 minutes.

3. Rebalancing Trigger: When the Kafka consumer attempts to fetch data from a deleted topic, it will encounter an error like UnknownTopicOrPartitionException. This error can trigger a rebalance in the consumer group. The rebalance process redistributes the available partitions among the remaining topics to the consumers. The time it takes to complete the rebalance can vary based on the size of the consumer group and the number of partitions involved. Typically, rebalancing can take anywhere from a few seconds to a minute, depending on these factors.

### Kafka topic creation:

1. Metadata Discovery:

**Metadata Refresh Interval** (`metadata.max.age.ms`): The consumer discovers the new topic during its next metadata refresh, which can take up to 5 minutes by default. If this interval is reduced or a manual refresh is triggered, the discovery happens faster.

2. Rebalancing:

Once the new topic is discovered, the consumer group coordinator triggers a rebalance. During rebalancing, the coordinator redistributes the topic partitions among all the consumers in the group.
**Rebalance Time**: The rebalance process can take anywhere from a few seconds to a minute or more, depending on the size of the consumer group and the number of partitions.


## Related issue(s)

Fixes # https://issues.redhat.com/browse/ACM-13317