### PR TITLE
:sparkles: Split the multiclusterhub controller from global hub

### DIFF
--- a/manager/pkg/spec/controllers/generic.go
+++ b/manager/pkg/spec/controllers/generic.go
@@ -160,7 +160,9 @@ func (r *genericSpecController) insertInstanceToDatabase(ctx context.Context, in
 	return instanceInTheDatabase, nil
 }
 
-func (r *genericSpecController) cleanInstance(instance client.Object) client.Object {
+func (r *genericSpecController) cleanInstance(originInstance client.Object) client.Object {
+	instance := originInstance.DeepCopyObject().(client.Object)
+
 	// instance.SetUID("")
 	instance.SetResourceVersion("")
 	instance.SetManagedFields(nil)

--- a/operator/pkg/controllers/meta.go
+++ b/operator/pkg/controllers/meta.go
@@ -49,6 +49,8 @@ type Func func(initOption config.ControllerOption) error
 
 // controllerStartFuncList store all the controllers that need started
 var controllerStartFuncList = []Func{
+	// start the multilcusterhub controller to update the ACM status of the mgh
+	multiclusterhub.AddMulticlusterHubController,
 	transporter.StartController,
 	storage.StartController,
 	grafana.StartController,
@@ -125,11 +127,6 @@ func (r *MetaController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	}
 	reconcileErr = config.SetMulticlusterGlobalHubConfig(ctx, mgh, r.client, r.imageClient)
 	if reconcileErr != nil {
-		return ctrl.Result{}, reconcileErr
-	}
-
-	// start the multilcusterhub controller to update the ACM status of the mgh
-	if reconcileErr = multiclusterhub.AddMulticlusterHubController(r.mgr); err != nil {
 		return ctrl.Result{}, reconcileErr
 	}
 

--- a/operator/pkg/controllers/meta.go
+++ b/operator/pkg/controllers/meta.go
@@ -38,6 +38,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/grafana"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/inventory"
 	globalhubmanager "github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/manager"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/multiclusterhub"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/storage"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/transporter"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/utils"
@@ -124,6 +125,11 @@ func (r *MetaController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	}
 	reconcileErr = config.SetMulticlusterGlobalHubConfig(ctx, mgh, r.client, r.imageClient)
 	if reconcileErr != nil {
+		return ctrl.Result{}, reconcileErr
+	}
+
+	// start the multilcusterhub controller to update the ACM status of the mgh
+	if reconcileErr = multiclusterhub.AddMulticlusterHubController(r.mgr); err != nil {
 		return ctrl.Result{}, reconcileErr
 	}
 

--- a/operator/pkg/controllers/multiclusterhub/acm.go
+++ b/operator/pkg/controllers/multiclusterhub/acm.go
@@ -101,7 +101,6 @@ func AddMulticlusterHubController(opts config.ControllerOption) error {
 	}
 	mch := &MulticlusterhubController{Manager: opts.Manager}
 	err := ctrl.NewControllerManagedBy(opts.Manager).
-		Named("acm-controller").
 		WatchesMetadata(
 			&apiextensionsv1.CustomResourceDefinition{},
 			&handler.EnqueueRequestForObject{},

--- a/operator/pkg/controllers/multiclusterhub/acm.go
+++ b/operator/pkg/controllers/multiclusterhub/acm.go
@@ -100,7 +100,7 @@ func AddMulticlusterHubController(opts config.ControllerOption) error {
 		return nil
 	}
 	mch := &MulticlusterhubController{Manager: opts.Manager}
-	err := ctrl.NewControllerManagedBy(opts.Manager).
+	err := ctrl.NewControllerManagedBy(opts.Manager).Named("acm-controller").
 		WatchesMetadata(
 			&apiextensionsv1.CustomResourceDefinition{},
 			&handler.EnqueueRequestForObject{},

--- a/operator/pkg/controllers/multiclusterhub/acm.go
+++ b/operator/pkg/controllers/multiclusterhub/acm.go
@@ -95,12 +95,12 @@ func (r *MulticlusterhubController) Reconcile(ctx context.Context, req ctrl.Requ
 	return ctrl.Result{}, nil
 }
 
-func AddMulticlusterHubController(mgr ctrl.Manager) error {
+func AddMulticlusterHubController(opts config.ControllerOption) error {
 	if acmConstrollerStarted {
 		return nil
 	}
-	mch := &MulticlusterhubController{Manager: mgr}
-	err := ctrl.NewControllerManagedBy(mgr).
+	mch := &MulticlusterhubController{Manager: opts.Manager}
+	err := ctrl.NewControllerManagedBy(opts.Manager).
 		Named("acm-controller").
 		WatchesMetadata(
 			&apiextensionsv1.CustomResourceDefinition{},

--- a/operator/pkg/controllers/multiclusterhub/acm.go
+++ b/operator/pkg/controllers/multiclusterhub/acm.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multiclusterhub
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-kratos/kratos/v2/errors"
+	mchv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
+)
+
+const MULTICLUSTER_HUB_CRD_NAME = "multiclusterhubs.operator.open-cluster-management.io"
+
+var (
+	log                   = logger.DefaultZapLogger()
+	acmConstrollerStarted = false
+)
+
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;update
+
+type MulticlusterhubController struct {
+	manager.Manager
+}
+
+func (r *MulticlusterhubController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	mch := &mchv1.MultiClusterHub{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      req.Name,
+			Namespace: req.Namespace,
+		},
+	}
+	err := r.GetClient().Get(ctx, client.ObjectKeyFromObject(mch), mch)
+	if err != nil && errors.IsNotFound(err) {
+		config.SetACMResourceReady(false)
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+	} else if err != nil {
+		log.Errorf("failed to get the multiclusterhub: %v", err)
+		return ctrl.Result{}, err
+	}
+
+	if mch.Status.Phase != mchv1.HubRunning {
+		config.SetACMResourceReady(false)
+		err = config.UpdateCondition(ctx, r.GetClient(), config.GetMGHNamespacedName(),
+			metav1.Condition{
+				Type:    config.CONDITION_TYPE_ACM_READY,
+				Status:  config.CONDITION_STATUS_FALSE,
+				Reason:  config.CONDITION_REASON_ACM_NOT_READY,
+				Message: config.CONDITION_MESSAGE_ACM_NOT_READY,
+			}, v1alpha4.GlobalHubError)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+	// MCH is running
+	config.SetACMResourceReady(true)
+	err = config.UpdateCondition(ctx, r.GetClient(), config.GetMGHNamespacedName(),
+		metav1.Condition{
+			Type:    config.CONDITION_TYPE_ACM_READY,
+			Status:  config.CONDITION_STATUS_TRUE,
+			Reason:  config.CONDITION_REASON_ACM_READY,
+			Message: config.CONDITION_MESSAGE_ACM_READY,
+		}, v1alpha4.GlobalHubError)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+func AddMulticlusterHubController(mgr ctrl.Manager) error {
+	if acmConstrollerStarted {
+		return nil
+	}
+	mch := &MulticlusterhubController{Manager: mgr}
+	if err := mch.SetupWithManager(mgr); err != nil {
+		return err
+	}
+	acmConstrollerStarted = true
+	return nil
+}
+
+func (r *MulticlusterhubController) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("acm-controller").
+		WatchesMetadata(
+			&apiextensionsv1.CustomResourceDefinition{},
+			&handler.EnqueueRequestForObject{},
+			builder.WithPredicates(crdPred),
+		).
+		Complete(r)
+}
+
+var crdPred = predicate.Funcs{
+	CreateFunc: func(e event.CreateEvent) bool {
+		return e.Object.GetName() == MULTICLUSTER_HUB_CRD_NAME
+	},
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		return e.ObjectNew.GetName() == MULTICLUSTER_HUB_CRD_NAME
+	},
+	DeleteFunc: func(e event.DeleteEvent) bool {
+		return false
+	},
+}

--- a/operator/pkg/controllers/transporter/protocol/strimzi_kafka_controller.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_kafka_controller.go
@@ -6,7 +6,6 @@ package protocol
 import (
 	"context"
 	"embed"
-	"sync"
 	"time"
 
 	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
@@ -27,10 +26,7 @@ import (
 //go:embed manifests
 var manifests embed.FS
 
-var (
-	kafkaMutex             sync.Mutex
-	startedKafkaController = false
-)
+var startedKafkaController = false
 
 type KafkaStatus struct {
 	kakfaReason  string
@@ -114,9 +110,6 @@ var kafkaPred = predicate.Funcs{
 }
 
 func StartKafkaController(ctx context.Context, mgr ctrl.Manager, transporter transport.Transporter) error {
-	kafkaMutex.Lock()
-	defer kafkaMutex.Unlock()
-
 	if startedKafkaController {
 		return nil
 	}

--- a/operator/pkg/controllers/transporter/transport_reconciler.go
+++ b/operator/pkg/controllers/transporter/transport_reconciler.go
@@ -29,8 +29,7 @@ var started bool
 
 type TransportReconciler struct {
 	ctrl.Manager
-	kafkaController *protocol.KafkaController
-	transporter     transport.Transporter
+	transporter transport.Transporter
 }
 
 func StartController(controllerOption config.ControllerOption) error {
@@ -140,8 +139,8 @@ func (r *TransportReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 
 		// this controller also will update the transport connection
-		if config.GetKafkaResourceReady() && r.kafkaController == nil {
-			r.kafkaController, err = protocol.StartKafkaController(ctx, r.Manager, r.transporter)
+		if config.GetKafkaResourceReady() {
+			err = protocol.StartKafkaController(ctx, r.Manager, r.transporter)
 			if err != nil {
 				return ctrl.Result{}, err
 			}

--- a/test/integration/operator/controllers/grafana_test.go
+++ b/test/integration/operator/controllers/grafana_test.go
@@ -87,7 +87,7 @@ var _ = Describe("grafana", Ordered, func() {
 				return err
 			}
 			return deleteNamespace(namespace)
-		}, 10*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
+		}, 30*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
 	})
 })
 
@@ -97,7 +97,10 @@ func deleteNamespace(name string) error {
 			Name: name,
 		},
 	}
-	err := runtimeClient.Delete(ctx, ns)
+
+	err := runtimeClient.Delete(ctx, ns, &client.DeleteOptions{
+		PropagationPolicy: &[]metav1.DeletionPropagation{metav1.DeletePropagationForeground}[0],
+	})
 	if err != nil {
 		return err
 	}

--- a/test/integration/operator/controllers/grafana_test.go
+++ b/test/integration/operator/controllers/grafana_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -18,7 +17,6 @@ import (
 	"github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/grafana"
-	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 	testutils "github.com/stolostron/multicluster-global-hub/test/integration/utils"
 )
 
@@ -97,16 +95,5 @@ func deleteNamespace(name string) error {
 			Name: name,
 		},
 	}
-
-	err := runtimeClient.Delete(ctx, ns, &client.DeleteOptions{
-		PropagationPolicy: &[]metav1.DeletionPropagation{metav1.DeletePropagationForeground}[0],
-	})
-	if err != nil {
-		return err
-	}
-	if err = runtimeClient.Get(ctx, client.ObjectKeyFromObject(ns), ns); errors.IsNotFound(err) {
-		return nil
-	}
-	utils.PrettyPrint(ns)
-	return fmt.Errorf("the namespace should be deleted: %s", ns.Name)
+	return runtimeClient.Delete(ctx, ns)
 }

--- a/test/integration/operator/controllers/grafana_test.go
+++ b/test/integration/operator/controllers/grafana_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/grafana"
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 	testutils "github.com/stolostron/multicluster-global-hub/test/integration/utils"
 )
 
@@ -103,5 +104,6 @@ func deleteNamespace(name string) error {
 	if err = runtimeClient.Get(ctx, client.ObjectKeyFromObject(ns), ns); errors.IsNotFound(err) {
 		return nil
 	}
-	return fmt.Errorf("the namespace should be deleted: %s", name)
+	utils.PrettyPrint(ns)
+	return fmt.Errorf("the namespace should be deleted: %s", ns.Name)
 }

--- a/test/integration/operator/controllers/inventory_test.go
+++ b/test/integration/operator/controllers/inventory_test.go
@@ -86,7 +86,10 @@ var _ = Describe("inventory-api", Ordered, func() {
 
 	AfterAll(func() {
 		Eventually(func() error {
-			return testutils.DeleteMgh(ctx, runtimeClient, mgh)
+			if err := testutils.DeleteMgh(ctx, runtimeClient, mgh); err != nil {
+				return err
+			}
+			return deleteNamespace(namespace)
 		}, 10*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
 
 		err := runtimeClient.Delete(ctx, &corev1.Namespace{

--- a/test/integration/operator/controllers/inventory_test.go
+++ b/test/integration/operator/controllers/inventory_test.go
@@ -90,7 +90,7 @@ var _ = Describe("inventory-api", Ordered, func() {
 				return err
 			}
 			return deleteNamespace(namespace)
-		}, 10*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
+		}, 30*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
 
 		err := runtimeClient.Delete(ctx, &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{

--- a/test/integration/operator/controllers/manager_test.go
+++ b/test/integration/operator/controllers/manager_test.go
@@ -105,7 +105,7 @@ var _ = Describe("manager", Ordered, func() {
 				return err
 			}
 			return deleteNamespace(namespace)
-		}, 10*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
+		}, 30*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
 
 		err := runtimeClient.Delete(ctx, &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{

--- a/test/integration/operator/controllers/manager_test.go
+++ b/test/integration/operator/controllers/manager_test.go
@@ -101,20 +101,16 @@ var _ = Describe("manager", Ordered, func() {
 
 	AfterAll(func() {
 		Eventually(func() error {
-			return testutils.DeleteMgh(ctx, runtimeClient, mgh)
+			if err := testutils.DeleteMgh(ctx, runtimeClient, mgh); err != nil {
+				return err
+			}
+			return deleteNamespace(namespace)
 		}, 10*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
 
 		err := runtimeClient.Delete(ctx, &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      constants.GHTransportSecretName,
 				Namespace: mgh.Namespace,
-			},
-		})
-		Expect(err).To(Succeed())
-
-		err = runtimeClient.Delete(ctx, &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: namespace,
 			},
 		})
 		Expect(err).To(Succeed())

--- a/test/integration/operator/controllers/meta_controller_test.go
+++ b/test/integration/operator/controllers/meta_controller_test.go
@@ -102,14 +102,10 @@ var _ = Describe("meta", Ordered, func() {
 	})
 	AfterAll(func() {
 		Eventually(func() error {
-			return testutils.DeleteMgh(ctx, runtimeClient, mgh)
+			if err := testutils.DeleteMgh(ctx, runtimeClient, mgh); err != nil {
+				return err
+			}
+			return deleteNamespace(namespace)
 		}, 10*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
-
-		err := runtimeClient.Delete(ctx, &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: namespace,
-			},
-		})
-		Expect(err).To(Succeed())
 	})
 })

--- a/test/integration/operator/controllers/meta_controller_test.go
+++ b/test/integration/operator/controllers/meta_controller_test.go
@@ -57,15 +57,15 @@ var _ = Describe("meta", Ordered, func() {
 			currentMgh := &v1alpha4.MulticlusterGlobalHub{}
 			Expect(runtimeClient.Get(ctx, client.ObjectKeyFromObject(mgh), currentMgh)).To(Succeed())
 			if len(currentMgh.Finalizers) == 0 {
-				return fmt.Errorf("Should add finalizer to mgh, mgh:%v", currentMgh)
+				return fmt.Errorf("Should add finalizer to mgh, mgh: %+v", currentMgh)
 			}
 
 			if currentMgh.Status.Phase != v1alpha4.GlobalHubProgressing {
-				return fmt.Errorf("mgh phase should be progressing, %v", currentMgh)
+				return fmt.Errorf("mgh phase should be progressing, %+v", currentMgh)
 			}
 
 			if meta.IsStatusConditionTrue(currentMgh.GetConditions(), config.CONDITION_TYPE_GLOBALHUB_READY) {
-				return fmt.Errorf("mgh status should not be ready, %v", currentMgh)
+				return fmt.Errorf("mgh status should not be ready, %+v", currentMgh)
 			}
 			return nil
 		}, 10*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())

--- a/test/integration/operator/controllers/meta_controller_test.go
+++ b/test/integration/operator/controllers/meta_controller_test.go
@@ -106,6 +106,6 @@ var _ = Describe("meta", Ordered, func() {
 				return err
 			}
 			return deleteNamespace(namespace)
-		}, 10*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
+		}, 30*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
 	})
 })

--- a/test/integration/operator/controllers/multiclusterhub_test.go
+++ b/test/integration/operator/controllers/multiclusterhub_test.go
@@ -58,6 +58,7 @@ var _ = Describe("MulticlusterhubController", Ordered, func() {
 	AfterAll(func() {
 		// Clean up created resources
 		Expect(runtimeClient.Delete(ctx, mch)).To(Succeed())
+		Expect(runtimeClient.Delete(ctx, mgh)).To(Succeed())
 	})
 
 	It("should set ACMResourceReady to false and requeue", func() {
@@ -78,6 +79,7 @@ var _ = Describe("MulticlusterhubController", Ordered, func() {
 			},
 		}
 		Expect(runtimeClient.Create(ctx, mch)).To(Succeed())
+		time.Sleep(1 * time.Second)
 
 		result, err := controller.Reconcile(ctx, req)
 		utils.PrettyPrint(err)

--- a/test/integration/operator/controllers/multiclusterhub_test.go
+++ b/test/integration/operator/controllers/multiclusterhub_test.go
@@ -1,0 +1,117 @@
+package controllers
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	mchv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/multiclusterhub"
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
+)
+
+// go test ./test/integration/operator/controllers -ginkgo.focus "MulticlusterhubController" -v
+var _ = Describe("MulticlusterhubController", Ordered, func() {
+	var controller *multiclusterhub.MulticlusterhubController
+	var mch *mchv1.MultiClusterHub
+	var namespace string
+	var mgh *v1alpha4.MulticlusterGlobalHub
+	mchName := "test-mch"
+
+	BeforeAll(func() {
+		// Initialize the controller and necessary resources
+		controller = &multiclusterhub.MulticlusterhubController{
+			Manager: runtimeManager, // assuming testManager is set up for testing
+		}
+
+		namespace = fmt.Sprintf("namespace-%s", rand.String(6))
+
+		Expect(runtimeClient.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		})).To(Succeed())
+
+		mgh = &v1alpha4.MulticlusterGlobalHub{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "multiclusterglobalhub",
+				Namespace: namespace,
+			},
+			Spec: v1alpha4.MulticlusterGlobalHubSpec{
+				EnableMetrics: true,
+			},
+		}
+		Expect(runtimeClient.Create(ctx, mgh)).To(Succeed())
+		config.SetMGHNamespacedName(types.NamespacedName{Namespace: mgh.Namespace, Name: mgh.Name})
+	})
+
+	AfterAll(func() {
+		// Clean up created resources
+		Expect(runtimeClient.Delete(ctx, mch)).To(Succeed())
+	})
+
+	It("should set ACMResourceReady to false and requeue", func() {
+		req := reconcile.Request{
+			NamespacedName: client.ObjectKey{
+				Name:      mchName,
+				Namespace: namespace,
+			},
+		}
+
+		mch = &mchv1.MultiClusterHub{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      mchName,
+				Namespace: namespace,
+			},
+			Status: mchv1.MultiClusterHubStatus{
+				Phase: mchv1.HubPending, // Initialize to non-running state
+			},
+		}
+		Expect(runtimeClient.Create(ctx, mch)).To(Succeed())
+
+		result, err := controller.Reconcile(ctx, req)
+		utils.PrettyPrint(err)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result.RequeueAfter).To(BeNumerically("~", 10*time.Second))
+
+		// Check if ACMResourceReady was set to false
+		Expect(config.IsACMResourceReady()).To(BeFalse())
+
+		err = runtimeClient.Get(ctx, client.ObjectKeyFromObject(mgh), mgh)
+		Expect(err).ToNot(HaveOccurred())
+		// utils.PrettyPrint(mgh.Status)
+	})
+
+	It("should set ACMResourceReady to true", func() {
+		req := reconcile.Request{
+			NamespacedName: client.ObjectKey{
+				Name:      mchName,
+				Namespace: namespace,
+			},
+		}
+
+		// Update MCH resource to running phase
+		mch.Status.Phase = mchv1.HubRunning
+		Expect(runtimeClient.Status().Update(ctx, mch)).To(Succeed())
+
+		_, err := controller.Reconcile(ctx, req)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Validate if ACMResourceReady was set to true
+		Expect(config.IsACMResourceReady()).To(BeTrue())
+
+		err = runtimeClient.Get(ctx, client.ObjectKeyFromObject(mgh), mgh)
+		Expect(err).ToNot(HaveOccurred())
+		utils.PrettyPrint(mgh.Status)
+	})
+})

--- a/test/integration/operator/controllers/storage_test.go
+++ b/test/integration/operator/controllers/storage_test.go
@@ -216,14 +216,10 @@ var _ = Describe("storage", Ordered, func() {
 
 		// cleanup
 		Eventually(func() error {
-			return testutils.DeleteMgh(ctx, runtimeClient, mgh)
+			if err := testutils.DeleteMgh(ctx, runtimeClient, mgh); err != nil {
+				return err
+			}
+			return deleteNamespace(namespace)
 		}, 10*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
-
-		err = runtimeClient.Delete(ctx, &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: namespace,
-			},
-		})
-		Expect(err).To(Succeed())
 	})
 })

--- a/test/integration/operator/controllers/storage_test.go
+++ b/test/integration/operator/controllers/storage_test.go
@@ -220,6 +220,6 @@ var _ = Describe("storage", Ordered, func() {
 				return err
 			}
 			return deleteNamespace(namespace)
-		}, 10*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
+		}, 30*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
 	})
 })

