### PR TITLE
:sparkles: Inventory policy

### DIFF
--- a/agent/pkg/config/agent_config.go
+++ b/agent/pkg/config/agent_config.go
@@ -35,3 +35,13 @@ func SetAgentConfig(agentConfig *AgentConfig) {
 func GetAgentConfig() *AgentConfig {
 	return agentConfigData
 }
+
+var mchVersion string
+
+func GetMCHVersion() string {
+	return mchVersion
+}
+
+func SetMCHVersion(version string) {
+	mchVersion = version
+}

--- a/agent/pkg/controllers/hub_clusterclaim_controller.go
+++ b/agent/pkg/controllers/hub_clusterclaim_controller.go
@@ -20,7 +20,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	"github.com/stolostron/multicluster-global-hub/agent/pkg/config"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
@@ -36,10 +35,7 @@ func (c *hubClusterClaimController) Reconcile(ctx context.Context, request ctrl.
 	reqLogger := c.log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	reqLogger.V(2).Info("hub clusterClaim controller", "NamespacedName:", request.NamespacedName)
 
-	mch, err := updateHubClusterClaim(ctx, c.client, request.NamespacedName)
-	if mch != nil {
-		config.SetMCHVersion(mch.Status.CurrentVersion)
-	}
+	_, err := updateHubClusterClaim(ctx, c.client, request.NamespacedName)
 	return ctrl.Result{}, err
 }
 

--- a/agent/pkg/controllers/hub_clusterclaim_controller.go
+++ b/agent/pkg/controllers/hub_clusterclaim_controller.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/config"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
@@ -35,7 +36,10 @@ func (c *hubClusterClaimController) Reconcile(ctx context.Context, request ctrl.
 	reqLogger := c.log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	reqLogger.V(2).Info("hub clusterClaim controller", "NamespacedName:", request.NamespacedName)
 
-	_, err := updateHubClusterClaim(ctx, c.client, request.NamespacedName)
+	mch, err := updateHubClusterClaim(ctx, c.client, request.NamespacedName)
+	if mch != nil {
+		config.SetMCHVersion(mch.Status.CurrentVersion)
+	}
 	return ctrl.Result{}, err
 }
 

--- a/agent/pkg/controllers/version_clusterclaim_controller.go
+++ b/agent/pkg/controllers/version_clusterclaim_controller.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/config"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 )
 
@@ -39,6 +40,7 @@ func (c *versionClusterClaimController) Reconcile(ctx context.Context, request c
 	}
 
 	if mch != nil && mch.Status.CurrentVersion != "" {
+		config.SetMCHVersion(mch.Status.CurrentVersion)
 		return ctrl.Result{}, updateClusterClaim(ctx, c.client,
 			constants.VersionClusterClaimName, mch.Status.CurrentVersion)
 	}

--- a/agent/pkg/status/controller/controller.go
+++ b/agent/pkg/status/controller/controller.go
@@ -39,7 +39,7 @@ func AddControllers(ctx context.Context, mgr ctrl.Manager, transportClient trans
 	case string(transport.Kafka):
 		err = addKafkaSyncer(ctx, mgr, transportClient.GetProducer(), agentConfig)
 	case string(transport.Rest):
-		err = addInventorySyncer(ctx, mgr, transportClient.GetRequester(), agentConfig)
+		err = addInventorySyncer(mgr, transportClient.GetRequester())
 	}
 	if err != nil {
 		return fmt.Errorf("failed to add the syncer: %w", err)
@@ -49,10 +49,11 @@ func AddControllers(ctx context.Context, mgr ctrl.Manager, transportClient trans
 	return nil
 }
 
-func addInventorySyncer(ctx context.Context, mgr ctrl.Manager, inventoryRequester transport.Requester,
-	agentConfig *config.AgentConfig,
-) error {
+func addInventorySyncer(mgr ctrl.Manager, inventoryRequester transport.Requester) error {
 	if err := managedclusters.AddManagedClusterInfoCtrl(mgr, inventoryRequester); err != nil {
+		return err
+	}
+	if err := policies.AddPolicyController(mgr, inventoryRequester); err != nil {
 		return err
 	}
 	return nil

--- a/agent/pkg/status/controller/managedclusters/managed_cluster_info_syncer.go
+++ b/agent/pkg/status/controller/managedclusters/managed_cluster_info_syncer.go
@@ -41,13 +41,16 @@ func (r *ManagedClusterInfoCtrl) Reconcile(ctx context.Context, req ctrl.Request
 	k8sCluster := GetK8SCluster(clusterInfo, r.clientCN)
 
 	// create
-	if clusterInfo.CreationTimestamp.IsZero() {
-		if resp, err := r.requester.GetHttpClient().K8sClusterService.CreateK8SCluster(ctx,
-			&kessel.CreateK8SClusterRequest{K8SCluster: k8sCluster}); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to create k8sCluster %v: %w", resp, err)
-		}
-		return ctrl.Result{}, nil
+	if resp, err := r.requester.GetHttpClient().K8sClusterService.CreateK8SCluster(ctx,
+		&kessel.CreateK8SClusterRequest{K8SCluster: k8sCluster}); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to create k8sCluster %v: %w", resp, err)
 	}
+
+	// may check the response to decide whether need to update or not
+	// if resp, err := r.requester.GetHttpClient().K8sClusterService.UpdateK8SCluster(ctx,
+	// 	&kessel.UpdateK8SClusterRequest{K8SCluster: k8sCluster}); err != nil {
+	// 	return ctrl.Result{}, fmt.Errorf("failed to update k8sCluster %v: %w", resp, err)
+	// }
 
 	// delete
 	if !clusterInfo.DeletionTimestamp.IsZero() {
@@ -56,12 +59,6 @@ func (r *ManagedClusterInfoCtrl) Reconcile(ctx context.Context, req ctrl.Request
 			return ctrl.Result{}, fmt.Errorf("failed to delete k8sCluster %v: %w", resp, err)
 		}
 		return ctrl.Result{}, nil
-	}
-
-	// update
-	if resp, err := r.requester.GetHttpClient().K8sClusterService.UpdateK8SCluster(ctx,
-		&kessel.UpdateK8SClusterRequest{K8SCluster: k8sCluster}); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to update k8sCluster %v: %w", resp, err)
 	}
 
 	return ctrl.Result{}, nil

--- a/agent/pkg/status/controller/managedclusters/managed_cluster_info_syncer.go
+++ b/agent/pkg/status/controller/managedclusters/managed_cluster_info_syncer.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/config"
 	statusconfig "github.com/stolostron/multicluster-global-hub/agent/pkg/status/controller/config"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport/requester"
@@ -99,7 +100,7 @@ func GetK8SCluster(clusterInfo *clusterinfov1beta1.ManagedClusterInfo,
 		ReporterData: &kessel.ReporterData{
 			ReporterType:       kessel.ReporterData_ACM,
 			ReporterInstanceId: clientCN,
-			ReporterVersion:    "0.1",
+			ReporterVersion:    config.GetMCHVersion(),
 			LocalResourceId:    clusterInfo.Name,
 			ApiHref:            clusterInfo.Spec.MasterEndpoint,
 			ConsoleHref:        clusterInfo.Status.ConsoleURL,

--- a/agent/pkg/status/controller/managedclusters/managed_cluster_info_syncer.go
+++ b/agent/pkg/status/controller/managedclusters/managed_cluster_info_syncer.go
@@ -80,7 +80,7 @@ func AddManagedClusterInfoCtrl(mgr ctrl.Manager, inventoryRequester transport.Re
 		},
 	}
 
-	return ctrl.NewControllerManagedBy(mgr).
+	return ctrl.NewControllerManagedBy(mgr).Named("inventory-managedclusterinfo-controller").
 		For(&clusterinfov1beta1.ManagedClusterInfo{}).
 		WithEventFilter(clusterInfoPredicate).
 		Complete(&ManagedClusterInfoCtrl{

--- a/agent/pkg/status/controller/managedclusters/managed_cluster_info_syncer_test.go
+++ b/agent/pkg/status/controller/managedclusters/managed_cluster_info_syncer_test.go
@@ -45,18 +45,18 @@ func TestManagedClusterInfoCtrlReconcile(t *testing.T) {
 			expectedResult: reconcile.Result{},
 			expectedError:  false,
 		},
-		{
-			name: "Updating existing cluster",
-			clusterInfo: &clusterinfov1beta1.ManagedClusterInfo{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "test-cluster",
-					Namespace:         "default",
-					CreationTimestamp: creatingTime,
-				},
-			},
-			expectedResult: reconcile.Result{},
-			expectedError:  false,
-		},
+		// {
+		// 	name: "Updating existing cluster",
+		// 	clusterInfo: &clusterinfov1beta1.ManagedClusterInfo{
+		// 		ObjectMeta: metav1.ObjectMeta{
+		// 			Name:              "test-cluster",
+		// 			Namespace:         "default",
+		// 			CreationTimestamp: creatingTime,
+		// 		},
+		// 	},
+		// 	expectedResult: reconcile.Result{},
+		// 	expectedError:  false,
+		// },
 		{
 			name: "Deleting cluster",
 			clusterInfo: &clusterinfov1beta1.ManagedClusterInfo{

--- a/agent/pkg/status/controller/policies/policy_controller.go
+++ b/agent/pkg/status/controller/policies/policy_controller.go
@@ -62,13 +62,15 @@ func (p *PolicyController) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, err
 	}
 
-	if policy.CreationTimestamp.IsZero() {
-		if resp, err := p.requester.GetHttpClient().PolicyServiceClient.CreateK8SPolicy(
-			ctx, createK8SClusterPolicy(*policy, p.reporterInstanceId)); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to create k8s-policy %v: %w", resp, err)
-		}
-		return ctrl.Result{}, nil
+	if resp, err := p.requester.GetHttpClient().PolicyServiceClient.CreateK8SPolicy(
+		ctx, createK8SClusterPolicy(*policy, p.reporterInstanceId)); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to create k8s-policy %v: %w", resp, err)
 	}
+	// may check the response to decide whether need to update or not
+	// if resp, err := p.requester.GetHttpClient().PolicyServiceClient.UpdateK8SPolicy(
+	// 	ctx, updateK8SClusterPolicy(*policy, p.reporterInstanceId)); err != nil {
+	// 	return ctrl.Result{}, fmt.Errorf("failed to update k8s-policy %v: %w", resp, err)
+	// }
 
 	if !policy.DeletionTimestamp.IsZero() {
 		if resp, err := p.requester.GetHttpClient().PolicyServiceClient.DeleteK8SPolicy(
@@ -76,10 +78,6 @@ func (p *PolicyController) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			return ctrl.Result{}, fmt.Errorf("failed to delete k8s-policy %v: %w", resp, err)
 		}
 		return ctrl.Result{}, nil
-	}
-	if resp, err := p.requester.GetHttpClient().PolicyServiceClient.UpdateK8SPolicy(
-		ctx, updateK8SClusterPolicy(*policy, p.reporterInstanceId)); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to update k8s-policy %v: %w", resp, err)
 	}
 	return ctrl.Result{}, nil
 }

--- a/agent/pkg/status/controller/policies/policy_controller.go
+++ b/agent/pkg/status/controller/policies/policy_controller.go
@@ -96,29 +96,31 @@ func createK8SClusterPolicy(policy policiesv1.Policy, reporterInstanceId string)
 			},
 			ResourceData: &kessel.K8SPolicyDetail{
 				Disabled: policy.Spec.Disabled,
+				Severity: kessel.K8SPolicyDetail_MEDIUM, // need to update
 			},
 		},
 	}
 }
 
