### PR TITLE
:bug: Switch the minimum TLS version of webhook from 1.2 to 1.3

### DIFF
--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -185,7 +185,7 @@ func createManager(ctx context.Context,
 				CertDir: webhookCertDir,
 				TLSOpts: []func(*tls.Config){
 					func(config *tls.Config) {
-						config.MinVersion = tls.VersionTLS12
+						config.MinVersion = tls.VersionTLS13
 					},
 				},
 			},

--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -179,7 +179,7 @@ func getManager(restConfig *rest.Config, operatorConfig *config.OperatorConfig) 
 				Port: webhookPort,
 				TLSOpts: []func(*tls.Config){
 					func(config *tls.Config) {
-						config.MinVersion = tls.VersionTLS12
+						config.MinVersion = tls.VersionTLS13
 					},
 				},
 			},


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes # https://issues.redhat.com/browse/ACM-14621

References: https://github.com/kubernetes-sigs/controller-runtime/pull/1548, https://github.com/kubernetes-sigs/controller-runtime/issues/1431, https://github.com/kubernetes-sigs/controller-runtime/issues/1754

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
