### PR TITLE
:bug: The Kafka cluster enabled the KRaft should not validate the zookeeper 

### DIFF
--- a/operator/pkg/controllers/transporter/protocol/manifests/global-hub-kafka.yaml
+++ b/operator/pkg/controllers/transporter/protocol/manifests/global-hub-kafka.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: {{.Namespace}}
 spec:
   kafka:
-    version: 3.7.0
+    version: 3.7.1 # https://github.com/strimzi/strimzi-kafka-operator/blob/release-0.42.x/examples/kafka/kraft/kafka-with-dual-role-nodes.yaml
     metadataVersion: 3.7-IV4
     listeners:
       - name: plain

--- a/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
@@ -54,15 +54,16 @@ const (
 	DefaultCatalogSourceName = "redhat-operators"
 
 	// subscription - community
-	CommunityChannel           = "strimzi-0.41.x"
+	// The KRaft Compatibility: https://github.com/orgs/strimzi/discussions/10836
+	CommunityChannel           = "strimzi-0.42.x"
 	CommunityPackageName       = "strimzi-kafka-operator"
 	CommunityCatalogSourceName = "community-operators"
 )
 
 var (
+	DefaultAMQKafkaVersion         = "3.7.0"
 	KafkaStorageIdentifier   int32 = 0
 	KafkaStorageDeleteClaim        = false
-	KafkaVersion                   = "3.7.0"
 	DefaultPartition         int32 = 1
 	DefaultPartitionReplicas int32 = 3
 	// kafka metrics constants
@@ -758,7 +759,7 @@ func (k *strimziTransporter) newKafkaCluster(mgh *operatorv1alpha4.MulticlusterG
 						kafkaSpecKafkaStorageVolumesElem,
 					},
 				},
-				Version: &KafkaVersion,
+				Version: &DefaultAMQKafkaVersion,
 			},
 			Zookeeper: kafkav1beta2.KafkaSpecZookeeper{
 				Replicas:  3,


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

The Kafka cluster enabled the KRaft should not validate the zookeeper. Reference: https://github.com/orgs/strimzi/discussions/10836

## Related issue(s)

Fixes #

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
