### PR TITLE
:bug: Owned CRDs should have resources specified

### DIFF
--- a/operator/api/migration/v1alpha1/managedclustermigration_types.go
+++ b/operator/api/migration/v1alpha1/managedclustermigration_types.go
@@ -22,6 +22,7 @@ import (
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +operator-sdk:csv:customresourcedefinitions:resources={{Deployment,v1,multicluster-global-hub-manager}}
 // ManagedClusterMigration is a global hub resource that allows you to migrate managed clusters from one hub to another
 type ManagedClusterMigration struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -31,7 +31,7 @@ metadata:
     categories: Integration & Delivery,OpenShift Optional
     certified: "false"
     containerImage: quay.io/stolostron/multicluster-global-hub-operator:latest
-    createdAt: "2024-09-23T15:30:14Z"
+    createdAt: "2024-09-25T01:50:43Z"
     description: Manages the installation and upgrade of the Multicluster Global Hub.
     olm.skipRange: '>=1.2.0 <1.3.0'
     operatorframework.io/initialization-resource: '{"apiVersion":"operator.open-cluster-management.io/v1alpha4",
@@ -53,6 +53,10 @@ spec:
       displayName: Managed Cluster Migration
       kind: ManagedClusterMigration
       name: managedclustermigrations.global-hub.open-cluster-management.io
+      resources:
+      - kind: Deployment
+        name: multicluster-global-hub-manager
+        version: v1
       specDescriptors:
       - description: IncludedManagedClusters is a list of managed clusters that you
           want to migrate

--- a/operator/config/manifests/bases/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -28,6 +28,10 @@ spec:
       displayName: Managed Cluster Migration
       kind: ManagedClusterMigration
       name: managedclustermigrations.global-hub.open-cluster-management.io
+      resources:
+      - kind: Deployment
+        name: multicluster-global-hub-manager
+        version: v1
       specDescriptors:
       - description: IncludedManagedClusters is a list of managed clusters that you
           want to migrate


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Owned CRDs should have resources specified

## Related issue(s)

Fixes #
```
      "status": {
        "results": [
          {
            "name": "olm-crds-have-resources",
            "log": "Loaded ClusterServiceVersion: multicluster-global-hub-operator-rh.v1.3.0\n",
            "state": "fail",
            "errors": [
              "Owned CRDs do not have resources specified"
            ],
            "creationTimestamp": null
          }
        ]
      }
```

ref: http://external-ci-coldstorage.datahub.redhat.com/cvp/cvp-redhat-operator-bundle-image-validation-test/multicluster-globalhub-operator-bundle-container-v1.3.0-31/b854a993-d8f2-4b8e-9e82-b3804a40e233/operator-custom-scorecard-tests-bundle-image-output.txt

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