-func updateK8SClusterPolicy(policy policiesv1.Policy, reporterInstanceId string) *kessel.UpdateK8SPolicyRequest {
-	return &kessel.UpdateK8SPolicyRequest{
-		K8SPolicy: &kessel.K8SPolicy{
-			Metadata: &kessel.Metadata{
-				ResourceType: "k8s-policy",
-			},
-			ReporterData: &kessel.ReporterData{
-				ReporterType:       kessel.ReporterData_ACM,
-				ReporterInstanceId: reporterInstanceId,
-				ReporterVersion:    config.GetMCHVersion(),
-				LocalResourceId:    policy.Namespace + "/" + policy.Name,
-			},
-			ResourceData: &kessel.K8SPolicyDetail{
-				Disabled: policy.Spec.Disabled,
-			},
-		},
-	}
-}
+// func updateK8SClusterPolicy(policy policiesv1.Policy, reporterInstanceId string) *kessel.UpdateK8SPolicyRequest {
+// 	return &kessel.UpdateK8SPolicyRequest{
+// 		K8SPolicy: &kessel.K8SPolicy{
+// 			Metadata: &kessel.Metadata{
+// 				ResourceType: "k8s-policy",
+// 			},
+// 			ReporterData: &kessel.ReporterData{
+// 				ReporterType:       kessel.ReporterData_ACM,
+// 				ReporterInstanceId: reporterInstanceId,
+// 				ReporterVersion:    config.GetMCHVersion(),
+// 				LocalResourceId:    policy.Namespace + "/" + policy.Name,
+// 			},
+// 			ResourceData: &kessel.K8SPolicyDetail{
+// 				Disabled: policy.Spec.Disabled,
+// 				Severity: kessel.K8SPolicyDetail_MEDIUM, //need to update
+// 			},
+// 		},
+// 	}
+// }
 
 func deleteK8SClusterPolicy(policy policiesv1.Policy, reporterInstanceId string) *kessel.DeleteK8SPolicyRequest {
 	return &kessel.DeleteK8SPolicyRequest{

--- a/agent/pkg/status/controller/policies/policy_controller.go
+++ b/agent/pkg/status/controller/policies/policy_controller.go
@@ -42,7 +42,7 @@ func AddPolicyController(mgr ctrl.Manager, inventoryRequester transport.Requeste
 		},
 	}
 
-	return ctrl.NewControllerManagedBy(mgr).
+	return ctrl.NewControllerManagedBy(mgr).Named("inventory-policy-controller").
 		For(&policiesv1.Policy{}).
 		WithEventFilter(policyPredicate).
 		Complete(&PolicyController{

--- a/agent/pkg/status/controller/policies/policy_controller.go
+++ b/agent/pkg/status/controller/policies/policy_controller.go
@@ -1,0 +1,134 @@
+// Copyright (c) 2024 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Policy Controller is used to send the policy create/update/delete to restful API
+
+package policies
+
+import (
+	"context"
+	"fmt"
+
+	kessel "github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta1/resources"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/config"
+	statusconfig "github.com/stolostron/multicluster-global-hub/agent/pkg/status/controller/config"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport/requester"
+)
+
+type PolicyController struct {
+	runtimeClient      client.Client
+	reporterInstanceId string
+	requester          transport.Requester
+}
+
+func AddPolicyController(mgr ctrl.Manager, inventoryRequester transport.Requester) error {
+	policyPredicate := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return e.ObjectOld.GetResourceVersion() < e.ObjectNew.GetResourceVersion()
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			return true
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return !e.DeleteStateUnknown
+		},
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&policiesv1.Policy{}).
+		WithEventFilter(policyPredicate).
+		Complete(&PolicyController{
+			runtimeClient:      mgr.GetClient(),
+			reporterInstanceId: requester.GetInventoryClientName(statusconfig.GetLeafHubName()),
+			requester:          inventoryRequester,
+		})
+}
+
+func (p *PolicyController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	policy := &policiesv1.Policy{}
+	err := p.runtimeClient.Get(ctx, types.NamespacedName{Namespace: req.Namespace, Name: req.Name}, policy)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	if policy.CreationTimestamp.IsZero() {
+		if resp, err := p.requester.GetHttpClient().PolicyServiceClient.CreateK8SPolicy(
+			ctx, createK8SClusterPolicy(*policy, p.reporterInstanceId)); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to create k8s-policy %v: %w", resp, err)
+		}
+		return ctrl.Result{}, nil
+	}
+
+	if !policy.DeletionTimestamp.IsZero() {
+		if resp, err := p.requester.GetHttpClient().PolicyServiceClient.DeleteK8SPolicy(
+			ctx, deleteK8SClusterPolicy(*policy, p.reporterInstanceId)); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to delete k8s-policy %v: %w", resp, err)
+		}
+		return ctrl.Result{}, nil
+	}
+	if resp, err := p.requester.GetHttpClient().PolicyServiceClient.UpdateK8SPolicy(
+		ctx, updateK8SClusterPolicy(*policy, p.reporterInstanceId)); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to update k8s-policy %v: %w", resp, err)
+	}
+	return ctrl.Result{}, nil
+}
+
+func createK8SClusterPolicy(policy policiesv1.Policy, reporterInstanceId string) *kessel.CreateK8SPolicyRequest {
+	return &kessel.CreateK8SPolicyRequest{
+		K8SPolicy: &kessel.K8SPolicy{
+			Metadata: &kessel.Metadata{
+				ResourceType: "k8s-policy",
+			},
+			ReporterData: &kessel.ReporterData{
+				ReporterType:       kessel.ReporterData_ACM,
+				ReporterInstanceId: reporterInstanceId,
+				ReporterVersion:    config.GetMCHVersion(),
+				LocalResourceId:    policy.Namespace + "/" + policy.Name,
+			},
+			ResourceData: &kessel.K8SPolicyDetail{
+				Disabled: policy.Spec.Disabled,
+			},
+		},
+	}
+}
+
+func updateK8SClusterPolicy(policy policiesv1.Policy, reporterInstanceId string) *kessel.UpdateK8SPolicyRequest {
+	return &kessel.UpdateK8SPolicyRequest{
+		K8SPolicy: &kessel.K8SPolicy{
+			Metadata: &kessel.Metadata{
+				ResourceType: "k8s-policy",
+			},
+			ReporterData: &kessel.ReporterData{
+				ReporterType:       kessel.ReporterData_ACM,
+				ReporterInstanceId: reporterInstanceId,
+				ReporterVersion:    config.GetMCHVersion(),
+				LocalResourceId:    policy.Namespace + "/" + policy.Name,
+			},
+			ResourceData: &kessel.K8SPolicyDetail{
+				Disabled: policy.Spec.Disabled,
+			},
+		},
+	}
+}
+
+func deleteK8SClusterPolicy(policy policiesv1.Policy, reporterInstanceId string) *kessel.DeleteK8SPolicyRequest {
+	return &kessel.DeleteK8SPolicyRequest{
+		ReporterData: &kessel.ReporterData{
+			ReporterType:       kessel.ReporterData_ACM,
+			ReporterInstanceId: reporterInstanceId,
+			ReporterVersion:    config.GetMCHVersion(),
+			LocalResourceId:    policy.Namespace + "/" + policy.Name,
+		},
+	}
+}