--- a/test/integration/operator/controllers/transporter_test.go
+++ b/test/integration/operator/controllers/transporter_test.go
@@ -436,15 +436,11 @@ var _ = Describe("transporter", Ordered, func() {
 
 	AfterAll(func() {
 		Eventually(func() error {
-			return testutils.DeleteMgh(ctx, runtimeClient, mgh)
+			if err := testutils.DeleteMgh(ctx, runtimeClient, mgh); err != nil {
+				return err
+			}
+			return deleteNamespace(namespace)
 		}, 10*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
-
-		err := runtimeClient.Delete(ctx, &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: namespace,
-			},
-		})
-		Expect(err).To(Succeed())
 	})
 })
 

--- a/test/integration/operator/controllers/transporter_test.go
+++ b/test/integration/operator/controllers/transporter_test.go
@@ -440,7 +440,7 @@ var _ = Describe("transporter", Ordered, func() {
 				return err
 			}
 			return deleteNamespace(namespace)
-		}, 10*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
+		}, 30*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
 	})
 })
 

--- a/test/integration/operator/meta_controller_test.go
+++ b/test/integration/operator/meta_controller_test.go
@@ -1,4 +1,4 @@
-package controllers
+package operator
 
 import (
 	"fmt"
@@ -105,7 +105,12 @@ var _ = Describe("meta", Ordered, func() {
 			if err := testutils.DeleteMgh(ctx, runtimeClient, mgh); err != nil {
 				return err
 			}
-			return deleteNamespace(namespace)
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: namespace,
+				},
+			}
+			return runtimeClient.Delete(ctx, ns)
 		}, 30*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
 	})
 })

