### PR TITLE
:bug: Fix the acm controller be added multiple times

### DIFF
--- a/operator/pkg/controllers/acm/resources.go
+++ b/operator/pkg/controllers/acm/resources.go
@@ -113,8 +113,8 @@ func StartController(opts config.ControllerOption) (config.ControllerInterface, 
 			}),
 		).Complete(acmController)
 	if err != nil {
-		acmResourceController = nil
 		return nil, err
 	}
+	acmResourceController = acmController
 	return acmResourceController, nil
 }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
```
 conditions:
    - lastTransitionTime: "2024-11-28T03:53:35Z"
      message: controller with name acm-controller already exists. Controller names
        must be unique to avoid multiple controllers reporting to the same metric
      reason: MulticlusterGlobalHubNotReady
      status: "False"
      type: Ready
    - lastTransitionTime: "2024-11-28T03:50:40Z"
```
## Related issue(s)

Fixes #

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
