### PR TITLE
[WIP] :bug: fix e2e issue

### DIFF
--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -145,7 +145,7 @@ var _ = BeforeSuite(func() {
 	Eventually(func() (err error) {
 		managedClusters, err = getManagedCluster(httpClient)
 		return err
-	}, 3*time.Minute, 1*time.Second).ShouldNot(HaveOccurred())
+	}, 30*time.Minute, 1*time.Second).ShouldNot(HaveOccurred())
 	Expect(len(managedClusters)).Should(Equal(ExpectedMC * ExpectedMH))
 })
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

e2e failed with the following error:
```
   [FAILED] Timed out after 180.000s.
  Unexpected error:
      <*errors.errorString | 0xc000ae1900>: 
      managed cluster number: want 2, got 0
      {
          s: "managed cluster number: want 2, got 0",
      }
  occurred 
```
the multicluster-global-hub-agent does not throw any errors.
the multicluster-global-hub-manager has an error `{"level":"info","ts":1724319103.4982526,"logger":"fallback","caller":"v2@v2.0.0-20240413090539-7fef29478991/protocol.go:202","msg":"Error Broker: Unknown topic or partition: Subscribed topic not available: ^gh-event.*: Broker: Unknown topic or partition"}`

## Related issue(s)

Fixes #