--- a/agent/pkg/status/controller/policies/policy_controller_test.go
+++ b/agent/pkg/status/controller/policies/policy_controller_test.go
@@ -45,18 +45,18 @@ func TestPolicyControllerReconcile(t *testing.T) {
 			expectedResult: reconcile.Result{},
 			expectedError:  false,
 		},
-		{
-			name: "Updating existing policy",
-			policy: &policiesv1.Policy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "test-policy",
-					Namespace:         "default",
-					CreationTimestamp: creatingTime,
-				},
-			},
-			expectedResult: reconcile.Result{},
-			expectedError:  false,
-		},
+		// {
+		// 	name: "Updating existing policy",
+		// 	policy: &policiesv1.Policy{
+		// 		ObjectMeta: metav1.ObjectMeta{
+		// 			Name:              "test-policy",
+		// 			Namespace:         "default",
+		// 			CreationTimestamp: creatingTime,
+		// 		},
+		// 	},
+		// 	expectedResult: reconcile.Result{},
+		// 	expectedError:  false,
+		// },
 		{
 			name: "Deleting cluster",
 			policy: &policiesv1.Policy{

--- a/agent/pkg/status/controller/policies/policy_controller_test.go
+++ b/agent/pkg/status/controller/policies/policy_controller_test.go
@@ -1,0 +1,134 @@
+package policies
+
+import (
+	"context"
+	"testing"
+
+	http "github.com/go-kratos/kratos/v2/transport/http"
+	kessel "github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta1/resources"
+	"github.com/project-kessel/inventory-client-go/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"helm.sh/helm/v3/pkg/time"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/transport"
+)
+
+func TestPolicyControllerReconcile(t *testing.T) {
+	// Setup scheme and mock requester
+	scheme := runtime.NewScheme()
+	_ = policiesv1.AddToScheme(scheme)
+	mockRequester := &MockRequest{}
+
+	// Define test cases
+	creatingTime := metav1.Now()
+	deletintTime := metav1.NewTime(time.Now().Time)
+	tests := []struct {
+		name           string
+		policy         *policiesv1.Policy
+		expectedResult reconcile.Result
+		expectedError  bool
+	}{
+		{
+			name: "Creating new policy",
+			policy: &policiesv1.Policy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-policy",
+					Namespace: "default",
+				},
+			},
+			expectedResult: reconcile.Result{},
+			expectedError:  false,
+		},
+		{
+			name: "Updating existing policy",
+			policy: &policiesv1.Policy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-policy",
+					Namespace:         "default",
+					CreationTimestamp: creatingTime,
+				},
+			},
+			expectedResult: reconcile.Result{},
+			expectedError:  false,
+		},
+		{
+			name: "Deleting cluster",
+			policy: &policiesv1.Policy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-policy",
+					Namespace:         "default",
+					CreationTimestamp: creatingTime,
+					DeletionTimestamp: &deletintTime,
+					Finalizers:        []string{"test"},
+				},
+			},
+			expectedResult: reconcile.Result{},
+			expectedError:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup the fake Kubernetes client with test objects
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.policy).Build()
+
+			// Create the controller with the mock requester and fake client
+			r := &PolicyController{
+				runtimeClient:      fakeClient,
+				requester:          mockRequester,
+				reporterInstanceId: "test-clientCN",
+			}
+
+			// Call the Reconcile method
+			result, err := r.Reconcile(context.TODO(), reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: "test-policy", Namespace: "default"},
+			})
+
+			// Assert results
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expectedResult, result)
+		})
+	}
+}
+
+type MockRequest struct{}
+
+func (c *MockRequest) RefreshClient(ctx context.Context, restfulConn *transport.RestfulConfig) error {
+	return nil
+}
+
+func (c *MockRequest) GetHttpClient() *v1beta1.InventoryHttpClient {
+	return &v1beta1.InventoryHttpClient{
+		PolicyServiceClient: &PolicyServiceClient{},
+	}
+}
+
+type PolicyServiceClient struct{}
+
+func (p *PolicyServiceClient) CreateK8SPolicy(ctx context.Context, in *kessel.CreateK8SPolicyRequest,
+	opts ...http.CallOption,
+) (*kessel.CreateK8SPolicyResponse, error) {
+	return nil, nil
+}
+
+func (p *PolicyServiceClient) UpdateK8SPolicy(ctx context.Context, in *kessel.UpdateK8SPolicyRequest,
+	opts ...http.CallOption,
+) (*kessel.UpdateK8SPolicyResponse, error) {
+	return nil, nil
+}
+
+func (p *PolicyServiceClient) DeleteK8SPolicy(ctx context.Context, in *kessel.DeleteK8SPolicyRequest,
+	opts ...http.CallOption,
+) (*kessel.DeleteK8SPolicyResponse, error) {
+	return nil, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/fergusstrange/embedded-postgres v1.17.0
 	github.com/gin-gonic/gin v1.9.1
 	github.com/go-co-op/gocron v1.23.0
+	github.com/go-kratos/kratos/v2 v2.8.0
 	github.com/go-logr/logr v1.4.2
 	github.com/gonvenience/ytbx v1.4.4
 	github.com/google/uuid v1.6.0
@@ -43,6 +44,7 @@ require (
 	gorm.io/datatypes v1.2.0
 	gorm.io/driver/postgres v1.5.9
 	gorm.io/gorm v1.25.11
+	helm.sh/helm/v3 v3.14.4
 	k8s.io/api v0.31.0
 	k8s.io/apiextensions-apiserver v0.31.0
 	k8s.io/apimachinery v0.31.0
@@ -72,7 +74,6 @@ require (
 	github.com/docker/cli v26.1.4+incompatible // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/go-kratos/aegis v0.2.0 // indirect
-	github.com/go-kratos/kratos/v2 v2.8.0 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/go-playground/form/v4 v4.2.1 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
@@ -93,7 +94,6 @@ require (
 	go.starlark.net v0.0.0-20230525235612-a134d8f9ddca // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240903143218-8af14fe29dc1 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
-	helm.sh/helm/v3 v3.14.4 // indirect
 )
 
 require (

--- a/operator/pkg/controllers/hubofhubs/inventory/manifests/secret.yaml
+++ b/operator/pkg/controllers/hubofhubs/inventory/manifests/secret.yaml
@@ -34,3 +34,7 @@ stringData:
         user: {{.PostgresUser}}
         password: {{.PostgresPassword}}
         dbname: "inventory"
+    log:
+      level: "info"
+      livez: true
+      readyz: true


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

1. support k8s-policy
2. update to remove the creationtimestamp. see https://github.com/kubernetes-sigs/controller-runtime/blob/master/FAQ.md#q-how-do-i-have-different-logic-in-my-reconciler-for-different-types-of-events-eg-create-update-delete


## Related issue(s)

Fixes #

## Tests
* [x] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
