### PR TITLE
Only watch metadata of CRDs in agent

### DIFF
--- a/agent/pkg/controllers/crd_controller.go
+++ b/agent/pkg/controllers/crd_controller.go
@@ -68,21 +68,25 @@ func AddCRDController(mgr ctrl.Manager, restConfig *rest.Config, agentConfig *co
 		return nil
 	}
 	if err := ctrl.NewControllerManagedBy(mgr).
-		For(&apiextensionsv1.CustomResourceDefinition{}, builder.WithPredicates(predicate.Funcs{
-			// trigger the reconciler only if the crd is created
-			CreateFunc: func(e event.CreateEvent) bool {
-				return true
-			},
-			UpdateFunc: func(e event.UpdateEvent) bool {
-				return false
-			},
-			DeleteFunc: func(e event.DeleteEvent) bool {
-				return false
-			},
-			GenericFunc: func(e event.GenericEvent) bool {
-				return false
-			},
-		})).
+		For(
+			&apiextensionsv1.CustomResourceDefinition{},
+			builder.OnlyMetadata,
+			builder.WithPredicates(predicate.Funcs{
+				// trigger the reconciler only if the crd is created
+				CreateFunc: func(e event.CreateEvent) bool {
+					return true
+				},
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					return false
+				},
+				DeleteFunc: func(e event.DeleteEvent) bool {
+					return false
+				},
+				GenericFunc: func(e event.GenericEvent) bool {
+					return false
+				},
+			}),
+		).
 		Complete(&crdController{
 			mgr:         mgr,
 			restConfig:  restConfig,


### PR DESCRIPTION
## Summary

Currently the agent has controller that watches custom resource definitions and acts when a new one is created. This controller doesn't really need to retrieve the details of those custom resource definitions: it only needs to detect when they are present. But the cache used for that will contain the complete definition anyhow. This patch changes that controller to use the `builder.OnlyMetadata` option, so that the cache will only hold the metadata of the CRDs, which consumes less space. In an OpenShift cluster with ACM installed, for example, the complete set of CRDs consumes approx 7 MiB, while the metadata consumes only 100 KiB.

Related: https://github.com/kubernetes-sigs/controller-runtime/blob/b901db121e1f53c47ec9f9683fad90a546688c3e/pkg/builder/options.go#L103-L133