### PR TITLE
:sparkles: Support the agent to deploy in a standalone mode

### DIFF
--- a/agent/cmd/agent/main.go
+++ b/agent/cmd/agent/main.go
@@ -167,8 +167,7 @@ func completeConfig(agentConfig *config.AgentConfig) error {
 	if agentConfig.MetricsAddress == "" {
 		agentConfig.MetricsAddress = fmt.Sprintf("%s:%d", metricsHost, metricsPort)
 	}
-	// if deploy the agent as a event exporter, then enable it reports event to multiple targets,
-	// disable the consumer features
+	// if deploy the agent as a event exporter, then disable the consumer features
 	if agentConfig.Standalone {
 		agentConfig.TransportConfig.ConsumerGroupId = ""
 		agentConfig.SpecWorkPoolSize = 0

--- a/agent/cmd/agent/main.go
+++ b/agent/cmd/agent/main.go
@@ -248,7 +248,6 @@ func transportCallback(mgr ctrl.Manager, agentConfig *config.AgentConfig,
 }
 
 func initCache(restConfig *rest.Config, cacheOpts cache.Options) (cache.Cache, error) {
-	namespace := config.GetAgentConfig().PodNamespace
 	cacheOpts.ByObject = map[client.Object]cache.ByObject{
 		&apiextensionsv1.CustomResourceDefinition{}: {
 			Field: fields.OneTermEqualSelector("metadata.name", "clustermanagers.operator.open-cluster-management.io"),
@@ -262,11 +261,11 @@ func initCache(restConfig *rest.Config, cacheOpts cache.Options) (cache.Cache, e
 		&clusterv1beta1.PlacementDecision{}: {},
 		&appsv1alpha1.SubscriptionReport{}:  {},
 		&coordinationv1.Lease{}: {
-			Field: fields.OneTermEqualSelector("metadata.namespace", namespace),
+			Field: fields.OneTermEqualSelector("metadata.namespace", config.GetAgentConfig().PodNamespace),
 		},
 		&corev1.Event{}: {}, // TODO: need a filter for the target events
 		&corev1.Secret{}: {
-			Field: fields.OneTermEqualSelector("metadata.namespace", namespace),
+			Field: fields.OneTermEqualSelector("metadata.namespace", config.GetAgentConfig().PodNamespace),
 		},
 	}
 	return cache.New(restConfig, cacheOpts)

--- a/agent/cmd/agent/main_test.go
+++ b/agent/cmd/agent/main_test.go
@@ -56,6 +56,7 @@ func TestCompleteConfig(t *testing.T) {
 				SpecWorkPoolSize: 10,
 				TransportConfig: &transport.TransportConfig{
 					ConsumerGroupId: "test-hub",
+					TransportType:   string(transport.Kafka),
 				},
 			},
 			expectConfig: &config.AgentConfig{
@@ -65,7 +66,7 @@ func TestCompleteConfig(t *testing.T) {
 				MetricsAddress:   fmt.Sprintf("%s:%d", metricsHost, metricsPort),
 				TransportConfig: &transport.TransportConfig{
 					ConsumerGroupId: "",
-					TransportType:   string(transport.Rest),
+					TransportType:   string(transport.Kafka),
 				},
 			},
 			expectErrorMsg: "",

--- a/agent/cmd/agent/main_test.go
+++ b/agent/cmd/agent/main_test.go
@@ -29,7 +29,7 @@ func TestParseFlags(t *testing.T) {
 	agentConfig := parseFlags()
 
 	assert.Equal(t, "test-hub", agentConfig.LeafHubName)
-	assert.Equal(t, "test-namespace", agentConfig.PodNameSpace)
+	assert.Equal(t, "test-namespace", agentConfig.PodNamespace)
 	assert.Equal(t, "kafka", agentConfig.TransportConfig.TransportType)
 	assert.Equal(t, 5, agentConfig.SpecWorkPoolSize)
 }
@@ -65,7 +65,7 @@ func TestCompleteConfig(t *testing.T) {
 				MetricsAddress:   fmt.Sprintf("%s:%d", metricsHost, metricsPort),
 				TransportConfig: &transport.TransportConfig{
 					ConsumerGroupId: "",
-					TransportType:   string(transport.Multiple),
+					TransportType:   string(transport.Rest),
 				},
 			},
 			expectErrorMsg: "",

--- a/agent/cmd/agent/main_test.go
+++ b/agent/cmd/agent/main_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport"
+)
+
+func TestParseFlags(t *testing.T) {
+	// Save original command-line arguments
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+
+	// Set up test arguments
+	os.Args = []string{
+		"cmd",
+		"--leaf-hub-name=test-hub",
+		"--pod-namespace=test-namespace",
+		"--transport-type=kafka",
+		"--consumer-worker-pool-size=5",
+	}
+
+	agentConfig := parseFlags()
+
+	assert.Equal(t, "test-hub", agentConfig.LeafHubName)
+	assert.Equal(t, "test-namespace", agentConfig.PodNameSpace)
+	assert.Equal(t, "kafka", agentConfig.TransportConfig.TransportType)
+	assert.Equal(t, 5, agentConfig.SpecWorkPoolSize)
+}
+
+func TestCompleteConfig(t *testing.T) {
+	testCases := []struct {
+		name           string
+		agentConfig    *config.AgentConfig
+		expectConfig   *config.AgentConfig
+		expectErrorMsg string
+	}{
+		{
+			name: "Invalid leaf-hub-name",
+			agentConfig: &config.AgentConfig{
+				LeafHubName: "",
+			},
+			expectErrorMsg: "flag leaf-hub-name can't be empty",
+		},
+		{
+			name: "Standalone configuration",
+			agentConfig: &config.AgentConfig{
+				LeafHubName:      "test-hub",
+				Standalone:       true,
+				SpecWorkPoolSize: 10,
+				TransportConfig: &transport.TransportConfig{
+					ConsumerGroupId: "test-hub",
+				},
+			},
+			expectConfig: &config.AgentConfig{
+				LeafHubName:      "test-hub",
+				Standalone:       true,
+				SpecWorkPoolSize: 0,
+				MetricsAddress:   fmt.Sprintf("%s:%d", metricsHost, metricsPort),
+				TransportConfig: &transport.TransportConfig{
+					ConsumerGroupId: "",
+					TransportType:   string(transport.Multiple),
+				},
+			},
+			expectErrorMsg: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := completeConfig(tc.agentConfig)
+			if tc.expectErrorMsg != "" {
+				assert.Equal(t, err.Error(), tc.expectErrorMsg)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, reflect.DeepEqual(tc.agentConfig, tc.expectConfig), true)
+			}
+		})
+	}
+}

--- a/agent/pkg/config/agent_config.go
+++ b/agent/pkg/config/agent_config.go
@@ -9,7 +9,7 @@ var agentConfigData *AgentConfig
 
 type AgentConfig struct {
 	LeafHubName                  string
-	PodNameSpace                 string
+	PodNamespace                 string
 	SpecWorkPoolSize             int
 	SpecEnforceHohRbac           bool
 	StatusDeltaCountSwitchFactor int

--- a/agent/pkg/config/agent_config.go
+++ b/agent/pkg/config/agent_config.go
@@ -5,6 +5,8 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 )
 
+var agentConfigData *AgentConfig
+
 type AgentConfig struct {
 	LeafHubName                  string
 	PodNameSpace                 string
@@ -19,4 +21,13 @@ type AgentConfig struct {
 	QPS                          float32
 	Burst                        int
 	EnablePprof                  bool
+	Standalone                   bool
+}
+
+func SetAgentConfig(agentConfig *AgentConfig) {
+	agentConfigData = agentConfig
+}
+
+func GetAgentConfig() *AgentConfig {
+	return agentConfigData
 }

--- a/agent/pkg/controllers/crd_controller.go
+++ b/agent/pkg/controllers/crd_controller.go
@@ -36,15 +36,20 @@ func (c *crdController) Reconcile(ctx context.Context, request ctrl.Request) (ct
 	reqLogger := c.log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	reqLogger.V(2).Info("crd controller", "NamespacedName:", request.NamespacedName)
 
+	if err := statusController.AddControllers(ctx, c.mgr, c.producer, c.agentConfig); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to add status syncer: %w", err)
+	}
+
+	// only enable the status controller in the standalone mode
+	if c.agentConfig.Standalone {
+		return ctrl.Result{}, nil
+	}
+
 	// add spec controllers
 	if err := specController.AddToManager(c.mgr, c.consumer, c.agentConfig); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to add spec syncer: %w", err)
 	}
 	reqLogger.V(2).Info("add spec controllers to manager")
-
-	if err := statusController.AddControllers(ctx, c.mgr, c.producer, c.agentConfig); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to add status syncer: %w", err)
-	}
 
 	// Need this controller to update the value of clusterclaim version.open-cluster-management.io
 	if err := AddVersionClusterClaimController(c.mgr); err != nil {

--- a/agent/pkg/controllers/crd_controller.go
+++ b/agent/pkg/controllers/crd_controller.go
@@ -56,7 +56,7 @@ func (c *crdController) Reconcile(ctx context.Context, request ctrl.Request) (ct
 		return ctrl.Result{}, fmt.Errorf("failed to add controllers: %w", err)
 	}
 
-	if err := config.AddHoHLeaseUpdater(c.mgr, c.agentConfig.PodNameSpace,
+	if err := config.AddHoHLeaseUpdater(c.mgr, c.agentConfig.PodNamespace,
 		"multicluster-global-hub-controller"); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to add lease updater: %w", err)
 	}

--- a/agent/pkg/controllers/crd_controller_test.go
+++ b/agent/pkg/controllers/crd_controller_test.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stolostron/multicluster-global-hub/agent/pkg/config"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/config"
 )
 
 func TestAddCRDController(t *testing.T) {

--- a/agent/pkg/controllers/crd_controller_test.go
+++ b/agent/pkg/controllers/crd_controller_test.go
@@ -1,0 +1,33 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/config"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestAddCRDController(t *testing.T) {
+	cfg := &rest.Config{
+		Host:            "https://mock-cluster",
+		APIPath:         "/api",
+		BearerToken:     "mock-token",
+		TLSClientConfig: rest.TLSClientConfig{Insecure: true},
+	}
+	mgr, err := manager.New(cfg, manager.Options{})
+	require.NoError(t, err)
+	crdCtrl := &crdController{
+		mgr:         mgr,
+		agentConfig: &config.AgentConfig{LeafHubName: "hub1"},
+	}
+	_, err = crdCtrl.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{
+		Namespace: "hello",
+		Name:      "world",
+	}})
+	require.Contains(t, err.Error(), "failed to add status syncer")
+}

--- a/agent/pkg/status/controller/controller.go
+++ b/agent/pkg/status/controller/controller.go
@@ -81,7 +81,7 @@ func AddControllers(ctx context.Context, mgr ctrl.Manager, producer transport.Pr
 	}
 
 	// lunch a time filter, it must be called after filter.RegisterTimeFilter(key)
