### PR TITLE
fix manager do not recreted after delete manager deploy

### DIFF
--- a/operator/pkg/config/status.go
+++ b/operator/pkg/config/status.go
@@ -232,6 +232,7 @@ func NeedUpdateConditions(conditions []metav1.Condition,
 func UpdateMGHComponent(ctx context.Context,
 	c client.Client,
 	desiredComponent v1alpha4.StatusCondition,
+	forceUpdate bool,
 ) error {
 	now := metav1.Time{Time: time.Now()}
 	desiredComponent.LastTransitionTime = now
@@ -248,8 +249,7 @@ func UpdateMGHComponent(ctx context.Context,
 		} else {
 			originComponent := curmgh.Status.Components[desiredComponent.Name]
 			originComponent.LastTransitionTime = now
-
-			if reflect.DeepEqual(desiredComponent, originComponent) {
+			if !forceUpdate && reflect.DeepEqual(desiredComponent, originComponent) {
 				return nil
 			}
 		}

--- a/operator/pkg/config/storage_config.go
+++ b/operator/pkg/config/storage_config.go
@@ -141,14 +141,16 @@ func GetPGConnectionFromBuildInPostgres(ctx context.Context, client client.Clien
 
 // SetStorageConnection update the postgres connection
 func SetStorageConnection(conn *PostgresConnection) bool {
+	log.Debugf("Set Storage Connection: %v", conn == nil)
 	if conn != nil && !reflect.DeepEqual(conn, postgresConn) {
 		postgresConn = conn
+		log.Debugf("Update Storage Connection")
 		return true
 	}
 	return false
 }
 
 func GetStorageConnection() *PostgresConnection {
-	log.Debugf("Set Storage Connection: %v", postgresConn != nil)
+	log.Debugf("Get Storage Connection: %v", postgresConn != nil)
 	return postgresConn
 }

--- a/operator/pkg/config/transport_config.go
+++ b/operator/pkg/config/transport_config.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"reflect"
 	"regexp"
 	"strings"
 
@@ -42,9 +43,14 @@ var (
 	inventoryConn         *transport.RestfulConfig
 )
 
-func SetTransporterConn(conn *transport.KafkaConfig) {
-	log.Debug("Set Transporter Conn")
-	transporterConn = conn
+func SetTransporterConn(conn *transport.KafkaConfig) bool {
+	log.Debug("set Transporter Conn")
+	if conn != nil && !reflect.DeepEqual(conn, transporterConn) {
+		transporterConn = conn
+		log.Debug("update Transporter Conn")
+		return true
+	}
+	return false
 }
 
 func GetTransporterConn() *transport.KafkaConfig {

--- a/operator/pkg/controllers/acm/resources.go
+++ b/operator/pkg/controllers/acm/resources.go
@@ -58,6 +58,7 @@ func (r *ACMResourceController) IsResourceRemoved() bool {
 }
 
 func (r *ACMResourceController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log.Debugf("reconcile acm controller: %v", req)
 	r.Resources[req.Name] = true
 
 	if !r.readyToWatchACMResources() {
@@ -89,6 +90,7 @@ func (r *ACMResourceController) readyToWatchACMResources() bool {
 }
 
 func StartController(opts config.ControllerOption) (config.ControllerInterface, error) {
+	log.Info("start acm controller")
 	if acmResourceController != nil {
 		return acmResourceController, nil
 	}
@@ -116,5 +118,6 @@ func StartController(opts config.ControllerOption) (config.ControllerInterface, 
 		return nil, err
 	}
 	acmResourceController = acmController
+	log.Infof("inited acm controller")
 	return acmResourceController, nil
 }

--- a/operator/pkg/controllers/agent/addon_manager.go
+++ b/operator/pkg/controllers/agent/addon_manager.go
@@ -61,6 +61,8 @@ func ReadyToEnableAddonManager(mgh *v1alpha4.MulticlusterGlobalHub) bool {
 }
 
 func StartAddonManagerController(initOption config.ControllerOption) (config.ControllerInterface, error) {
+	log.Info("start addon manager controller")
+
 	if addonManagerController != nil {
 		return addonManagerController, nil
 	}

--- a/operator/pkg/controllers/agent/default_agent_controller.go
+++ b/operator/pkg/controllers/agent/default_agent_controller.go
@@ -128,6 +128,7 @@ func NewDefaultAgentController(c client.Client) *DefaultAgentController {
 }
 
 func StartDefaultAgentController(initOption config.ControllerOption) (config.ControllerInterface, error) {
+	log.Info("start default agent controller")
 	if defaultAgentController != nil {
 		return defaultAgentController, nil
 	}
@@ -166,7 +167,7 @@ func StartDefaultAgentController(initOption config.ControllerOption) (config.Con
 		defaultAgentController = nil
 		return nil, err
 	}
-	log.Info("the default addon reconciler is started")
+	log.Info("the default agent controller is started")
 	return defaultAgentController, nil
 }
 
@@ -176,6 +177,8 @@ func (c *DefaultAgentController) IsResourceRemoved() bool {
 }
 
 func (r *DefaultAgentController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log.Debugf("reconcile default agent controller: %v", req)
+
 	mgh, err := config.GetMulticlusterGlobalHub(ctx, r.Client)
 	if err != nil {
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil

--- a/operator/pkg/controllers/agent/hosted_agent_controller.go
+++ b/operator/pkg/controllers/agent/hosted_agent_controller.go
@@ -56,6 +56,8 @@ var (
 )
 
 func StartHostedAgentController(initOption config.ControllerOption) (config.ControllerInterface, error) {
+	log.Info("start hosted agent  controller")
+
 	if hostedAgentController != nil {
 		return hostedAgentController, nil
 	}
@@ -72,6 +74,7 @@ func StartHostedAgentController(initOption config.ControllerOption) (config.Cont
 		hostedAgentController = nil
 		return nil, err
 	}
+	log.Info("inited hosted agent controller")
 	return hostedAgentController, nil
 }
 
@@ -138,7 +141,7 @@ var mghPred = predicate.Funcs{
 }
 
 func (r *HostedAgentController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log.Debug("Reconcile ClusterManagementAddOn: %v", req.NamespacedName)
+	log.Debugf("reconcile ClusterManagementAddOn: %v", req.NamespacedName)
 	mgh, err := config.GetMulticlusterGlobalHub(ctx, r.c)
 	if err != nil {
 		log.Error(err)

--- a/operator/pkg/controllers/backup/backup_reconcile.go
+++ b/operator/pkg/controllers/backup/backup_reconcile.go
@@ -53,6 +53,8 @@ var log = logger.DefaultZapLogger()
 // So for request.Namespace, we set it as request type, like "Secret","Configmap","MulticlusterGlobalHub" and so on.
 // In the reconcile, we identy the request kind and get it by request.Name.
 func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log.Debugf("reconcile backup")
+
 	// mgh is used to update backup condition
 	mghList := &globalhubv1alpha4.MulticlusterGlobalHubList{}
 	err := r.Client.List(ctx, mghList)

--- a/operator/pkg/controllers/backup/backup_start.go
+++ b/operator/pkg/controllers/backup/backup_start.go
@@ -69,6 +69,7 @@ func GetBackupController() *BackupReconciler {
 }
 
 func StartController(initOption config.ControllerOption) (config.ControllerInterface, error) {
+	log.Infof("start backup controller")
 	if backupController != nil {
 		return backupController, nil
 	}
@@ -85,6 +86,7 @@ func StartController(initOption config.ControllerOption) (config.ControllerInter
 		return nil, err
 	}
 	backupController = c
+	log.Infof("inited backup controller")
 	return backupController, nil
 }
 

--- a/operator/pkg/controllers/grafana/grafana_reconciler.go
+++ b/operator/pkg/controllers/grafana/grafana_reconciler.go
@@ -125,6 +125,7 @@ func (r *GrafanaReconciler) IsResourceRemoved() bool {
 }
 
 func StartController(initOption config.ControllerOption) (config.ControllerInterface, error) {
+	log.Info("start grafana controller")
 	if grafanaController != nil {
 		return grafanaController, nil
 	}
@@ -141,7 +142,7 @@ func StartController(initOption config.ControllerOption) (config.ControllerInter
 		grafanaController = nil
 		return grafanaController, err
 	}
-	log.Infof("inited grafana controller")
+	log.Infof("Inited grafana controller")
 	return grafanaController, nil
 }
 
@@ -249,6 +250,7 @@ var secretPred = predicate.Funcs{
 }
 
 func (r *GrafanaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log.Debugf("reconcile grafana controller")
 	mgh, err := config.GetMulticlusterGlobalHub(ctx, r.GetClient())
 	if err != nil {
 		return ctrl.Result{}, err
@@ -262,6 +264,7 @@ func (r *GrafanaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		err = config.UpdateMGHComponent(ctx, r.GetClient(),
 			config.GetComponentStatusWithReconcileError(ctx, r.GetClient(),
 				mgh.Namespace, config.COMPONENTS_GRAFANA_NAME, reconcileErr),
+			false,
 		)
 		if err != nil {
 			log.Errorf("failed to update mgh status, err:%v", err)

--- a/operator/pkg/controllers/inventory/inventory_reconciler.go
+++ b/operator/pkg/controllers/inventory/inventory_reconciler.go
@@ -68,6 +68,7 @@ func (r *InventoryReconciler) IsResourceRemoved() bool {
 }
 
 func StartController(initOption config.ControllerOption) (config.ControllerInterface, error) {
+	log.Info("start inventory controller")
 	if inventoryReconciler != nil {
 		return inventoryReconciler, nil
 	}
@@ -128,6 +129,7 @@ func NewInventoryReconciler(mgr ctrl.Manager, kubeClient kubernetes.Interface) *
 func (r *InventoryReconciler) Reconcile(ctx context.Context,
 	req ctrl.Request,
 ) (ctrl.Result, error) {
+	log.Debugf("reconcile inventory controller")
 	mgh, err := config.GetMulticlusterGlobalHub(ctx, r.GetClient())
 	if err != nil {
 		return ctrl.Result{}, nil
@@ -142,6 +144,7 @@ func (r *InventoryReconciler) Reconcile(ctx context.Context,
 		err = config.UpdateMGHComponent(ctx, r.GetClient(),
 			config.GetComponentStatusWithReconcileError(ctx, r.GetClient(),
 				mgh.Namespace, config.COMPONENTS_INVENTORY_API_NAME, reconcileErr),
+			false,
 		)
 		if err != nil {
 			log.Errorf("failed to update mgh status, err:%v", err)

--- a/operator/pkg/controllers/managedhub/managedhub_controller.go
+++ b/operator/pkg/controllers/managedhub/managedhub_controller.go
@@ -50,11 +50,12 @@ var (
 var log = logger.DefaultZapLogger()
 
 func (r *ManagedHubController) IsResourceRemoved() bool {
-	log.Infof("ManagedHubController resource removed: %v", isResourceRemoved)
+	log.Infof("managedHubController resource removed: %v", isResourceRemoved)
 	return isResourceRemoved
 }
 
 func StartController(initOption config.ControllerOption) (config.ControllerInterface, error) {
+	log.Info("start managedhub controller")
 	if managedHubController != nil {
 		return managedHubController, nil
 	}
@@ -72,6 +73,8 @@ func StartController(initOption config.ControllerOption) (config.ControllerInter
 }
 
 func (r *ManagedHubController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log.Debugf("reconcile managedhub controller")
+
 	mgh, err := config.GetMulticlusterGlobalHub(ctx, r.c)
 	if err != nil {
 		return ctrl.Result{}, nil

--- a/operator/pkg/controllers/manager/manager_reconciler.go
+++ b/operator/pkg/controllers/manager/manager_reconciler.go
@@ -85,6 +85,8 @@ var (
 )
 
 func StartController(initOption config.ControllerOption) (config.ControllerInterface, error) {
+	log.Info("start manager controller")
+
 	if managerController != nil {
 		return managerController, nil
 	}
@@ -107,7 +109,7 @@ func StartController(initOption config.ControllerOption) (config.ControllerInter
 }
 
 func (r *ManagerReconciler) IsResourceRemoved() bool {
-	log.Infof("ManagerController resource removed: %v", isResourceRemoved)
+	log.Infof("managerController resource removed: %v", isResourceRemoved)
 	return isResourceRemoved
 }
 
@@ -149,6 +151,7 @@ func NewManagerReconciler(mgr ctrl.Manager, kubeClient kubernetes.Interface,
 func (r *ManagerReconciler) Reconcile(ctx context.Context,
 	req ctrl.Request,
 ) (ctrl.Result, error) {
+	log.Debug("reconcile manager controller")
 	mgh, err := config.GetMulticlusterGlobalHub(ctx, r.GetClient())
 	if err != nil {
 		return ctrl.Result{}, nil
@@ -170,6 +173,7 @@ func (r *ManagerReconciler) Reconcile(ctx context.Context,
 		err = config.UpdateMGHComponent(ctx, r.GetClient(),
 			config.GetComponentStatusWithReconcileError(ctx, r.GetClient(),
 				mgh.Namespace, config.COMPONENTS_MANAGER_NAME, reconcileErr),
+			false,
 		)
 		if err != nil {
 			log.Errorf("failed to update mgh status, err:%v", err)

--- a/operator/pkg/controllers/webhook/webhook_controller.go
+++ b/operator/pkg/controllers/webhook/webhook_controller.go
@@ -59,6 +59,7 @@ func NewWebhookReconciler(mgr ctrl.Manager,
 }
 
 func StartController(opts config.ControllerOption) (config.ControllerInterface, error) {
+	log.Info("start webhook controller")
 	if webhookReconciler != nil {
 		return webhookReconciler, nil
 	}
@@ -74,11 +75,12 @@ func StartController(opts config.ControllerOption) (config.ControllerInterface, 
 }
 
 func (r *WebhookReconciler) IsResourceRemoved() bool {
-	log.Infof("WebhookController resource removed: %v", isResourceRemoved)
+	log.Infof("webhookController resource removed: %v", isResourceRemoved)
 	return isResourceRemoved
 }
 
 func (r *WebhookReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log.Debugf("reconcile webhook controller")
 	mgh, err := config.GetMulticlusterGlobalHub(ctx, r.c)
 	if err != nil {
 		return ctrl.Result{}, err


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
When operator restart, the transport connection is null, so the controllers(manager) which depend on the transport connection will not be start. But when transport connection is set, the kafka component status in mgh is not updated, so controller-runtime will not trigger reconcile to start manager controller. 
In this pr, we update the kafka component status in mgh when transport connection set.
The storage connection has the same problem, so we do it as the same way.
## Related issue(s)

Fixes #

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
