### PR TITLE
:bug:  kafka replicas topic

### DIFF
--- a/operator/pkg/controllers/hubofhubs/transporter/protocol/strimzi_transporter.go
+++ b/operator/pkg/controllers/hubofhubs/transporter/protocol/strimzi_transporter.go
@@ -200,6 +200,10 @@ func (k *strimziTransporter) renderKafkaResources(mgh *operatorv1alpha4.Multiclu
 		statusPlaceholderTopic = strings.Replace(config.GetRawStatusTopic(), "*", "global-hub", -1)
 		topicParttern = kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypePrefix
 	}
+	topicReplicas := DefaultPartitionReplicas
+	if mgh.Spec.AvailabilityConfig == operatorv1alpha4.HABasic {
+		topicReplicas = 1
+	}
 	// render the kafka objects
 	kafkaRenderer, kafkaDeployer := renderer.NewHoHRenderer(manifests), deployer.NewHoHDeployer(k.manager.GetClient())
 	kafkaObjects, err := kafkaRenderer.Render("manifests", "",
@@ -225,7 +229,7 @@ func (k *strimziTransporter) renderKafkaResources(mgh *operatorv1alpha4.Multiclu
 				StatusTopicParttern:    string(topicParttern),
 				StatusPlaceholderTopic: statusPlaceholderTopic,
 				TopicPartition:         DefaultPartition,
-				TopicReplicas:          DefaultPartitionReplicas,
+				TopicReplicas:          topicReplicas,
 			}, nil
 		})
 	if err != nil {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

```yaml
- apiVersion: kafka.strimzi.io/v1beta2
  kind: KafkaTopic
  metadata:
    creationTimestamp: "2024-08-26T01:54:44Z"
    finalizers:
    - strimzi.io/topic-operator
    generation: 2
    labels:
      global-hub.open-cluster-management.io/managed-by: global-hub-operator
      strimzi.io/cluster: kafka
    name: gh-event.global-hub
    namespace: multicluster-global-hub
    ownerReferences:
    - apiVersion: operator.open-cluster-management.io/v1alpha4
      blockOwnerDeletion: true
      controller: true
      kind: MulticlusterGlobalHub
      name: multiclusterglobalhub
      uid: b5aa1fdc-8699-4078-8f5b-6f104f67db0c
    resourceVersion: "6156"
    uid: 6ab99671-3af5-485f-a091-9d30038e0788
  spec:
    config:
      cleanup.policy: compact
    partitions: 1
    replicas: 3
  status:
    conditions:
    - lastTransitionTime: "2024-08-26T02:15:04.974685907Z"
      message: Replication factor change not supported, but required for partitions
        [0]
      reason: NotSupported
      status: "False"
      type: Ready
    observedGeneration: 2
    topicId: rS8oimldQwu5ikwG3j5LXg
    topicName: gh-event.global-hub
```

## Related issue(s)

Fixes #