### PR TITLE
 :seedling:  Clean the resource when the addon is not found

### DIFF
--- a/manager/pkg/processes/hubmanagement/hub_addon_controller.go
+++ b/manager/pkg/processes/hubmanagement/hub_addon_controller.go
@@ -56,7 +56,7 @@ func (c *managerClusterAddonController) Reconcile(ctx context.Context, request c
 		if request.Namespace == "" {
 			return ctrl.Result{}, nil
 		}
-		log.Infof("inactive the agent when the global hub addon(%s) is deleted", addon.Namespace)
+		log.Infof("inactive the agent when the global hub addon(%s) is deleted", request.Namespace)
 		err := hubStatusManager.inactive(ctx, []models.LeafHubHeartbeat{{
 			Name: request.Namespace,
 		}})

--- a/manager/pkg/processes/hubmanagement/hub_addon_controller_test.go
+++ b/manager/pkg/processes/hubmanagement/hub_addon_controller_test.go
@@ -28,7 +28,7 @@ func (m *mockHubManagement) reactive(ctx context.Context, hubs []models.LeafHubH
 	return nil
 }
 
-func TestManagerClusterAddonController_Reconcile(t *testing.T) {
+func TestManagerClusterAddonReconcile(t *testing.T) {
 	scheme := runtime.NewScheme()
 	err := addonv1alpha1.AddToScheme(scheme)
 	assert.NoError(t, err)
@@ -40,7 +40,7 @@ func TestManagerClusterAddonController_Reconcile(t *testing.T) {
 		client: fakeClient,
 	}
 
-	t.Run("addon not found", func(t *testing.T) {
+	t.Run("hub manager is not ready", func(t *testing.T) {
 		request := ctrl.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: "test-namespace",
@@ -50,7 +50,7 @@ func TestManagerClusterAddonController_Reconcile(t *testing.T) {
 
 		res, err := controller.Reconcile(ctx, request)
 		assert.NoError(t, err)
-		assert.Equal(t, ctrl.Result{}, res)
+		assert.Equal(t, ctrl.Result{Requeue: true, RequeueAfter: 5 * time.Second}, res)
 	})
 
 	t.Run("addon with deletion timestamp", func(t *testing.T) {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes # https://issues.redhat.com/browse/ACM-16060

## Tests
* [x] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [x] List other manual tests you have done.
