### PR TITLE
:bug:  set public_url for inventory-api server

### DIFF
--- a/operator/pkg/controllers/hubofhubs/inventory/inventory_reconciler.go
+++ b/operator/pkg/controllers/hubofhubs/inventory/inventory_reconciler.go
@@ -115,41 +115,51 @@ func (r *InventoryReconciler) Reconcile(ctx context.Context,
 		return fmt.Errorf("the transport connection(%s) must not be empty", transportConn)
 	}
 
+	inventoryRoute := &routev1.Route{}
+	if err := r.GetClient().Get(ctx, types.NamespacedName{
+		Name:      constants.InventoryRouteName,
+		Namespace: mgh.Namespace,
+	}, inventoryRoute); err != nil {
+		return err
+	}
+
 	inventoryObjects, err := hohRenderer.Render("manifests", "", func(profile string) (interface{}, error) {
 		return struct {
-			Image                string
-			Replicas             int32
-			ImagePullSecret      string
-			ImagePullPolicy      string
-			PostgresHost         string
-			PostgresPort         string
-			PostgresUser         string
-			PostgresPassword     string
-			PostgresCACert       string
-			Namespace            string
-			NodeSelector         map[string]string
-			Tolerations          []corev1.Toleration
-			KafkaBootstrapServer string
-			KafkaSSLCAPEM        string
-			KafkaSSLCertPEM      string
-			KafkaSSLKeyPEM       string
+			Image                 string
+			Replicas              int32
+			ImagePullSecret       string
+			ImagePullPolicy       string
+			PostgresHost          string
+			PostgresPort          string
+			PostgresUser          string
+			PostgresPassword      string
+			PostgresCACert        string
+			Namespace             string
+			NodeSelector          map[string]string
+			Tolerations           []corev1.Toleration
+			KafkaBootstrapServer  string
+			KafkaSSLCAPEM         string
+			KafkaSSLCertPEM       string
+			KafkaSSLKeyPEM        string
+			InventoryAPIRouteHost string
 		}{
-			Image:                config.GetImage(config.InventoryImageKey),
-			Replicas:             replicas,
-			ImagePullSecret:      mgh.Spec.ImagePullSecret,
-			ImagePullPolicy:      string(imagePullPolicy),
-			PostgresHost:         postgresURI.Hostname(),
-			PostgresPort:         postgresURI.Port(),
-			PostgresUser:         postgresURI.User.Username(),
-			PostgresPassword:     postgresPassword,
-			PostgresCACert:       base64.StdEncoding.EncodeToString(storageConn.CACert),
-			Namespace:            mgh.Namespace,
-			NodeSelector:         mgh.Spec.NodeSelector,
-			Tolerations:          mgh.Spec.Tolerations,
-			KafkaBootstrapServer: transportConn.BootstrapServer,
-			KafkaSSLCAPEM:        transportConn.CACert,
-			KafkaSSLCertPEM:      transportConn.ClientCert,
-			KafkaSSLKeyPEM:       transportConn.ClientKey,
+			Image:                 config.GetImage(config.InventoryImageKey),
+			Replicas:              replicas,
+			ImagePullSecret:       mgh.Spec.ImagePullSecret,
+			ImagePullPolicy:       string(imagePullPolicy),
+			PostgresHost:          postgresURI.Hostname(),
+			PostgresPort:          postgresURI.Port(),
+			PostgresUser:          postgresURI.User.Username(),
+			PostgresPassword:      postgresPassword,
+			PostgresCACert:        base64.StdEncoding.EncodeToString(storageConn.CACert),
+			Namespace:             mgh.Namespace,
+			NodeSelector:          mgh.Spec.NodeSelector,
+			Tolerations:           mgh.Spec.Tolerations,
+			KafkaBootstrapServer:  transportConn.BootstrapServer,
+			KafkaSSLCAPEM:         transportConn.CACert,
+			KafkaSSLCertPEM:       transportConn.ClientCert,
+			KafkaSSLKeyPEM:        transportConn.ClientKey,
+			InventoryAPIRouteHost: fmt.Sprintf("https://%s", inventoryRoute.Spec.Host),
 		}, nil
 	})
 	if err != nil {

--- a/operator/pkg/controllers/hubofhubs/inventory/manifests/secret.yaml
+++ b/operator/pkg/controllers/hubofhubs/inventory/manifests/secret.yaml
@@ -7,6 +7,7 @@ type: Opaque
 stringData:
   inventory-api-config.yaml: |
     server:
+      public_url: {{.InventoryAPIRouteHost}}
       http:
         address: 0.0.0.0:8081
         keyfile: /inventory/certs/tls.key


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

the default source is `http://localhost:8081`. we need to update with the real route host

## Related issue(s)

Fixes #

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [x] List other manual tests you have done.
- ```{
  "specversion": "1.0",
  "id": "22357adf-8f77-11ef-9d2b-0a580a8002bf",
  "source": "https://inventory-api-multicluster-global-hub.apps.aws-jb-invent-1.dev05.red-chesterfield.com",
  "type": "redhat.inventory.resources.k8s-policy.updated",
  "subject": "/resources/k8s-policy/default/test",
  "datacontenttype": "application/json",
  "time": "2024-10-21T06:38:50.958504216Z",
  "data": {
    "metadata": {
      "id": 0,
      "last_reported": "2024-10-21T06:38:50.958504216Z",
      "resource_type": "k8s-policy",
      "workspace": "",
      "labels": null
    },
    "reporter_data": {
      "reporter_instance_id": "mgdhub-1-client",
      "reporter_type": "ACM",
      "last_reported": "2024-10-21T06:38:50.958504216Z",
      "local_resource_id": "default/test",
      "reporter_version": "2.11.3",
      "console_href": "",
      "api_href": ""
    },
    "resource_data": {
      "disabled": true,
      "severity": "MEDIUM"
    }
  }
