### PR TITLE
:bug: Add annotations to the managedcluster if the global hub addon is there

### DIFF
--- a/operator/pkg/controllers/crd/crd_controller.go
+++ b/operator/pkg/controllers/crd/crd_controller.go
@@ -230,13 +230,9 @@ func (r *CrdController) watchACMRelatedResources() error {
 	if err := r.globalHubController.Watch(
 		source.Kind(
 			r.Manager.GetCache(), &v1alpha1.ManagedClusterAddOn{},
-			handler.TypedEnqueueRequestsFromMapFunc(func(ctx context.Context,
-				c *v1alpha1.ManagedClusterAddOn,
+			handler.TypedEnqueueRequestsFromMapFunc(func(ctx context.Context, c *v1alpha1.ManagedClusterAddOn,
 			) []reconcile.Request {
-				return []reconcile.Request{
-					// trigger MGH instance reconcile
-					{NamespacedName: config.GetMGHNamespacedName()},
-				}
+				return []reconcile.Request{{NamespacedName: config.GetMGHNamespacedName()}}
 			}), watchManagedClusterAddOnPredict(),
 		)); err != nil {
 		return err
@@ -287,8 +283,7 @@ func watchManagedClusterAddOnPredict() predicate.TypedPredicate[*v1alpha1.Manage
 			return false
 		},
 		UpdateFunc: func(e event.TypedUpdateEvent[*v1alpha1.ManagedClusterAddOn]) bool {
-			if e.ObjectNew.GetLabels()[constants.GlobalHubOwnerLabelKey] !=
-				constants.GHOperatorOwnerLabelVal {
+			if e.ObjectNew.GetLabels()[constants.GlobalHubOwnerLabelKey] != constants.GHOperatorOwnerLabelVal {
 				return false
 			}
 			// only requeue when spec change, if the resource do not have spec field, the generation is always 0
@@ -298,8 +293,7 @@ func watchManagedClusterAddOnPredict() predicate.TypedPredicate[*v1alpha1.Manage
 			return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()
 		},
 		DeleteFunc: func(e event.TypedDeleteEvent[*v1alpha1.ManagedClusterAddOn]) bool {
-			return e.Object.GetLabels()[constants.GlobalHubOwnerLabelKey] ==
-				constants.GHOperatorOwnerLabelVal
+			return e.Object.GetLabels()[constants.GlobalHubOwnerLabelKey] == constants.GHOperatorOwnerLabelVal
 		},
 	}
 }

--- a/operator/pkg/controllers/crd/crd_controller.go
+++ b/operator/pkg/controllers/crd/crd_controller.go
@@ -229,6 +229,20 @@ func (r *CrdController) watchACMRelatedResources() error {
 	}
 	if err := r.globalHubController.Watch(
 		source.Kind(
+			r.Manager.GetCache(), &v1alpha1.ManagedClusterAddOn{},
+			handler.TypedEnqueueRequestsFromMapFunc(func(ctx context.Context,
+				c *v1alpha1.ManagedClusterAddOn,
+			) []reconcile.Request {
+				return []reconcile.Request{
+					// trigger MGH instance reconcile
+					{NamespacedName: config.GetMGHNamespacedName()},
+				}
+			}), watchManagedClusterAddOnPredict(),
+		)); err != nil {
+		return err
+	}
+	if err := r.globalHubController.Watch(
+		source.Kind(
 			r.Manager.GetCache(), &clusterv1.ManagedCluster{},
 			handler.TypedEnqueueRequestsFromMapFunc(func(ctx context.Context,
 				c *clusterv1.ManagedCluster,
@@ -261,6 +275,29 @@ func watchClusterManagementAddOnPredict() predicate.TypedPredicate[*v1alpha1.Clu
 			return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()
 		},
 		DeleteFunc: func(e event.TypedDeleteEvent[*v1alpha1.ClusterManagementAddOn]) bool {
+			return e.Object.GetLabels()[constants.GlobalHubOwnerLabelKey] ==
+				constants.GHOperatorOwnerLabelVal
+		},
+	}
+}
+
+func watchManagedClusterAddOnPredict() predicate.TypedPredicate[*v1alpha1.ManagedClusterAddOn] {
+	return predicate.TypedFuncs[*v1alpha1.ManagedClusterAddOn]{
+		CreateFunc: func(e event.TypedCreateEvent[*v1alpha1.ManagedClusterAddOn]) bool {
+			return false
+		},
+		UpdateFunc: func(e event.TypedUpdateEvent[*v1alpha1.ManagedClusterAddOn]) bool {
+			if e.ObjectNew.GetLabels()[constants.GlobalHubOwnerLabelKey] !=
+				constants.GHOperatorOwnerLabelVal {
+				return false
+			}
+			// only requeue when spec change, if the resource do not have spec field, the generation is always 0
+			if e.ObjectNew.GetGeneration() == 0 {
+				return true
+			}
+			return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()
+		},
+		DeleteFunc: func(e event.TypedDeleteEvent[*v1alpha1.ManagedClusterAddOn]) bool {
 			return e.Object.GetLabels()[constants.GlobalHubOwnerLabelKey] ==
 				constants.GHOperatorOwnerLabelVal
 		},

--- a/operator/pkg/utils/utils.go
+++ b/operator/pkg/utils/utils.go
@@ -34,7 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -411,13 +411,12 @@ func AnnotateManagedHubCluster(ctx context.Context, c client.Client) error {
 
 	globalHubAddons := &addonapiv1alpha1.ManagedClusterAddOnList{}
 	if err := c.List(ctx, globalHubAddons, &client.ListOptions{
-		FieldSelector: fields.SelectorFromSet(map[string]string{"name": operatorconstants.GHManagedClusterAddonName}),
+		LabelSelector: labels.SelectorFromSet(
+			labels.Set{
+				constants.GlobalHubOwnerLabelKey: constants.GHOperatorOwnerLabelVal,
+			}),
 	}); err != nil {
 		return err
-	}
-	// no global hub agent installed in the managed hub clusters, just return
-	if len(globalHubAddons.Items) == 0 {
-		return nil
 	}
 
 	for idx, managedHub := range clusters.Items {

--- a/operator/pkg/utils/utils.go
+++ b/operator/pkg/utils/utils.go
@@ -445,6 +445,7 @@ func AnnotateManagedHubCluster(ctx context.Context, c client.Client) error {
 		orgAnnotations[operatorconstants.AnnotationONMulticlusterHub] = "true"
 		orgAnnotations[operatorconstants.AnnotationPolicyONMulticlusterHub] = "true"
 		if !equality.Semantic.DeepEqual(annotations, orgAnnotations) {
+			clusters.Items[idx].SetAnnotations(orgAnnotations)
 			if err := c.Update(ctx, &clusters.Items[idx], &client.UpdateOptions{}); err != nil {
 				return err
 			}

--- a/test/e2e/cluster_test.go
+++ b/test/e2e/cluster_test.go
@@ -114,6 +114,9 @@ var _ = Describe("Managed Clusters", Label("e2e-test-cluster"), Ordered, func() 
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      operatorconstants.GHManagedClusterAddonName,
 					Namespace: mh_name,
+					Labels: map[string]string{
+						constants.GlobalHubOwnerLabelKey: constants.GHOperatorOwnerLabelVal,
+					},
 				},
 				Spec: addonapiv1alpha1.ManagedClusterAddOnSpec{},
 			}

--- a/test/e2e/cluster_test.go
+++ b/test/e2e/cluster_test.go
@@ -14,6 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -97,6 +98,9 @@ var _ = Describe("Managed Clusters", Label("e2e-test-cluster"), Ordered, func() 
 		It("create managedhub cluster, should have annotation", func() {
 			By("Create the managed cluster")
 			mh_name := "test-mc-annotation"
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+				Name: mh_name,
+			}}
 			mh := &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: mh_name,
@@ -106,8 +110,16 @@ var _ = Describe("Managed Clusters", Label("e2e-test-cluster"), Ordered, func() 
 					LeaseDurationSeconds: 60,
 				},
 			}
-
+			globalhubAddon := &addonapiv1alpha1.ManagedClusterAddOn{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      operatorconstants.GHManagedClusterAddonName,
+					Namespace: mh_name,
+				},
+				Spec: addonapiv1alpha1.ManagedClusterAddOnSpec{},
+			}
+			Expect(globalHubClient.Create(ctx, ns)).To(Succeed())
 			Expect(globalHubClient.Create(ctx, mh)).To(Succeed())
+			Expect(globalHubClient.Create(ctx, globalhubAddon)).To(Succeed())
 
 			Eventually(func() error {
 				curMh := &clusterv1.ManagedCluster{}
@@ -155,6 +167,39 @@ var _ = Describe("Managed Clusters", Label("e2e-test-cluster"), Ordered, func() 
 				_, ok = curMh.GetAnnotations()[operatorconstants.AnnotationPolicyONMulticlusterHub]
 				if !ok {
 					return fmt.Errorf("failed to add annotation to managedhub%v", curMh.GetAnnotations())
+				}
+				return nil
+			}, 1*time.Minute, 1*time.Second).ShouldNot(HaveOccurred())
+
+			Expect(globalHubClient.Delete(ctx, mh)).To(Succeed())
+			Expect(globalHubClient.Delete(ctx, globalhubAddon)).To(Succeed())
+			Expect(globalHubClient.Delete(ctx, ns)).To(Succeed())
+		})
+	})
+
+	Context("Cluster Managedcluster, should not have some annotation", func() {
+		It("create managedhub cluster, should have annotation", func() {
+			By("Create the managed cluster")
+			mh_name := "test-mc-without-annotation"
+			mh := &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: mh_name,
+				},
+				Spec: clusterv1.ManagedClusterSpec{
+					HubAcceptsClient:     true,
+					LeaseDurationSeconds: 60,
+				},
+			}
+			Expect(globalHubClient.Create(ctx, mh)).To(Succeed())
+
+			Consistently(func() error {
+				curMh := &clusterv1.ManagedCluster{}
+				Expect(globalHubClient.Get(ctx, types.NamespacedName{
+					Name: mh_name,
+				}, curMh)).To(Succeed())
+
+				if len(curMh.Annotations) != 0 {
+					return fmt.Errorf("should not add annotation to managedhub")
 				}
 				return nil
 			}, 1*time.Minute, 1*time.Second).ShouldNot(HaveOccurred())


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

follow up https://github.com/stolostron/multicluster-global-hub/pull/1128
if the managed clusters do not have global hub addon enabled, then do not add the annotations

## Related issue(s)

Fixes #

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [x] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
