### PR TITLE
:sparkles: Kafka resource reconcile deadlock

### DIFF
--- a/operator/pkg/controllers/hubofhubs/transporter/protocol/byo_transporter.go
+++ b/operator/pkg/controllers/hubofhubs/transporter/protocol/byo_transporter.go
@@ -33,12 +33,12 @@ func NewBYOTransporter(ctx context.Context, namespacedName types.NamespacedName,
 ) *BYOTransporter {
 	if byoTransporter == nil {
 		byoTransporter = &BYOTransporter{
-			log: ctrl.Log.WithName("secret-transporter"),
+			log:           ctrl.Log.WithName("secret-transporter"),
+			ctx:           ctx,
+			runtimeClient: c,
 		}
 		config.SetTransporter(byoTransporter)
 	}
-	byoTransporter.ctx = ctx
-	byoTransporter.runtimeClient = c
 	byoTransporter.name = namespacedName.Name
 	byoTransporter.namespace = namespacedName.Namespace
 	return byoTransporter

--- a/operator/pkg/controllers/hubofhubs/transporter/protocol/byo_transporter.go
+++ b/operator/pkg/controllers/hubofhubs/transporter/protocol/byo_transporter.go
@@ -23,19 +23,24 @@ type BYOTransporter struct {
 	runtimeClient client.Client
 }
 
+var byoTransporter *BYOTransporter
+
 // create the transport with secret(BYO case), it should meet the following conditions
 // 1. name: "multicluster-global-hub-transport"
 // 2. properties: "bootstrap_server", "ca.crt", "client.crt" and "client.key"
 func NewBYOTransporter(ctx context.Context, namespacedName types.NamespacedName,
 	c client.Client,
 ) *BYOTransporter {
-	return &BYOTransporter{
-		log:           ctrl.Log.WithName("secret-transporter"),
-		ctx:           ctx,
-		name:          namespacedName.Name,
-		namespace:     namespacedName.Namespace,
-		runtimeClient: c,
+	if byoTransporter == nil {
+		byoTransporter = &BYOTransporter{
+			log:           ctrl.Log.WithName("secret-transporter"),
+			ctx:           ctx,
+			name:          namespacedName.Name,
+			namespace:     namespacedName.Namespace,
+			runtimeClient: c,
+		}
 	}
+	return byoTransporter
 }
 
 func (s *BYOTransporter) EnsureUser(clusterName string) (string, error) {

--- a/operator/pkg/controllers/hubofhubs/transporter/protocol/byo_transporter.go
+++ b/operator/pkg/controllers/hubofhubs/transporter/protocol/byo_transporter.go
@@ -33,13 +33,14 @@ func NewBYOTransporter(ctx context.Context, namespacedName types.NamespacedName,
 ) *BYOTransporter {
 	if byoTransporter == nil {
 		byoTransporter = &BYOTransporter{
-			log:           ctrl.Log.WithName("secret-transporter"),
-			ctx:           ctx,
-			name:          namespacedName.Name,
-			namespace:     namespacedName.Namespace,
-			runtimeClient: c,
+			log: ctrl.Log.WithName("secret-transporter"),
 		}
+		config.SetTransporter(byoTransporter)
 	}
+	byoTransporter.ctx = ctx
+	byoTransporter.runtimeClient = c
+	byoTransporter.name = namespacedName.Name
+	byoTransporter.namespace = namespacedName.Namespace
 	return byoTransporter
 }
 

--- a/operator/pkg/controllers/hubofhubs/transporter/protocol/strimzi_transporter.go
+++ b/operator/pkg/controllers/hubofhubs/transporter/protocol/strimzi_transporter.go
@@ -101,55 +101,59 @@ type strimziTransporter struct {
 
 type KafkaOption func(*strimziTransporter)
 
+var transporter *strimziTransporter
+
 func NewStrimziTransporter(mgr ctrl.Manager, mgh *operatorv1alpha4.MulticlusterGlobalHub,
 	opts ...KafkaOption,
 ) *strimziTransporter {
-	k := &strimziTransporter{
-		log:                   ctrl.Log.WithName("strimzi-transporter"),
-		ctx:                   context.TODO(),
-		kafkaClusterName:      KafkaClusterName,
-		kafkaClusterNamespace: mgh.Namespace,
+	if transporter == nil {
+		transporter = &strimziTransporter{
+			log:                   ctrl.Log.WithName("strimzi-transporter"),
+			ctx:                   context.TODO(),
+			kafkaClusterName:      KafkaClusterName,
+			kafkaClusterNamespace: mgh.Namespace,
 
-		subName:                   DefaultKafkaSubName,
-		subCommunity:              false,
-		subChannel:                DefaultAMQChannel,
-		subPackageName:            DefaultAMQPackageName,
-		subCatalogSourceName:      DefaultCatalogSourceName,
-		subCatalogSourceNamespace: DefaultCatalogSourceNamespace,
+			subName:                   DefaultKafkaSubName,
+			subCommunity:              false,
+			subChannel:                DefaultAMQChannel,
+			subPackageName:            DefaultAMQPackageName,
+			subCatalogSourceName:      DefaultCatalogSourceName,
+			subCatalogSourceNamespace: DefaultCatalogSourceNamespace,
 
-		waitReady:              true,
-		enableTLS:              true,
-		sharedTopics:           false,
-		topicPartitionReplicas: DefaultPartitionReplicas,
+			waitReady:              true,
+			enableTLS:              true,
+			sharedTopics:           false,
+			topicPartitionReplicas: DefaultPartitionReplicas,
 
-		manager: mgr,
-		mgh:     mgh,
+			manager: mgr,
+			mgh:     mgh,
+		}
 	}
 	// apply options
 	for _, opt := range opts {
-		opt(k)
+		opt(transporter)
 	}
 
-	if k.subCommunity {
-		k.subChannel = CommunityChannel
-		k.subPackageName = CommunityPackageName
-		k.subCatalogSourceName = CommunityCatalogSourceName
+	if transporter.subCommunity {
+		transporter.subChannel = CommunityChannel
+		transporter.subPackageName = CommunityPackageName
+		transporter.subCatalogSourceName = CommunityCatalogSourceName
 		// it will be operatorhubio-catalog to install kafka in KinD cluster
 		catalogSourceName, ok := mgh.Annotations[operatorconstants.CommunityCatalogSourceNameKey]
 		if ok && catalogSourceName != "" {
-			k.subCatalogSourceName = catalogSourceName
+			transporter.subCatalogSourceName = catalogSourceName
 		}
 		catalogSourceNamespace, ok := mgh.Annotations[operatorconstants.CommunityCatalogSourceNamespaceKey]
 		if ok && catalogSourceNamespace != "" {
-			k.subCatalogSourceNamespace = catalogSourceNamespace
+			transporter.subCatalogSourceNamespace = catalogSourceNamespace
 		}
 	}
 
 	if mgh.Spec.AvailabilityConfig == operatorv1alpha4.HABasic {
-		k.topicPartitionReplicas = 1
+		transporter.topicPartitionReplicas = 1
 	}
 
-	return k
+	return transporter
 }
 
 func WithNamespacedName(name types.NamespacedName) KafkaOption {

--- a/operator/pkg/controllers/hubofhubs/transporter/protocol/strimzi_transporter.go
+++ b/operator/pkg/controllers/hubofhubs/transporter/protocol/strimzi_transporter.go
@@ -123,12 +123,13 @@ func NewStrimziTransporter(mgr ctrl.Manager, mgh *operatorv1alpha4.MulticlusterG
 			enableTLS:              true,
 			sharedTopics:           false,
 			topicPartitionReplicas: DefaultPartitionReplicas,
+
+			manager: mgr,
 		}
 		config.SetTransporter(transporter)
 	}
 
 	transporter.mgh = mgh
-	transporter.manager = mgr
 	transporter.kafkaClusterNamespace = mgh.Namespace
 	// apply options
 	for _, opt := range opts {

--- a/operator/pkg/controllers/hubofhubs/transporter/protocol/strimzi_transporter.go
+++ b/operator/pkg/controllers/hubofhubs/transporter/protocol/strimzi_transporter.go
@@ -123,12 +123,12 @@ func NewStrimziTransporter(mgr ctrl.Manager, mgh *operatorv1alpha4.MulticlusterG
 			enableTLS:              true,
 			sharedTopics:           false,
 			topicPartitionReplicas: DefaultPartitionReplicas,
-
-			manager: mgr,
 		}
+		config.SetTransporter(transporter)
 	}
 
 	transporter.mgh = mgh
+	transporter.manager = mgr
 	transporter.kafkaClusterNamespace = mgh.Namespace
 	// apply options
 	for _, opt := range opts {

--- a/operator/pkg/controllers/hubofhubs/transporter/protocol/strimzi_transporter.go
+++ b/operator/pkg/controllers/hubofhubs/transporter/protocol/strimzi_transporter.go
@@ -108,10 +108,9 @@ func NewStrimziTransporter(mgr ctrl.Manager, mgh *operatorv1alpha4.MulticlusterG
 ) *strimziTransporter {
 	if transporter == nil {
 		transporter = &strimziTransporter{
-			log:                   ctrl.Log.WithName("strimzi-transporter"),
-			ctx:                   context.TODO(),
-			kafkaClusterName:      KafkaClusterName,
-			kafkaClusterNamespace: mgh.Namespace,
+			log:              ctrl.Log.WithName("strimzi-transporter"),
+			ctx:              context.TODO(),
+			kafkaClusterName: KafkaClusterName,
 
 			subName:                   DefaultKafkaSubName,
 			subCommunity:              false,
@@ -126,9 +125,11 @@ func NewStrimziTransporter(mgr ctrl.Manager, mgh *operatorv1alpha4.MulticlusterG
 			topicPartitionReplicas: DefaultPartitionReplicas,
 
 			manager: mgr,
-			mgh:     mgh,
 		}
 	}
+
+	transporter.mgh = mgh
+	transporter.kafkaClusterNamespace = mgh.Namespace
 	// apply options
 	for _, opt := range opts {
 		opt(transporter)

--- a/operator/pkg/controllers/hubofhubs/transporter/transport_reconciler.go
+++ b/operator/pkg/controllers/hubofhubs/transporter/transport_reconciler.go
@@ -40,8 +40,6 @@ func (r *TransportReconciler) Reconcile(ctx context.Context, mgh *v1alpha4.Multi
 		if _, err := r.transporter.EnsureKafka(); err != nil {
 			return err
 		}
-		// update the transporter
-		config.SetTransporter(r.transporter)
 
 		// this controller also will update the transport connection
 		if config.GetKafkaResourceReady() && r.kafkaController == nil {
@@ -55,7 +53,6 @@ func (r *TransportReconciler) Reconcile(ctx context.Context, mgh *v1alpha4.Multi
 			Namespace: mgh.Namespace,
 			Name:      constants.GHTransportSecretName,
 		}, r.GetClient())
-		config.SetTransporter(r.transporter)
 		// all of hubs will get the same credential
 		conn, err := r.transporter.GetConnCredential("")
 		if err != nil {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

When install the mgh, the operator will always waiting for the Kafka resource
```
oc logs -f -l name=multicluster-global-hub-operator -n multicluster-global-hub
I0923 04:33:59.194138       1 strimzi_transporter.go:580] Wait kafka cluster ready
I0923 04:33:59.497324       1 strimzi_transporter.go:580] Wait kafka cluster ready
...
```

The reason is the Kafka resource cannot ready 
```bash
❯ oc get kafka kafka -oyaml
apiVersion: kafka.strimzi.io/v1beta2
kind: Kafka
metadata:
  creationTimestamp: "2024-09-23T03:50:21Z"
  generation: 1
  labels:
    global-hub.open-cluster-management.io/managed-by: global-hub
  name: kafka
  namespace: multicluster-global-hub
      port: 9093
      tls: true
      type: route
    metricsConfig:
      type: jmxPrometheusExporter
      valueFrom:
        configMapKeyRef:
          key: kafka-metrics-config.yml
          name: kafka-metrics
...
status:
  conditions:
  - lastTransitionTime: "2024-09-23T03:50:55.566749838Z"
    message: ConfigMap kafka-metrics does not exist
    reason: InvalidConfigurationException
    status: "True"
    type: NotReady
  observedGeneration: 1
```

## Related issue(s)

Fixes #

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.

Reference: https://github.com/stolostron/multicluster-global-hub/pull/1066
