### PR TITLE
:bug: Adjust the order

### DIFF
--- a/operator/pkg/controllers/crd/crd_controller.go
+++ b/operator/pkg/controllers/crd/crd_controller.go
@@ -75,16 +75,6 @@ type CrdController struct {
 }
 
 func (r *CrdController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	// Check if mgh exist or deleting
-	mgh, err := config.GetMulticlusterGlobalHub(ctx, r.GetClient())
-	if err != nil || mgh == nil {
-		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
-	}
-	if mgh.DeletionTimestamp != nil {
-		klog.V(2).Info("mgh instance is deleting")
-		return ctrl.Result{}, nil
-	}
-
 	// set resource as ready
 	r.resources[req.Name] = true
 
@@ -99,6 +89,16 @@ func (r *CrdController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			return ctrl.Result{}, err
 		}
 	} else {
+		return ctrl.Result{}, nil
+	}
+
+	// Check if mgh exist or deleting
+	mgh, err := config.GetMulticlusterGlobalHub(ctx, r.GetClient())
+	if err != nil || mgh == nil {
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	}
+	if mgh.DeletionTimestamp != nil {
+		klog.V(2).Info("mgh instance is deleting")
 		return ctrl.Result{}, nil
 	}
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

The case only occurs when the mgh CR is deleting and the global hub operator is restarted in the same time. so the SetKafkaResourceReady is not called.

## Related issue(s)

Fixes # https://issues.redhat.com/browse/ACM-15011

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
