### PR TITLE
:sparkles:  Switch zap log for global hub operator

### DIFF
--- a/operator/pkg/config/multiclusterglobalhub_config.go
+++ b/operator/pkg/config/multiclusterglobalhub_config.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog/v2"
 	"open-cluster-management.io/addon-framework/pkg/addonmanager"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -39,6 +38,7 @@ import (
 
 	"github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
 	operatorconstants "github.com/stolostron/multicluster-global-hub/operator/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 )
 
 // ManifestImage contains details for a specific image version
@@ -88,6 +88,7 @@ var (
 	addonMgr              addonmanager.AddonManager
 	importClusterInHosted = false
 	mu                    sync.Mutex
+	log                   = logger.DefaultZapLogger()
 )
 
 func SetAddonManager(addonManager addonmanager.AddonManager) {
@@ -172,7 +173,7 @@ func GetStackroxPollInterval(mgh *v1alpha4.MulticlusterGlobalHub) time.Duration 
 	}
 	value, err := time.ParseDuration(text)
 	if err != nil {
-		klog.Errorf(
+		log.Errorf(
 			"Failed to parse value '%s' of annotation '%s', will ignore it: %v",
 			text, operatorconstants.AnnotationMGHWithStackroxPollInterval, err,
 		)
@@ -371,7 +372,7 @@ func GetMulticlusterGlobalHub(ctx context.Context, c client.Client) (*v1alpha4.M
 		return nil, err
 	}
 	if len(mghList.Items) != 1 {
-		klog.Errorf("mgh should have 1 instance, but got %v", len(mghList.Items))
+		log.Errorf("mgh should have 1 instance, but got %v", len(mghList.Items))
 		return nil, nil
 	}
 	return &mghList.Items[0], nil

--- a/operator/pkg/config/status.go
+++ b/operator/pkg/config/status.go
@@ -27,7 +27,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
-	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
@@ -188,7 +187,7 @@ func UpdateConditionWithErr(ctx context.Context, c client.Client, err error,
 			Message: err.Error(),
 		}, globalhubv1alpha4.GlobalHubError)
 		if err != nil {
-			klog.Errorf("failed to update mgh condition:%v", err)
+			log.Errorf("failed to update mgh condition:%v", err)
 		}
 		return
 	}
@@ -202,7 +201,7 @@ func UpdateConditionWithErr(ctx context.Context, c client.Client, err error,
 		Message: conditionMessage,
 	}, "")
 	if err != nil {
-		klog.Errorf("failed to update mgh condition:%v", err)
+		log.Errorf("failed to update mgh condition:%v", err)
 	}
 }
 
@@ -280,7 +279,7 @@ func GetStatefulSetComponentStatus(ctx context.Context, c client.Client,
 				Message: fmt.Sprintf("waiting statefulset %s created", name),
 			}
 		}
-		klog.Errorf("failed to get statefulset, err: %v", err)
+		log.Errorf("failed to get statefulset, err: %v", err)
 		return v1alpha4.StatusCondition{
 			Kind:    "StatefulSet",
 			Name:    name,
@@ -329,7 +328,7 @@ func GetDeploymentComponentStatus(ctx context.Context, c client.Client,
 				Message: fmt.Sprintf("waiting deployment %s created", name),
 			}
 		}
