### PR TITLE
revert cma when uninstall globalhub

### DIFF
--- a/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -481,8 +481,19 @@ spec:
         - apiGroups:
           - cluster.open-cluster-management.io
           resources:
-          - managedclustersets
+          - managedclustersetbindings
           - placements
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+        - apiGroups:
+          - cluster.open-cluster-management.io
+          resources:
+          - managedclustersets
           verbs:
           - get
           - list

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -201,8 +201,19 @@ rules:
 - apiGroups:
   - cluster.open-cluster-management.io
   resources:
-  - managedclustersets
+  - managedclustersetbindings
   - placements
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclustersets
   verbs:
   - get
   - list

--- a/operator/pkg/config/multiclusterglobalhub_config.go
+++ b/operator/pkg/config/multiclusterglobalhub_config.go
@@ -358,7 +358,7 @@ func GetMulticlusterGlobalHub(ctx context.Context, c client.Client) (*v1alpha4.M
 		return nil, err
 	}
 	if len(mghList.Items) != 1 {
-		klog.Infof("mgh should have 1 instance, but got %v", len(mghList.Items))
+		klog.V(2).Infof("mgh should have 1 instance, but got %v", len(mghList.Items))
 		return nil, nil
 	}
 	return &mghList.Items[0], nil

--- a/operator/pkg/controllers/addons/addons_controller_test.go
+++ b/operator/pkg/controllers/addons/addons_controller_test.go
@@ -52,8 +52,8 @@ func Test_addAddonConfig(t *testing.T) {
 						Placements: []v1alpha1.PlacementStrategy{
 							{
 								PlacementRef: v1alpha1.PlacementRef{
-									Namespace: "open-cluster-management-global-set",
-									Name:      "global",
+									Namespace: constants.GHDefaultNamespace,
+									Name:      "non-local-cluster",
 								},
 								Configs: []v1alpha1.AddOnConfig{
 									{
@@ -112,8 +112,8 @@ func Test_addAddonConfig(t *testing.T) {
 							},
 							{
 								PlacementRef: v1alpha1.PlacementRef{
-									Namespace: "open-cluster-management-global-set",
-									Name:      "global",
+									Namespace: constants.GHDefaultNamespace,
+									Name:      "non-local-cluster",
 								},
 								Configs: []v1alpha1.AddOnConfig{
 									{
@@ -147,8 +147,8 @@ func Test_addAddonConfig(t *testing.T) {
 						Placements: []v1alpha1.PlacementStrategy{
 							{
 								PlacementRef: v1alpha1.PlacementRef{
-									Namespace: "open-cluster-management-global-set",
-									Name:      "global",
+									Namespace: constants.GHDefaultNamespace,
+									Name:      "non-local-cluster",
 								},
 								Configs: []v1alpha1.AddOnConfig{
 									{
@@ -178,8 +178,8 @@ func Test_addAddonConfig(t *testing.T) {
 						Placements: []v1alpha1.PlacementStrategy{
 							{
 								PlacementRef: v1alpha1.PlacementRef{
-									Namespace: "open-cluster-management-global-set",
-									Name:      "global",
+									Namespace: constants.GHDefaultNamespace,
+									Name:      "non-local-cluster",
 								},
 								Configs: []v1alpha1.AddOnConfig{
 									{

--- a/operator/pkg/controllers/hubofhubs/controller.go
+++ b/operator/pkg/controllers/hubofhubs/controller.go
@@ -561,7 +561,8 @@ func watchMutatingWebhookConfigurationPredicate() predicate.TypedPredicate[*admi
 // +kubebuilder:rbac:groups=policy.open-cluster-management.io,resources=policies,verbs=get;list;patch;update
 // +kubebuilder:rbac:groups=policy.open-cluster-management.io,resources=placementbindings,verbs=get;list;patch;update
 // +kubebuilder:rbac:groups=app.k8s.io,resources=applications,verbs=get;list;patch;update
-// +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=placements,verbs=get;list;patch;update
+// +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=placements,verbs=create;get;list;patch;update;delete
+// +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclustersetbindings,verbs=create;get;list;patch;update;delete
 // +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclustersets,verbs=get;list;patch;update
 // +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;update
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;create;update;delete

--- a/operator/pkg/controllers/hubofhubs/prune/prune_reconciler_test.go
+++ b/operator/pkg/controllers/hubofhubs/prune/prune_reconciler_test.go
@@ -2,6 +2,7 @@ package prune
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
@@ -12,12 +13,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
+	"open-cluster-management.io/api/addon/v1alpha1"
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	globalhubv1alpha4 "github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	operatorconstants "github.com/stolostron/multicluster-global-hub/operator/pkg/constants"
+	addonController "github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/addons"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/hubofhubs/grafana"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/hubofhubs/transporter/protocol"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
@@ -350,6 +354,176 @@ func TestWebhookResources(t *testing.T) {
 			}
 			if len(webhookServiceList.Items) != tt.webhookItem {
 				t.Errorf("Name:%v,Existing webhookServiceList:%v, want webhook items:%v", tt.name, len(webhookServiceList.Items), tt.webhookItem)
+			}
+		})
+	}
+}
+
+func TestPruneReconciler_hasManagedHub(t *testing.T) {
+	tests := []struct {
+		name    string
+		cmas    []runtime.Object
+		want    bool
+		wantErr bool
+	}{
+		{
+			name:    "no mca",
+			cmas:    []runtime.Object{},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "has mca",
+			cmas: []runtime.Object{
+				&addonv1alpha1.ManagedClusterAddOn{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      operatorconstants.GHManagedClusterAddonName,
+						Namespace: "mh1",
+					},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addonv1alpha1.AddToScheme(scheme.Scheme)
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(tt.cmas...).Build()
+			r := NewPruneReconciler(fakeClient)
+			ctx := context.Background()
+			got, err := r.hasManagedHub(ctx)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("PruneReconciler.hasManagedHub() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("PruneReconciler.hasManagedHub() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPruneReconciler_revertClusterManagementAddon(t *testing.T) {
+	tests := []struct {
+		name    string
+		cmas    []runtime.Object
+		wantErr bool
+	}{
+		{
+			name:    "no cma",
+			cmas:    []runtime.Object{},
+			wantErr: false,
+		},
+		{
+			name: "cma do not have placements",
+			cmas: []runtime.Object{
+				&v1alpha1.ClusterManagementAddOn{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "work-manager",
+						Namespace: utils.GetDefaultNamespace(),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "cma do not have target placements",
+			cmas: []runtime.Object{
+				&v1alpha1.ClusterManagementAddOn{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "work-manager",
+						Namespace: utils.GetDefaultNamespace(),
+					},
+					Spec: addonv1alpha1.ClusterManagementAddOnSpec{
+						InstallStrategy: addonv1alpha1.InstallStrategy{
+							Placements: []addonv1alpha1.PlacementStrategy{
+								v1alpha1.PlacementStrategy{
+									PlacementRef: v1alpha1.PlacementRef{
+										Namespace: constants.GHDefaultNamespace,
+										Name:      "global",
+									},
+									Configs: []v1alpha1.AddOnConfig{
+										{
+											ConfigReferent: v1alpha1.ConfigReferent{
+												Name:      "global-hub",
+												Namespace: constants.GHDefaultNamespace,
+											},
+											ConfigGroupResource: v1alpha1.ConfigGroupResource{
+												Group:    "addon.open-cluster-management.io",
+												Resource: "addondeploymentconfigs",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "cma have target placements",
+			cmas: []runtime.Object{
+				&v1alpha1.ClusterManagementAddOn{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "work-manager",
+						Namespace: utils.GetDefaultNamespace(),
+					},
+					Spec: addonv1alpha1.ClusterManagementAddOnSpec{
+						InstallStrategy: addonv1alpha1.InstallStrategy{
+							Placements: []addonv1alpha1.PlacementStrategy{
+								v1alpha1.PlacementStrategy{
+									PlacementRef: v1alpha1.PlacementRef{
+										Namespace: constants.GHDefaultNamespace,
+										Name:      "non-local-cluster",
+									},
+									Configs: []v1alpha1.AddOnConfig{
+										{
+											ConfigReferent: v1alpha1.ConfigReferent{
+												Name:      "global-hub",
+												Namespace: constants.GHDefaultNamespace,
+											},
+											ConfigGroupResource: v1alpha1.ConfigGroupResource{
+												Group:    "addon.open-cluster-management.io",
+												Resource: "addondeploymentconfigs",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addonv1alpha1.AddToScheme(scheme.Scheme)
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(tt.cmas...).Build()
+			r := NewPruneReconciler(fakeClient)
+			ctx := context.Background()
+			if err := r.revertClusterManagementAddon(ctx); (err != nil) != tt.wantErr {
+				t.Errorf("PruneReconciler.revertClusterManagementAddon() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			cmaList := &v1alpha1.ClusterManagementAddOnList{}
+
+			err := r.Client.List(ctx, cmaList)
+			if err != nil {
+				t.Errorf("Failed to list cma:%v", err)
+			}
+			for _, cma := range cmaList.Items {
+				if !addonController.AddonList.Has(cma.Name) {
+					continue
+				}
+				for _, pl := range cma.Spec.InstallStrategy.Placements {
+					if reflect.DeepEqual(pl.PlacementRef, addonController.GlobalhubCmaConfig.PlacementRef) {
+						t.Errorf("Failed to revert cma")
+					}
+				}
 			}
 		})
 	}

--- a/operator/pkg/controllers/hubofhubs/webhook/manifests/addondeploymentconfig.yaml
+++ b/operator/pkg/controllers/hubofhubs/webhook/manifests/addondeploymentconfig.yaml
@@ -8,4 +8,7 @@ metadata:
     cluster.open-cluster-management.io/backup: globalhub
 spec:
   agentInstallNamespace: open-cluster-management-global-hub-agent-addon
+  customizedVariables:
+  - name: enableSyncLabelsToClusterClaims
+    value: "false"
 {{ end }}

--- a/operator/pkg/controllers/hubofhubs/webhook/manifests/managedclustersetbinding.yaml
+++ b/operator/pkg/controllers/hubofhubs/webhook/manifests/managedclustersetbinding.yaml
@@ -1,0 +1,9 @@
+{{- if .ImportClusterInHosted}}
+apiVersion: cluster.open-cluster-management.io/v1beta2
+kind: ManagedClusterSetBinding
+metadata:
+  name: global
+  namespace: {{.Namespace}}
+spec:
+  clusterSet: global
+{{ end }}

--- a/operator/pkg/controllers/hubofhubs/webhook/manifests/placement.yaml
+++ b/operator/pkg/controllers/hubofhubs/webhook/manifests/placement.yaml
@@ -1,0 +1,16 @@
+{{- if .ImportClusterInHosted}}
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: non-local-cluster
+  namespace: {{.Namespace}}
+spec:
+  clusterSets:
+  - global
+  predicates:
+  - requiredClusterSelector:
+      labelSelector:
+        matchExpressions:
+        - key: local-cluster
+          operator: "DoesNotExist"
+{{ end }}

--- a/test/integration/operator/addons/addons_hosted_test.go
+++ b/test/integration/operator/addons/addons_hosted_test.go
@@ -10,7 +10,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog"
 	"open-cluster-management.io/api/addon/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -18,40 +17,15 @@ import (
 	globalhubv1alpha4 "github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/addons"
-	"github.com/stolostron/multicluster-global-hub/pkg/constants"
-	"github.com/stolostron/multicluster-global-hub/pkg/utils"
-)
-
-var addonList = sets.NewString(
-	"work-manager",
-	"cluster-proxy",
-	"managed-serviceaccount",
+	addonController "github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/addons"
 )
 
 var (
 	timeout         = time.Second * 30
 	interval        = time.Millisecond * 250
 	hostedNamespace = "mc-hosted"
+	mghName         = "test-mgh"
 )
-
-var newNamespaceConfig = v1alpha1.PlacementStrategy{
-	PlacementRef: v1alpha1.PlacementRef{
-		Namespace: "open-cluster-management-global-set",
-		Name:      "global",
-	},
-	Configs: []v1alpha1.AddOnConfig{
-		{
-			ConfigReferent: v1alpha1.ConfigReferent{
-				Name:      "global-hub",
-				Namespace: constants.GHDefaultNamespace,
-			},
-			ConfigGroupResource: v1alpha1.ConfigGroupResource{
-				Group:    "addon.open-cluster-management.io",
-				Resource: "addondeploymentconfigs",
-			},
-		},
-	},
-}
 
 var workManager = v1alpha1.ClusterManagementAddOn{
 	ObjectMeta: metav1.ObjectMeta{
@@ -88,7 +62,7 @@ var msa = v1alpha1.ClusterManagementAddOn{
 
 var mgh = globalhubv1alpha4.MulticlusterGlobalHub{
 	ObjectMeta: metav1.ObjectMeta{
-		Namespace: utils.GetDefaultNamespace(),
+		Namespace: mghName,
 		Name:      "mgh",
 		Annotations: map[string]string{
 			"global-hub.open-cluster-management.io/import-cluster-in-hosted": "true",
@@ -101,9 +75,17 @@ var _ = Describe("addons hosted mode test", Ordered, func() {
 	var addonsReconciler *addons.AddonsReconciler
 	BeforeAll(func() {
 		config.SetImportClusterInHosted(&mgh)
+
 		addonsReconciler = addons.NewAddonsReconciler(mgr)
 		err := addonsReconciler.SetupWithManager(mgr)
 		Expect(err).NotTo(HaveOccurred())
+		Expect(mgr.GetClient().Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: mghName,
+			},
+		})).To(Succeed())
+		Expect(mgr.GetClient().Create(ctx, &mgh)).To(Succeed())
+
 		mcHostedNamespace := &corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: hostedNamespace}}
 		err = mgr.GetClient().Create(ctx, mcHostedNamespace)
 		Expect(err).Should(Succeed())
@@ -137,7 +119,7 @@ var _ = Describe("addons hosted mode test", Ordered, func() {
 	It("addons should be added the new config", func() {
 		Eventually(func() bool {
 			cma := &v1alpha1.ClusterManagementAddOn{}
-			for addonName := range addonList {
+			for addonName := range addonController.AddonList {
 				_, err := addonsReconciler.Reconcile(ctx, reconcile.Request{
 					NamespacedName: types.NamespacedName{
 						Namespace: hostedNamespace,
@@ -160,8 +142,8 @@ var _ = Describe("addons hosted mode test", Ordered, func() {
 
 				found := false
 				for _, ps := range cma.Spec.InstallStrategy.Placements {
-					if reflect.DeepEqual(ps.PlacementRef, newNamespaceConfig.PlacementRef) &&
-						reflect.DeepEqual(ps.Configs, newNamespaceConfig.Configs) {
+					if reflect.DeepEqual(ps.PlacementRef, addonController.GlobalhubCmaConfig.PlacementRef) &&
+						reflect.DeepEqual(ps.Configs, addonController.GlobalhubCmaConfig.Configs) {
 						found = true
 					}
 				}

--- a/test/integration/operator/addons/suite_test.go
+++ b/test/integration/operator/addons/suite_test.go
@@ -45,6 +45,7 @@ var _ = BeforeSuite(func() {
 	testenv = &envtest.Environment{
 		CRDDirectoryPaths: []string{
 			filepath.Join("..", "..", "..", "manifest", "crd"),
+			filepath.Join("..", "..", "..", "..", "operator", "config", "crd", "bases"),
 		},
 		ErrorIfCRDPathMissing: true,
 	}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This pr revert the cma when uninstall globalhub
We also redefine the placement and addondeploymentconfig to disable the sync managedhubcluster label to clusterclaim 
## Related issue(s)

Fixes #
https://issues.redhat.com/browse/ACM-14313
## Tests
* [x] Unit/function tests have been added and incorporated into `make unit-tests`.
* [x] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [x] List other manual tests you have done.

-   Manually tested the whole flow about importing hosted cluster and uninstall mgh