### PR TITLE
🐛 Fix typo in RHACS integration instructions

### DIFF
--- a/doc/dev-preview.md
+++ b/doc/dev-preview.md
@@ -145,7 +145,7 @@ Create that secret, and then add the
 object:
 
 ```shell
-$ oc annotate -n rhacs-central central stackrox-central-services \
+$ oc annotate -n rhacs-operator central stackrox-central-services \
 global-hub.open-cluster-management.io/with-stackrox-credentials-secret=multicluster-global-hub-agent/rhacs-connection-details
 ```
 


### PR DESCRIPTION
## Summary

This patch fixes a typo in the instructions to enable the integration with _Red Hat Advanced Cluster Security_: the name of the namespace should be `rhacs-operator`.

## Related issue(s)

None.

## Tests

* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [X] List other manual tests you have done.

Tested the instructions manually.
