### PR TITLE
:bug: Modify the kafka HA by operand

### DIFF
--- a/operator/pkg/controllers/hubofhubs/transporter/protocol/strimzi_transporter.go
+++ b/operator/pkg/controllers/hubofhubs/transporter/protocol/strimzi_transporter.go
@@ -664,6 +664,11 @@ func (k *strimziTransporter) newKafkaCluster(mgh *operatorv1alpha4.MulticlusterG
 		kafkaSpecZookeeperStorage.Class = &mgh.Spec.DataLayerSpec.StorageClass
 	}
 
+	replicas := int32(3)
+	if mgh.Spec.AvailabilityConfig == operatorv1alpha4.HABasic {
+		replicas = 1
+	}
+
 	kafkaCluster := &kafkav1beta2.Kafka{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      k.kafkaClusterName,
@@ -703,7 +708,7 @@ func (k *strimziTransporter) newKafkaCluster(mgh *operatorv1alpha4.MulticlusterG
 				Authorization: &kafkav1beta2.KafkaSpecKafkaAuthorization{
 					Type: kafkav1beta2.KafkaSpecKafkaAuthorizationTypeSimple,
 				},
-				Replicas: 3,
+				Replicas: replicas,
 				Storage: kafkav1beta2.KafkaSpecKafkaStorage{
 					Type: kafkav1beta2.KafkaSpecKafkaStorageTypeJbod,
 					Volumes: []kafkav1beta2.KafkaSpecKafkaStorageVolumesElem{
@@ -713,7 +718,7 @@ func (k *strimziTransporter) newKafkaCluster(mgh *operatorv1alpha4.MulticlusterG
 				Version: &KafkaVersion,
 			},
 			Zookeeper: kafkav1beta2.KafkaSpecZookeeper{
-				Replicas:  3,
+				Replicas:  replicas,
 				Storage:   kafkaSpecZookeeperStorage,
 				Resources: k.getZookeeperResources(mgh),
 			},


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

When I set the availability with `Basic` mode 
```
apiVersion: operator.open-cluster-management.io/v1alpha4
kind: MulticlusterGlobalHub
metadata:
...
spec:
  availabilityConfig: Basic
  dataLayer:
    kafka:
      topics:
        specTopic: gh-spec
        statusTopic: gh-status.*
    postgres:
      retention: 18m
  enableMetrics: true
```

Still get the high availability configuration of the Kafka cluster
```bash
❯ oc get pods
NAME                                                READY   STATUS    RESTARTS   AGE
inventory-api-5547c8fb4-h9mgx                       1/1     Running   0          25m
kafka-entity-operator-7774786575-69lfj              2/2     Running   0          26m
kafka-kafka-0                                       1/1     Running   0          26m
kafka-kafka-1                                       1/1     Running   0          26m
kafka-kafka-2                                       1/1     Running   0          26m
kafka-zookeeper-0                                   1/1     Running   0          27m
kafka-zookeeper-1                                   1/1     Running   0          27m
kafka-zookeeper-2                                   1/1     Running   0          27m
```

Description:
when I tried to scale the broker size from 3 to 1, the connection between the component and the kafka cluster was broken. Like
```bash
%3|1727409250.005|FAIL|rdkafka#consumer-1| [thrd:GroupCoordinator]: GroupCoordinator: kafka-kafka-tls-2-multicluster-global-hub.apps.obs-hub-of-hubs-aws-416-sno-69hrc.scale.red-chesterfield.com:443: SSL handshake failed: Disconnected: connecting to a PLAINTEXT broker listener? (after 4ms in state SSL_HANDSHAKE)
{"level":"info","ts":1727409250.005757,"logger":"fallback","caller":"v2@v2.0.0-20240911135016-682f3a9684e4/protocol.go:202","msg":"Error Local: Broker transport failure: GroupCoordinator: kafka-kafka-tls-2-multicluster-global-hub.apps.obs-hub-of-hubs-aws-416-sno-69hrc.scale.red-chesterfield.com:443: SSL handshake failed: Disconnected: connecting to a PLAINTEXT broker listener? (after 4ms in state SSL_HANDSHAKE)"}
%3|1727409250.110|FAIL|rdkafka#consumer-1| [thrd:GroupCoordinator]: GroupCoordinator: kafka-kafka-tls-2-multicluster-global-hub.apps.obs-hub-of-hubs-aws-416-sno-69hrc.scale.red-chesterfield.com:443: SSL handshake failed: Disconnected: connecting to a PLAINTEXT broker listener? (after 2ms in state SSL_HANDSHAKE, 1 identical error(s) suppressed)
{"level":"info","ts":1727409250.110673,"logger":"fallback","caller":"v2@v2.0.0-20240911135016-682f3a9684e4/protocol.go:202","msg":"Error Local: Broker transport failure: GroupCoordinator: kafka-kafka-tls-2-multicluster-global-hub.apps.obs-hub-of-hubs-aws-416-sno-69hrc.scale.red-chesterfield.com:443: SSL handshake failed: Disconnected: connecting to a PLAINTEXT broker listener? (after 2ms in state SSL_HANDSHAKE, 1 identical error(s) suppressed)"}
```
```bash
2024-09-27T03:57:35.458Z        INFO    kafka-producer  Delivery failed {"error": "Broker: Topic authorization failed"}
{"level":"info","ts":1727409455.4788327,"logger":"fallback","caller":"v2@v2.0.0-20240911135016-682f3a9684e4/protocol.go:202","msg":"Error Broker: Unknown topic or partition: Subscribed topic not available: ^gh-status.*: Broker: Unknown topic or partition"}
```

Solution:

The kafka broker and topic replicas scaling do not support the upgrade case. That means when you want to scale the kafka and zookeeper cluster replicas by the `availabilityConfig` of the operand. It will not work. The HA configuration only works when you initialize the operand.

## Related issue(s)

Fixes #

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
