### PR TITLE
:sparkles: Migration enhancement

### DIFF
--- a/agent/pkg/spec/dispatcher.go
+++ b/agent/pkg/spec/dispatcher.go
@@ -89,13 +89,14 @@ func (d *genericDispatcher) dispatch(ctx context.Context) {
 					"syncer", syncer, "event", evt)
 				continue
 			}
-			retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+			if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 				if err := syncer.Sync(ctx, evt.Data()); err != nil {
-					d.log.Errorw("sync failed", "type", evt.Type(), "error", err)
 					return err
 				}
 				return nil
-			})
+			}); err != nil {
+				d.log.Errorw("sync failed", "type", evt.Type(), "error", err)
+			}
 		}
 	}
 }

--- a/agent/pkg/spec/syncers/migration_from_syncer.go
+++ b/agent/pkg/spec/syncers/migration_from_syncer.go
@@ -133,6 +133,7 @@ func (s *managedClusterMigrationFromSyncer) Sync(ctx context.Context, payload []
 	// check managed cluster available unknown status and detach the managed cluster in new go routine
 	if err := s.detachManagedClusters(ctx, managedClusters); err != nil {
 		s.log.Error(err, "failed to detach managed clusters")
+		return err
 	}
 
 	return nil

--- a/agent/pkg/spec/syncers/migration_from_syncer.go
+++ b/agent/pkg/spec/syncers/migration_from_syncer.go
@@ -19,6 +19,9 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 )
 