-	if err := filter.LaunchTimeFilter(ctx, mgr.GetClient(), agentConfig.PodNameSpace,
+	if err := filter.LaunchTimeFilter(ctx, mgr.GetClient(), agentConfig.PodNamespace,
 		agentConfig.TransportConfig.KafkaCredential.StatusTopic); err != nil {
 		return fmt.Errorf("failed to launch time filter: %w", err)
 	}

--- a/pkg/transport/consumer/generic_consumer.go
+++ b/pkg/transport/consumer/generic_consumer.go
@@ -79,7 +79,7 @@ func (c *GenericConsumer) initClient(tranConfig *transport.TransportConfig) erro
 	}
 
 	switch tranConfig.TransportType {
-	case string(transport.Kafka):
+	case string(transport.Kafka), string(transport.Multiple):
 		c.log.Info("transport consumer with cloudevents-kafka receiver")
 		clientProtocol, err = getConfluentReceiverProtocol(tranConfig, topics)
 		if err != nil {

--- a/pkg/transport/consumer/generic_consumer.go
+++ b/pkg/transport/consumer/generic_consumer.go
@@ -79,7 +79,7 @@ func (c *GenericConsumer) initClient(tranConfig *transport.TransportConfig) erro
 	}
 
 	switch tranConfig.TransportType {
-	case string(transport.Kafka), string(transport.Multiple):
+	case string(transport.Kafka):
 		c.log.Info("transport consumer with cloudevents-kafka receiver")
 		clientProtocol, err = getConfluentReceiverProtocol(tranConfig, topics)
 		if err != nil {

--- a/pkg/transport/controller/controller.go
+++ b/pkg/transport/controller/controller.go
@@ -89,11 +89,11 @@ func (c *TransportCtrl) Reconcile(ctx context.Context, request ctrl.Request) (ct
 
 	// if credentials aren't updated, then return
 	if reflect.DeepEqual(c.transportConfig.KafkaCredential, kafkaConn) &&
-		reflect.DeepEqual(c.transportConfig.InventoryCredentail, inventoryConn) {
+		reflect.DeepEqual(c.transportConfig.RestfulCredentail, inventoryConn) {
 		return ctrl.Result{}, nil
 	}
 	c.transportConfig.KafkaCredential = kafkaConn
-	c.transportConfig.InventoryCredentail = inventoryConn
+	c.transportConfig.RestfulCredentail = inventoryConn
 
 	// transport config is changed, then create/update the consumer/producer
 	if c.producer == nil {
@@ -180,13 +180,13 @@ func (c *TransportCtrl) credentialSecret(name string) bool {
 }
 
 func (c *TransportCtrl) GetInventoryConnBySecret(transportConfig *corev1.Secret) (
-	*transport.InventoryConnCredentail, error,
+	*transport.RestfulConnCredentail, error,
 ) {
 	inventoryYaml, ok := transportConfig.Data["inventory.yaml"]
 	if !ok {
 		return nil, nil
 	}
-	inventoryConn := &transport.InventoryConnCredentail{}
+	inventoryConn := &transport.RestfulConnCredentail{}
 	if err := yaml.Unmarshal(inventoryYaml, inventoryConn); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal kafka config to transport credentail: %w", err)
 	}

--- a/pkg/transport/controller/controller.go
+++ b/pkg/transport/controller/controller.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"reflect"
 	"sync"
@@ -14,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
 
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport/config"
@@ -65,24 +67,33 @@ func (c *TransportCtrl) Reconcile(ctx context.Context, request ctrl.Request) (ct
 	if err := c.runtimeClient.Get(ctx, client.ObjectKeyFromObject(secret), secret); err != nil {
 		return ctrl.Result{}, err
 	}
-	conn, err := config.GetTransportCredentailBySecret(secret, c.runtimeClient)
+
+	// load the kafka connection credentail based on the transport type. kafka, multiple
+	kafkaConn, err := config.GetTransportCredentailBySecret(secret, c.runtimeClient)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	// update the credential secret colletions for the predicates
-	if conn.CASecretName != "" || !utils.ContainsString(c.extraSecretNames, conn.CASecretName) {
-		c.extraSecretNames = append(c.extraSecretNames, conn.CASecretName)
+	// update the kafka credential secret colletions for the predicates
+	if kafkaConn.CASecretName != "" || !utils.ContainsString(c.extraSecretNames, kafkaConn.CASecretName) {
+		c.extraSecretNames = append(c.extraSecretNames, kafkaConn.CASecretName)
 	}
-	if conn.ClientSecretName != "" || utils.ContainsString(c.extraSecretNames, conn.ClientSecretName) {
-		c.extraSecretNames = append(c.extraSecretNames, conn.ClientSecretName)
+	if kafkaConn.ClientSecretName != "" || utils.ContainsString(c.extraSecretNames, kafkaConn.ClientSecretName) {
+		c.extraSecretNames = append(c.extraSecretNames, kafkaConn.ClientSecretName)
 	}
 
-	// if credential not update, then return
-	if reflect.DeepEqual(c.transportConfig.KafkaCredential, conn) {
+	inventoryConn, err := c.GetInventoryConnBySecret(secret)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// if credentials aren't updated, then return
+	if reflect.DeepEqual(c.transportConfig.KafkaCredential, kafkaConn) &&
+		reflect.DeepEqual(c.transportConfig.InventoryCredentail, inventoryConn) {
 		return ctrl.Result{}, nil
 	}
-	c.transportConfig.KafkaCredential = conn
+	c.transportConfig.KafkaCredential = kafkaConn
+	c.transportConfig.InventoryCredentail = inventoryConn
 
 	// transport config is changed, then create/update the consumer/producer
 	if c.producer == nil {
@@ -97,22 +108,26 @@ func (c *TransportCtrl) Reconcile(ctx context.Context, request ctrl.Request) (ct
 		}
 	}
 
-	if c.consumer == nil {
-		receiver, err := consumer.NewGenericConsumer(c.transportConfig)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to create the consumer: %w", err)
-		}
-		c.consumer = receiver
-		go func() {
-			if err = c.consumer.Start(ctx); err != nil {
-				klog.Errorf("failed to start the consumser: %v", err)
+	// don't create the consumer when the consumer groupId is empty, that means the agent maybe in the standalone mode
+	if c.transportConfig.ConsumerGroupId != "" {
+		if c.consumer == nil {
+			receiver, err := consumer.NewGenericConsumer(c.transportConfig)
+			if err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to create the consumer: %w", err)
 			}
-		}()
-	} else {
-		if err := c.consumer.Reconnect(ctx, c.transportConfig); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to reconnect the consumer: %w", err)
+			c.consumer = receiver
+			go func() {
+				if err = c.consumer.Start(ctx); err != nil {
+					klog.Errorf("failed to start the consumser: %v", err)
+				}
+			}()
+		} else {
+			if err := c.consumer.Reconnect(ctx, c.transportConfig); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to reconnect the consumer: %w", err)
+			}
 		}
 	}
+
 	klog.Info("the transport secret(producer, consumer) is created/updated")
 
 	if c.callback != nil {
@@ -162,4 +177,41 @@ func (c *TransportCtrl) credentialSecret(name string) bool {
 		}
 	}
 	return false
+}
+
+func (c *TransportCtrl) GetInventoryConnBySecret(transportConfig *corev1.Secret) (
+	*transport.InventoryConnCredentail, error,
+) {
+	inventoryYaml, ok := transportConfig.Data["inventory.yaml"]
+	if !ok {
+		return nil, nil
+	}
+	inventoryConn := &transport.InventoryConnCredentail{}
+	if err := yaml.Unmarshal(inventoryYaml, inventoryConn); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal kafka config to transport credentail: %w", err)
+	}
+
+	// decode the ca and client cert
+	if inventoryConn.CACert != "" {
+		bytes, err := base64.StdEncoding.DecodeString(inventoryConn.CACert)
+		if err != nil {
+			return nil, err
+		}
+		inventoryConn.CACert = string(bytes)
+	}
+	if inventoryConn.ClientCert != "" {
+		bytes, err := base64.StdEncoding.DecodeString(inventoryConn.ClientCert)
+		if err != nil {
+			return nil, err
+		}
+		inventoryConn.ClientCert = string(bytes)
+	}
+	if inventoryConn.ClientKey != "" {
+		bytes, err := base64.StdEncoding.DecodeString(inventoryConn.ClientKey)
+		if err != nil {
+			return nil, err
+		}
+		inventoryConn.ClientKey = string(bytes)
+	}
+	return inventoryConn, nil
 }

--- a/pkg/transport/controller/controller_test.go
+++ b/pkg/transport/controller/controller_test.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
 func TestSecretCtrlReconcile(t *testing.T) {
@@ -29,7 +30,8 @@ func TestSecretCtrlReconcile(t *testing.T) {
 		secretNamespace: "default",
 		secretName:      "test-secret",
 		transportConfig: &transport.TransportConfig{
-			TransportType: string(transport.Chan),
+			TransportType:   string(transport.Chan),
+			ConsumerGroupId: "test",
 		},
 		callback: func(p transport.Producer, c transport.Consumer) error {
 			callbackInvoked = true
@@ -54,13 +56,25 @@ func TestSecretCtrlReconcile(t *testing.T) {
 	kafkaConnYaml, err := kafkaConn.YamlMarshal(false)
 	assert.NoError(t, err)
 
+	inventoryConn := &transport.InventoryConnCredentail{
+		Host: "localhost:123",
+		// the following fields are only for the manager, and the agent of byo/standalone kafka
+		CACert:     base64.StdEncoding.EncodeToString([]byte("11")),
+		ClientCert: base64.StdEncoding.EncodeToString([]byte("12")),
+		ClientKey:  base64.StdEncoding.EncodeToString([]byte("13")),
+	}
+
+	inventoryConnYaml, err := inventoryConn.YamlMarshal()
+	assert.NoError(t, err)
+
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
 			Name:      "test-secret",
 		},
 		Data: map[string][]byte{
-			"kafka.yaml": kafkaConnYaml,
+			"kafka.yaml":     kafkaConnYaml,
+			"inventory.yaml": inventoryConnYaml,
 		},
 	}
 	_ = fakeClient.Create(ctx, secret)
@@ -83,4 +97,5 @@ func TestSecretCtrlReconcile(t *testing.T) {
 	result, err = secretController.Reconcile(ctx, req)
 	assert.NoError(t, err)
 	assert.False(t, result.Requeue)
+	utils.PrettyPrint(secretController.transportConfig.InventoryCredentail)
 }

--- a/pkg/transport/controller/controller_test.go
+++ b/pkg/transport/controller/controller_test.go
@@ -56,7 +56,7 @@ func TestSecretCtrlReconcile(t *testing.T) {
 	kafkaConnYaml, err := kafkaConn.YamlMarshal(false)
 	assert.NoError(t, err)
 
-	inventoryConn := &transport.InventoryConnCredentail{
+	inventoryConn := &transport.RestfulConnCredentail{
 		Host: "localhost:123",
 		// the following fields are only for the manager, and the agent of byo/standalone kafka
 		CACert:     base64.StdEncoding.EncodeToString([]byte("11")),
@@ -97,5 +97,5 @@ func TestSecretCtrlReconcile(t *testing.T) {
 	result, err = secretController.Reconcile(ctx, req)
 	assert.NoError(t, err)
 	assert.False(t, result.Requeue)
-	utils.PrettyPrint(secretController.transportConfig.InventoryCredentail)
+	utils.PrettyPrint(secretController.transportConfig.RestfulCredentail)
 }

--- a/pkg/transport/controller/controller_test.go
+++ b/pkg/transport/controller/controller_test.go
@@ -56,7 +56,7 @@ func TestSecretCtrlReconcile(t *testing.T) {
 	kafkaConnYaml, err := kafkaConn.YamlMarshal(false)
 	assert.NoError(t, err)
 
-	inventoryConn := &transport.RestfulConnCredentail{
+	restfulConn := &transport.RestfulConnCredentail{
 		Host: "localhost:123",
 		// the following fields are only for the manager, and the agent of byo/standalone kafka
 		CACert:     base64.StdEncoding.EncodeToString([]byte("11")),
@@ -64,7 +64,7 @@ func TestSecretCtrlReconcile(t *testing.T) {
 		ClientKey:  base64.StdEncoding.EncodeToString([]byte("13")),
 	}
 
-	inventoryConnYaml, err := inventoryConn.YamlMarshal()
+	restfulConnYaml, err := restfulConn.YamlMarshal()
 	assert.NoError(t, err)
 
 	secret := &corev1.Secret{
@@ -73,8 +73,8 @@ func TestSecretCtrlReconcile(t *testing.T) {
 			Name:      "test-secret",
 		},
 		Data: map[string][]byte{
-			"kafka.yaml":     kafkaConnYaml,
-			"inventory.yaml": inventoryConnYaml,
+			"kafka.yaml": kafkaConnYaml,
+			"rest.yaml":  restfulConnYaml,
 		},
 	}
 	_ = fakeClient.Create(ctx, secret)

--- a/pkg/transport/producer/generic_producer.go
+++ b/pkg/transport/producer/generic_producer.go
@@ -95,9 +95,10 @@ func (p *GenericProducer) initClient(transportConfig *transport.TransportConfig)
 		topic = transportConfig.KafkaCredential.StatusTopic
 	}
 
-	if (transportConfig.TransportType == string(transport.Kafka) ||
-		transportConfig.TransportType == string(transport.Multiple)) &&
-		transportConfig.KafkaCredential != nil {
+	if transportConfig.TransportType == string(transport.Kafka) {
+		if transportConfig.KafkaCredential == nil {
+			return fmt.Errorf("the kafka credentail must not be nil")
+		}
 		kafkaProtocol, err := getConfluentSenderProtocol(transportConfig.KafkaCredential, topic)
 		if err != nil {
 			return err
@@ -130,7 +131,7 @@ func (p *GenericProducer) initClient(transportConfig *transport.TransportConfig)
 	p.client = client
 
 	// TODO: init the inventory api
-	if transportConfig.TransportType == string(transport.Multiple) && transportConfig.InventoryCredentail != nil {
+	if transportConfig.TransportType == string(transport.Rest) && transportConfig.RestfulCredentail != nil {
 		p.log.Info("Init the REST API Client")
 	}
 	return nil

--- a/pkg/transport/producer/generic_producer.go
+++ b/pkg/transport/producer/generic_producer.go
@@ -97,9 +97,6 @@ func (p *GenericProducer) initClient(transportConfig *transport.TransportConfig)
 
 	switch transportConfig.TransportType {
 	case string(transport.Kafka):
-		if transportConfig.KafkaCredential == nil {
-			return fmt.Errorf("the kafka credentail must not be nil")
-		}
 		kafkaProtocol, err := getConfluentSenderProtocol(transportConfig.KafkaCredential, topic)
 		if err != nil {
 			return err
@@ -123,7 +120,6 @@ func (p *GenericProducer) initClient(transportConfig *transport.TransportConfig)
 		if transportConfig.RestfulCredentail == nil {
 			return fmt.Errorf("the restful credentail must not be nil")
 		}
-		p.log.Info("Init the REST API Client")
 	default:
 		return fmt.Errorf("transport-type - %s is not a valid option", transportConfig.TransportType)
 	}

--- a/pkg/transport/producer/generic_producer_test.go
+++ b/pkg/transport/producer/generic_producer_test.go
@@ -6,8 +6,9 @@ package producer
 import (
 	"testing"
 
-	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 	"github.com/stretchr/testify/require"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 )
 
 func TestGenericProducer(t *testing.T) {

--- a/pkg/transport/producer/generic_producer_test.go
+++ b/pkg/transport/producer/generic_producer_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2023 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package producer
+
+import (
+	"testing"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/transport"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenericProducer(t *testing.T) {
+	p := &GenericProducer{}
+	tranConfig := &transport.TransportConfig{
+		TransportType: string(transport.Rest),
+		KafkaCredential: &transport.KafkaConnCredential{
+			SpecTopic:   "gh-spec",
+			StatusTopic: "gh-status",
+		},
+	}
+	err := p.initClient(tranConfig)
+	require.Equal(t, "the restful credentail must not be nil", err.Error())
+}

--- a/pkg/transport/type.go
+++ b/pkg/transport/type.go
@@ -26,6 +26,8 @@ const (
 	// transportType values
 	Kafka TransportType = "kafka"
 	Chan  TransportType = "chan"
+	// Multiple indciates the agent maybe report the event to multiple target, like kafka and rest API
+	Multiple TransportType = "multiple"
 )
 
 // transport protocol
@@ -48,9 +50,22 @@ type TransportConfig struct {
 	// EnableDatabaseOffset affects only the manager, deciding if consumption starts from a database-stored offset
 	EnableDatabaseOffset bool
 	ConsumerGroupId      string
-	// set the credentail in the transport controller
-	KafkaCredential *KafkaConnCredential
-	Extends         map[string]interface{}
+	// set the kafka credentail in the transport controller
+	KafkaCredential     *KafkaConnCredential
+	InventoryCredentail *InventoryConnCredentail
+	Extends             map[string]interface{}
+}
+
+type InventoryConnCredentail struct {
+	Host       string `yaml:"host"`
+	CACert     string `yaml:"ca.crt,omitempty"`
+	ClientCert string `yaml:"client.crt,omitempty"`
+	ClientKey  string `yaml:"client.key,omitempty"`
+}
+
+func (k *InventoryConnCredentail) YamlMarshal() ([]byte, error) {
+	bytes, err := yaml.Marshal(k)
+	return bytes, err
 }
 
 // Kafka Config

--- a/pkg/transport/type.go
+++ b/pkg/transport/type.go
@@ -26,8 +26,7 @@ const (
 	// transportType values
 	Kafka TransportType = "kafka"
 	Chan  TransportType = "chan"
-	// Multiple indciates the agent maybe report the event to multiple target, like kafka and rest API
-	Multiple TransportType = "multiple"
+	Rest  TransportType = "rest"
 )
 
 // transport protocol
@@ -51,19 +50,19 @@ type TransportConfig struct {
 	EnableDatabaseOffset bool
 	ConsumerGroupId      string
 	// set the kafka credentail in the transport controller
-	KafkaCredential     *KafkaConnCredential
-	InventoryCredentail *InventoryConnCredentail
-	Extends             map[string]interface{}
+	KafkaCredential   *KafkaConnCredential
+	RestfulCredentail *RestfulConnCredentail
+	Extends           map[string]interface{}
 }
 
-type InventoryConnCredentail struct {
+type RestfulConnCredentail struct {
 	Host       string `yaml:"host"`
 	CACert     string `yaml:"ca.crt,omitempty"`
 	ClientCert string `yaml:"client.crt,omitempty"`
 	ClientKey  string `yaml:"client.key,omitempty"`
 }
 
-func (k *InventoryConnCredentail) YamlMarshal() ([]byte, error) {
+func (k *RestfulConnCredentail) YamlMarshal() ([]byte, error) {
 	bytes, err := yaml.Marshal(k)
 	return bytes, err
 }

--- a/samples/cloudevent/receiver/main.go
+++ b/samples/cloudevent/receiver/main.go
@@ -23,13 +23,13 @@ func main() {
 	}
 	topic := os.Args[1]
 
-	bootstrapServer, saramaConfig, err := config.GetSaramaConfigFromKafkaUser()
+	bootstrapServer, saramaConfig, err := config.GetSaramaConfigByTranportConfig("")
 	if err != nil {
 		log.Fatalf("failed to get sarama config: %v", err)
 	}
 	// if set this to false, it will consume message from beginning when restart the client,
 	// otherwise it will consume message from the last committed offset.
-	saramaConfig.Consumer.Offsets.AutoCommit.Enable = false
+	saramaConfig.Consumer.Offsets.AutoCommit.Enable = true
 	saramaConfig.Consumer.Offsets.Initial = sarama.OffsetOldest
 
 	receiver, err := kafka_sarama.NewConsumer([]string{bootstrapServer}, saramaConfig, groupId, topic)
@@ -54,5 +54,5 @@ func main() {
 }
 
 func receive(ctx context.Context, event cloudevents.Event) {
-	fmt.Printf("%s \n", event.Data())
+	fmt.Println(event)
 }

--- a/samples/cloudevent/sender/main.go
+++ b/samples/cloudevent/sender/main.go
@@ -25,7 +25,7 @@ func main() {
 	topic := os.Args[1]
 
 	// bootstrapServer, saramaConfig, err := config.GetSaramaConfig()
-	bootstrapServer, saramaConfig, err := config.GetSaramaConfigFromKafkaUser()
+	bootstrapServer, saramaConfig, err := config.GetSaramaConfigByTranportConfig("")
 	if err != nil {
 		log.Fatalf("failed to get sarama config: %v", err)
 	}

--- a/samples/config/sarama_config.go
+++ b/samples/config/sarama_config.go
@@ -136,6 +136,10 @@ func GetSaramaConfigByTranportConfig(namespace string) (string, *sarama.Config, 
 		return "", nil, fmt.Errorf("failed to get runtime client")
 	}
 
+	return GetSaramaConfigByClient(namespace, c)
+}
+
+func GetSaramaConfigByClient(namespace string, c client.Client) (string, *sarama.Config, error) {
 	if namespace == "" {
 		namespace = KAFKA_NAMESPACE
 	}
@@ -146,7 +150,7 @@ func GetSaramaConfigByTranportConfig(namespace string) (string, *sarama.Config, 
 			Name:      constants.GHTransportConfigSecret,
 		},
 	}
-	err = c.Get(context.Background(), client.ObjectKeyFromObject(transportConfig), transportConfig)
+	err := c.Get(context.Background(), client.ObjectKeyFromObject(transportConfig), transportConfig)
 	if err != nil {
 		return "", nil, err
 	}

--- a/samples/config/sarama_config.go
+++ b/samples/config/sarama_config.go
@@ -8,7 +8,11 @@ import (
 
 	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
 	"github.com/Shopify/sarama"
+	operatorconfig "github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	transportconfig "github.com/stolostron/multicluster-global-hub/pkg/transport/config"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -120,4 +124,56 @@ func GetSaramaConfigFromKafkaUser() (string, *sarama.Config, error) {
 	saramaConfig.Net.TLS.Enable = true
 
 	return bootstrapServer, saramaConfig, nil
+}
+
+func GetSaramaConfigByTranportConfig(namespace string) (string, *sarama.Config, error) {
+	kubeconfig, err := DefaultKubeConfig()
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to get kubeconfig")
+	}
+	c, err := client.New(kubeconfig, client.Options{Scheme: operatorconfig.GetRuntimeScheme()})
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to get runtime client")
+	}
+
+	if namespace == "" {
+		namespace = KAFKA_NAMESPACE
+	}
+
+	transportConfig := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      constants.GHTransportConfigSecret,
+		},
+	}
+	err = c.Get(context.Background(), client.ObjectKeyFromObject(transportConfig), transportConfig)
+	if err != nil {
+		return "", nil, err
+	}
+	conn, err := transportconfig.GetTransportCredentailBySecret(transportConfig, c)
+	if err != nil {
+		return "", nil, err
+	}
+
+	// #nosec G402
+	tlsConfig := &tls.Config{}
+
+	// Load CA cert
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM([]byte(conn.CACert))
+	tlsConfig.RootCAs = caCertPool
+
+	// Load client cert
+	cert, err := tls.X509KeyPair([]byte(conn.ClientCert), []byte(conn.ClientKey))
+	if err != nil {
+		return "", nil, err
+	}
+	tlsConfig.Certificates = []tls.Certificate{cert}
+
+	saramaConfig := sarama.NewConfig()
+	saramaConfig.Version = sarama.V2_0_0_0
+	saramaConfig.Net.TLS.Config = tlsConfig
+	saramaConfig.Net.TLS.Enable = true
+
+	return conn.BootstrapServer, saramaConfig, nil
 }

--- a/test/Makefile
+++ b/test/Makefile
@@ -12,10 +12,10 @@ e2e-cleanup:
 	./test/script/e2e_cleanup.sh
 
 e2e-test-all: tidy vendor
-	./test/script/e2e_run.sh -f "e2e-test-localpolicy,e2e-test-placement,e2e-test-app,e2e-test-policy,e2e-tests-backup,e2e-test-grafana" -v $(VERBOSE)
+	./test/script/e2e_run.sh -f "e2e-test-localpolicy,e2e-test-placement,e2e-test-app,e2e-test-policy,e2e-tests-backup,e2e-test-grafana,e2e-test-agent" -v $(VERBOSE)
 	./test/script/e2e_run_byo.sh -v $(VERBOSE)
 
-e2e-test-cluster e2e-test-placement e2e-test-app e2e-test-policy e2e-test-localpolicy e2e-test-grafana: tidy vendor
+e2e-test-cluster e2e-test-placement e2e-test-app e2e-test-policy e2e-test-localpolicy e2e-test-grafana e2e-test-agent: tidy vendor
 	./test/script/e2e_run.sh -f $@ -v $(VERBOSE)
 
 e2e-test-prune: tidy vendor

--- a/test/Makefile
+++ b/test/Makefile
@@ -12,8 +12,8 @@ e2e-cleanup:
 	./test/script/e2e_cleanup.sh
 
 e2e-test-all: tidy vendor
-	./test/script/e2e_run.sh -f "e2e-test-localpolicy,e2e-test-placement,e2e-test-app,e2e-test-policy,e2e-tests-backup,e2e-test-grafana,e2e-test-agent" -v $(VERBOSE)
-	./test/script/e2e_run_byo.sh -v $(VERBOSE)
+	sh -x ./test/script/e2e_run.sh -f "e2e-test-localpolicy,e2e-test-placement,e2e-test-app,e2e-test-policy,e2e-tests-backup,e2e-test-grafana,e2e-test-agent" -v $(VERBOSE)
+	sh -x ./test/script/e2e_run_byo.sh -v $(VERBOSE)
 
 e2e-test-cluster e2e-test-placement e2e-test-app e2e-test-policy e2e-test-localpolicy e2e-test-grafana e2e-test-agent: tidy vendor
 	./test/script/e2e_run.sh -f $@ -v $(VERBOSE)

--- a/test/e2e/agent_test.go
+++ b/test/e2e/agent_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Standalone Agent", Label("e2e-test-agent"), Ordered, func() {
 			transportSecret)
 		Expect(err).To(Succeed())
 
-		bootstrapServer, saramaConfig, err := sampleconfig.GetSaramaConfigByTranportConfig("")
+		bootstrapServer, saramaConfig, err := sampleconfig.GetSaramaConfigByClient(STANDALONE_NAMESPACE, globalHubClient)
 		if err != nil {
 			log.Fatalf("failed to get sarama config: %v", err)
 		}

--- a/test/e2e/agent_test.go
+++ b/test/e2e/agent_test.go
@@ -41,8 +41,7 @@ var _ = Describe("Standalone Agent", Label("e2e-test-agent"), Ordered, func() {
 				Name:      constants.GHTransportConfigSecret,
 			},
 		}
-		err := globalHubClient.Get(context.Background(), runtimeclient.ObjectKeyFromObject(transportSecret),
-			transportSecret)
+		err := globalHubClient.Get(agentCtx, runtimeclient.ObjectKeyFromObject(transportSecret), transportSecret)
 		Expect(err).To(Succeed())
 
 		bootstrapServer, saramaConfig, err := sampleconfig.GetSaramaConfigByClient(STANDALONE_NAMESPACE, globalHubClient)
@@ -57,7 +56,6 @@ var _ = Describe("Standalone Agent", Label("e2e-test-agent"), Ordered, func() {
 		receiver, err := kafka_sarama.NewConsumer([]string{bootstrapServer}, saramaConfig,
 			STANDALONE_CONSUMER_GROUP_ID, STANDALONE_TOPIC)
 		Expect(err).To(Succeed())
-		defer receiver.Close(context.Background())
 
 		c, err := cloudevents.NewClient(receiver, client.WithPollGoroutines(1), client.WithBlockingCallback())
 		Expect(err).To(Succeed())

--- a/test/e2e/agent_test.go
+++ b/test/e2e/agent_test.go
@@ -1,0 +1,95 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	kafka_confluent "github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/cloudevents/sdk-go/v2/client"
+	set "github.com/deckarep/golang-set"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/enum"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport/config"
+)
+
+const (
+	STANDALONE_NAMESPACE         = "open-cluster-management"
+	STANDALONE_CONSUMER_GROUP_ID = "standalone-consumer-group"
+	STANDALONE_TOPIC             = "gh-status.standalone"
+)
+
+var _ = Describe("Standalone Agent", Label("e2e-test-agent"), Ordered, func() {
+	It("should receive the cluster event from the standalone agent", func() {
+		agentCtx, agentCancel := context.WithCancel(ctx)
+		defer agentCancel()
+
+		transportSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: STANDALONE_NAMESPACE,
+				Name:      constants.GHTransportConfigSecret,
+			},
+		}
+		err := globalHubClient.Get(context.Background(), runtimeclient.ObjectKeyFromObject(transportSecret),
+			transportSecret)
+		Expect(err).To(Succeed())
+
+		configMap, err := config.GetConfluentConfigMapByConfig(transportSecret, globalHubClient,
+			STANDALONE_CONSUMER_GROUP_ID)
+		Expect(err).To(Succeed())
+
+		receiver, err := kafka_confluent.New(kafka_confluent.WithConfigMap(configMap),
+			kafka_confluent.WithReceiverTopics([]string{STANDALONE_TOPIC}))
+		Expect(err).To(Succeed())
+		defer receiver.Close(ctx)
+
+		c, err := cloudevents.NewClient(receiver, cloudevents.WithTimeNow(), cloudevents.WithUUIDs(),
+			client.WithPollGoroutines(1), client.WithBlockingCallback())
+		if err != nil {
+			log.Fatalf("failed to create client, %v", err)
+		}
+
+		clusters := set.NewSet()
+		var mutex sync.Mutex
+		go func() {
+			err = c.StartReceiver(agentCtx, func(ctx context.Context, event cloudevents.Event) {
+				if event.Type() == string(enum.ManagedClusterType) {
+					mutex.Lock()
+					defer mutex.Unlock()
+					var data []clusterv1.ManagedCluster
+					if err := event.DataAs(&data); err != nil {
+						log.Fatalf("failed to parse the clusters: %s", err)
+					}
+					for _, cluster := range data {
+						clusters.Add(cluster.Name)
+					}
+				}
+			})
+			if err != nil {
+				log.Fatalf("failed to start receiver: %s", err)
+			}
+		}()
+
+		Eventually(func() error {
+			cluster := "hub1"
+			if !clusters.Contains(cluster) {
+				return fmt.Errorf("should receive the cluster: %s from the standalone agent", cluster)
+			}
+			cluster = "hub2"
+			if !clusters.Contains(cluster) {
+				return fmt.Errorf("should receive the cluster: %s from the standalone agent", cluster)
+			}
+			return nil
+		}, 3*time.Minute, 1*time.Second).ShouldNot(HaveOccurred())
+	})
+})

--- a/test/manifest/standalone-agent/generate_transport_config.sh
+++ b/test/manifest/standalone-agent/generate_transport_config.sh
@@ -14,6 +14,7 @@ secret_namespace=open-cluster-management
 standalone_user=global-hub-standalone-user
 status_topic="gh-status.standalone"
 kubectl apply -f "$CURRENT_DIR/standalone-agent-resources.yaml" -n "$kafka_namespace"
+wait_cmd "kubectl get kafkauser $standalone_user -n $kafka_namespace | grep -C 1 True"
 
 cat <<EOF >"$CURRENT_DIR/kafka.yaml"
 bootstrap.server: $(kubectl get kafka kafka -n "$kafka_namespace" -o jsonpath='{.status.listeners[1].bootstrapServers}')

--- a/test/manifest/standalone-agent/generate_transport_config.sh
+++ b/test/manifest/standalone-agent/generate_transport_config.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+CURRENT_DIR=$(
+  cd "$(dirname "$0")" || exit
+  pwd
+)
+
+KUBECONFIG=${1:-$KUBECONFIG}        # the kubeconfig for running the kafka
+SECRET_KUBECONFIG=${2:-$KUBECONFIG} # generate the crenditial secret
+
+kafka_namespace=${KAFKA_NAMESPACE:-"kafka"}
+secret_namespace=open-cluster-management
+
+standalone_user=global-hub-standalone-user
+status_topic="gh-status.standalone"
+kubectl apply -f "$CURRENT_DIR/standalone-agent-resources.yaml" -n "$kafka_namespace"
+
+cat <<EOF >"$CURRENT_DIR/kafka.yaml"
+bootstrap.server: $(kubectl get kafka kafka -n "$kafka_namespace" -o jsonpath='{.status.listeners[1].bootstrapServers}')
+topic.status: $status_topic
+ca.crt: $(kubectl get kafka kafka -n "$kafka_namespace" -o jsonpath='{.status.listeners[1].certificates[0]}' | base64 -w 0)
+client.crt: $(kubectl get secret $standalone_user -n "$kafka_namespace" -o jsonpath='{.data.user\.crt}')
+client.key: $(kubectl get secret $standalone_user -n "$kafka_namespace" -o jsonpath='{.data.user\.key}')
+EOF
+
+kubectl create secret generic transport-config -n $secret_namespace --kubeconfig "$SECRET_KUBECONFIG" \
+  --from-file=kafka.yaml="$CURRENT_DIR/kafka.yaml"
+echo "event exporter kafka configuration is ready!"
+
+host=$(kubectl get route inventory-api -n "$kafka_namespace" -ojsonpath='{.spec.host}')
+cat <<EOF >"$CURRENT_DIR/inventory.yaml"
+host: https://$host
+ca.crt: $(kubectl get secret inventory-api-server-ca-certs -n "$kafka_namespace" -ojsonpath='{.data.ca\.crt}')
+client.crt: $(kubectl get secret inventory-api-guest-certs -n "$kafka_namespace" -ojsonpath='{.data.tls\.crt}')
+client.key: $(kubectl get secret inventory-api-guest-certs -n "$kafka_namespace" -ojsonpath='{.data.tls\.key}')
+EOF
+
+kubectl patch secret transport-config -n $secret_namespace --kubeconfig "$SECRET_KUBECONFIG" \
+  --type='json' \
+  -p='[{"op": "add", "path": "/data/inventory.yaml", "value":"'"$(base64 -w 0 "$CURRENT_DIR/inventory.yaml")"'"}]'
+
+rm "$CURRENT_DIR/kafka.yaml"
+rm "$CURRENT_DIR/inventory.yaml"

--- a/test/manifest/standalone-agent/generate_transport_config.sh
+++ b/test/manifest/standalone-agent/generate_transport_config.sh
@@ -45,7 +45,7 @@ kubectl create secret generic transport-config -n $secret_namespace --kubeconfig
 echo "event exporter kafka configuration is ready!"
 
 host=$(kubectl get route inventory-api -n "$kafka_namespace" -ojsonpath='{.spec.host}')
-cat <<EOF >"$CURRENT_DIR/inventory.yaml"
+cat <<EOF >"$CURRENT_DIR/rest.yaml"
 host: https://$host
 ca.crt: $(kubectl get secret inventory-api-server-ca-certs -n "$kafka_namespace" -ojsonpath='{.data.ca\.crt}')
 client.crt: $(kubectl get secret inventory-api-guest-certs -n "$kafka_namespace" -ojsonpath='{.data.tls\.crt}')
@@ -54,7 +54,7 @@ EOF
 
 kubectl patch secret transport-config -n $secret_namespace --kubeconfig "$SECRET_KUBECONFIG" \
   --type='json' \
-  -p='[{"op": "add", "path": "/data/inventory.yaml", "value":"'"$(base64 -w 0 "$CURRENT_DIR/inventory.yaml")"'"}]'
+  -p='[{"op": "add", "path": "/data/rest.yaml", "value":"'"$(base64 -w 0 "$CURRENT_DIR/rest.yaml")"'"}]'
 
 rm "$CURRENT_DIR/kafka.yaml"
-rm "$CURRENT_DIR/inventory.yaml"
+rm "$CURRENT_DIR/rest.yaml"

--- a/test/manifest/standalone-agent/standalone-agent-resources.yaml
+++ b/test/manifest/standalone-agent/standalone-agent-resources.yaml
@@ -1,0 +1,40 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: gh-status.standalone
+  labels:
+    strimzi.io/cluster: kafka
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    cleanup.policy: compact
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: global-hub-standalone-user
+  labels:
+    strimzi.io/cluster: kafka
+spec:
+  authentication:
+    type: tls
+  authorization:
+    acls:
+    - host: '*'
+      operations:
+      - Describe
+      - Read
+      - Write
+      resource:
+        name: gh-status.standalone
+        patternType: literal
+        type: topic
+    - host: '*'
+      operations:
+      - Read
+      resource:
+        name: '*'
+        patternType: literal
+        type: group
+    type: simple

--- a/test/manifest/standalone-agent/workload/clusterrole.yaml
+++ b/test/manifest/standalone-agent/workload/clusterrole.yaml
@@ -1,0 +1,186 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: open-cluster-management:multicluster-global-hub-agent
+  labels:
+    addon.open-cluster-management.io/hosted-manifest-location: none
+rules:
+- apiGroups:
+  - "app.k8s.io"
+  resources:
+  - applications
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+  - deletecollection
+- apiGroups:
+  - "apps.open-cluster-management.io"
+  resources:
+  - channels
+  - placementrules
+  - subscriptionreports
+  - subscriptions
+  - subscriptionstatuses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+  - deletecollection
+- apiGroups:
+  - "policy.open-cluster-management.io"
+  resources:
+  - placementbindings
+  - policies
+  - policyautomations
+  - policysets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+  - deletecollection
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - placements
+  - managedclustersets
+  - managedclustersetbindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+  - deletecollection
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclustersets/join
+  - managedclustersets/bind
+  verbs:
+  - create
+  - delete
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclusters
+  - managedclusters/finalizers
+  - placementdecisions
+  - placementdecisions/finalizers
+  - placements
+  - placements/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - pods
+  - configmaps
+  - events
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - users
+  - groups
+  - serviceaccounts
+  verbs:
+  - impersonate
+- apiGroups:
+  - "coordination.k8s.io"
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - operator.open-cluster-management.io
+  resources:
+  - multiclusterhubs
+  - clustermanagers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - clusterclaims
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - list
+  - watch
+  - get

--- a/test/manifest/standalone-agent/workload/clusterrolebinding.yaml
+++ b/test/manifest/standalone-agent/workload/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: open-cluster-management:multicluster-global-hub-agent
+  labels:
+    addon.open-cluster-management.io/hosted-manifest-location: none
+subjects:
+- kind: ServiceAccount
+  name: multicluster-global-hub-agent
+  namespace: open-cluster-management
+roleRef:
+  kind: ClusterRole
+  name: open-cluster-management:multicluster-global-hub-agent
+  apiGroup: rbac.authorization.k8s.io

--- a/test/manifest/standalone-agent/workload/configmap.yaml
+++ b/test/manifest/standalone-agent/workload/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: multicluster-global-hub-agent-config
+  namespace: open-cluster-management
+data:
+  managedClusters: "5s"
+  policies: "5s"
+  hubClusterInfo: "60s"
+  hubClusterHeartbeat: "60s"
+  aggregationLevel: full
+  enableLocalPolicies: "true"

--- a/test/manifest/standalone-agent/workload/deployment.yaml
+++ b/test/manifest/standalone-agent/workload/deployment.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: multicluster-global-hub-agent
+  namespace: open-cluster-management
+  labels:
+    addon.open-cluster-management.io/hosted-manifest-location: none
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: multicluster-global-hub-agent
+  template:
+    metadata:
+      labels:
+        name: multicluster-global-hub-agent
+    spec:
+      serviceAccountName: multicluster-global-hub-agent
+      containers:
+        - name: multicluster-global-hub-agent
+          image: quay.io/stolostron/multicluster-global-hub-agent:latest
+          imagePullPolicy: Always
+          args:
+            - --zap-log-level=info
+            - --pod-namespace=$(POD_NAMESPACE)
+            - --leaf-hub-name=event-exporter-cluster
+            - --lease-duration=137
+            - --renew-deadline=107
+            - --retry-period=26
+            - --enable-global-resource=false
+            - --qps=150
+            - --burst=300
+            - --enable-pprof=false
+            - --standalone=true
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                 apiVersion: v1
+                 fieldPath: metadata.namespace
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                 apiVersion: v1
+                 fieldPath: metadata.namespace

--- a/test/manifest/standalone-agent/workload/namespace.yaml
+++ b/test/manifest/standalone-agent/workload/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: open-cluster-management

--- a/test/manifest/standalone-agent/workload/serviceaccount.yaml
+++ b/test/manifest/standalone-agent/workload/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: multicluster-global-hub-agent
+  namespace: open-cluster-management

--- a/test/script/e2e_kafka.sh
+++ b/test/script/e2e_kafka.sh
@@ -7,7 +7,7 @@ CURRENT_DIR=$(
 # shellcheck source=/dev/null
 source "$CURRENT_DIR/util.sh"
 
-KAFKA_KUBECONFIG=${1:-$KUBECONFIG}        # install the kafka
+KAFKA_KUBECONFIG=${1:-$KUBECONFIG}  # install the kafka
 SECRET_KUBECONFIG=${2:-$KUBECONFIG} # generate the crenditial secret
 
 echo "KAFKA_KUBECONFIG=$KAFKA_KUBECONFIG"
@@ -17,11 +17,13 @@ start_time=$(date +%s)
 echo -e "\r${BOLD_GREEN}[ START - $(date +"%T") ] Install Kafka $NC"
 
 # check the transport secret
-transport_secret=${TRANSPORT_SECRET_NAME:-"multicluster-global-hub-transport"}
-target_namespace=${TARGET_NAMESPACE:-"multicluster-global-hub"}
+secret_name=${TRANSPORT_SECRET_NAME:-"multicluster-global-hub-transport"}
+secret_namespace=${TRANSPORT_SECRET_NAMESPACE:-"multicluster-global-hub"}
 kafka_namespace=${KAFKA_NAMESPACE:-"kafka"}
-if kubectl get secret "$transport_secret" -n "$target_namespace" --kubeconfig "$SECRET_KUBECONFIG"; then
-  echo "transport_secret $transport_secret already exists in $target_namespace namespace"
+
+kubectl create ns "$secret_namespace" --dry-run=client -oyaml | kubectl --kubeconfig "$SECRET_KUBECONFIG" apply -f -
+if kubectl get secret "$secret_name" -n "$secret_namespace" --kubeconfig "$SECRET_KUBECONFIG"; then
+  echo "secret_name $secret_name already exists in $secret_namespace namespace"
   exit 0
 fi
 
@@ -39,17 +41,21 @@ sed -i -e "s;NODE_PORT_HOST;$node_port_host;" "$TEST_DIR"/manifest/kafka/kafka-c
 # deploy kafka cluster
 kubectl apply -k "$TEST_DIR"/manifest/kafka/kafka-cluster -n "$kafka_namespace" --kubeconfig "$KAFKA_KUBECONFIG"
 
-wait_cmd "kubectl get kafka kafka -n $kafka_namespace --kubeconfig "$KAFKA_KUBECONFIG" -o jsonpath='{.status.listeners[1]}' | grep bootstrapServers"
+wait_cmd "kubectl get kafka kafka -n $kafka_namespace --kubeconfig $KAFKA_KUBECONFIG -o jsonpath='{.status.listeners[1]}' | grep bootstrapServers"
 
 # kafka
-wait_cmd "kubectl get kafkatopic gh-spec -n $kafka_namespace --kubeconfig "$KAFKA_KUBECONFIG" | grep -C 1 True"
-wait_cmd "kubectl get kafkatopic gh-status.hub1 -n $kafka_namespace --kubeconfig "$KAFKA_KUBECONFIG" | grep -C 1 True"
-wait_cmd "kubectl get kafkatopic gh-status.hub2 -n $kafka_namespace --kubeconfig "$KAFKA_KUBECONFIG" | grep -C 1 True"
-wait_cmd "kubectl get kafkauser global-hub-kafka-user -n $kafka_namespace --kubeconfig "$KAFKA_KUBECONFIG" | grep -C 1 True"
+wait_cmd "kubectl get kafkatopic gh-spec -n $kafka_namespace --kubeconfig $KAFKA_KUBECONFIG | grep -C 1 True"
+wait_cmd "kubectl get kafkatopic gh-status.hub1 -n $kafka_namespace --kubeconfig $KAFKA_KUBECONFIG | grep -C 1 True"
+wait_cmd "kubectl get kafkatopic gh-status.hub2 -n $kafka_namespace --kubeconfig $KAFKA_KUBECONFIG | grep -C 1 True"
+wait_cmd "kubectl get kafkauser global-hub-kafka-user -n $kafka_namespace --kubeconfig $KAFKA_KUBECONFIG | grep -C 1 True"
 echo "Kafka topic/user are ready"
 
 # Note: skip to create the transport secret, trying to use the the internal multi users and topics for managed hubs
 byo_user=global-hub-byo-user
-wait_cmd "kubectl get kafkauser $byo_user -n $kafka_namespace --kubeconfig "$KAFKA_KUBECONFIG" | grep -C 1 True"
+wait_cmd "kubectl get kafkauser $byo_user -n $kafka_namespace --kubeconfig $KAFKA_KUBECONFIG | grep -C 1 True"
+
+# generate transport secret for standalone agent
+bash "$TEST_DIR/manifest/standalone-agent/generate_transport_config.sh" "$KUBECONFIG" "$SECRET_KUBECONFIG"
+echo "standalone secret is ready! KUBECONFIG=$SECRET_KUBECONFIG"
 
 echo -e "\r${BOLD_GREEN}[ END - $(date +"%T") ] Install Kafka ${NC} $(($(date +%s) - start_time)) seconds"

--- a/test/script/e2e_kafka.sh
+++ b/test/script/e2e_kafka.sh
@@ -43,20 +43,18 @@ kubectl apply -k "$TEST_DIR"/manifest/kafka/kafka-cluster -n "$kafka_namespace" 
 
 wait_cmd "kubectl get kafka kafka -n $kafka_namespace --kubeconfig $KAFKA_KUBECONFIG -o jsonpath='{.status.listeners[1]}' | grep bootstrapServers"
 
-# kafka
-wait_cmd "kubectl get kafkatopic gh-spec -n $kafka_namespace --kubeconfig $KAFKA_KUBECONFIG | grep -C 1 True"
-wait_cmd "kubectl get kafkatopic gh-status.hub1 -n $kafka_namespace --kubeconfig $KAFKA_KUBECONFIG | grep -C 1 True"
-wait_cmd "kubectl get kafkatopic gh-status.hub2 -n $kafka_namespace --kubeconfig $KAFKA_KUBECONFIG | grep -C 1 True"
-wait_cmd "kubectl get kafkauser global-hub-kafka-user -n $kafka_namespace --kubeconfig $KAFKA_KUBECONFIG | grep -C 1 True"
-echo "Kafka topic/user are ready"
+echo "Kafka cluster is ready"
 
-# Note: skip to create the transport secret, trying to use the the internal multi users and topics for managed hubs
+# byo kafkatopic and kafkauser
+wait_cmd "kubectl get kafkatopic gh-spec -n $kafka_namespace --kubeconfig $KAFKA_KUBECONFIG | grep -C 1 True"
+wait_cmd "kubectl get kafkatopic gh-status -n $kafka_namespace --kubeconfig $KAFKA_KUBECONFIG | grep -C 1 True"
 byo_user=global-hub-byo-user
 wait_cmd "kubectl get kafkauser $byo_user -n $kafka_namespace --kubeconfig $KAFKA_KUBECONFIG | grep -C 1 True"
+echo "Kafka topic and user is ready"
 
 # generate transport secret for standalone agent
 export KAFKA_NAMESPACE=$kafka_namespace
 bash "$TEST_DIR/manifest/standalone-agent/generate_transport_config.sh" "$KAFKA_KUBECONFIG" "$SECRET_KUBECONFIG"
-echo "standalone secret is ready! KUBECONFIG=$SECRET_KUBECONFIG"
+echo "Kafka standalone secret is ready! KUBECONFIG=$SECRET_KUBECONFIG"
 
 echo -e "\r${BOLD_GREEN}[ END - $(date +"%T") ] Install Kafka ${NC} $(($(date +%s) - start_time)) seconds"

--- a/test/script/e2e_kafka.sh
+++ b/test/script/e2e_kafka.sh
@@ -42,15 +42,7 @@ sed -i -e "s;NODE_PORT_HOST;$node_port_host;" "$TEST_DIR"/manifest/kafka/kafka-c
 kubectl apply -k "$TEST_DIR"/manifest/kafka/kafka-cluster -n "$kafka_namespace" --kubeconfig "$KAFKA_KUBECONFIG"
 
 wait_cmd "kubectl get kafka kafka -n $kafka_namespace --kubeconfig $KAFKA_KUBECONFIG -o jsonpath='{.status.listeners[1]}' | grep bootstrapServers"
-
 echo "Kafka cluster is ready"
-
-# byo kafkatopic and kafkauser
-wait_cmd "kubectl get kafkatopic gh-spec -n $kafka_namespace --kubeconfig $KAFKA_KUBECONFIG | grep -C 1 True"
-wait_cmd "kubectl get kafkatopic gh-status -n $kafka_namespace --kubeconfig $KAFKA_KUBECONFIG | grep -C 1 True"
-byo_user=global-hub-byo-user
-wait_cmd "kubectl get kafkauser $byo_user -n $kafka_namespace --kubeconfig $KAFKA_KUBECONFIG | grep -C 1 True"
-echo "Kafka topic and user is ready"
 
 # generate transport secret for standalone agent
 export KAFKA_NAMESPACE=$kafka_namespace

--- a/test/script/e2e_kafka.sh
+++ b/test/script/e2e_kafka.sh
@@ -31,7 +31,7 @@ fi
 kubectl create namespace "$kafka_namespace" --kubeconfig "$KAFKA_KUBECONFIG" --dry-run=client -o yaml | kubectl apply -f - --kubeconfig "$KAFKA_KUBECONFIG"
 
 # deploy kafka operator
-kubectl -n $kafka_namespace create -f "https://strimzi.io/install/latest?namespace=$kafka_namespace" --kubeconfig "$KAFKA_KUBECONFIG"
+kubectl -n "$kafka_namespace" create -f "https://strimzi.io/install/latest?namespace=$kafka_namespace" --kubeconfig "$KAFKA_KUBECONFIG"
 retry "(kubectl get pods -n $kafka_namespace --kubeconfig $KAFKA_KUBECONFIG -l name=strimzi-cluster-operator | grep Running)" 60
 
 echo "Kafka operator is ready"
@@ -55,6 +55,7 @@ byo_user=global-hub-byo-user
 wait_cmd "kubectl get kafkauser $byo_user -n $kafka_namespace --kubeconfig $KAFKA_KUBECONFIG | grep -C 1 True"
 
 # generate transport secret for standalone agent
+export KAFKA_NAMESPACE=$kafka_namespace
 bash "$TEST_DIR/manifest/standalone-agent/generate_transport_config.sh" "$KAFKA_KUBECONFIG" "$SECRET_KUBECONFIG"
 echo "standalone secret is ready! KUBECONFIG=$SECRET_KUBECONFIG"
 

--- a/test/script/e2e_kafka.sh
+++ b/test/script/e2e_kafka.sh
@@ -32,7 +32,7 @@ kubectl create namespace "$kafka_namespace" --kubeconfig "$KAFKA_KUBECONFIG" --d
 
 # deploy kafka operator
 kubectl -n $kafka_namespace create -f "https://strimzi.io/install/latest?namespace=$kafka_namespace" --kubeconfig "$KAFKA_KUBECONFIG"
-retry "(kubectl get pods -n $kafka_namespace --kubeconfig "$KAFKA_KUBECONFIG" -l name=strimzi-cluster-operator | grep Running)" 60
+retry "(kubectl get pods -n $kafka_namespace --kubeconfig $KAFKA_KUBECONFIG -l name=strimzi-cluster-operator | grep Running)" 60
 
 echo "Kafka operator is ready"
 
@@ -55,7 +55,7 @@ byo_user=global-hub-byo-user
 wait_cmd "kubectl get kafkauser $byo_user -n $kafka_namespace --kubeconfig $KAFKA_KUBECONFIG | grep -C 1 True"
 
 # generate transport secret for standalone agent
-bash "$TEST_DIR/manifest/standalone-agent/generate_transport_config.sh" "$KUBECONFIG" "$SECRET_KUBECONFIG"
+bash "$TEST_DIR/manifest/standalone-agent/generate_transport_config.sh" "$KAFKA_KUBECONFIG" "$SECRET_KUBECONFIG"
 echo "standalone secret is ready! KUBECONFIG=$SECRET_KUBECONFIG"
 
 echo -e "\r${BOLD_GREEN}[ END - $(date +"%T") ] Install Kafka ${NC} $(($(date +%s) - start_time)) seconds"

--- a/test/script/e2e_log.sh
+++ b/test/script/e2e_log.sh
@@ -25,10 +25,10 @@ kubectl logs deployment/"$COMPONENT" -n "$NAMESPACE" --all-containers=true
 [ "$COMPONENT" != "multicluster-global-hub-operator" ] && exit 0
 
 echo ">>>> KafkaCluster"
-kubectl get kafka -n "$NAMESPACE" --kubeconfig="$CONFIG_DIR/hub2" -oyaml
+kubectl get kafka -n "$NAMESPACE" -oyaml
 
 echo ">>>> KafkaUsers"
-kubectl get kafkauser -n "$NAMESPACE" --kubeconfig="$CONFIG_DIR/hub2" -oyaml
+kubectl get kafkauser -n "$NAMESPACE" -oyaml
 
 echo ">>>> KafkaTopics"
-kubectl get kafkatopics -n "$NAMESPACE" --kubeconfig="$CONFIG_DIR/hub2" -oyaml
+kubectl get kafkatopics -n "$NAMESPACE" -oyaml

--- a/test/script/e2e_postgres.sh
+++ b/test/script/e2e_postgres.sh
@@ -24,19 +24,10 @@ if kubectl get secret "$storage_secret" -n "$target_namespace" --kubeconfig "$SE
   exit 0
 fi
 
-# load all the image to kind cluster
-docker pull "$PG_OPERATOR_IMG"
-docker pull "$PG_BACKUP_IMG"
-docker pull "$PG_IMG"
-cluster_name=$(basename "$KUBECONFIG")
-kind load docker-image "$PG_OPERATOR_IMG" --name "$cluster_name"
-kind load docker-image "$PG_BACKUP_IMG" --name "$cluster_name"
-kind load docker-image "$PG_IMG" --name "$cluster_name"
-
 # installed credentials
 pg_ns="hoh-postgres"
 ps_user="hoh-pguser-postgres"
-pg_cert="hoh-cluster-cert"
+# pg_cert="hoh-cluster-cert"
 
 # step2: deploy postgres operator pgo
 retry "kubectl apply --server-side --kubeconfig $POSTGRES_KUBECONFIG -k $TEST_DIR/manifest/postgres/postgres-operator && (kubectl get pods -n postgres-operator --kubeconfig $POSTGRES_KUBECONFIG | grep pgo | grep Running)" 60

--- a/test/script/e2e_postgres.sh
+++ b/test/script/e2e_postgres.sh
@@ -44,9 +44,9 @@ for sts in ${stss}; do
 done
 kubectl delete pod -n $pg_ns --kubeconfig "$POSTGRES_KUBECONFIG" --all --ignore-not-found=true 2>/dev/null
 
-# postgres
-wait_cmd "kubectl get pods --kubeconfig $POSTGRES_KUBECONFIG -l postgres-operator.crunchydata.com/instance-set=pgha1 -n $pg_ns | grep Running"
-kubectl wait --for=condition=ready pod -l postgres-operator.crunchydata.com/instance-set=pgha1 -n $pg_ns--timeout=100s --kubeconfig "$POSTGRES_KUBECONFIG"
-echo "Postgres cluster is ready!"
+# wait the resources ready before testing byo db
+# wait_cmd "kubectl get pods --kubeconfig $POSTGRES_KUBECONFIG -l postgres-operator.crunchydata.com/instance-set=pgha1 -n $pg_ns | grep Running"
+# kubectl wait --for=condition=ready pod -l postgres-operator.crunchydata.com/instance-set=pgha1 -n $pg_ns --timeout=100s --kubeconfig "$POSTGRES_KUBECONFIG"
+# echo "Postgres cluster is ready!"
 
 echo -e "\r${BOLD_GREEN}[ END - $(date +"%T") ] Install Postgres ${NC} $(($(date +%s) - start_time)) seconds"

--- a/test/script/e2e_prow.sh
+++ b/test/script/e2e_prow.sh
@@ -22,7 +22,7 @@ echo "export VERBOSE=6" >>${PROJECT_DIR}/test/script/env.list
 
 scp "${OPT[@]}" -r ../multicluster-global-hub "$HOST:$HOST_DIR"
 
-ssh "${OPT[@]}" "$HOST" sudo yum install git wget jq -y
+ssh "${OPT[@]}" "$HOST" sudo yum install git wget jq librdkafka gcc -y
 # Insufficient resources creating kind clusters, modify parameters to expand
 ssh "${OPT[@]}" "$HOST" "sudo sh -c 'echo \"fs.inotify.max_user_watches=524288\" >> /etc/sysctl.conf && \
                                      echo \"fs.inotify.max_user_instances=8192\" >> /etc/sysctl.conf && \

--- a/test/script/e2e_prow.sh
+++ b/test/script/e2e_prow.sh
@@ -22,7 +22,7 @@ echo "export VERBOSE=6" >>${PROJECT_DIR}/test/script/env.list
 
 scp "${OPT[@]}" -r ../multicluster-global-hub "$HOST:$HOST_DIR"
 
-ssh "${OPT[@]}" "$HOST" sudo yum install git wget jq librdkafka -y
+ssh "${OPT[@]}" "$HOST" sudo yum install git wget jq librdkafka gcc -y
 # Insufficient resources creating kind clusters, modify parameters to expand
 ssh "${OPT[@]}" "$HOST" "sudo sh -c 'echo \"fs.inotify.max_user_watches=524288\" >> /etc/sysctl.conf && \
                                      echo \"fs.inotify.max_user_instances=8192\" >> /etc/sysctl.conf && \

--- a/test/script/e2e_prow.sh
+++ b/test/script/e2e_prow.sh
@@ -22,7 +22,7 @@ echo "export VERBOSE=6" >>${PROJECT_DIR}/test/script/env.list
 
 scp "${OPT[@]}" -r ../multicluster-global-hub "$HOST:$HOST_DIR"
 
-ssh "${OPT[@]}" "$HOST" sudo yum install git wget jq librdkafka-devel -y
+ssh "${OPT[@]}" "$HOST" sudo yum install git wget jq librdkafka -y
 # Insufficient resources creating kind clusters, modify parameters to expand
 ssh "${OPT[@]}" "$HOST" "sudo sh -c 'echo \"fs.inotify.max_user_watches=524288\" >> /etc/sysctl.conf && \
                                      echo \"fs.inotify.max_user_instances=8192\" >> /etc/sysctl.conf && \

--- a/test/script/e2e_prow.sh
+++ b/test/script/e2e_prow.sh
@@ -14,17 +14,15 @@ PROJECT_DIR="$(
 )"
 HOST_DIR="/tmp/multicluster-global-hub"
 
-
 echo "export MULTICLUSTER_GLOBAL_HUB_OPERATOR_IMAGE_REF=$MULTICLUSTER_GLOBAL_HUB_OPERATOR_IMAGE_REF" >>${PROJECT_DIR}/test/script/env.list
 echo "export MULTICLUSTER_GLOBAL_HUB_MANAGER_IMAGE_REF=$MULTICLUSTER_GLOBAL_HUB_MANAGER_IMAGE_REF" >>${PROJECT_DIR}/test/script/env.list
 echo "export MULTICLUSTER_GLOBAL_HUB_AGENT_IMAGE_REF=$MULTICLUSTER_GLOBAL_HUB_AGENT_IMAGE_REF" >>${PROJECT_DIR}/test/script/env.list
 echo "export OPENSHIFT_CI=$OPENSHIFT_CI" >>${PROJECT_DIR}/test/script/env.list
 echo "export VERBOSE=6" >>${PROJECT_DIR}/test/script/env.list
 
-
 scp "${OPT[@]}" -r ../multicluster-global-hub "$HOST:$HOST_DIR"
 
-ssh "${OPT[@]}" "$HOST" sudo yum install git wget jq -y
+ssh "${OPT[@]}" "$HOST" sudo yum install git wget jq librdkafka-devel -y
 # Insufficient resources creating kind clusters, modify parameters to expand
 ssh "${OPT[@]}" "$HOST" "sudo sh -c 'echo \"fs.inotify.max_user_watches=524288\" >> /etc/sysctl.conf && \
                                      echo \"fs.inotify.max_user_instances=8192\" >> /etc/sysctl.conf && \
@@ -35,10 +33,10 @@ ssh "${OPT[@]}" "$HOST" "cd $HOST_DIR && . test/script/env.list && sudo make e2e
 
 trap 'echo "An error occurred" >&2; log_component_logs; exit 1;' ERR
 log_component_logs() {
-    ssh "${OPT[@]}" "$HOST" "cd $HOST_DIR && . test/script/env.list && make e2e-log/operator" > >(tee "$ARTIFACT_DIR/e2e-operator.log")
-    ssh "${OPT[@]}" "$HOST" "cd $HOST_DIR && . test/script/env.list && make e2e-log/manager" > >(tee "$ARTIFACT_DIR/e2e-manager.log")
-    ssh "${OPT[@]}" "$HOST" "cd $HOST_DIR && . test/script/env.list && make e2e-log/grafana" > >(tee "$ARTIFACT_DIR/e2e-grafana.log")
-    ssh "${OPT[@]}" "$HOST" "cd $HOST_DIR && . test/script/env.list && make e2e-log/agent" > >(tee "$ARTIFACT_DIR/e2e-agent.log")
+  ssh "${OPT[@]}" "$HOST" "cd $HOST_DIR && . test/script/env.list && make e2e-log/operator" > >(tee "$ARTIFACT_DIR/e2e-operator.log")
+  ssh "${OPT[@]}" "$HOST" "cd $HOST_DIR && . test/script/env.list && make e2e-log/manager" > >(tee "$ARTIFACT_DIR/e2e-manager.log")
+  ssh "${OPT[@]}" "$HOST" "cd $HOST_DIR && . test/script/env.list && make e2e-log/grafana" > >(tee "$ARTIFACT_DIR/e2e-grafana.log")
+  ssh "${OPT[@]}" "$HOST" "cd $HOST_DIR && . test/script/env.list && make e2e-log/agent" > >(tee "$ARTIFACT_DIR/e2e-agent.log")
 }
 
 echo "runn e2e tests"

--- a/test/script/e2e_prow.sh
+++ b/test/script/e2e_prow.sh
@@ -22,7 +22,7 @@ echo "export VERBOSE=6" >>${PROJECT_DIR}/test/script/env.list
 
 scp "${OPT[@]}" -r ../multicluster-global-hub "$HOST:$HOST_DIR"
 
-ssh "${OPT[@]}" "$HOST" sudo yum install git wget jq librdkafka gcc -y
+ssh "${OPT[@]}" "$HOST" sudo yum install git wget jq -y
 # Insufficient resources creating kind clusters, modify parameters to expand
 ssh "${OPT[@]}" "$HOST" "sudo sh -c 'echo \"fs.inotify.max_user_watches=524288\" >> /etc/sysctl.conf && \
                                      echo \"fs.inotify.max_user_instances=8192\" >> /etc/sysctl.conf && \

--- a/test/script/e2e_run.sh
+++ b/test/script/e2e_run.sh
@@ -100,6 +100,9 @@ bash "$CURRENT_DIR/e2e_kafka.sh" "$CONFIG_DIR/hub2" "$GH_KUBECONFIG" 2>&1 &
 echo "$!" >>"$CONFIG_DIR/PID"
 ###################################################
 
+# Go programs typically use dynamic linking for C libraries: confluent-kafka package is used in e2e test
+export CGO_ENABLED=1
+
 if [ "${filter}" = "e2e-test-prune" ]; then
   export ISPRUNE="true"
   echo "run prune"

--- a/test/script/e2e_run.sh
+++ b/test/script/e2e_run.sh
@@ -100,9 +100,6 @@ bash "$CURRENT_DIR/e2e_kafka.sh" "$CONFIG_DIR/hub2" "$GH_KUBECONFIG" 2>&1 &
 echo "$!" >>"$CONFIG_DIR/PID"
 ###################################################
 
-# Go programs typically use dynamic linking for C libraries: confluent-kafka package is used in e2e test
-export CGO_ENABLED=1
-
 if [ "${filter}" = "e2e-test-prune" ]; then
   export ISPRUNE="true"
   echo "run prune"

--- a/test/script/e2e_run.sh
+++ b/test/script/e2e_run.sh
@@ -92,13 +92,6 @@ while getopts ":f:v:" opt; do
 done
 
 verbose=${verbose:=5}
-################# deploy byo kafka and postgres
-bash "$CURRENT_DIR/e2e_postgres.sh" "$CONFIG_DIR/hub1" "$GH_KUBECONFIG" 2>&1 &
-echo "$!" >"$CONFIG_DIR/PID"
-
-bash "$CURRENT_DIR/e2e_kafka.sh" "$CONFIG_DIR/hub2" "$GH_KUBECONFIG" 2>&1 &
-echo "$!" >>"$CONFIG_DIR/PID"
-###################################################
 
 # Go programs typically use dynamic linking for C libraries: confluent-kafka package is used in e2e test
 export CGO_ENABLED=1

--- a/test/script/e2e_run.sh
+++ b/test/script/e2e_run.sh
@@ -98,7 +98,10 @@ echo "$!" >"$CONFIG_DIR/PID"
 
 bash "$CURRENT_DIR/e2e_kafka.sh" "$CONFIG_DIR/hub2" "$GH_KUBECONFIG" 2>&1 &
 echo "$!" >>"$CONFIG_DIR/PID"
-################################################### 
+###################################################
+
+# Go programs typically use dynamic linking for C libraries: confluent-kafka package is used in e2e test
+export CGO_ENABLED=1
 
 if [ "${filter}" = "e2e-test-prune" ]; then
   export ISPRUNE="true"

--- a/test/script/e2e_run_byo.sh
+++ b/test/script/e2e_run_byo.sh
@@ -10,7 +10,7 @@ source "$CURRENT_DIR/util.sh"
 
 CONFIG_DIR=$CURRENT_DIR/config
 GH_KUBECONFIG="${CONFIG_DIR}/global-hub"
-KAKFA_KUBECONFIG="${CONFIG_DIR}/hub2"
+KAFKA_KUBECONFIG="${CONFIG_DIR}/hub2"
 POSTGRES_KUBECONFIG="${CONFIG_DIR}/hub1"
 
 export ISBYO="true"
@@ -18,20 +18,23 @@ export ISBYO="true"
 # CleanUp globalhub
 bash "$CURRENT_DIR/e2e_clean_globalhub.sh"
 
+target_namespace=${TARGET_NAMESPACE:-"multicluster-global-hub"}
+
+######################################### Generate Storage Secret ###################################################
+storage_secret=${STORAGE_SECRET_NAME:-"multicluster-global-hub-storage"}
 pg_ns="hoh-postgres"
 ps_user="hoh-pguser-postgres"
 pg_cert="hoh-cluster-cert"
-target_namespace=${TARGET_NAMESPACE:-"multicluster-global-hub"}
-transport_secret=${TRANSPORT_SECRET_NAME:-"multicluster-global-hub-transport"}
-kafka_namespace=${KAFKA_NAMESPACE:-"kafka"}
-storage_secret=${STORAGE_SECRET_NAME:-"multicluster-global-hub-storage"}
-byo_user=global-hub-byo-user
 
-#################### apply postgres secret to globalhub ###################
-if kubectl get secret "$storage_secret" -n "$target_namespace" --kubeconfig "$GH_KUBECONFIG"; then
-  echo "storage_secret $storage_secret already exists in $target_namespace namespace"
+if kubectl get secret "$storage_secret" -n "$target_namespace" --kubeconfig "$GH_KUBECONFIG" >/dev/null 2>&1; then
+  echo "storage: $storage_secret already exists in $target_namespace namespace"
   kubectl delete secret "$storage_secret" -n "$target_namespace" --kubeconfig "$GH_KUBECONFIG"
 fi
+
+# wait the pg cluster is ready
+wait_cmd "kubectl get pods --kubeconfig $POSTGRES_KUBECONFIG -l postgres-operator.crunchydata.com/instance-set=pgha1 -n $pg_ns | grep Running"
+kubectl wait --for=condition=ready pod -l postgres-operator.crunchydata.com/instance-set=pgha1 -n $pg_ns--timeout=100s --kubeconfig "$POSTGRES_KUBECONFIG"
+
 database_uri=$(kubectl get secrets -n "${pg_ns}" --kubeconfig "$POSTGRES_KUBECONFIG" "${ps_user}" -o go-template='{{index (.data) "uri" | base64decode}}')
 kubectl get secret $pg_cert -n $pg_ns --kubeconfig "$POSTGRES_KUBECONFIG" -o jsonpath='{.data.ca\.crt}' | base64 -d >"$CONFIG_DIR/postgres-cluster-ca.crt"
 
@@ -40,11 +43,6 @@ external_host=$(kubectl config view --minify --kubeconfig "$POSTGRES_KUBECONFIG"
 external_port=32432
 database_uri=$(echo "${database_uri}" | sed "s|@[^/]*|@$external_host:$external_port|")
 
-# step4: generate storage secret
-if kubectl get secret "$transport_secret" -n "$target_namespace" --kubeconfig "$GH_KUBECONFIG"; then
-  echo "transport_secret $transport_secret already exists in $target_namespace namespace"
-  kubectl delete secret "$transport_secret" -n "$target_namespace" --kubeconfig "$GH_KUBECONFIG"
-fi
 kubectl create namespace "$target_namespace" --dry-run=client -o yaml | kubectl --kubeconfig "$GH_KUBECONFIG" apply -f -
 kubectl create secret generic "$storage_secret" -n "$target_namespace" --kubeconfig "$GH_KUBECONFIG" \
   --from-literal=database_uri="${database_uri}?sslmode=verify-ca" \
@@ -52,12 +50,29 @@ kubectl create secret generic "$storage_secret" -n "$target_namespace" --kubecon
 
 echo "storage secret is ready in $target_namespace namespace!"
 
-######################## apply kafka secret to globalhub###########
-wait_cmd "kubectl get kafka kafka -n $kafka_namespace --kubeconfig $KAKFA_KUBECONFIG -o jsonpath='{.status.listeners[1]}' | grep bootstrapServers"
-bootstrap_server=$(kubectl get kafka kafka -n "$kafka_namespace" --kubeconfig "$KAKFA_KUBECONFIG" -o jsonpath='{.status.listeners[1].bootstrapServers}')
-kubectl get kafka kafka -n "$kafka_namespace" --kubeconfig "$KAKFA_KUBECONFIG" -o jsonpath='{.status.listeners[1].certificates[0]}' >"$CURRENT_DIR"/config/kafka-ca-cert.pem
-kubectl get secret $byo_user -n "$kafka_namespace" --kubeconfig "$KAKFA_KUBECONFIG" -o jsonpath='{.data.user\.crt}' | base64 -d >"$CURRENT_DIR"/config/kafka-client-cert.pem
-kubectl get secret $byo_user -n "$kafka_namespace" --kubeconfig "$KAKFA_KUBECONFIG" -o jsonpath='{.data.user\.key}' | base64 -d >"$CURRENT_DIR"/config/kafka-client-key.pem
+######################################### Generate Transport Secret ###################################################
+byo_user=global-hub-byo-user
+transport_secret=${TRANSPORT_SECRET_NAME:-"multicluster-global-hub-transport"}
+kafka_namespace=${KAFKA_NAMESPACE:-"kafka"}
+
+if kubectl get secret "$transport_secret" -n "$target_namespace" --kubeconfig "$GH_KUBECONFIG" >/dev/null 2>&1; then
+  echo "transport: $transport_secret already exists in $target_namespace namespace"
+  kubectl delete secret "$transport_secret" -n "$target_namespace" --kubeconfig "$GH_KUBECONFIG"
+fi
+
+# wait the cluster is ready
+wait_cmd "kubectl get kafka kafka -n $kafka_namespace --kubeconfig $KAFKA_KUBECONFIG -o jsonpath='{.status.listeners[1]}' | grep bootstrapServers"
+
+# wait the byo kafkatopic and kafkauser
+wait_cmd "kubectl get kafkatopic gh-spec -n $kafka_namespace --kubeconfig $KAFKA_KUBECONFIG | grep -C 1 True"
+wait_cmd "kubectl get kafkatopic gh-status -n $kafka_namespace --kubeconfig $KAFKA_KUBECONFIG | grep -C 1 True"
+wait_cmd "kubectl get kafkauser $byo_user -n $kafka_namespace --kubeconfig $KAFKA_KUBECONFIG | grep -C 1 True"
+echo "Kafka topic and user is ready"
+
+bootstrap_server=$(kubectl get kafka kafka -n "$kafka_namespace" --kubeconfig "$KAFKA_KUBECONFIG" -o jsonpath='{.status.listeners[1].bootstrapServers}')
+kubectl get kafka kafka -n "$kafka_namespace" --kubeconfig "$KAFKA_KUBECONFIG" -o jsonpath='{.status.listeners[1].certificates[0]}' >"$CURRENT_DIR"/config/kafka-ca-cert.pem
+kubectl get secret $byo_user -n "$kafka_namespace" --kubeconfig "$KAFKA_KUBECONFIG" -o jsonpath='{.data.user\.crt}' | base64 -d >"$CURRENT_DIR"/config/kafka-client-cert.pem
+kubectl get secret $byo_user -n "$kafka_namespace" --kubeconfig "$KAFKA_KUBECONFIG" -o jsonpath='{.data.user\.key}' | base64 -d >"$CURRENT_DIR"/config/kafka-client-key.pem
 
 # generate the secret in the target cluster: GH_KUBECONFIG
 kubectl create secret generic "$transport_secret" -n "$target_namespace" --kubeconfig "$GH_KUBECONFIG" \
@@ -65,7 +80,7 @@ kubectl create secret generic "$transport_secret" -n "$target_namespace" --kubec
   --from-file=ca.crt="$CURRENT_DIR"/config/kafka-ca-cert.pem \
   --from-file=client.crt="$CURRENT_DIR"/config/kafka-client-cert.pem \
   --from-file=client.key="$CURRENT_DIR"/config/kafka-client-key.pem
-echo "transport secret is ready!"
 
+echo "transport secret is ready in $target_namespace namespace!"
 ## run e2e
-bash $CURRENT_DIR/e2e_run.sh -f "e2e-test-localpolicy,e2e-test-grafana"
+bash "$CURRENT_DIR/e2e_run.sh" -f "e2e-test-localpolicy,e2e-test-grafana"

--- a/test/script/e2e_run_byo.sh
+++ b/test/script/e2e_run_byo.sh
@@ -33,7 +33,8 @@ fi
 
 # wait the pg cluster is ready
 wait_cmd "kubectl get pods --kubeconfig $POSTGRES_KUBECONFIG -l postgres-operator.crunchydata.com/instance-set=pgha1 -n $pg_ns | grep Running"
-kubectl wait --for=condition=ready pod -l postgres-operator.crunchydata.com/instance-set=pgha1 -n $pg_ns--timeout=100s --kubeconfig "$POSTGRES_KUBECONFIG"
+kubectl wait --for=condition=ready pod -l postgres-operator.crunchydata.com/instance-set=pgha1 -n $pg_ns --timeout=100s --kubeconfig "$POSTGRES_KUBECONFIG"
+echo "postgres cluster is ready!"
 
 database_uri=$(kubectl get secrets -n "${pg_ns}" --kubeconfig "$POSTGRES_KUBECONFIG" "${ps_user}" -o go-template='{{index (.data) "uri" | base64decode}}')
 kubectl get secret $pg_cert -n $pg_ns --kubeconfig "$POSTGRES_KUBECONFIG" -o jsonpath='{.data.ca\.crt}' | base64 -d >"$CONFIG_DIR/postgres-cluster-ca.crt"

--- a/test/script/e2e_setup.sh
+++ b/test/script/e2e_setup.sh
@@ -65,6 +65,15 @@ wait
 echo -e "${YELLOW} installing ocm, app and policy:${NC} $(($(date +%s) - start_time)) seconds"
 enable_olm global-hub
 
+# apply standalone agent
+kubectl apply -f "$TEST_DIR/manifest/standalone-agent/workload" --kubeconfig="$GH_KUBECONFIG"
+if [ -n "$MULTICLUSTER_GLOBAL_HUB_AGENT_IMAGE_REF" ]; then
+  kubectl --kubeconfig="$GH_KUBECONFIG" set image "deployment/multicluster-global-hub-agent" \
+    multicluster-global-hub-agent="$MULTICLUSTER_GLOBAL_HUB_AGENT_IMAGE_REF" \
+    -n open-cluster-management
+  echo "Updated container: multicluster-global-hub-agent with image $MULTICLUSTER_GLOBAL_HUB_AGENT_IMAGE_REF"
+fi
+
 # kubeconfig
 for i in $(seq 1 "${MH_NUM}"); do
   echo -e "$CYAN [Access the ManagedHub]: export KUBECONFIG=$CONFIG_DIR/hub$i $NC"

--- a/test/script/e2e_setup.sh
+++ b/test/script/e2e_setup.sh
@@ -65,6 +65,12 @@ for i in $(seq 1 "${MH_NUM}"); do
   done
 done
 
+# install the BYO (Bring Your Own) PostgreSQL and Kafka asynchronously during the OCMS installation
+bash "$CURRENT_DIR/e2e_postgres.sh" "$CONFIG_DIR/hub1" "$GH_KUBECONFIG" 2>&1 &
+echo "$!" >"$CONFIG_DIR/PID"
+bash "$CURRENT_DIR/e2e_kafka.sh" "$CONFIG_DIR/hub2" "$GH_KUBECONFIG" 2>&1 &
+echo "$!" >>"$CONFIG_DIR/PID"
+
 wait
 echo -e "${YELLOW} installing ocm, app and policy:${NC} $(($(date +%s) - start_time)) seconds"
 

--- a/test/script/util.sh
+++ b/test/script/util.sh
@@ -104,14 +104,14 @@ check_kind() {
 
 kind_cluster() {
   dir="${CONFIG_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
-  cluster_name="$1"
+  local cluster_name="$1"
   echo "dir $dir"
   if ! kind get clusters | grep -q "^$cluster_name$"; then
     retry "kind create cluster --name $cluster_name --image=kindest/node:v1.23.0 --wait 5m"
     # modify the context = KinD cluster name = kubeconfig name
     retry "kubectl config rename-context kind-$cluster_name $cluster_name"
     # modify the apiserver, so that the spoken cluster can use the kubeconfig to connect it:  governance-policy-framework-addon
-    node_ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$1-control-plane")
+    local node_ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$1-control-plane")
     # context is changed but name not
     retry "kubectl config set-cluster kind-$cluster_name --server=https://$node_ip:6443"
     kubectl config view --context="$cluster_name" --minify --flatten >"$dir/$cluster_name"


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

- Support to deploy the agent in a standalone mode
- Given the ability to send messages to multiple targets
- Remove the useless kafka cert secret for the manager and agent： https://github.com/stolostron/multicluster-global-hub/pull/1086
- Covered the new code in UT and e2e

## Related issue(s)

Fixes # https://issues.redhat.com/browse/ACM-12395