### PR TITLE
Fix multiple creation events

### DIFF
--- a/agent/pkg/controllers/inventory/managedclusterinfo/managed_cluster_info_controller.go
+++ b/agent/pkg/controllers/inventory/managedclusterinfo/managed_cluster_info_controller.go
@@ -48,6 +48,7 @@ func (r *ManagedClusterInfoInventorySyncer) Reconcile(ctx context.Context, req c
 				&kessel.CreateK8SClusterRequest{K8SCluster: k8sCluster}); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to create k8sCluster %v: %w", resp, err)
 			}
+			return ctrl.Result{}, nil
 		}
 	}
 

--- a/agent/pkg/controllers/inventory/managedclusterinfo/managed_cluster_info_controller.go
+++ b/agent/pkg/controllers/inventory/managedclusterinfo/managed_cluster_info_controller.go
@@ -6,6 +6,7 @@ import (
 
 	kessel "github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta1/resources"
 	clusterinfov1beta1 "github.com/stolostron/cluster-lifecycle-api/clusterinfo/v1beta1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -86,7 +87,10 @@ func (r *ManagedClusterInfoInventorySyncer) Reconcile(ctx context.Context, req c
 func AddManagedClusterInfoInventorySyncer(mgr ctrl.Manager, inventoryRequester transport.Requester) error {
 	clusterInfoPredicate := predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return e.ObjectOld.GetResourceVersion() < e.ObjectNew.GetResourceVersion()
+			return !equality.Semantic.DeepEqual(e.ObjectNew.(*clusterinfov1beta1.ManagedClusterInfo).Status,
+				e.ObjectOld.(*clusterinfov1beta1.ManagedClusterInfo).Status) ||
+				!equality.Semantic.DeepEqual(e.ObjectNew.GetLabels(), e.ObjectOld.GetLabels()) ||
+				e.ObjectNew.GetGeneration() != e.ObjectOld.GetGeneration()
 		},
 		CreateFunc: func(e event.CreateEvent) bool {
 			// add the annotation to identify the request is creating

--- a/agent/pkg/controllers/inventory/managedclusterinfo/managed_cluster_info_controller.go
+++ b/agent/pkg/controllers/inventory/managedclusterinfo/managed_cluster_info_controller.go
@@ -87,8 +87,10 @@ func (r *ManagedClusterInfoInventorySyncer) Reconcile(ctx context.Context, req c
 func AddManagedClusterInfoInventorySyncer(mgr ctrl.Manager, inventoryRequester transport.Requester) error {
 	clusterInfoPredicate := predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return !reflect.DeepEqual(GetK8SCluster(e.ObjectNew.(*clusterinfov1beta1.ManagedClusterInfo), ""),
-				GetK8SCluster(e.ObjectOld.(*clusterinfov1beta1.ManagedClusterInfo), ""))
+			return !reflect.DeepEqual(e.ObjectNew.(*clusterinfov1beta1.ManagedClusterInfo).Status,
+				e.ObjectOld.(*clusterinfov1beta1.ManagedClusterInfo).Status) ||
+				!reflect.DeepEqual(e.ObjectNew.GetLabels(), e.ObjectOld.GetLabels()) ||
+				e.ObjectNew.GetGeneration() != e.ObjectOld.GetGeneration()
 		},
 		CreateFunc: func(e event.CreateEvent) bool {
 			// add the annotation to identify the request is creating

--- a/agent/pkg/controllers/inventory/managedclusterinfo/managed_cluster_info_controller.go
+++ b/agent/pkg/controllers/inventory/managedclusterinfo/managed_cluster_info_controller.go
@@ -3,10 +3,10 @@ package managedclusterinfo
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	kessel "github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta1/resources"
 	clusterinfov1beta1 "github.com/stolostron/cluster-lifecycle-api/clusterinfo/v1beta1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -87,10 +87,8 @@ func (r *ManagedClusterInfoInventorySyncer) Reconcile(ctx context.Context, req c
 func AddManagedClusterInfoInventorySyncer(mgr ctrl.Manager, inventoryRequester transport.Requester) error {
 	clusterInfoPredicate := predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return !equality.Semantic.DeepEqual(e.ObjectNew.(*clusterinfov1beta1.ManagedClusterInfo).Status,
-				e.ObjectOld.(*clusterinfov1beta1.ManagedClusterInfo).Status) ||
-				!equality.Semantic.DeepEqual(e.ObjectNew.GetLabels(), e.ObjectOld.GetLabels()) ||
-				e.ObjectNew.GetGeneration() != e.ObjectOld.GetGeneration()
+			return !reflect.DeepEqual(GetK8SCluster(e.ObjectNew.(*clusterinfov1beta1.ManagedClusterInfo), ""),
+				GetK8SCluster(e.ObjectOld.(*clusterinfov1beta1.ManagedClusterInfo), ""))
 		},
 		CreateFunc: func(e event.CreateEvent) bool {
 			// add the annotation to identify the request is creating

--- a/agent/pkg/controllers/inventory/policy/policy_controller.go
+++ b/agent/pkg/controllers/inventory/policy/policy_controller.go
@@ -39,8 +39,10 @@ func AddPolicyInventorySyncer(mgr ctrl.Manager, inventoryRequester transport.Req
 			if _, exist := e.ObjectOld.GetLabels()[constants.PolicyEventRootPolicyNameLabelKey]; exist {
 				return false
 			}
-			return !reflect.DeepEqual(generateK8SPolicy(e.ObjectOld.(*policiesv1.Policy), ""),
-				generateK8SPolicy(e.ObjectNew.(*policiesv1.Policy), ""))
+			return !reflect.DeepEqual(e.ObjectNew.(*policiesv1.Policy).Status,
+				e.ObjectOld.(*policiesv1.Policy).Status) ||
+				!reflect.DeepEqual(e.ObjectNew.GetLabels(), e.ObjectOld.GetLabels()) ||
+				e.ObjectNew.GetGeneration() != e.ObjectOld.GetGeneration()
 		},
 		CreateFunc: func(e event.CreateEvent) bool {
 			// do not trigger the create event for the replicated policies

--- a/agent/pkg/controllers/inventory/policy/policy_controller.go
+++ b/agent/pkg/controllers/inventory/policy/policy_controller.go
@@ -90,6 +90,7 @@ func (p *PolicyInventorySyncer) Reconcile(ctx context.Context, req ctrl.Request)
 				ctx, createK8SClusterPolicy(*policy, p.reporterInstanceId)); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to create k8s-policy %v: %w", resp, err)
 			}
+			return ctrl.Result{}, nil
 		}
 	}
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Duplicated create message can be received by kafka. the current logic is sending the create request and then update the resource to add a new finalizer. the temporary annotation is updated to real resource. the fix is to return after creation.

## Related issue(s)

Fixes # 

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [x] List other manual tests you have done.
- verified in local environment