+// This is a temporary solution to wait for applying the klusterletconfig
+var sleepForApplying = 10 * time.Second
+
 type managedClusterMigrationFromSyncer struct {
 	log    *zap.SugaredLogger
 	client client.Client
@@ -114,7 +117,7 @@ func (s *managedClusterMigrationFromSyncer) Sync(ctx context.Context, payload []
 
 	// wait for 10 seconds to ensure the klusterletconfig is applied and then trigger the migration
 	// right now, no condition indicates the klusterletconfig is applied
-	time.Sleep(10 * time.Second)
+	time.Sleep(sleepForApplying)
 	for _, managedCluster := range managedClusters {
 		mc := &clusterv1.ManagedCluster{}
 		if err := s.client.Get(ctx, types.NamespacedName{
@@ -129,8 +132,7 @@ func (s *managedClusterMigrationFromSyncer) Sync(ctx context.Context, payload []
 		}
 	}
 
-	time.Sleep(10 * time.Second)
-	// check managed cluster available unknown status and detach the managed cluster in new go routine
+	time.Sleep(sleepForApplying)
 	if err := s.detachManagedClusters(ctx, managedClusters); err != nil {
 		s.log.Error(err, "failed to detach managed clusters")
 		return err

--- a/agent/pkg/spec/syncers/migration_from_syncer.go
+++ b/agent/pkg/spec/syncers/migration_from_syncer.go
@@ -51,7 +51,6 @@ func (s *managedClusterMigrationFromSyncer) Sync(ctx context.Context, payload []
 		}, foundBootstrapSecret); err != nil {
 		if apierrors.IsNotFound(err) {
 			s.log.Infof("creating bootstrap secret %s", bootstrapSecret.GetName())
-			s.log.Debugf("creating bootstrap secret %v", bootstrapSecret)
 			if err := s.client.Create(ctx, bootstrapSecret); err != nil {
 				return err
 			}
@@ -61,7 +60,6 @@ func (s *managedClusterMigrationFromSyncer) Sync(ctx context.Context, payload []
 	} else {
 		// update the bootstrap secret if it already exists
 		s.log.Infof("updating bootstrap secret %s", bootstrapSecret.GetName())
-		s.log.Debugf("updating bootstrap secret %v", bootstrapSecret)
 		if err := s.client.Update(ctx, bootstrapSecret); err != nil {
 			return err
 		}
@@ -118,6 +116,7 @@ func (s *managedClusterMigrationFromSyncer) Sync(ctx context.Context, payload []
 	}
 
 	// wait for 10 seconds to ensure the klusterletconfig is applied and then trigger the migration
+	// TODO: right now, no condition indicates the klusterletconfig is applied
 	time.Sleep(10 * time.Second)
 	for _, managedCluster := range managedClusters {
 		mcl := &clusterv1.ManagedCluster{}
@@ -127,7 +126,7 @@ func (s *managedClusterMigrationFromSyncer) Sync(ctx context.Context, payload []
 			return err
 		}
 		mcl.Spec.HubAcceptsClient = false
-		s.log.Info("updating managedcluster to set HubAcceptsClient as false", "managedcluster", mcl.Name)
+		s.log.Infof("updating managedcluster %s to set HubAcceptsClient as false", mcl.Name)
 		if err := s.client.Update(ctx, mcl); err != nil {
 			return err
 		}

--- a/agent/pkg/spec/syncers/migration_from_syncer.go
+++ b/agent/pkg/spec/syncers/migration_from_syncer.go
@@ -50,7 +50,7 @@ func (s *managedClusterMigrationFromSyncer) Sync(ctx context.Context, payload []
 			Namespace: bootstrapSecret.Namespace,
 		}, foundBootstrapSecret); err != nil {
 		if apierrors.IsNotFound(err) {
-			s.log.Info("creating bootstrap secret", "bootstrap secret", bootstrapSecret)
+			s.log.Debugf("creating bootstrap secret %v", bootstrapSecret)
 			if err := s.client.Create(ctx, bootstrapSecret); err != nil {
 				return err
 			}
@@ -59,7 +59,7 @@ func (s *managedClusterMigrationFromSyncer) Sync(ctx context.Context, payload []
 		}
 	} else {
 		// update the bootstrap secret if it already exists
-		s.log.Info("updating bootstrap secret", "bootstrap secret", bootstrapSecret)
+		s.log.Debugf("updating bootstrap secret %v", bootstrapSecret)
 		if err := s.client.Update(ctx, bootstrapSecret); err != nil {
 			return err
 		}
@@ -79,7 +79,7 @@ func (s *managedClusterMigrationFromSyncer) Sync(ctx context.Context, payload []
 			Name: klusterletConfig.Name,
 		}, foundKlusterletConfig); err != nil {
 		if apierrors.IsNotFound(err) {
-			s.log.Info("creating klusterlet config", "klusterlet config", klusterletConfig)
+			s.log.Debugf("creating klusterlet config %v", klusterletConfig)
 			if err := s.client.Create(ctx, klusterletConfig); err != nil {
 				return err
 			}

--- a/agent/pkg/spec/syncers/migration_from_syncer.go
+++ b/agent/pkg/spec/syncers/migration_from_syncer.go
@@ -113,7 +113,7 @@ func (s *managedClusterMigrationFromSyncer) Sync(ctx context.Context, payload []
 	}
 
 	// wait for 10 seconds to ensure the klusterletconfig is applied and then trigger the migration
-	// TODO: right now, no condition indicates the klusterletconfig is applied
+	// right now, no condition indicates the klusterletconfig is applied
 	time.Sleep(10 * time.Second)
 	for _, managedCluster := range managedClusters {
 		mc := &clusterv1.ManagedCluster{}

--- a/agent/pkg/spec/syncers/migration_to_syncer.go
+++ b/agent/pkg/spec/syncers/migration_to_syncer.go
@@ -157,7 +157,7 @@ func (s *managedClusterMigrationToSyncer) ensureMigrationClusterRole(ctx context
 			Name: migrationClusterRoleName,
 		}, foundMigrationClusterRole); err != nil {
 		if apierrors.IsNotFound(err) {
-			s.log.Info("creating migration clusterrole", "clusterrole", migrationClusterRoleName)
+			s.log.Debugf("creating migration clusterrole %v", foundMigrationClusterRole)
 			if err := s.client.Create(ctx, migrationClusterRole); err != nil {
 				return err
 			}
@@ -166,7 +166,7 @@ func (s *managedClusterMigrationToSyncer) ensureMigrationClusterRole(ctx context
 		}
 	} else {
 		if !apiequality.Semantic.DeepDerivative(migrationClusterRole, foundMigrationClusterRole) {
-			s.log.Info("updating migration clusterrole", "clusterrole", migrationClusterRoleName)
+			s.log.Debugf("updating migration clusterrole %v", migrationClusterRole)
 			if err := s.client.Update(ctx, migrationClusterRole); err != nil {
 				return err
 			}
@@ -255,8 +255,8 @@ func (s *managedClusterMigrationToSyncer) ensureSARClusterRoleBinding(ctx contex
 			Name: sarMigrationClusterRoleBindingName,
 		}, foundSAMigrationClusterRoleBinding); err != nil {
 		if apierrors.IsNotFound(err) {
-			s.log.Info("creating subjectaccessreviews clusterrolebinding",
-				"clusterrolebinding", sarMigrationClusterRoleBindingName)
+			s.log.Debugf("creating subjectaccessreviews clusterrolebinding %v",
+				foundSAMigrationClusterRoleBinding)
 			if err := s.client.Create(ctx, sarMigrationClusterRoleBinding); err != nil {
 				return err
 			}
@@ -265,8 +265,8 @@ func (s *managedClusterMigrationToSyncer) ensureSARClusterRoleBinding(ctx contex
 		}
 	} else {
 		if !apiequality.Semantic.DeepDerivative(sarMigrationClusterRoleBinding, foundSAMigrationClusterRoleBinding) {
-			s.log.Info("updating subjectaccessreviews clusterrolebinding",
-				"clusterrolebinding", sarMigrationClusterRoleBindingName)
+			s.log.Debugf("updating subjectaccessreviews clusterrolebinding %v",
+				sarMigrationClusterRoleBinding)
 			if err := s.client.Update(ctx, sarMigrationClusterRoleBinding); err != nil {
 				return err
 			}

--- a/agent/pkg/spec/syncers/migration_to_syncer.go
+++ b/agent/pkg/spec/syncers/migration_to_syncer.go
@@ -157,6 +157,7 @@ func (s *managedClusterMigrationToSyncer) ensureMigrationClusterRole(ctx context
 			Name: migrationClusterRoleName,
 		}, foundMigrationClusterRole); err != nil {
 		if apierrors.IsNotFound(err) {
+			s.log.Infof("creating migration clusterrole %s", foundMigrationClusterRole.GetName())
 			s.log.Debugf("creating migration clusterrole %v", foundMigrationClusterRole)
 			if err := s.client.Create(ctx, migrationClusterRole); err != nil {
 				return err
@@ -166,6 +167,7 @@ func (s *managedClusterMigrationToSyncer) ensureMigrationClusterRole(ctx context
 		}
 	} else {
 		if !apiequality.Semantic.DeepDerivative(migrationClusterRole, foundMigrationClusterRole) {
+			s.log.Infof("updating migration clusterrole %s", migrationClusterRole.GetName())
 			s.log.Debugf("updating migration clusterrole %v", migrationClusterRole)
 			if err := s.client.Update(ctx, migrationClusterRole); err != nil {
 				return err
@@ -255,6 +257,8 @@ func (s *managedClusterMigrationToSyncer) ensureSARClusterRoleBinding(ctx contex
 			Name: sarMigrationClusterRoleBindingName,
 		}, foundSAMigrationClusterRoleBinding); err != nil {
 		if apierrors.IsNotFound(err) {
+			s.log.Infof("creating subjectaccessreviews clusterrolebinding %s",
+				foundSAMigrationClusterRoleBinding.GetName())
 			s.log.Debugf("creating subjectaccessreviews clusterrolebinding %v",
 				foundSAMigrationClusterRoleBinding)
 			if err := s.client.Create(ctx, sarMigrationClusterRoleBinding); err != nil {
@@ -265,6 +269,8 @@ func (s *managedClusterMigrationToSyncer) ensureSARClusterRoleBinding(ctx contex
 		}
 	} else {
 		if !apiequality.Semantic.DeepDerivative(sarMigrationClusterRoleBinding, foundSAMigrationClusterRoleBinding) {
+			s.log.Infof("updating subjectaccessreviews clusterrolebinding %v",
+				sarMigrationClusterRoleBinding.GetName())
 			s.log.Debugf("updating subjectaccessreviews clusterrolebinding %v",
 				sarMigrationClusterRoleBinding)
 			if err := s.client.Update(ctx, sarMigrationClusterRoleBinding); err != nil {

--- a/pkg/transport/controller/controller_test.go
+++ b/pkg/transport/controller/controller_test.go
@@ -156,7 +156,6 @@ func TestInventorySecretCtrlReconcile(t *testing.T) {
 	result, err = secretController.Reconcile(ctx, req)
 	assert.NoError(t, err)
 	assert.False(t, result.Requeue)
-	utils.PrettyPrint(secretController.transportConfig.RestfulCredential)
 }
 
 var rootPEM = []byte(`


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

1. remove the backup secret since the `-current-hub` bookstrap secret can be added by default
2. retry for conflict error
3. wait for 10 seconds to ensure klusterletconfig is applied and then update `hubAcceptClient` to false to trigger the migration (TODO: there is condition indicates the klusterletconfig is applied)
4. remove the managed cluster when the cluster hubAcceptClient is false

## Related issue(s)

Fixes # https://issues.redhat.com/browse/ACM-15220

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [x] List other manual tests you have done.
- verified in local environment