### PR TITLE
:bug: Delete all kafkausers and kafkatopics in global hub namespace

### DIFF
--- a/operator/pkg/controllers/hubofhubs/prune/prune_reconciler.go
+++ b/operator/pkg/controllers/hubofhubs/prune/prune_reconciler.go
@@ -464,7 +464,7 @@ func (r *PruneReconciler) pruneManagedHubs(ctx context.Context) error {
 func (r *PruneReconciler) pruneStrimziResources(ctx context.Context) (bool, error) {
 	klog.Infof("Remove strimzi resources")
 	listOpts := []client.ListOption{
-		client.HasLabels{constants.GlobalHubOwnerLabelKey},
+		client.InNamespace(utils.GetDefaultNamespace()),
 	}
 	kafkaUserList := &kafkav1beta2.KafkaUserList{}
 	klog.Infof("Delete kafkaUsers")


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Delete all kafkausers and kafkatopics in the global hub namespace instead of just managed by global hub. that is because we do not provide support for other purpose.

## Related issue(s)

Fixes #
https://issues.redhat.com/browse/ACM-15062
## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [x] List other manual tests you have done
- verified in the upgrade environment
