### PR TITLE
:sparkles: remove wait login in kafka controller

### DIFF
--- a/operator/pkg/controllers/transporter/protocol/strimzi_kafka_controller.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_kafka_controller.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -86,9 +85,12 @@ func (r *KafkaController) Reconcile(ctx context.Context, request ctrl.Request) (
 	config.SetTransporter(r.trans)
 
 	// update the transport connection
-	conn, err := waitManagerTransportConn(ctx, r.trans, DefaultGlobalHubKafkaUserName)
+	conn, needRequeue, err := getManagerTransportConn(r.trans, DefaultGlobalHubKafkaUserName)
 	if err != nil {
 		return ctrl.Result{}, err
+	}
+	if needRequeue {
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 	config.SetTransporterConn(conn)
 
@@ -133,34 +135,28 @@ func StartKafkaController(ctx context.Context, mgr ctrl.Manager, transporter tra
 	return r, nil
 }
 
-func waitManagerTransportConn(ctx context.Context, trans *strimziTransporter, kafkaUserSecret string) (
-	*transport.KafkaConfig, error,
+func getManagerTransportConn(trans *strimziTransporter, kafkaUserSecret string) (
+	*transport.KafkaConfig, bool, error,
 ) {
 	// set transporter connection
 	var conn *transport.KafkaConfig
 	var err error
-	err = wait.PollUntilContextTimeout(ctx, 2*time.Second, 10*time.Minute, true,
-		func(ctx context.Context) (bool, error) {
-			// boostrapServer, clusterId, clusterCA
-			conn, err = trans.getConnCredentailByCluster()
-			if err != nil {
-				klog.Info("waiting the kafka cluster credential to be ready...", "message", err.Error())
-				return false, err
-			}
-			// topics
-			conn.SpecTopic = config.GetSpecTopic()
-			conn.StatusTopic = config.ManagerStatusTopic()
-			// clientCert and clientCA
-			if err := trans.loadUserCredentail(kafkaUserSecret, conn); err != nil {
-				klog.Info("waiting the kafka user credential to be ready...", "message", err.Error())
-				return false, err
-			}
-			return true, nil
-		})
+
+	// boostrapServer, clusterId, clusterCA
+	conn, err = trans.getConnCredentailByCluster()
 	if err != nil {
-		return nil, err
+		klog.Info("waiting the kafka cluster credential to be ready...", "message", err.Error())
+		return conn, true, err
 	}
-	return conn, nil
+	// topics
+	conn.SpecTopic = config.GetSpecTopic()
+	conn.StatusTopic = config.ManagerStatusTopic()
+	// clientCert and clientCA
+	if err := trans.loadUserCredentail(kafkaUserSecret, conn); err != nil {
+		klog.Info("waiting the kafka user credential to be ready...", "message", err.Error())
+		return conn, true, err
+	}
+	return conn, false, nil
 }
 
 func (r *KafkaController) getKafkaComponentStatus(reconcileErr error, kafkaClusterStatus KafkaStatus,


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
We should not have any wait logic in reconciler. so remove the kafakconnection wait login
## Related issue(s)
https://issues.redhat.com/browse/ACM-15413
Fixes #

## Tests
* [x] Unit/function tests have been added and incorporated into `make unit-tests`.
* [x] Integration tests have been added and incorporated into `make integration-test`.
* [x] E2E tests have been added and incorporated into `make e2e-test-all`.
* [x] List other manual tests you have done.