--- a/test/integration/operator/suite_test.go
+++ b/test/integration/operator/suite_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2022.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operator
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/transporter/protocol"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/test/integration/utils/testpostgres"
+)
+
+var (
+	cfg            *rest.Config
+	runtimeClient  client.Client
+	runtimeManager ctrl.Manager
+	kubeClient     *kubernetes.Clientset
+	testPostgres   *testpostgres.TestPostgres
+	testEnv        *envtest.Environment
+	ctx            context.Context
+	cancel         context.CancelFunc
+	operatorConfig *config.OperatorConfig
+
+	testNamespace = "default"
+)
+
+func TestControllers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Controller Integration Suite")
+}
+
+var _ = BeforeSuite(func() {
+	Expect(os.Setenv("POD_NAMESPACE", testNamespace)).To(Succeed())
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		ControlPlane: envtest.ControlPlane{},
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "..", "operator", "config", "crd", "bases"),
+			filepath.Join("..", "..", "manifest", "crd"),
+		},
+		ErrorIfCRDPathMissing: true,
+	}
+	config.SetKafkaResourceReady(true)
+	config.SetACMResourceReady(true)
+	operatorConfig = &config.OperatorConfig{
+		GlobalResourceEnabled: false,
+	}
+	testEnv.ControlPlane.GetAPIServer().Configure().Set("disable-admission-plugins",
+		"ServiceAccount,MutatingAdmissionWebhook,ValidatingAdmissionWebhook")
+
+	var err error
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	// create test postgres
+	testPostgres, err = testpostgres.NewTestPostgres()
+	Expect(err).NotTo(HaveOccurred())
+
+	// add scheme
+	runtimeScheme := config.GetRuntimeScheme()
+
+	runtimeClient, err = client.New(cfg, client.Options{Scheme: runtimeScheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(runtimeClient).NotTo(BeNil())
+
+	leaseDuration := 137 * time.Second
+	renewDeadline := 126 * time.Second
+	retryPeriod := 16 * time.Second
+	runtimeManager, err = ctrl.NewManager(cfg, ctrl.Options{
+		Metrics: metricsserver.Options{
+			BindAddress: "0", // disable the metrics serving
+		}, Scheme: runtimeScheme,
+		LeaderElection:          true,
+		LeaderElectionNamespace: testNamespace,
+		LeaderElectionID:        "549a8919.open-cluster-management.io",
+		LeaseDuration:           &leaseDuration,
+		RenewDeadline:           &renewDeadline,
+		RetryPeriod:             &retryPeriod,
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	kubeClient, err = kubernetes.NewForConfig(runtimeManager.GetConfig())
+	Expect(err).ToNot(HaveOccurred())
+
+	go func() {
+		defer GinkgoRecover()
+		err = runtimeManager.Start(ctx)
+		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
+	}()
+
+	Expect(runtimeManager.GetCache().WaitForCacheSync(ctx)).To(BeTrue())
+})
+
+var _ = AfterSuite(func() {
+	cancel()
+	Expect(testPostgres.Stop()).To(Succeed())
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	// https://github.com/kubernetes-sigs/controller-runtime/issues/1571
+	// Set 4 with random
+	if err != nil {
+		time.Sleep(4 * time.Second)
+		Expect(testEnv.Stop()).To(Succeed())
+	}
+})
+
+func CreateTestSecretTransport(c client.Client, namespace string) error {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.GHTransportSecretName,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			"bootstrap_server": []byte("localhost:test"),
+			"ca.crt":           []byte("ca.crt"),
+			"client.crt":       []byte("client.crt"),
+			"client.key":       []byte("client.key"),
+		},
+		Type: corev1.SecretTypeOpaque,
+	}
+	err := c.Create(context.Background(), secret)
+	if err != nil {
+		return err
+	}
+	trans := protocol.NewBYOTransporter(ctx, types.NamespacedName{
+		Namespace: namespace,
+		Name:      constants.GHTransportSecretName,
+	}, runtimeClient)
+	config.SetTransporter(trans)
+	conn, err := trans.GetConnCredential("")
+	if err != nil {
+		return err
+	}
+	config.SetTransporterConn(conn)
+	_, _ = trans.EnsureTopic("")
+	return nil
+}