-		klog.Errorf("failed to get deployment, err: %v", err)
+		log.Errorf("failed to get deployment, err: %v", err)
 		return v1alpha4.StatusCondition{
 			Kind:    "Deployment",
 			Name:    name,

--- a/operator/pkg/config/transport_config.go
+++ b/operator/pkg/config/transport_config.go
@@ -11,7 +11,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
@@ -219,11 +218,11 @@ func SetInventoryClientCA(ctx context.Context, namespace, name string, c client.
 	}
 
 	if inventoryClientCAKey == nil || !bytes.Equal(clientCASecret.Data["tls.key"], inventoryClientCAKey) {
-		klog.Infof("set the inventory clientCA - key: %s", clientCASecret.Name)
+		log.Infof("set the inventory clientCA - key: %s", clientCASecret.Name)
 		inventoryClientCAKey = clientCASecret.Data["tls.key"]
 	}
 	if inventoryClientCACert == nil || !bytes.Equal(clientCASecret.Data["tls.crt"], inventoryClientCACert) {
-		klog.Infof("set the inventory clientCA - cert: %s", clientCASecret.Name)
+		log.Infof("set the inventory clientCA - cert: %s", clientCASecret.Name)
 		inventoryClientCACert = clientCASecret.Data["tls.crt"]
 	}
 	return nil
@@ -241,7 +240,7 @@ func SetKafkaClientCA(ctx context.Context, namespace, name string, c client.Clie
 		return err
 	}
 	if kafkaClientCAKey == nil || !bytes.Equal(clientCAKeySecret.Data["ca.key"], kafkaClientCAKey) {
-		klog.Infof("set the ca - client key: %s", clientCAKeySecret.Name)
+		log.Infof("set the ca - client key: %s", clientCAKeySecret.Name)
 		kafkaClientCAKey = clientCAKeySecret.Data["ca.key"]
 	}
 
@@ -257,7 +256,7 @@ func SetKafkaClientCA(ctx context.Context, namespace, name string, c client.Clie
 	}
 
 	if kafkaClientCACert == nil || !bytes.Equal(clientCACertSecret.Data["ca.crt"], kafkaClientCACert) {
-		klog.Infof("set the ca - client cert: %s", clientCACertSecret.Name)
+		log.Infof("set the ca - client cert: %s", clientCACertSecret.Name)
 		kafkaClientCACert = clientCACertSecret.Data["ca.crt"]
 	}
 	return nil

--- a/operator/pkg/controllers/agent/addon_agent_manifest_acm.go
+++ b/operator/pkg/controllers/agent/addon_agent_manifest_acm.go
@@ -9,7 +9,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/klog"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
@@ -101,7 +100,7 @@ func GetPackageManifestConfig(ctx context.Context, dynClient dynamic.Interface) 
 
 	for _, pm := range packageManifestList.Items {
 		if pm.GetName() == operatorconstants.ACMPackageManifestName {
-			klog.V(2).Info("found ACM PackageManifest")
+			log.Debug("found ACM PackageManifest")
 			acmDefaultChannel, acmCurrentCSV, ACMImages, err := getSinglePackageManifestConfig(pm)
 			if err != nil {
 				return nil, err
@@ -112,7 +111,7 @@ func GetPackageManifestConfig(ctx context.Context, dynClient dynamic.Interface) 
 			packageManifestConfigInstance.ACMImages = ACMImages
 		}
 		if pm.GetName() == operatorconstants.MCEPackageManifestName {
-			klog.V(2).Info("found MCE PackageManifest")
+			log.Debug("found MCE PackageManifest")
 			mceDefaultChannel, mceCurrentCSV, MCEImages, err := getSinglePackageManifestConfig(pm)
 			if err != nil {
 				return nil, err

--- a/operator/pkg/controllers/agent/addon_manager.go
+++ b/operator/pkg/controllers/agent/addon_manager.go
@@ -7,7 +7,6 @@ import (
 	certificatesv1 "k8s.io/api/certificates/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/rest"
-	"k8s.io/klog"
 	"open-cluster-management.io/addon-framework/pkg/addonfactory"
 	"open-cluster-management.io/addon-framework/pkg/addonmanager"
 	addonframeworkagent "open-cluster-management.io/addon-framework/pkg/agent"
@@ -69,7 +68,7 @@ func StartAddonManagerController(initOption config.ControllerOption) error {
 		return err
 	}
 
-	klog.Infof("inited GlobalHubAddonManager controller")
+	log.Infof("inited GlobalHubAddonManager controller")
 	started = true
 	return nil
 }

--- a/operator/pkg/controllers/agent/certificates/csr.go
+++ b/operator/pkg/controllers/agent/certificates/csr.go
@@ -5,7 +5,6 @@
 package certificates
 
 import (
-	"k8s.io/klog/v2"
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 
@@ -15,7 +14,7 @@ import (
 // default: https://github.com/open-cluster-management-io/addon-framework/blob/main/pkg/agent/inteface.go#L213
 func SignerAndCsrConfigurations(cluster *clusterv1.ManagedCluster) []addonapiv1alpha1.RegistrationConfig {
 	userName := config.GetTransportConfigClientName(cluster.Name)
-	klog.Infof("specify the clientName(CN: %s) for managed hub cluster(%s)", userName, cluster.Name)
+	log.Infof("specify the clientName(CN: %s) for managed hub cluster(%s)", userName, cluster.Name)
 	globalHubRegistrationConfig := addonapiv1alpha1.RegistrationConfig{
 		SignerName: config.SignerName,
 		Subject: addonapiv1alpha1.Subject{

--- a/operator/pkg/controllers/agent/certificates/signer.go
+++ b/operator/pkg/controllers/agent/certificates/signer.go
@@ -15,14 +15,13 @@ import (
 	"github.com/cloudflare/cfssl/signer"
 	"github.com/cloudflare/cfssl/signer/local"
 	certificatesv1 "k8s.io/api/certificates/v1"
-	"k8s.io/klog/v2"
 )
 
 // default: https://github.com/open-cluster-management-io/addon-framework/blob/main/pkg/utils/csr_helpers.go#L65
 func Sign(csr *certificatesv1.CertificateSigningRequest, clientCaKey, clientCaCert []byte) []byte {
 	caKey, caCert, err := parseClientCA(clientCaKey, clientCaCert)
 	if err != nil {
-		klog.Infof("The singer checks CSR(%s), not get client CA: %v", csr.Name, err)
+		log.Infof("The singer checks CSR(%s), not get client CA: %v", csr.Name, err)
 		return nil
 	}
 
@@ -34,7 +33,7 @@ func Sign(csr *certificatesv1.CertificateSigningRequest, clientCaKey, clientCaCe
 	certExpiryDuration := 365 * 24 * time.Hour
 	durationUntilExpiry := time.Until(caCert.NotAfter)
 	if durationUntilExpiry <= 0 {
-		klog.Infof("The signer has expired, expired time: %v", caCert.NotAfter)
+		log.Infof("The signer has expired, expired time: %v", caCert.NotAfter)
 		return nil
 	}
 	if durationUntilExpiry < certExpiryDuration {
@@ -50,7 +49,7 @@ func Sign(csr *certificatesv1.CertificateSigningRequest, clientCaKey, clientCaCe
 	}
 	singer, err := local.NewSigner(caKey, caCert, signer.DefaultSigAlgo(caKey), policy)
 	if err != nil {
-		klog.Infof("failed to create new local signer: %v", err)
+		log.Infof("failed to create new local signer: %v", err)
 		return nil
 	}
 
@@ -58,7 +57,7 @@ func Sign(csr *certificatesv1.CertificateSigningRequest, clientCaKey, clientCaCe
 		Request: string(csr.Spec.Request),
 	})
 	if err != nil {
-		klog.Infof("failed to sign the CSR(%s): %v", csr.Name, err)
+		log.Infof("failed to sign the CSR(%s): %v", csr.Name, err)
 		return nil
 	}
 	return signedCert
@@ -74,13 +73,13 @@ func parseClientCA(caKey, caCert []byte) (crypto.Signer, *x509.Certificate, erro
 	}
 	caCerts, err := x509.ParseCertificates(block1.Bytes)
 	if err != nil {
-		klog.Errorf("failed to parse the cert: %v", err)
+		log.Errorf("failed to parse the cert: %v", err)
 		return nil, nil, err
 	}
 
 	signer, err := DecodePrivateKeyBytes(caKey)
 	if err != nil {
-		klog.Errorf("failed to decode private key: %v", err)
+		log.Errorf("failed to decode private key: %v", err)
 		return nil, nil, err
 	}
 	return signer, caCerts[0], nil

--- a/operator/pkg/controllers/agent/hosted_agent_controller.go
+++ b/operator/pkg/controllers/agent/hosted_agent_controller.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog"
 	"open-cluster-management.io/api/addon/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -122,13 +121,13 @@ var mghPred = predicate.Funcs{
 }
 
 func (r *HostedAgentController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	klog.V(2).Infof("Reconcile ClusterManagementAddOn: %v", req.NamespacedName)
+	log.Debug("Reconcile ClusterManagementAddOn: %v", req.NamespacedName)
 	if !config.GetImportClusterInHosted() {
 		return ctrl.Result{}, nil
 	}
 	mgh, err := config.GetMulticlusterGlobalHub(ctx, r.Manager.GetClient())
 	if err != nil {
-		klog.Error("error ", err)
+		log.Error(err)
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 	if mgh == nil || config.IsPaused(mgh) || mgh.DeletionTimestamp != nil {
@@ -147,7 +146,7 @@ func (r *HostedAgentController) Reconcile(ctx context.Context, req ctrl.Request)
 
 	err = r.Manager.GetClient().Update(ctx, cma)
 	if err != nil {
-		klog.Errorf("Failed to update cma, err:%v", err)
+		log.Errorf("Failed to update cma, err:%v", err)
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{}, nil

--- a/operator/pkg/controllers/backup/backup_reconcile.go
+++ b/operator/pkg/controllers/backup/backup_reconcile.go
@@ -24,12 +24,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/klog"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	globalhubv1alpha4 "github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
@@ -47,6 +47,8 @@ var allResourcesBackup = map[string]Backup{
 	pvcType:       NewPvcBackup(),
 }
 
+var log = logger.DefaultZapLogger()
+
 // As we need to watch mgh, secret, configmap. they should be in the same namespace.
 // So for request.Namespace, we set it as request type, like "Secret","Configmap","MulticlusterGlobalHub" and so on.
 // In the reconcile, we identy the request kind and get it by request.Name.
@@ -55,7 +57,7 @@ func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	mghList := &globalhubv1alpha4.MulticlusterGlobalHubList{}
 	err := r.Client.List(ctx, mghList)
 	if err != nil {
-		klog.Error(err, "Failed to list MulticlusterGlobalHub")
+		log.Error(err)
 		return ctrl.Result{}, err
 	}
 	if len(mghList.Items) == 0 {

--- a/operator/pkg/controllers/inventory/inventory_reconciler.go
+++ b/operator/pkg/controllers/inventory/inventory_reconciler.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/restmapper"
-	"k8s.io/klog"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -40,11 +39,14 @@ import (
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/renderer"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/utils"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 	commonutils "github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
 //go:embed manifests
 var fs embed.FS
+
+var log = logger.DefaultZapLogger()
 
 type InventoryReconciler struct {
 	kubeClient kubernetes.Interface
@@ -74,7 +76,7 @@ func StartController(initOption config.ControllerOption) error {
 		return err
 	}
 	started = true
-	klog.Infof("inited inventory controller")
+	log.Infof("inited inventory controller")
 	return nil
 }
 
@@ -130,7 +132,7 @@ func (r *InventoryReconciler) Reconcile(ctx context.Context,
 				mgh.Namespace, config.COMPONENTS_INVENTORY_API_NAME, reconcileErr),
 		)
 		if err != nil {
-			klog.Errorf("failed to update mgh status, err:%v", err)
+			log.Errorf("failed to update mgh status, err:%v", err)
 		}
 	}()
 	// start certificate controller

--- a/operator/pkg/controllers/managedhub/managedhub_controller.go
+++ b/operator/pkg/controllers/managedhub/managedhub_controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"time"
 
-	"k8s.io/klog"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -31,6 +30,7 @@ import (
 
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/utils"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 )
 
 // +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;update;create;delete
@@ -40,6 +40,8 @@ type ManagedHubController struct {
 }
 
 var started bool
+
+var log = logger.DefaultZapLogger()
 
 func StartController(initOption config.ControllerOption) error {
 	if started {
@@ -52,7 +54,7 @@ func StartController(initOption config.ControllerOption) error {
 	if err != nil {
 		return err
 	}
-	klog.Infof("inited managedhub controller")
+	log.Infof("inited managedhub controller")
 	started = true
 	return nil
 }

--- a/operator/pkg/controllers/manager/manager_reconciler.go
+++ b/operator/pkg/controllers/manager/manager_reconciler.go
@@ -19,7 +19,6 @@ import (
 	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/restmapper"
-	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,12 +33,15 @@ import (
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/renderer"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/utils"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 	commonutils "github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
 //go:embed manifests
 var fs embed.FS
+
+var log = logger.DefaultZapLogger()
 
 var (
 	storageConnectionCache   *config.PostgresConnection
@@ -70,7 +72,7 @@ func StartController(initOption config.ControllerOption) error {
 		return err
 	}
 	started = true
-	klog.Infof("inited manager controller")
+	log.Infof("inited manager controller")
 	return nil
 }
 
@@ -130,7 +132,7 @@ func (r *ManagerReconciler) Reconcile(ctx context.Context,
 				mgh.Namespace, config.COMPONENTS_MANAGER_NAME, reconcileErr),
 		)
 		if err != nil {
-			klog.Errorf("failed to update mgh status, err:%v", err)
+			log.Errorf("failed to update mgh status, err:%v", err)
 		}
 	}()
 
@@ -176,7 +178,7 @@ func (r *ManagerReconciler) Reconcile(ctx context.Context,
 
 	transportConn := config.GetTransporterConn()
 	if transportConn == nil || transportConn.BootstrapServer == "" {
-		klog.V(2).Infof("Wait kafka connection created")
+		log.Debug("Wait kafka connection created")
 
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}

--- a/operator/pkg/controllers/storage/postgres_crunchy.go
+++ b/operator/pkg/controllers/storage/postgres_crunchy.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	postgresv1beta1 "github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
-	"github.com/go-logr/logr"
 	subv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -77,7 +76,7 @@ func EnsureCrunchyPostgresSub(ctx context.Context, c client.Client, mgh *v1alpha
 }
 
 // EnsureCrunchyPostgres verifies PostgresCluster operand is created
-func EnsureCrunchyPostgres(ctx context.Context, c client.Client, log logr.Logger) (*config.PostgresConnection, error) {
+func EnsureCrunchyPostgres(ctx context.Context, c client.Client) (*config.PostgresConnection, error) {
 	// store crunchy postgres connection
 	var pgConnection *config.PostgresConnection
 	err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 10*time.Minute, true,

--- a/operator/pkg/controllers/storage/postgres_statefulset.go
+++ b/operator/pkg/controllers/storage/postgres_statefulset.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -35,7 +34,7 @@ type postgresCredential struct {
 }
 
 func InitPostgresByStatefulset(ctx context.Context, mgh *globalhubv1alpha4.MulticlusterGlobalHub,
-	mgr ctrl.Manager, log logr.Logger,
+	mgr ctrl.Manager,
 ) (*config.PostgresConnection, error) {
 	// install the postgres statefulset only
 	credential, err := getPostgresCredential(ctx, mgh, mgr.GetClient())

--- a/operator/pkg/controllers/transporter/protocol/byo_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/byo_transporter.go
@@ -8,10 +8,10 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 )
 
@@ -33,7 +33,7 @@ func NewBYOTransporter(ctx context.Context, namespacedName types.NamespacedName,
 ) *BYOTransporter {
 	if byoTransporter == nil {
 		byoTransporter = &BYOTransporter{
-			log:           ctrl.Log.WithName("secret-transporter"),
+			log:           logger.ZaprLogger(),
 			ctx:           ctx,
 			runtimeClient: c,
 		}

--- a/operator/pkg/controllers/transporter/transport_reconciler.go
+++ b/operator/pkg/controllers/transporter/transport_reconciler.go
@@ -7,7 +7,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -20,13 +19,18 @@ import (
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/transporter/protocol"
 	operatorutils "github.com/stolostron/multicluster-global-hub/operator/pkg/utils"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 )
 
 var WatchedSecret = sets.NewString(
 	constants.GHTransportSecretName,
 )
-var started bool
+
+var (
+	log     = logger.DefaultZapLogger()
+	started bool
+)
 
 type TransportReconciler struct {
 	ctrl.Manager
@@ -42,7 +46,7 @@ func StartController(controllerOption config.ControllerOption) error {
 		return err
 	}
 	started = true
-	klog.Infof("inited transport controller")
+	log.Infof("inited transport controller")
 	return nil
 }
 
@@ -117,7 +121,7 @@ func (r *TransportReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			getTransportComponentStatus(reconcileErr),
 		)
 		if err != nil {
-			klog.Errorf("failed to update mgh status, err:%v", err)
+			log.Errorf("failed to update mgh status, err:%v", err)
 		}
 	}()
 

--- a/operator/pkg/utils/utils.go
+++ b/operator/pkg/utils/utils.go
@@ -40,7 +40,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/util/retry"
-	"k8s.io/klog"
 	"open-cluster-management.io/addon-framework/pkg/addonmanager"
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
@@ -160,7 +159,7 @@ func ApplyConfigMap(ctx context.Context, runtimeClient client.Client, required *
 	err := runtimeClient.Get(ctx, client.ObjectKeyFromObject(required), curAlertConfigMap)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			klog.Infof("creating configmap, namespace: %v, name: %v", required.Namespace, required.Name)
+			log.Infof("creating configmap, namespace: %v, name: %v", required.Namespace, required.Name)
 			err = runtimeClient.Create(ctx, required)
 			if err != nil {
 				return false, fmt.Errorf("failed to create alert configmap, namespace: %v, name: %v, error:%v",
@@ -175,7 +174,7 @@ func ApplyConfigMap(ctx context.Context, runtimeClient client.Client, required *
 		return false, nil
 	}
 
-	klog.Infof("Update alert configmap, namespace: %v, name: %v", required.Namespace, required.Name)
+	log.Infof("Update alert configmap, namespace: %v, name: %v", required.Namespace, required.Name)
 	curAlertConfigMap.Data = required.Data
 	err = runtimeClient.Update(ctx, curAlertConfigMap)
 	if err != nil {
@@ -190,7 +189,7 @@ func ApplySecret(ctx context.Context, runtimeClient client.Client, requiredSecre
 	err := runtimeClient.Get(ctx, client.ObjectKeyFromObject(requiredSecret), currentSecret)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			klog.Infof("creating secret, namespace: %v, name: %v", requiredSecret.Namespace, requiredSecret.Name)
+			log.Infof("creating secret, namespace: %v, name: %v", requiredSecret.Namespace, requiredSecret.Name)
 			err = runtimeClient.Create(ctx, requiredSecret)
 			if err != nil {
 				return false, fmt.Errorf("failed to create secret, namespace: %v, name: %v, error:%v",
@@ -205,7 +204,7 @@ func ApplySecret(ctx context.Context, runtimeClient client.Client, requiredSecre
 		return false, nil
 	}
 
-	klog.Infof("Update secret, namespace: %v, name: %v", requiredSecret.Namespace, requiredSecret.Name)
+	log.Infof("Update secret, namespace: %v, name: %v", requiredSecret.Namespace, requiredSecret.Name)
 	currentSecret.Data = requiredSecret.Data
 	err = runtimeClient.Update(ctx, currentSecret)
 	if err != nil {
@@ -276,7 +275,7 @@ func WaitGlobalHubReady(ctx context.Context,
 	err := wait.PollUntilContextCancel(timeOutCtx, interval, true, func(ctx context.Context) (bool, error) {
 		err := client.Get(ctx, config.GetMGHNamespacedName(), mgh)
 		if errors.IsNotFound(err) {
-			klog.V(2).Info("wait until the mgh instance is created")
+			log.Debug("wait until the mgh instance is created")
 			return false, nil
 		} else if err != nil {
 			return true, err
@@ -286,7 +285,7 @@ func WaitGlobalHubReady(ctx context.Context,
 			return true, nil
 		}
 
-		klog.V(2).Info("mgh instance ready condition is not true")
+		log.Debug("mgh instance ready condition is not true")
 		return false, nil
 	})
 	if err != nil {
@@ -394,7 +393,7 @@ func WaitTransporterReady(ctx context.Context, timeout time.Duration) error {
 	return wait.PollUntilContextTimeout(ctx, 1*time.Second, timeout, true,
 		func(ctx context.Context) (bool, error) {
 			if config.GetTransporter() == nil {
-				klog.V(2).Info("wait transporter ready")
+				log.Debug("wait transporter ready")
 				return false, nil
 			}
 			return true, nil

--- a/operator/pkg/webhook/admission_handler.go
+++ b/operator/pkg/webhook/admission_handler.go
@@ -14,13 +14,15 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 )
+
+var log = logger.DefaultZapLogger()
 
 // NewAdmissionHandler is to handle the admission webhook for placementrule and placement
 func NewAdmissionHandler(c client.Client, s *runtime.Scheme) admission.Handler {
@@ -36,7 +38,7 @@ type admissionHandler struct {
 }
 
 func (a *admissionHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
-	klog.V(2).Infof("admission webhook is called, name:%v, namespace:%v, kind:%v, operation:%v", req.Name,
+	log.Infof("admission webhook is called, name:%v, namespace:%v, kind:%v, operation:%v", req.Name,
 		req.Namespace, req.Kind.Kind, req.Operation)
 	switch req.Kind.Kind {
 	case "ManagedCluster":
@@ -59,7 +61,7 @@ func (a *admissionHandler) Handle(ctx context.Context, req admission.Request) ad
 			return admission.Allowed("")
 		}
 
-		klog.Infof("Add hosted annotation for managedcluster: %v", cluster.Name)
+		log.Infof("Add hosted annotation for managedcluster: %v", cluster.Name)
 
 		marshaledCluster, err := json.Marshal(cluster)
 		if err != nil {
@@ -87,7 +89,7 @@ func (a *admissionHandler) Handle(ctx context.Context, req admission.Request) ad
 		if !changed {
 			return admission.Allowed("")
 		}
-		klog.Infof("Disable addons in cluster :%v", klusterletaddonconfig.Namespace)
+		log.Infof("Disable addons in cluster :%v", klusterletaddonconfig.Namespace)
 
 		marshaledKlusterletAddon, err := json.Marshal(klusterletaddonconfig)
 		if err != nil {
@@ -108,7 +110,7 @@ func isInHostedCluster(ctx context.Context, client client.Client, mcName string)
 			return true, nil
 		}
 		errMsg := fmt.Errorf("failed to get managedcluster, err:%v", err)
-		klog.Errorf(errMsg.Error())
+		log.Errorf(errMsg.Error())
 		return false, errMsg
 	}
 

--- a/pkg/transport/config/confluent_config.go
+++ b/pkg/transport/config/confluent_config.go
@@ -12,13 +12,15 @@ import (
 	kafkav2 "github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
+
+var log = logger.DefaultZapLogger()
 
 func GetBasicConfigMap() *kafkav2.ConfigMap {
 	return &kafkav2.ConfigMap{
@@ -126,7 +128,7 @@ func GetConfluentConfigMapByKafkaCredential(conn *transport.KafkaConfig, consume
 	_ = kafkaConfigMap.SetKey("bootstrap.servers", conn.BootstrapServer)
 	// if the certs is invalid
 	if conn.CACert == "" || conn.ClientCert == "" || conn.ClientKey == "" {
-		klog.Warning("Connect to Kafka without SSL")
+		log.Warn("Connect to Kafka without SSL")
 		return kafkaConfigMap, nil
 	}
 

--- a/pkg/utils/meta.go
+++ b/pkg/utils/meta.go
@@ -7,9 +7,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
-	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 )
+
+var log = logger.DefaultZapLogger()
 
 const faildGetMsg = "Failed to get %v/%v, err:%v"
 
@@ -96,7 +99,7 @@ func AddAnnotation(
 			if errors.IsNotFound(err) {
 				return nil
 			}
-			klog.Errorf(faildGetMsg, namespace, name, err)
+			log.Errorf(faildGetMsg, namespace, name, err)
 			return err
 		}
 		if HasItem(obj.GetAnnotations(), key, value) {
@@ -111,7 +114,7 @@ func AddAnnotation(
 		objNewAnnotation[key] = value
 		obj.SetAnnotations(objNewAnnotation)
 		if err := client.Update(ctx, obj); err != nil {
-			klog.Errorf("Failed to update %v/%v with err:%v", namespace, name, err)
+			log.Errorf("Failed to update %v/%v with err:%v", namespace, name, err)
 			return err
 		}
 		return nil
@@ -132,7 +135,7 @@ func DeleteAnnotation(
 			if errors.IsNotFound(err) {
 				return nil
 			}
-			klog.Errorf(faildGetMsg, namespace, name, err)
+			log.Errorf(faildGetMsg, namespace, name, err)
 			return err
 		}
 		if !HasItemKey(obj.GetAnnotations(), key) {
@@ -143,7 +146,7 @@ func DeleteAnnotation(
 		delete(objNewAnnotations, key)
 		obj.SetAnnotations(objNewAnnotations)
 		if err := client.Update(ctx, obj); err != nil {
-			klog.Errorf("Failed to update obj %v/%v with err:%v", namespace, name, err)
+			log.Errorf("Failed to update obj %v/%v with err:%v", namespace, name, err)
 			return err
 		}
 		return nil
@@ -164,7 +167,7 @@ func AddLabel(
 			if errors.IsNotFound(err) {
 				return nil
 			}
-			klog.Errorf(faildGetMsg, namespace, name, err)
+			log.Errorf(faildGetMsg, namespace, name, err)
 			return err
 		}
 		if HasItem(obj.GetLabels(), labelKey, labelValue) {
@@ -179,7 +182,7 @@ func AddLabel(
 		objNewLabels[labelKey] = labelValue
 		obj.SetLabels(objNewLabels)
 		if err := client.Update(ctx, obj); err != nil {
-			klog.Errorf("Failed to update obj %v/%v, err:%v", namespace, name, err)
+			log.Errorf("Failed to update obj %v/%v, err:%v", namespace, name, err)
 			return err
 		}
 		return nil
@@ -200,7 +203,7 @@ func DeleteLabel(
 			if errors.IsNotFound(err) {
 				return nil
 			}
-			klog.Errorf(faildGetMsg, namespace, name, err)
+			log.Errorf(faildGetMsg, namespace, name, err)
 			return err
 		}
 
@@ -213,7 +216,7 @@ func DeleteLabel(
 		obj.SetLabels(objNewLabels)
 
 		if err := client.Update(ctx, obj); err != nil {
-			klog.Errorf("Failed to update %v/%v, err:%v", namespace, name, err)
+			log.Errorf("Failed to update %v/%v, err:%v", namespace, name, err)
 			return err
 		}
 		return nil

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -3,12 +3,10 @@ package utils
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"runtime"
 	"strings"
 
-	"github.com/go-logr/logr"
 	mchv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
 	uberzap "go.uber.org/zap"
 	uberzapcore "go.uber.org/zap/zapcore"
@@ -28,12 +26,6 @@ func PrintRuntimeInfo() {
 	log.Infof("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH)
 	log.Infof("Go Version: %s", runtime.Version())
 	log.Infof("Git Commit: %s", os.Getenv("GIT_COMMIT"))
-}
-
-func PrintVersion(log logr.Logger) {
-	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
-	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
-	log.Info(fmt.Sprintf("Git Commit: %s", os.Getenv("GIT_COMMIT")))
 }
 
 func CtrlZapOptions() zap.Options {
@@ -57,7 +49,7 @@ func Validate(filePath string) (string, bool) {
 	}
 	content, err := os.ReadFile(filePath) // #nosec G304
 	if err != nil {
-		log.Printf("failed to read file %s - %v", filePath, err)
+		log.Infof("failed to read file %s - %v", filePath, err)
 		return "", false
 	}
 	trimmedContent := strings.TrimSpace(string(content))


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

The log data
```bash
2024-11-21T01:08:46.276Z        INFO    utils/utils.go:26       Go OS/Arch: linux/amd64
2024-11-21T01:08:46.276Z        INFO    utils/utils.go:27       Go Version: go1.22.5
2024-11-21T01:08:46.276Z        INFO    utils/utils.go:28       Git Commit: 944c4e82
2024-11-21T01:08:46.297Z        INFO    cmd/main.go:110 registering webhooks to the webhook server
2024-11-21T01:08:46.297Z        INFO    controller-runtime.webhook      webhook/server.go:183   Registering webhook     {"path": "/mutating"}
2024-11-21T01:08:46.297Z        INFO    cmd/main.go:115 starting manager
2024-11-21T01:08:46.297Z        INFO    controller-runtime.metrics      server/server.go:208    Starting metrics server
2024-11-21T01:08:46.297Z        INFO    manager/server.go:83    starting server {"name": "health probe", "addr": "[::]:8081"}
2024-11-21T01:08:46.297Z        INFO    controller-runtime.metrics      server/server.go:247    Serving metrics server  {"bindAddress": ":8080", "secure": false}
2024-11-21T01:08:46.297Z        INFO    controller-runtime.webhook      webhook/server.go:191   Starting webhook server
I1121 01:08:46.297970       1 leaderelection.go:254] attempting to acquire leader lease multicluster-global-hub/multicluster-global-hub-operator-lock...
2024-11-21T01:08:46.298Z        INFO    controller-runtime.certwatcher  certwatcher/certwatcher.go:161  Updated current TLS certificate
2024-11-21T01:08:46.298Z        INFO    controller-runtime.webhook      webhook/server.go:242   Serving webhook server  {"host": "", "port": 9443}
2024-11-21T01:08:46.298Z        INFO    controller-runtime.certwatcher  certwatcher/certwatcher.go:115  Starting certificate watcher
```

## Related issue(s)

Fixes # https://issues.redhat.com/browse/ACM-13421

Reference: https://github.com/stolostron/multicluster-global-hub/issues/1178

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
