### PR TITLE
:bug: Create inventory always

### DIFF
--- a/operator/pkg/controllers/hubofhubs/storage/manifests.sts/init-configmap.yaml
+++ b/operator/pkg/controllers/hubofhubs/storage/manifests.sts/init-configmap.yaml
@@ -5,9 +5,7 @@ metadata:
   namespace: {{.Namespace}}
 data:
   postgresql-start.sh: |
-    {{if .EnableInventoryAPI}}
     psql -U postgres -tc "SELECT 1 FROM pg_database WHERE datname = 'inventory'" | grep -q 1 || psql -U postgres -c "CREATE DATABASE inventory"
-    {{end}}
     psql -U postgres -tc "SELECT 1 FROM pg_database WHERE datname = 'hoh'" | grep -q 1 || psql -U postgres -c "CREATE DATABASE hoh"
     psql -U postgres -tc "SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = '{{.PostgresReadonlyUsername}}'" | grep -q 1 || psql -U postgres -c "CREATE ROLE \"{{.PostgresReadonlyUsername}}\" LOGIN PASSWORD '{{.PostgresReadonlyUserPassword}}'"
     psql -U postgres -c "ALTER ROLE \"{{.PostgresReadonlyUsername}}\" WITH PASSWORD '{{.PostgresReadonlyUserPassword}}'"     


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Currently, only create `inventory` dbname when the CR has `with-inventory` annotation. the db won't be created if add `with-inventory` annotation latter because the postgres sts is already running, the init configmap won't be executed.
for the longer term, we will enable inventory by default. So, just create it regardless of whether we have this annotation or not.

## Related issue(s)

Fixes #

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [x] List other manual tests you have done.
Tested in local environment