--- a/test/integration/utils/utils.go
+++ b/test/integration/utils/utils.go
@@ -18,6 +18,7 @@ package utils
 
 import (
 	"context"
+	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -49,5 +50,9 @@ func DeleteMgh(ctx context.Context, runtimeClient client.Client, mgh *v1alpha4.M
 		return err
 	}
 
-	return nil
+	if err := runtimeClient.Get(ctx, client.ObjectKeyFromObject(mgh), mgh); errors.IsNotFound(err) {
+		return nil
+	}
+
+	return fmt.Errorf("mgh instance should be deleted: %s/%s", mgh.Namespace, mgh.Name)
 }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

encounter the error like
```bash
2024-11-05T07:07:20.920Z	ERROR	controller/controller.go:316	Reconciler error	{"controller": "transport", "controllerGroup": "operator.open-cluster-management.io", "controllerKind": "MulticlusterGlobalHub", "MulticlusterGlobalHub": {"name":"multicluster-global-hub-transport","namespace":"namespace-7g4m7k"}, "namespace": "namespace-7g4m7k", "name": "multicluster-global-hub-transport", "reconcileID": "2c3cbf7e-93dc-48aa-89b3-39789feb9e49", "error": "controller with name strimzi_controller already exists. Controller names must be unique to avoid multiple controllers reporting to the same metric"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:316
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:263
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:224
```

fixed in commit: https://github.com/stolostron/multicluster-global-hub/pull/1194/commits/9cc0bfaa891155cf292812810488c2735fcc6795
## Related issue(s)

Fixes # https://issues.redhat.com/browse/ACM-15415

## Tests
* [x] Unit/function tests have been added and incorporated into `make unit-tests`.
* [x] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
