### PR TITLE
fix policy number is not right

### DIFF
--- a/agent/pkg/status/controller/generic/generic_event_syncer.go
+++ b/agent/pkg/status/controller/generic/generic_event_syncer.go
@@ -67,8 +67,8 @@ func (s *genericEventSyncer) periodicSync() {
 	defer ticker.Stop()
 
 	for {
-		<-ticker.C // wait for next time interval
 		s.syncEvent()
+		<-ticker.C // wait for next time interval
 
 		resolvedInterval := s.syncIntervalFunc()
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
In code logic, if the policy and hub info in synced to db, but do not synced heart beat. then we detached the hub cluster. The related policy and hubinfo will not be removed forever. So in this pr, we send the event immediately instead of waiting interval.

Will enhance this in future: https://issues.redhat.com/browse/ACM-14560

## Related issue(s)
https://issues.redhat.com/browse/ACM-14401
Fixes #

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
