### PR TITLE
:bug: Clean the transport connection

### DIFF
--- a/operator/pkg/controllers/hubofhubs/prune/prune_reconciler.go
+++ b/operator/pkg/controllers/hubofhubs/prune/prune_reconciler.go
@@ -61,7 +61,7 @@ func (r *PruneReconciler) Reconcile(ctx context.Context,
 				return true, err
 			}
 			if hasmanagedHub {
-				klog.Errorf("please detach all the managedhub clusters before uninstall globalhub")
+				klog.Errorf("You need to detach all the managed hub clusters before uninstalling")
 				return true, nil
 			}
 		}
@@ -83,6 +83,8 @@ func (r *PruneReconciler) Reconcile(ctx context.Context,
 		if err := r.MetricsResources(ctx); err != nil {
 			return true, err
 		}
+		// clean the kafka connection so that the manager can use the new one after reinstall
+		config.SetTransporterConn(nil)
 		return false, nil
 	}
 	// If webhook do not need to enable, should remove the related resources

--- a/operator/pkg/controllers/hubofhubs/transporter/protocol/strimzi_transporter.go
+++ b/operator/pkg/controllers/hubofhubs/transporter/protocol/strimzi_transporter.go
@@ -195,7 +195,7 @@ func (k *strimziTransporter) EnsureKafka() (bool, error) {
 	}
 
 	if !config.GetKafkaResourceReady() {
-		klog.Infof("Wait kafka crd ready")
+		klog.Infof("wait for the Kafka CRD to be ready")
 		return true, nil
 	}
 
@@ -599,7 +599,7 @@ func (k *strimziTransporter) kafkaClusterReady() (bool, error) {
 			return isReady, nil
 		}
 	}
-	klog.Infof("Wait kafka cluster ready")
+	klog.Infof("wait for the Kafka cluster to be ready")
 	return isReady, nil
 }
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

the manager is waiting for the transport connection. in the first time, the transport connection is empty. once the kafka is ready, the transport connection will be set as correct value. when reinstall, the transport connection keeps the previous value so that the manager and grafana will be deploy at the beginning.

## Related issue(s)

Fixes # https://issues.redhat.com/browse/ACM-14761

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [x] List other manual tests you have done.
- tested in local environment for the re-installation 
