### PR TITLE
:seedling: Lower the log level for the producer error "brokers are down"

### DIFF
--- a/pkg/transport/producer/generic_producer.go
+++ b/pkg/transport/producer/generic_producer.go
@@ -212,7 +212,7 @@ func handleProducerEvents(log *zap.SugaredLogger, eventChan chan kafka.Event, tr
 					// to the application that currently there are no brokers to communicate with.
 					// But librdkafka will continue to try to reconnect indefinately,
 					// and it will attempt to re-send messages until message.timeout.ms or message.max.retries are exceeded.
-					log.Warnw("transport producer client error, ignore it for most cases", "error", ev)
+					log.Debugw("transport producer client error(ALL_BROKERS_DOWN), ignore it for most cases", "error", ev)
 				} else {
 					log.Warnw("transport producer client error", "error", ev)
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

```
2024-12-04T03:04:11.091Z        WARN    kafka-producer  producer/generic_producer.go:215        transport producer client error, ignore it for most cases       {"error": "4/4 brokers are down"}
github.com/stolostron/multicluster-global-hub/pkg/transport/producer.handleProducerEvents.func1
        /workspace/pkg/transport/producer/generic_producer.go:215
```

## Related issue(s)

https://github.com/confluentinc/librdkafka/issues/1072#issuecomment-281997806

Fixes #

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
