### PR TITLE
:bug:  Increase the operator memory limit

### DIFF
--- a/doc/simulation/scenario/Scenario3: 3000_clusters_500_policies.md
+++ b/doc/simulation/scenario/Scenario3: 3000_clusters_500_policies.md
@@ -88,4 +88,4 @@ cat /sys/fs/cgroup/memory.current
   | Request CPU(m)     | 5       | 10    | 2        | 5       | 100      | 20           | 10              |
   | Limit CPU(m)       | 500     | 50    | 100      | 50      | 8000     | 200          | 50              |
   | Request Memory(Mi) | 60      | 300   | 70       | 150     | 60       | 1.5 Gi       | 800             |
-  | Limit Memory(Mi)   | 500     | 1200  | 200      | 800     | 1000     | 5   Gi       | 2   Gi          | 
+  | Limit Memory(Mi)   | 500     | 1200  | 500      | 800     | 1000     | 5   Gi       | 2   Gi          | 

--- a/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
     categories: Integration & Delivery,OpenShift Optional
     certified: "false"
     containerImage: quay.io/stolostron/multicluster-global-hub-operator:latest
-    createdAt: "2024-09-13T07:24:35Z"
+    createdAt: "2024-09-20T08:53:14Z"
     description: Manages the installation and upgrade of the Multicluster Global Hub.
     olm.skipRange: '>=1.2.0 <1.3.0'
     operatorframework.io/initialization-resource: '{"apiVersion":"operator.open-cluster-management.io/v1alpha4",
@@ -721,7 +721,7 @@ spec:
                   periodSeconds: 10
                 resources:
                   limits:
-                    memory: 200Mi
+                    memory: 500Mi
                   requests:
                     cpu: 1m
                     memory: 100Mi

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -78,7 +78,7 @@ spec:
           limits:
             # cpu: 50m
             # https://home.robusta.dev/blog/stop-using-cpu-limits
-            memory: 200Mi
+            memory: 500Mi
           requests:
             cpu: 1m
             memory: 100Mi


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

The operator might be killed by the OOM. Suggest improving the limitation:
 
```bash
❯ oc adm top pods
NAME                                                CPU(cores)   MEMORY(bytes)
kafka-entity-operator-7774786575-vwgtq              5m           264Mi
multicluster-global-hub-operator-78969d589c-gb2mw   49m          224Mi
❯ oc adm top pods
NAME                                                CPU(cores)   MEMORY(bytes)
kafka-entity-operator-7774786575-vwgtq              5m           264Mi
multicluster-global-hub-operator-78969d589c-gb2mw   49m          224Mi
❯ oc adm top pods
NAME                                                CPU(cores)   MEMORY(bytes)
multicluster-global-hub-operator-78969d589c-gb2mw   1m           224Mi
❯ kubectl top pods
NAME                                                CPU(cores)   MEMORY(bytes)
multicluster-global-hub-operator-78969d589c-gb2mw   1m           224Mi
❯ kubectl top pods
NAME                                                CPU(cores)   MEMORY(bytes)
multicluster-global-hub-operator-78969d589c-gb2mw   2m           178Mi
❯ kubectl top pods
NAME                                                CPU(cores)   MEMORY(bytes)
multicluster-global-hub-operator-78969d589c-gb2mw   2m           178Mi
```

## Related issue(s)

Fixes #

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
