### PR TITLE
:sparkles:   Switch zap log for global hub manager 

### DIFF
--- a/agent/cmd/main.go
+++ b/agent/cmd/main.go
@@ -49,7 +49,7 @@ const (
 func main() {
 	log := logger.DefaultZapLogger()
 	defer func() { _ = log.Desugar().Sync() }() // ensure it's invoked only once within the main process
-	utils.RuntimeInfo()
+	utils.PrintRuntimeInfo()
 
 	// adding and parsing flags should be done before the call of 'ctrl.GetConfigOrDie()',
 	// otherwise kubeconfig will not be passed to agent main process

--- a/manager/cmd/main.go
+++ b/manager/cmd/main.go
@@ -276,7 +276,7 @@ func doMain(ctx context.Context, restConfig *rest.Config) error {
 		go utils.StartDefaultPprofServer()
 	}
 
-	utils.RuntimeInfo()
+	utils.PrintRuntimeInfo()
 	databaseConfig := &database.DatabaseConfig{
 		URL:        managerConfig.DatabaseConfig.ProcessDatabaseURL,
 		Dialect:    database.PostgresDialect,

--- a/manager/cmd/main.go
+++ b/manager/cmd/main.go
@@ -8,7 +8,6 @@ import (
 	"crypto/tls"
 	"database/sql"
 	"errors"
-	"flag"
 	"fmt"
 	"os"
 	"strings"
@@ -22,7 +21,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
@@ -36,6 +34,7 @@ import (
 	mgrwebhook "github.com/stolostron/multicluster-global-hub/manager/pkg/webhook"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/database"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 	commonobjects "github.com/stolostron/multicluster-global-hub/pkg/objects"
 	"github.com/stolostron/multicluster-global-hub/pkg/statistics"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
@@ -55,10 +54,10 @@ const (
 )
 
 var (
-	setupLog              = ctrl.Log.WithName("setup")
 	managerNamespace      = constants.GHDefaultNamespace
 	enableSimulation      = false
 	errFlagParameterEmpty = errors.New("flag parameter empty")
+	log                   = logger.DefaultZapLogger()
 )
 
 func parseFlags() *configs.ManagerConfig {
@@ -75,12 +74,6 @@ func parseFlags() *configs.ManagerConfig {
 		ElectionConfig:      &commonobjects.LeaderElectionConfig{},
 		LaunchJobNames:      "",
 	}
-
-	// add zap flags
-	opts := utils.CtrlZapOptions()
-	defaultFlags := flag.CommandLine
-	opts.BindFlags(defaultFlags)
-	pflag.CommandLine.AddGoFlagSet(defaultFlags)
 
 	pflag.StringVar(&managerConfig.ManagerNamespace, "manager-namespace", constants.GHDefaultNamespace,
 		"The manager running namespace, also used as leader election namespace.")
@@ -126,8 +119,6 @@ func parseFlags() *configs.ManagerConfig {
 		"import cluster in hosted mode")
 	pflag.BoolVar(&managerConfig.EnablePprof, "enable-pprof", false, "enable the pprof tool")
 	pflag.Parse()
-	// set zap logger
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	pflag.Visit(func(f *pflag.Flag) {
 		// set enableSimulation to be true when manually set 'scheduler-interval' flag
@@ -208,6 +199,11 @@ func createManager(ctx context.Context,
 		return nil, fmt.Errorf("failed to create a new manager: %w", err)
 	}
 
+	// add the configmap: logLevel
+	if err = controllers.AddConfigMapController(mgr); err != nil {
+		return nil, fmt.Errorf("failed to add configmap controller to manager: %w", err)
+	}
+
 	err = controller.NewTransportCtrl(managerConfig.ManagerNamespace, constants.GHTransportConfigSecret,
 		transportCallback(mgr, managerConfig),
 		managerConfig.TransportConfig,
@@ -265,24 +261,22 @@ func transportCallback(mgr ctrl.Manager, managerConfig *configs.ManagerConfig) c
 			return fmt.Errorf("failed to add migration controller to manager - %w", err)
 		}
 
-		setupLog.Info("add the manager controllers to ctrl.Manager")
 		return nil
 	}
 }
 
 // function to handle defers with exit, see https://stackoverflow.com/a/27629493/553720.
-func doMain(ctx context.Context, restConfig *rest.Config) int {
+func doMain(ctx context.Context, restConfig *rest.Config) error {
 	managerConfig := parseFlags()
 	if err := completeConfig(managerConfig); err != nil {
-		setupLog.Error(err, "failed to complete configuration")
-		return 1
+		return fmt.Errorf("failed to complete configuration %w", err)
 	}
 
 	if managerConfig.EnablePprof {
 		go utils.StartDefaultPprofServer()
 	}
 
-	utils.PrintVersion(setupLog)
+	utils.RuntimeInfo()
 	databaseConfig := &database.DatabaseConfig{
 		URL:        managerConfig.DatabaseConfig.ProcessDatabaseURL,
 		Dialect:    database.PostgresDialect,
@@ -292,49 +286,46 @@ func doMain(ctx context.Context, restConfig *rest.Config) int {
 	// Init the default gorm instance, it's used to sync data to db
 	err := database.InitGormInstance(databaseConfig)
 	if err != nil {
-		setupLog.Error(err, "failed to initialize GORM instance")
-		return 1
+		return fmt.Errorf("failed to initialize GORM instance %w", err)
 	}
 	defer database.CloseGorm(database.GetSqlDb())
 
 	// Init the backup gorm instance, it's used to add lock when backup database
 	_, sqlBackupConn, err := database.NewGormConn(databaseConfig)
 	if err != nil {
-		setupLog.Error(err, "failed to initialize GORM instance")
-		return 1
+		return fmt.Errorf("failed to initialize GORM conn instance %w", err)
 	}
 	defer database.CloseGorm(sqlBackupConn)
 
 	sqlConn, err := sqlBackupConn.Conn(ctx)
 	if err != nil {
-		setupLog.Error(err, "failed to get db connection")
-		return 1
+		return fmt.Errorf("failed to sql conn instance %w", err)
 	}
 	mgr, err := createManager(ctx, restConfig, managerConfig, sqlConn)
 	if err != nil {
-		setupLog.Error(err, "failed to create manager")
-		return 1
+		return fmt.Errorf("failed to create manager %w", err)
 	}
 
 	if managerConfig.EnableGlobalResource {
 		hookServer := mgr.GetWebhookServer()
-		setupLog.Info("registering webhooks to the webhook server")
+		log.Info("registering webhooks to the webhook server")
 		hookServer.Register("/mutating", &webhook.Admission{
 			Handler: mgrwebhook.NewAdmissionHandler(mgr.GetScheme()),
 		})
 	}
 
-	setupLog.Info("Starting the Manager")
 	if err := mgr.Start(ctx); err != nil {
-		setupLog.Error(err, "manager exited non-zero")
-		return 1
+		return fmt.Errorf("failed to start manager %w", err)
 	}
 
-	return 0
+	return nil
 }
 
 func main() {
-	os.Exit(doMain(ctrl.SetupSignalHandler(), ctrl.GetConfigOrDie()))
+	defer func() { _ = logger.CoreZapLogger().Sync() }()
+	if err := doMain(ctrl.SetupSignalHandler(), ctrl.GetConfigOrDie()); err != nil {
+		logger.DefaultZapLogger().Panicf("failed to run the main: %v", err)
+	}
 }
 
 func initCache(config *rest.Config, cacheOpts cache.Options) (cache.Cache, error) {

--- a/manager/pkg/controllers/configmap_controller.go
+++ b/manager/pkg/controllers/configmap_controller.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
+)
+
+const (
+	RequeueDuration = 5 * time.Second
+	LogLevelKey     = "logLevel"
+)
+
+type managerConfigMapController struct {
+	client client.Client
+}
+
+func AddConfigMapController(mgr ctrl.Manager) error {
+	configmapCtrl := &managerConfigMapController{
+		client: mgr.GetClient(),
+	}
+	configMapPredicate := predicate.NewPredicateFuncs(func(object client.Object) bool {
+		return object.GetName() == constants.GHConfigCMName
+	})
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.ConfigMap{}).
+		WithEventFilter(configMapPredicate).
+		Complete(configmapCtrl)
+}
+
+func (c *managerConfigMapController) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
+	log := logger.DefaultZapLogger()
+
+	configMap := &corev1.ConfigMap{}
+	if err := c.client.Get(ctx, request.NamespacedName, configMap); apierrors.IsNotFound(err) {
+		return ctrl.Result{}, nil
+	} else if err != nil {
+		return ctrl.Result{Requeue: true, RequeueAfter: RequeueDuration}, fmt.Errorf("failed to get configmap: %w", err)
+	}
+
+	logLevel := configMap.Data[string(LogLevelKey)]
+	if logLevel != "" {
+		log.Infof("set the log level to: %s", logLevel)
+		logger.SetLogLevel(logger.LogLevel(logLevel))
+	}
+	return ctrl.Result{}, nil
+}

--- a/manager/pkg/processes/cronjob/task/data_retention.go
+++ b/manager/pkg/processes/cronjob/task/data_retention.go
@@ -7,11 +7,11 @@ import (
 	"time"
 
 	"github.com/go-co-op/gocron"
-	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/processes/hubmanagement"
 	"github.com/stolostron/multicluster-global-hub/pkg/database"
 	"github.com/stolostron/multicluster-global-hub/pkg/database/models"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 )
 
 var (
@@ -40,7 +40,7 @@ var (
 		"history.local_compliance",
 		"event.managed_clusters",
 	}
-	retentionLog = ctrl.Log.WithName(RetentionTaskName)
+	retentionLog = logger.ZapLogger(RetentionTaskName)
 )
 
 func DataRetention(ctx context.Context, retentionMonth int, job gocron.Job) {

--- a/manager/pkg/processes/hubmanagement/hub_management.go
+++ b/manager/pkg/processes/hubmanagement/hub_management.go
@@ -44,7 +44,7 @@ type HubManagement struct {
 
 func NewHubManagement(producer transport.Producer, probeDuration, activeTimeout time.Duration) *HubManagement {
 	return &HubManagement{
-		log:           logger.ZapLogger("hub-management"),
+		log:           logger.DefaultZapLogger(),
 		producer:      producer,
 		probeDuration: probeDuration,
 		activeTimeout: activeTimeout,

--- a/manager/pkg/restapis/apis.go
+++ b/manager/pkg/restapis/apis.go
@@ -12,13 +12,14 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/go-logr/logr"
+	"go.uber.org/zap"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/restapis/authentication"
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/restapis/managedclusters"
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/restapis/policies"
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/restapis/subscriptions"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 )
 
 const secondsToFinishOnShutdown = 5
@@ -39,7 +40,7 @@ func (*restApiServer) NeedLeaderElection() bool {
 
 // restApiServer defines the non-k8s-api-server
 type restApiServer struct {
-	log logr.Logger
+	log *zap.SugaredLogger
 	svr *http.Server
 }
 
@@ -66,7 +67,7 @@ func AddRestApiServer(mgr ctrl.Manager, restApiConfig *RestApiServerConfig) erro
 	}
 
 	err = mgr.Add(&restApiServer{
-		log: ctrl.Log.WithName("non-k8s-api-server"),
+		log: logger.ZapLogger("restapi-server"),
 		svr: &http.Server{
 			Addr:              ":8080",
 			Handler:           router,

--- a/manager/pkg/spec/controllers/application_controller.go
+++ b/manager/pkg/spec/controllers/application_controller.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/specdb"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 )
 
 func AddApplicationController(mgr ctrl.Manager, specDB specdb.SpecDB) error {
@@ -22,7 +23,7 @@ func AddApplicationController(mgr ctrl.Manager, specDB specdb.SpecDB) error {
 		Complete(&genericSpecController{
 			client:         mgr.GetClient(),
 			specDB:         specDB,
-			log:            ctrl.Log.WithName("applications-spec-controller"),
+			log:            logger.ZapLogger("applications-spec-controller"),
 			tableName:      "applications",
 			finalizerName:  constants.GlobalHubCleanupFinalizer,
 			createInstance: func() client.Object { return &applicationv1beta1.Application{} },

--- a/manager/pkg/spec/controllers/channel_controller.go
+++ b/manager/pkg/spec/controllers/channel_controller.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/specdb"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 )
 
 func AddChannelController(mgr ctrl.Manager, specDB specdb.SpecDB) error {
@@ -32,7 +33,7 @@ func AddChannelController(mgr ctrl.Manager, specDB specdb.SpecDB) error {
 		Complete(&genericSpecController{
 			client:         mgr.GetClient(),
 			specDB:         specDB,
-			log:            ctrl.Log.WithName("channels-spec-controller"),
+			log:            logger.ZapLogger("channels-spec-controller"),
 			tableName:      "channels",
 			finalizerName:  constants.GlobalHubCleanupFinalizer,
 			createInstance: func() client.Object { return &channelv1.Channel{} },

--- a/manager/pkg/spec/controllers/managedclusterset_contrller.go
+++ b/manager/pkg/spec/controllers/managedclusterset_contrller.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/specdb"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 )
 
 func AddManagedClusterSetController(mgr ctrl.Manager, specDB specdb.SpecDB) error {
@@ -22,7 +23,7 @@ func AddManagedClusterSetController(mgr ctrl.Manager, specDB specdb.SpecDB) erro
 		Complete(&genericSpecController{
 			client:         mgr.GetClient(),
 			specDB:         specDB,
-			log:            ctrl.Log.WithName("managedclustersets-spec-syncer"),
+			log:            logger.ZapLogger("managedclustersets-spec-syncer"),
 			tableName:      "managedclustersets",
 			finalizerName:  constants.GlobalHubCleanupFinalizer,
 			createInstance: func() client.Object { return &clusterv1beta2.ManagedClusterSet{} },

--- a/manager/pkg/spec/controllers/managedclustersetbinding_controller.go
+++ b/manager/pkg/spec/controllers/managedclustersetbinding_controller.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/specdb"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 )
 
 func AddManagedClusterSetBindingController(mgr ctrl.Manager, specDB specdb.SpecDB) error {
@@ -22,7 +23,7 @@ func AddManagedClusterSetBindingController(mgr ctrl.Manager, specDB specdb.SpecD
 		Complete(&genericSpecController{
 			client:        mgr.GetClient(),
 			specDB:        specDB,
-			log:           ctrl.Log.WithName("managedclustersetbindings-spec-syncer"),
+			log:           logger.ZapLogger("managedclustersetbindings-spec-syncer"),
 			tableName:     "managedclustersetbindings",
 			finalizerName: constants.GlobalHubCleanupFinalizer,
 			createInstance: func() client.Object {

--- a/manager/pkg/spec/controllers/placement_controller.go
+++ b/manager/pkg/spec/controllers/placement_controller.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/specdb"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 )
 
 func AddPlacementController(mgr ctrl.Manager, specDB specdb.SpecDB) error {
@@ -22,7 +23,7 @@ func AddPlacementController(mgr ctrl.Manager, specDB specdb.SpecDB) error {
 		Complete(&genericSpecController{
 			client:         mgr.GetClient(),
 			specDB:         specDB,
-			log:            ctrl.Log.WithName("placements-spec-syncer"),
+			log:            logger.ZapLogger("placements-spec-syncer"),
 			tableName:      "placements",
 			finalizerName:  constants.GlobalHubCleanupFinalizer,
 			createInstance: func() client.Object { return &clusterv1beta1.Placement{} },

--- a/manager/pkg/spec/controllers/placementbinding_controller.go
+++ b/manager/pkg/spec/controllers/placementbinding_controller.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/specdb"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 )
 
 func AddPlacementBindingController(mgr ctrl.Manager, specDB specdb.SpecDB) error {
@@ -22,7 +23,7 @@ func AddPlacementBindingController(mgr ctrl.Manager, specDB specdb.SpecDB) error
 		Complete(&genericSpecController{
 			client:         mgr.GetClient(),
 			specDB:         specDB,
-			log:            ctrl.Log.WithName("placementbindings-spec-syncer"),
+			log:            logger.ZapLogger("placementbindings-spec-syncer"),
 			tableName:      "placementbindings",
 			finalizerName:  constants.GlobalHubCleanupFinalizer,
 			createInstance: func() client.Object { return &policyv1.PlacementBinding{} },

--- a/manager/pkg/spec/controllers/placementrule_controller.go
+++ b/manager/pkg/spec/controllers/placementrule_controller.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/specdb"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 )
 
 func AddPlacementRuleController(mgr ctrl.Manager, specDB specdb.SpecDB) error {
@@ -22,7 +23,7 @@ func AddPlacementRuleController(mgr ctrl.Manager, specDB specdb.SpecDB) error {
 		Complete(&genericSpecController{
 			client:         mgr.GetClient(),
 			specDB:         specDB,
-			log:            ctrl.Log.WithName("placementrules-spec-syncer"),
+			log:            logger.ZapLogger("placementrules-spec-syncer"),
 			tableName:      "placementrules",
 			finalizerName:  constants.GlobalHubCleanupFinalizer,
 			createInstance: func() client.Object { return &placementrulev1.PlacementRule{} },

--- a/manager/pkg/spec/controllers/policy_controller.go
+++ b/manager/pkg/spec/controllers/policy_controller.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/specdb"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 )
 
 func AddPolicyController(mgr ctrl.Manager, specDB specdb.SpecDB) error {
@@ -22,7 +23,7 @@ func AddPolicyController(mgr ctrl.Manager, specDB specdb.SpecDB) error {
 		Complete(&genericSpecController{
 			client:         mgr.GetClient(),
 			specDB:         specDB,
-			log:            ctrl.Log.WithName("policies-spec-syncer"),
+			log:            logger.ZapLogger("policies-spec-syncer"),
 			tableName:      "policies",
 			finalizerName:  constants.GlobalHubCleanupFinalizer,
 			createInstance: func() client.Object { return &policyv1.Policy{} },

--- a/manager/pkg/spec/controllers/subscription_controller.go
+++ b/manager/pkg/spec/controllers/subscription_controller.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/specdb"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 )
 
 func AddSubscriptionController(mgr ctrl.Manager, specDB specdb.SpecDB) error {
@@ -32,7 +33,7 @@ func AddSubscriptionController(mgr ctrl.Manager, specDB specdb.SpecDB) error {
 		Complete(&genericSpecController{
 			client:         mgr.GetClient(),
 			specDB:         specDB,
-			log:            ctrl.Log.WithName("subscriptions-spec-syncer"),
+			log:            logger.ZapLogger("subscriptions-spec-syncer"),
 			tableName:      "subscriptions",
 			finalizerName:  constants.GlobalHubCleanupFinalizer,
 			createInstance: func() client.Object { return &subscriptionv1.Subscription{} },

--- a/manager/pkg/spec/syncers/applications_syncer.go
+++ b/manager/pkg/spec/syncers/applications_syncer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/controllers/bundle"
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/specdb"
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/syncers/interval"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 )
 
@@ -28,7 +29,7 @@ func AddApplicationsDBToTransportSyncer(mgr ctrl.Manager, specDB specdb.SpecDB, 
 	lastSyncTimestampPtr := &time.Time{}
 
 	if err := mgr.Add(&genericDBToTransportSyncer{
-		log:            ctrl.Log.WithName("db-to-transport-syncer-application"),
+		log:            logger.ZapLogger("db-to-transport-syncer-application"),
 		intervalPolicy: interval.NewExponentialBackoffPolicy(specSyncInterval),
 		syncBundleFunc: func(ctx context.Context) (bool, error) {
 			return syncObjectsBundle(ctx, producer, applicationsMsgKey, specDB, applicationsTableName,

--- a/manager/pkg/spec/syncers/channels_syncer.go
+++ b/manager/pkg/spec/syncers/channels_syncer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/controllers/bundle"
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/specdb"
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/syncers/interval"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 )
 
@@ -28,7 +29,7 @@ func AddChannelsDBToTransportSyncer(mgr ctrl.Manager, specDB specdb.SpecDB, prod
 	lastSyncTimestampPtr := &time.Time{}
 
 	if err := mgr.Add(&genericDBToTransportSyncer{
-		log:            ctrl.Log.WithName("db-to-transport-syncer-channels"),
+		log:            logger.ZapLogger("db-to-transport-syncer-channels"),
 		intervalPolicy: interval.NewExponentialBackoffPolicy(specSyncInterval),
 		syncBundleFunc: func(ctx context.Context) (bool, error) {
 			return syncObjectsBundle(ctx, producer, channelsMsgKey, specDB, channelsTableName,

--- a/manager/pkg/spec/syncers/configmap_syncer.go
+++ b/manager/pkg/spec/syncers/configmap_syncer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/controllers/bundle"
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/specdb"
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/syncers/interval"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 )
 
@@ -29,7 +30,7 @@ func AddHoHConfigDBToTransportSyncer(mgr ctrl.Manager, specDB specdb.SpecDB, pro
 	lastSyncTimestampPtr := &time.Time{}
 
 	if err := mgr.Add(&genericDBToTransportSyncer{
-		log:            ctrl.Log.WithName("db-to-transport-syncer-configmap"),
+		log:            logger.ZapLogger("db-to-transport-syncer-configmap"),
 		intervalPolicy: interval.NewExponentialBackoffPolicy(specSyncInterval),
 		syncBundleFunc: func(ctx context.Context) (bool, error) {
 			return syncObjectsBundle(ctx, producer, configMsgKey, specDB, configTableName,

--- a/manager/pkg/spec/syncers/generic_syncer.go
+++ b/manager/pkg/spec/syncers/generic_syncer.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/go-logr/logr"
+	"go.uber.org/zap"
 
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/controllers/bundle"
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/specdb"
@@ -17,7 +17,7 @@ import (
 )
 
 type genericDBToTransportSyncer struct {
-	log            logr.Logger
+	log            *zap.SugaredLogger
 	intervalPolicy interval.IntervalPolicy
 	syncBundleFunc func(ctx context.Context) (bool, error)
 }

--- a/manager/pkg/spec/syncers/managedcluster_labels_syncer.go
+++ b/manager/pkg/spec/syncers/managedcluster_labels_syncer.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/database"
 	"github.com/stolostron/multicluster-global-hub/pkg/database/models"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
@@ -29,7 +30,7 @@ func AddManagedClusterLabelsDBToTransportSyncer(mgr ctrl.Manager, specDB specdb.
 	lastSyncTimestampPtr := &time.Time{}
 
 	if err := mgr.Add(&genericDBToTransportSyncer{
-		log:            ctrl.Log.WithName("db-to-transport-syncer-managedclusterlabel"),
+		log:            logger.ZapLogger("db-to-transport-syncer-managedclusterlabel"),
 		intervalPolicy: interval.NewExponentialBackoffPolicy(specSyncInterval),
 		syncBundleFunc: func(ctx context.Context) (bool, error) {
 			return syncManagedClusterLabelsBundles(ctx, producer,

--- a/manager/pkg/spec/syncers/managedclustersetbindings_syncer.go
+++ b/manager/pkg/spec/syncers/managedclustersetbindings_syncer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/controllers/bundle"
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/specdb"
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/syncers/interval"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 )
 
@@ -31,7 +32,7 @@ func AddManagedClusterSetBindingsDBToTransportSyncer(mgr ctrl.Manager, specDB sp
 	lastSyncTimestampPtr := &time.Time{}
 
 	if err := mgr.Add(&genericDBToTransportSyncer{
-		log:            ctrl.Log.WithName("db-to-transport-syncer-managedclustersetbinding"),
+		log:            logger.ZapLogger("db-to-transport-syncer-managedclustersetbinding"),
 		intervalPolicy: interval.NewExponentialBackoffPolicy(specSyncInterval),
 		syncBundleFunc: func(ctx context.Context) (bool, error) {
 			return syncObjectsBundle(ctx, producer, managedClusterSetBindingsMsgKey, specDB,

--- a/manager/pkg/spec/syncers/managedclustersets_syncer.go
+++ b/manager/pkg/spec/syncers/managedclustersets_syncer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/controllers/bundle"
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/specdb"
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/syncers/interval"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 )
 
@@ -28,7 +29,7 @@ func AddManagedClusterSetsDBToTransportSyncer(mgr ctrl.Manager, specDB specdb.Sp
 	lastSyncTimestampPtr := &time.Time{}
 
 	if err := mgr.Add(&genericDBToTransportSyncer{
-		log:            ctrl.Log.WithName("db-to-transport-syncer-managedclusterset"),
+		log:            logger.ZapLogger("db-to-transport-syncer-managedclusterset"),
 		intervalPolicy: interval.NewExponentialBackoffPolicy(specSyncInterval),
 		syncBundleFunc: func(ctx context.Context) (bool, error) {
 			return syncObjectsBundle(ctx, producer, managedClusterSetsMsgKey, specDB, managedClusterSetsTableName,

--- a/manager/pkg/spec/syncers/placementbindings_syncer.go
+++ b/manager/pkg/spec/syncers/placementbindings_syncer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/controllers/bundle"
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/specdb"
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/syncers/interval"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 )
 
@@ -28,7 +29,7 @@ func AddPlacementBindingsDBToTransportSyncer(mgr ctrl.Manager, specDB specdb.Spe
 	lastSyncTimestampPtr := &time.Time{}
 
 	if err := mgr.Add(&genericDBToTransportSyncer{
-		log:            ctrl.Log.WithName("db-to-transport-syncer-placementrulebiding"),
+		log:            logger.ZapLogger("db-to-transport-syncer-placementrulebiding"),
 		intervalPolicy: interval.NewExponentialBackoffPolicy(specSyncInterval),
 		syncBundleFunc: func(ctx context.Context) (bool, error) {
 			return syncObjectsBundle(ctx, producer, placementBindingsMsgKey, specDB, placementBindingsTableName,

--- a/manager/pkg/spec/syncers/placementrules_syncer.go
+++ b/manager/pkg/spec/syncers/placementrules_syncer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/controllers/bundle"
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/specdb"
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/syncers/interval"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 )
 
@@ -28,7 +29,7 @@ func AddPlacementRulesDBToTransportSyncer(mgr ctrl.Manager, specDB specdb.SpecDB
 	lastSyncTimestampPtr := &time.Time{}
 
 	if err := mgr.Add(&genericDBToTransportSyncer{
-		log:            ctrl.Log.WithName("db-to-transport-syncer-placementrule"),
+		log:            logger.ZapLogger("db-to-transport-syncer-placementrule"),
 		intervalPolicy: interval.NewExponentialBackoffPolicy(specSyncInterval),
 		syncBundleFunc: func(ctx context.Context) (bool, error) {
 			return syncObjectsBundle(ctx, producer, placementRulesMsgKey, specDB, placementRulesTableName,

--- a/manager/pkg/spec/syncers/placements_syncer.go
+++ b/manager/pkg/spec/syncers/placements_syncer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/controllers/bundle"
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/specdb"
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/syncers/interval"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 )
 
@@ -28,7 +29,7 @@ func AddPlacementsDBToTransportSyncer(mgr ctrl.Manager, specDB specdb.SpecDB, pr
 	lastSyncTimestampPtr := &time.Time{}
 
 	if err := mgr.Add(&genericDBToTransportSyncer{
-		log:            ctrl.Log.WithName("db-to-transport-syncer-placements"),
+		log:            logger.ZapLogger("db-to-transport-syncer-placements"),
 		intervalPolicy: interval.NewExponentialBackoffPolicy(specSyncInterval),
 		syncBundleFunc: func(ctx context.Context) (bool, error) {
 			return syncObjectsBundle(ctx, producer, placementsMsgKey, specDB, placementsTableName,

--- a/manager/pkg/spec/syncers/policies_syncer.go
+++ b/manager/pkg/spec/syncers/policies_syncer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/controllers/bundle"
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/specdb"
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/syncers/interval"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 )
 
@@ -28,7 +29,7 @@ func AddPoliciesDBToTransportSyncer(mgr ctrl.Manager, specDB specdb.SpecDB, prod
 	lastSyncTimestampPtr := &time.Time{}
 
 	if err := mgr.Add(&genericDBToTransportSyncer{
-		log:            ctrl.Log.WithName("db-to-transport-syncer-policy"),
+		log:            logger.ZapLogger("db-to-transport-syncer-policy"),
 		intervalPolicy: interval.NewExponentialBackoffPolicy(specSyncInterval),
 		syncBundleFunc: func(ctx context.Context) (bool, error) {
 			return syncObjectsBundle(ctx, producer, policiesMsgKey, specDB, policiesTableName,

--- a/manager/pkg/spec/syncers/subscriptions_syncer.go
+++ b/manager/pkg/spec/syncers/subscriptions_syncer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/controllers/bundle"
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/specdb"
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/spec/syncers/interval"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 )
 
@@ -28,7 +29,7 @@ func AddSubscriptionsDBToTransportSyncer(mgr ctrl.Manager, specDB specdb.SpecDB,
 	lastSyncTimestampPtr := &time.Time{}
 
 	if err := mgr.Add(&genericDBToTransportSyncer{
-		log:            ctrl.Log.WithName("db-to-transport-syncer-subscriptions"),
+		log:            logger.ZapLogger("db-to-transport-syncer-subscriptions"),
 		intervalPolicy: interval.NewExponentialBackoffPolicy(specSyncInterval),
 		syncBundleFunc: func(ctx context.Context) (bool, error) {
 			return syncObjectsBundle(ctx, producer, subscriptionMsgKey, specDB, subscriptionsTableName,

--- a/manager/pkg/status/conflator/conflation_committer.go
+++ b/manager/pkg/status/conflator/conflation_committer.go
@@ -74,7 +74,7 @@ func (k *ConflationCommitter) commit() error {
 			continue
 		}
 
-		k.log.Warnw("commit offset to database", "topic@partition", key, "offset", transPosition.Offset)
+		k.log.Debugw("commit offset to database", "topic@partition", key, "offset", transPosition.Offset)
 		payload, err := json.Marshal(transport.EventPosition{
 			OwnerIdentity: transPosition.OwnerIdentity,
 			Topic:         transPosition.Topic,

--- a/manager/pkg/status/conflator/metadata/threshold_metadata.go
+++ b/manager/pkg/status/conflator/metadata/threshold_metadata.go
@@ -7,9 +7,9 @@ import (
 	kafka_confluent "github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/cloudevents/sdk-go/v2/types"
-	ctrl "sigs.k8s.io/controller-runtime"
 
 	eventversion "github.com/stolostron/multicluster-global-hub/pkg/bundle/version"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 )
 
@@ -31,10 +31,10 @@ type ThresholdMetadata struct {
 	eventDependencyVersion *eventversion.Version
 }
 
+var log = logger.DefaultZapLogger()
+
 // the retry times(max) when the bundle has been failed processed
 func NewThresholdMetadata(clusterIdentity string, max int, evt *cloudevents.Event) *ThresholdMetadata {
-	log := ctrl.Log.WithName("event-metadata")
-
 	topic, err := types.ToString(evt.Extensions()[kafka_confluent.KafkaTopicKey])
 	if err != nil {
 		log.Info("failed to parse topic from event", "error", err)

--- a/manager/pkg/status/dispatcher/conflation_dispatcher.go
+++ b/manager/pkg/status/dispatcher/conflation_dispatcher.go
@@ -5,22 +5,23 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/go-logr/logr"
+	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/util/wait"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/configs"
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/status/conflator"
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/status/conflator/workerpool"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 	"github.com/stolostron/multicluster-global-hub/pkg/statistics"
 )
 
 // NewConflationDispatcher creates a new instance of Dispatcher.
-func NewConflationDispatcher(log logr.Logger, conflationReadyQueue *conflator.ConflationReadyQueue,
+func NewConflationDispatcher(conflationReadyQueue *conflator.ConflationReadyQueue,
 	dbWorkerPool *workerpool.DBWorkerPool,
 ) *ConflationDispatcher {
 	return &ConflationDispatcher{
-		log:                  log,
+		log:                  logger.DefaultZapLogger(),
 		conflationReadyQueue: conflationReadyQueue,
 		dbWorkerPool:         dbWorkerPool,
 	}
@@ -40,7 +41,7 @@ func AddConflationDispatcher(mgr ctrl.Manager, conflationManager *conflator.Conf
 
 	// conflation dispatcher -> work pool
 	conflationDispatcher := &ConflationDispatcher{
-		log:                  ctrl.Log.WithName("conflation-dispatcher"),
+		log:                  logger.DefaultZapLogger(),
 		conflationReadyQueue: conflationManager.GetReadyQueue(),
 		dbWorkerPool:         dbWorkerPool,
 	}
@@ -53,7 +54,7 @@ func AddConflationDispatcher(mgr ctrl.Manager, conflationManager *conflator.Conf
 // ConflationDispatcher abstracts the dispatching of db jobs to db workers. this is done by reading ready CU
 // and getting from them a ready to process bundles.
 type ConflationDispatcher struct {
-	log                  logr.Logger
+	log                  *zap.SugaredLogger
 	conflationReadyQueue *conflator.ConflationReadyQueue
 	dbWorkerPool         *workerpool.DBWorkerPool
 }

--- a/manager/pkg/status/handlers/managedcluster/managedcluster_event_handler.go
+++ b/manager/pkg/status/handlers/managedcluster/managedcluster_event_handler.go
@@ -6,19 +6,19 @@ import (
 	"strings"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"github.com/go-logr/logr"
+	"go.uber.org/zap"
 	"gorm.io/gorm/clause"
-	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/status/conflator"
 	"github.com/stolostron/multicluster-global-hub/pkg/bundle/event"
 	eventversion "github.com/stolostron/multicluster-global-hub/pkg/bundle/version"
 	"github.com/stolostron/multicluster-global-hub/pkg/database"
 	"github.com/stolostron/multicluster-global-hub/pkg/enum"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 )
 
 type managedClusterEventHandler struct {
-	log           logr.Logger
+	log           *zap.SugaredLogger
 	eventType     string
 	eventSyncMode enum.EventSyncMode
 	eventPriority conflator.ConflationPriority
@@ -28,7 +28,7 @@ func RegisterManagedClusterEventHandler(conflationManager *conflator.ConflationM
 	eventType := string(enum.ManagedClusterEventType)
 	logName := strings.Replace(eventType, enum.EventTypePrefix, "", -1)
 	h := &managedClusterEventHandler{
-		log:           ctrl.Log.WithName(logName),
+		log:           logger.ZapLogger(logName),
 		eventType:     eventType,
 		eventSyncMode: enum.DeltaStateMode,
 		eventPriority: conflator.ManagedClusterEventPriority,
@@ -44,7 +44,7 @@ func RegisterManagedClusterEventHandler(conflationManager *conflator.ConflationM
 func (h *managedClusterEventHandler) handleEvent(ctx context.Context, evt *cloudevents.Event) error {
 	version := evt.Extensions()[eventversion.ExtVersion]
 	leafHubName := evt.Source()
-	h.log.V(2).Info("handler start", "type", evt.Type(), "LH", evt.Source(), "version", version)
+	h.log.Debugw("handler start", "type", evt.Type(), "LH", evt.Source(), "version", version)
 
 	managedClusterEvents := event.ManagedClusterEventBundle{}
 	if err := evt.DataAs(&managedClusterEvents); err != nil {
@@ -69,6 +69,6 @@ func (h *managedClusterEventHandler) handleEvent(ctx context.Context, evt *cloud
 		return fmt.Errorf("failed handling leaf hub LocalPolicyStatusEvent event - %w", err)
 	}
 
-	h.log.V(2).Info("handler finished", "type", evt.Type(), "LH", evt.Source(), "version", version)
+	h.log.Debugw("handler finished", "type", evt.Type(), "LH", evt.Source(), "version", version)
 	return nil
 }

--- a/manager/pkg/status/handlers/policy/local_replicated_policy_event_handler.go
+++ b/manager/pkg/status/handlers/policy/local_replicated_policy_event_handler.go
@@ -7,9 +7,8 @@ import (
 	"strings"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"github.com/go-logr/logr"
+	"go.uber.org/zap"
 	"gorm.io/gorm/clause"
-	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/status/conflator"
 	"github.com/stolostron/multicluster-global-hub/pkg/bundle/event"
@@ -18,10 +17,11 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/database/common"
 	"github.com/stolostron/multicluster-global-hub/pkg/database/models"
 	"github.com/stolostron/multicluster-global-hub/pkg/enum"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 )
 
 type localReplicatedPolicyEventHandler struct {
-	log           logr.Logger
+	log           *zap.SugaredLogger
 	eventType     string
 	eventSyncMode enum.EventSyncMode
 	eventPriority conflator.ConflationPriority
@@ -31,7 +31,7 @@ func RegisterLocalReplicatedPolicyEventHandler(conflationManager *conflator.Conf
 	eventType := string(enum.LocalReplicatedPolicyEventType)
 	logName := strings.Replace(eventType, enum.EventTypePrefix, "", -1)
 	h := &localReplicatedPolicyEventHandler{
-		log:           ctrl.Log.WithName(logName),
+		log:           logger.ZapLogger(logName),
 		eventType:     eventType,
 		eventSyncMode: enum.DeltaStateMode,
 		eventPriority: conflator.LocalReplicatedPolicyEventPriority,
@@ -47,7 +47,7 @@ func RegisterLocalReplicatedPolicyEventHandler(conflationManager *conflator.Conf
 func (h *localReplicatedPolicyEventHandler) handleEvent(ctx context.Context, evt *cloudevents.Event) error {
 	version := evt.Extensions()[eventversion.ExtVersion]
 	leafHubName := evt.Source()
-	h.log.V(2).Info(startMessage, "type", evt.Type(), "LH", evt.Source(), "version", version)
+	h.log.Debugw(startMessage, "type", evt.Type(), "LH", evt.Source(), "version", version)
 
 	data := event.ReplicatedPolicyEventBundle{}
 	if err := evt.DataAs(&data); err != nil {
@@ -93,6 +93,6 @@ func (h *localReplicatedPolicyEventHandler) handleEvent(ctx context.Context, evt
 		return fmt.Errorf("failed handling leaf hub LocalPolicyStatusEvent event - %w", err)
 	}
 
-	h.log.V(2).Info(finishMessage, "type", evt.Type(), "LH", evt.Source(), "version", version)
+	h.log.Debugw(finishMessage, "type", evt.Type(), "LH", evt.Source(), "version", version)
 	return nil
 }

--- a/manager/pkg/status/handlers/policy/local_root_policy_event_handler.go
+++ b/manager/pkg/status/handlers/policy/local_root_policy_event_handler.go
@@ -7,9 +7,8 @@ import (
 	"strings"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"github.com/go-logr/logr"
+	"go.uber.org/zap"
 	"gorm.io/gorm/clause"
-	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/status/conflator"
 	"github.com/stolostron/multicluster-global-hub/pkg/bundle/event"
@@ -18,10 +17,11 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/database/common"
 	"github.com/stolostron/multicluster-global-hub/pkg/database/models"
 	"github.com/stolostron/multicluster-global-hub/pkg/enum"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 )
 
 type localRootPolicyEventHandler struct {
-	log           logr.Logger
+	log           *zap.SugaredLogger
 	eventType     string
 	eventSyncMode enum.EventSyncMode
 	eventPriority conflator.ConflationPriority
@@ -31,7 +31,7 @@ func RegisterLocalRootPolicyEventHandler(conflationManager *conflator.Conflation
 	eventType := string(enum.LocalRootPolicyEventType)
 	logName := strings.Replace(eventType, enum.EventTypePrefix, "", -1)
 	h := &localRootPolicyEventHandler{
-		log:           ctrl.Log.WithName(logName),
+		log:           logger.ZapLogger(logName),
 		eventType:     eventType,
 		eventSyncMode: enum.DeltaStateMode,
 		eventPriority: conflator.LocalEventRootPolicyPriority,
@@ -47,7 +47,7 @@ func RegisterLocalRootPolicyEventHandler(conflationManager *conflator.Conflation
 func (h *localRootPolicyEventHandler) handleEvent(ctx context.Context, evt *cloudevents.Event) error {
 	version := evt.Extensions()[eventversion.ExtVersion]
 	leafHubName := evt.Source()
-	h.log.V(2).Info(startMessage, "type", evt.Type(), "LH", evt.Source(), "version", version)
+	h.log.Debugw(startMessage, "type", evt.Type(), "LH", evt.Source(), "version", version)
 
 	data := []event.RootPolicyEvent{}
 	if err := evt.DataAs(&data); err != nil {
@@ -91,6 +91,6 @@ func (h *localRootPolicyEventHandler) handleEvent(ctx context.Context, evt *clou
 	if err != nil {
 		return fmt.Errorf("failed to handle the event to database %v", err)
 	}
-	h.log.V(2).Info(finishMessage, "type", evt.Type(), "LH", evt.Source(), "version", version)
+	h.log.Debugw(finishMessage, "type", evt.Type(), "LH", evt.Source(), "version", version)
 	return nil
 }

--- a/manager/pkg/status/handlers/policy/policy_delta_compliance_handler.go
+++ b/manager/pkg/status/handlers/policy/policy_delta_compliance_handler.go
@@ -6,9 +6,8 @@ import (
 	"strings"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"github.com/go-logr/logr"
+	"go.uber.org/zap"
 	"gorm.io/gorm"
-	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/status/conflator"
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/status/conflator/dependency"
@@ -17,10 +16,11 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/database"
 	"github.com/stolostron/multicluster-global-hub/pkg/database/models"
 	"github.com/stolostron/multicluster-global-hub/pkg/enum"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 )
 
 type policyDeltaComplianceHandler struct {
-	log            logr.Logger
+	log            *zap.SugaredLogger
 	eventType      string
 	dependencyType string
 	eventSyncMode  enum.EventSyncMode
@@ -31,7 +31,7 @@ func RegisterPolicyDeltaComplianceHandler(conflationManager *conflator.Conflatio
 	eventType := string(enum.DeltaComplianceType)
 	logName := strings.Replace(eventType, enum.EventTypePrefix, "", -1)
 	h := &policyDeltaComplianceHandler{
-		log:            ctrl.Log.WithName(logName),
+		log:            logger.ZapLogger(logName),
 		eventType:      eventType,
 		dependencyType: string(enum.CompleteComplianceType),
 		eventSyncMode:  enum.DeltaStateMode,
@@ -51,7 +51,7 @@ func RegisterPolicyDeltaComplianceHandler(conflationManager *conflator.Conflatio
 func (h *policyDeltaComplianceHandler) handleEvent(ctx context.Context, evt *cloudevents.Event) error {
 	version := evt.Extensions()[eventversion.ExtVersion]
 	leafHub := evt.Source()
-	h.log.V(2).Info(startMessage, "type", evt.Type(), "LH", evt.Source(), "version", version)
+	h.log.Debugw(startMessage, "type", evt.Type(), "LH", evt.Source(), "version", version)
 
 	data := grc.ComplianceBundle{}
 	if err := evt.DataAs(&data); err != nil {
@@ -98,7 +98,7 @@ func (h *policyDeltaComplianceHandler) handleEvent(ctx context.Context, evt *clo
 		return fmt.Errorf("failed to handle delta compliance bundle - %w", err)
 	}
 
-	h.log.V(2).Info(finishMessage, "type", evt.Type(), "LH", evt.Source(), "version", version)
+	h.log.Debugw(finishMessage, "type", evt.Type(), "LH", evt.Source(), "version", version)
 	return nil
 }
 

--- a/manager/pkg/webhook/admission_handler.go
+++ b/manager/pkg/webhook/admission_handler.go
@@ -9,13 +9,15 @@ import (
 	"net/http"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/klog"
 	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
 	placementrulesv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/placementrule/v1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 )
+
+var log = logger.DefaultZapLogger()
 
 // NewAdmissionHandler is to handle the admission webhook for placementrule and placement
 func NewAdmissionHandler(s *runtime.Scheme) admission.Handler {
@@ -29,7 +31,7 @@ type admissionHandler struct {
 }
 
 func (a *admissionHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
-	klog.V(2).Infof("admission webhook is called, name:%v, namespace:%v, kind:%v, operation:%v", req.Name,
+	log.Infof("admission webhook is called, name:%v, namespace:%v, kind:%v, operation:%v", req.Name,
 		req.Namespace, req.Kind.Kind, req.Operation)
 	switch req.Kind.Kind {
 	case "Placement":

--- a/operator/pkg/controllers/hubofhubs/manager/manifests/deployment.yaml
+++ b/operator/pkg/controllers/hubofhubs/manager/manifests/deployment.yaml
@@ -34,7 +34,6 @@ spec:
           {{- end }}
           imagePullPolicy: {{.ImagePullPolicy}}
           args:
-            - --zap-log-level={{.LogLevel}}
             - --manager-namespace=$(POD_NAMESPACE)
             - --watch-namespace=$(WATCH_NAMESPACE)
             - --postgres-ca-path=/postgres-credential/ca.crt

--- a/operator/pkg/controllers/hubofhubs/manager/manifests/transport-config-secret.yaml
+++ b/operator/pkg/controllers/hubofhubs/manager/manifests/transport-config-secret.yaml
@@ -3,9 +3,6 @@ kind: Secret
 metadata:
   name: {{.TransportConfigSecret}}
   namespace: {{.Namespace}}
-  annotations:
-    # todo put here or configmap
-    za-log-level: {{.LogLevel}}
   labels:
     name: multicluster-global-hub-manager
 type: Opaque

--- a/operator/pkg/controllers/hubofhubs/manager/manifests/transport-config-secret.yaml
+++ b/operator/pkg/controllers/hubofhubs/manager/manifests/transport-config-secret.yaml
@@ -3,6 +3,9 @@ kind: Secret
 metadata:
   name: {{.TransportConfigSecret}}
   namespace: {{.Namespace}}
+  annotations:
+    # todo put here or configmap
+    za-log-level: {{.LogLevel}}
   labels:
     name: multicluster-global-hub-manager
 type: Opaque

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -14,6 +14,10 @@ const (
 	InventoryDeploymentName = "inventory-api"
 	InventoryRouteName      = "inventory-api"
 
+	// GHConfigCMName is the name of configmap that stores important global hub settings
+	// eg. logLevel for both operator and manager.
+	GHConfigCMName = "multicluster-global-hub-config"
+
 	// GHAgentConfigCMName is the name of configmap that stores important global hub settings
 	// eg. aggregationLevel and enableLocalPolicy.
 	GHAgentConfigCMName = "multicluster-global-hub-agent-config"

--- a/pkg/logger/zap.go
+++ b/pkg/logger/zap.go
@@ -1,6 +1,10 @@
 package logger
 
 import (
+<<<<<<< HEAD
+=======
+	"github.com/go-logr/logr"
+>>>>>>> 613525ed (switch zap log for global hub agent)
 	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -33,8 +37,12 @@ func CoreZapLogger() *zap.Logger {
 		internalZapLogger, _ = internalZapConfig.Build()
 	}
 	// set the controller-runtime logger with the current zap logger
-	ctrl.SetLogger(zapr.NewLoggerWithOptions(internalZapLogger))
+	ctrl.SetLogger(zapr.NewLogger(internalZapLogger))
 	return internalZapLogger
+}
+
+func ZaprLogger() logr.Logger {
+	return zapr.NewLogger(internalZapLogger)
 }
 
 // DefaultZapLogger is a sugar wraps the Logger to provide a more ergonomic, but slightly slower, API

--- a/pkg/logger/zap.go
+++ b/pkg/logger/zap.go
@@ -1,10 +1,7 @@
 package logger
 
 import (
-<<<<<<< HEAD
-=======
 	"github.com/go-logr/logr"
->>>>>>> 613525ed (switch zap log for global hub agent)
 	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"

--- a/pkg/statistics/statistics.go
+++ b/pkg/statistics/statistics.go
@@ -8,8 +8,9 @@ import (
 	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"github.com/go-logr/logr"
-	ctrl "sigs.k8s.io/controller-runtime"
+	"go.uber.org/zap"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 )
 
 type StatisticsConfig struct {
@@ -19,7 +20,7 @@ type StatisticsConfig struct {
 // NewStatistics creates a new instance of Statistics.
 func NewStatistics(statisticsConfig *StatisticsConfig) *Statistics {
 	return &Statistics{
-		log:          ctrl.Log.WithName("statistics"),
+		log:          logger.DefaultZapLogger(),
 		eventMetrics: make(map[string]*eventMetrics),
 		logInterval:  statisticsConfig.LogInterval,
 	}
@@ -27,7 +28,7 @@ func NewStatistics(statisticsConfig *StatisticsConfig) *Statistics {
 
 // Statistics aggregates different statistics.
 type Statistics struct {
-	log                      logr.Logger
+	log                      *zap.SugaredLogger
 	numOfAvailableDBWorkers  int
 	conflationReadyQueueSize int
 	numOfConflationUnits     int
@@ -147,7 +148,7 @@ func (s *Statistics) run(ctx context.Context, duration time.Duration) {
 				s.numOfConflationUnits, s.conflationReadyQueueSize, s.numOfAvailableDBWorkers, success, fail,
 				conflationAvg, storageAvg)
 
-			s.log.V(4).Info(fmt.Sprintf("%s\n%s", metrics, stringBuilder.String()))
+			s.log.Debug(fmt.Sprintf("%s\n%s", metrics, stringBuilder.String()))
 		}
 	}
 }

--- a/pkg/transport/controller/controller.go
+++ b/pkg/transport/controller/controller.go
@@ -8,13 +8,13 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport/config"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport/consumer"
@@ -22,6 +22,8 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/transport/requester"
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
+
+var log = logger.DefaultZapLogger()
 
 type TransportCallback func(transportClient transport.TransportClient) error
 
@@ -169,7 +171,7 @@ func (c *TransportCtrl) ReconcileConsumer(ctx context.Context) error {
 		}
 		go func() {
 			if err = receiver.Start(ctx); err != nil {
-				klog.Errorf("failed to start the consumser: %v", err)
+				log.Errorf("failed to start the consumser: %v", err)
 			}
 		}()
 		c.transportClient.consumer = receiver
@@ -178,7 +180,6 @@ func (c *TransportCtrl) ReconcileConsumer(ctx context.Context) error {
 			return fmt.Errorf("failed to reconnect the consumer: %w", err)
 		}
 	}
-	klog.Info("the transport(kafka) consumer is created/updated")
 	return nil
 }
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 )
 
-func RuntimeInfo() {
+func PrintRuntimeInfo() {
 	log := logger.DefaultZapLogger()
 	log.Infof("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH)
 	log.Infof("Go Version: %s", runtime.Version())


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes # https://issues.redhat.com/browse/ACM-13421, https://github.com/stolostron/multicluster-global-hub/issues/1178

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [x] List other manual tests you have done.

```bash
2024-10-30T01:20:44.725Z        INFO    utils/utils.go:28       Go OS/Arch: linux/amd64
2024-10-30T01:20:44.725Z        INFO    utils/utils.go:29       Go Version: go1.22.5
2024-10-30T01:20:44.725Z        INFO    utils/utils.go:30       Git Commit: 0e0ccfa9
2024-10-30T01:20:44.744Z        INFO    cronjob/scheduler.go:68 set SyncLocalCompliance job     {"scheduleAt": "00:00"}
2024-10-30T01:20:44.744Z        INFO    cronjob/scheduler.go:77 set DataRetention jobscheduleAt00:00
2024-10-30T01:20:44.744Z        INFO    controller-runtime.metrics      server/server.go:208    Starting metrics server
I1030 01:20:44.744263       1 leaderelection.go:254] attempting to acquire leader lease multicluster-global-hub/multicluster-global-hub-manager-lock...
2024-10-30T01:20:44.744Z        INFO    controller-runtime.metrics      server/server.go:247    Serving metrics server  {"bindAddress": "0.0.0.0:8384", "secure": false}
I1030 01:23:06.543481       1 leaderelection.go:268] successfully acquired lease multicluster-global-hub/multicluster-global-hub-manager-lock
2024-10-30T01:23:06.543Z        INFO    cronjob/scheduler.go:86 start job scheduler
"ConfigMap", "worker count": 1}
2024-10-30T01:23:06.745Z        INFO    controller/controller.go:217    Starting workers        {"controller": "secret", "controllerGroup": "", "controllerKind": "Secret", "worker count": 1}
2024-10-30T01:23:06.745Z        INFO    controller/controller.go:217    Starting workers        {"controller": "backupPvcController", "controllerGroup": "", "controllerKind": "PersistentVolumeClaim", "worker count": 1}
2024-10-30T01:23:06.745Z        INFO    kafka-consumer  consumer/generic_consumer.go:84 transport consumer with cloudevents-kafka receiver
2024-10-30T01:23:06.750Z        INFO    dispatcher/transport_dispatcher.go:42   transport dispatcher starts dispatching received events...
2024-10-30T01:23:06.750Z        INFO    statistics      statistics/statistics.go:97     starting statistics
2024-10-30T01:23:06.750Z        INFO    dispatcher/conflation_dispatcher.go:64  starting dispatcher
2024-10-30T01:23:06.750Z        INFO    worker-pool     workerpool/worker_pool.go:38    connection stats        {"open connection(worker)": 1, "max": 10}
2024-10-30T01:23:06.750Z        INFO    worker-pool     workerpool/worker.go:46 started worker  {"WorkerID": 10}
...
2024-10-30T01:23:06.750Z        INFO    worker-pool     workerpool/worker.go:46 started worker  {"WorkerID": 5}
2024-10-30T01:23:06.750Z        INFO    worker-pool     workerpool/worker.go:46 started worker  {"WorkerID": 7}
2024-10-30T01:23:06.750Z        INFO    hub-management  hubmanagement/hub_management.go:73      hub management status switch frequency  {"interval": "2m0s"}
2024-10-30T01:23:06.750Z        INFO    controller/controller.go:175    Starting EventSource    {"controller": "migration-controller", "controllerGroup": "global-hub.open-cluster-management.io", "controllerKind": "ManagedClusterMigration", "source": "kind source: *v1alpha1.ManagedClusterMigration"}
2024-10-30T01:23:06.750Z        INFO    controller/controller.go:175    Starting EventSource    {"controller": "migration-controller", "controllerGroup": "global-hub.open-cluster-management.io", "controllerKind": "ManagedClusterMigration", "source": "kind source: *v1beta1.ManagedServiceAccount"}
2024-10-30T01:23:06.750Z        INFO    controller/controller.go:183    Starting Controller     {"controller": "migration-controller", "controllerGroup": "global-hub.open-cluster-management.io", "controllerKind": "ManagedClusterMigration"}
2024-10-30T01:23:06.754Z        INFO    kafka-consumer  consumer/generic_consumer.go:150        init consumeroffsets[]
2024-10-30T01:23:06.754Z        INFO    cloudevents     v2@v2.0.0-20240911135016-682f3a9684e4/protocol.go:166   Subscribing to topics: [^gh-status.*]
2024-10-30T01:23:06.853Z        INFO    controller/controller.go:217    Starting workers        {"controller": "migration-controller", "controllerGroup": "global-hub.open-cluster-management.io", "controllerKind": "ManagedClusterMigration", "worker count": 1}
2024-10-30T01:23:10.007Z        INFO    demo-hub-a.complete.policy.localspec    conflator/element_complete.go:66        resetting element processed version     {"version": "0.1"}
2024-10-30T01:23:10.007Z        INFO    demo-hub-a.complete.managedhub.heartbeat        conflator/element_complete.go:66        resetting element processed version     {"version": "0.0"}
2024-10-30T01:23:10.007Z        INFO    demo-hub-a.complete.policy.localcompletecompliance      conflator/element_complete.go:66        resetting element processed version     {"version": "0.1"}
2024-10-30T01:23:10.007Z        INFO    demo-hub-a.complete.policy.localcompliance      conflator/element_complete.go:66        resetting element processed version     {"version": "0.1"}
2024-10-30T01:23:10.007Z        INFO    demo-hub-a.complete.managedcluster      conflator/element_complete.go:66        resetting element processed version     {"version": "0.1"}
2024-10-30T01:23:10.007Z        INFO    demo-hub-a.complete.managedhub.info     conflator/element_complete.go:66        resetting element processed version     {"version": "0.2"}
```