### PR TITLE
:bug: Bump the postgres SSL min protocol version from 1.2 to 1.3

### DIFF
--- a/operator/pkg/controllers/hubofhubs/storage/manifests.sts/conf-configmap.yaml
+++ b/operator/pkg/controllers/hubofhubs/storage/manifests.sts/conf-configmap.yaml
@@ -8,6 +8,7 @@ data:
     ssl = on
     ssl_cert_file = '/opt/app-root/src/certs/tls.crt' # server certificate
     ssl_key_file =  '/opt/app-root/src/certs/tls.key' # server private key
+    ssl_min_protocol_version = TLSv1.3
     {{- if .EnablePostgresMetrics }}
     shared_preload_libraries = 'pg_stat_statements'
     pg_stat_statements.max = 10000


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Fix the warning "vulnerable cipher usage in service/multicluster-global-hub-postgres"

## Related issue(s)

Fixes # https://issues.redhat.com/browse/ACM-14622

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [x] List other manual tests you have done.

```
$ oc port-forward service/multicluster-global-hub-postgres 8123:5432
...
$ nmap -Pn -sV --script ssl-enum-ciphers -p 8123 localhost
Starting Nmap 7.95 ( https://nmap.org ) at 2024-10-11 11:29 CST
Nmap scan report for localhost (127.0.0.1)
Host is up (0.00033s latency).
Other addresses for localhost (not scanned): ::1

PORT     STATE SERVICE    VERSION
8123/tcp open  postgresql PostgreSQL DB 9.6.0 or later
| ssl-enum-ciphers:
|   TLSv1.3:
|     ciphers:
|       TLS_AKE_WITH_AES_256_GCM_SHA384 (secp256r1) - A
|       TLS_AKE_WITH_CHACHA20_POLY1305_SHA256 (secp256r1) - A
|       TLS_AKE_WITH_AES_128_GCM_SHA256 (secp256r1) - A
|       TLS_AKE_WITH_AES_128_CCM_SHA256 (secp256r1) - A
|     cipher preference: server
|_  least strength: A

Service detection performed. Please report any incorrect results at https://nmap.org/submit/ .
Nmap done: 1 IP address (1 host up) scanned in 38.35 seconds
```

