### PR TITLE
:bug: Resync the managed hub resources upon manager startup

### DIFF
--- a/agent/pkg/spec/dispatcher.go
+++ b/agent/pkg/spec/dispatcher.go
@@ -23,7 +23,7 @@ type genericDispatcher struct {
 }
 
 func AddGenericDispatcher(mgr ctrl.Manager, consumer transport.Consumer, config configs.AgentConfig,
-) (*genericDispatcher, error) {
+) (Dispatcher, error) {
 	if addToMgr {
 		return nil, nil
 	}

--- a/manager/pkg/processes/hubmanagement/hub_management.go
+++ b/manager/pkg/processes/hubmanagement/hub_management.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"time"
 
-	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -21,6 +20,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/enum"
 	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
 const (
@@ -212,10 +212,7 @@ func (h *HubManagement) resync(ctx context.Context, hubName string) error {
 		return err
 	}
 
-	e := cloudevents.NewEvent()
-	e.SetType(constants.ResyncMsgKey)
-	e.SetSource(hubName)
-	_ = e.SetData(cloudevents.ApplicationJSON, payloadBytes)
+	e := utils.ToCloudEvent(constants.ResyncMsgKey, constants.CloudEventSourceGlobalHub, hubName, payloadBytes)
 
 	return h.producer.SendEvent(ctx, e)
 }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

The agent produces the following log during the manager startup

```
2024-12-02T02:45:52.142Z        INFO    spec/dispatcher.go:70   event dropped due to cluster name retrieval error       {"error": "\"clustername\" not found"}
```

Related PR: https://github.com/stolostron/multicluster-global-hub/pull/1111/files#diff-7ac9c176d89d2e8f14840bfdd791862ab1781cb144a00553d02f296d3f194b34

The expected outcome is to resynchronize the resource from the agent. However, it appears that the resync signal is being blocked on the agent side!

## Related issue(s)


Fixes #

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [x] List other manual tests you have done.

```bash
2024-12-02T03:22:24.037Z        INFO    controllers/clusterclaim_version_controller.go:31       NamespacedName: open-cluster-management/multiclusterhub
2024-12-02T03:23:58.026Z        INFO    status-resyncer syncers/resync_syncer.go:39     resync eventtypeio.open-cluster-management.operator.multiclusterglobalhubs.managedhub.info
2024-12-02T03:23:58.026Z        INFO    status-resyncer syncers/resync_syncer.go:39     resync eventtypeio.open-cluster-management.operator.multiclusterglobalhubs.managedcluster
2024-12-02T03:23:58.026Z        INFO    status-resyncer syncers/resync_syncer.go:39     resync eventtypeio.open-cluster-management.operator.multiclusterglobalhubs.policy.localspec
2024-12-02T03:23:58.026Z        INFO    status-resyncer syncers/resync_syncer.go:39     resync eventtypeio.open-cluster-management.operator.multiclusterglobalhubs.policy.localcompliance
```