### PR TITLE
fix watch resources in each controller

### DIFF
--- a/operator/pkg/config/multiclusterglobalhub_config.go
+++ b/operator/pkg/config/multiclusterglobalhub_config.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
 	operatorconstants "github.com/stolostron/multicluster-global-hub/operator/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 )
 
@@ -128,6 +129,27 @@ var MGHPred = predicate.Funcs{
 	},
 	DeleteFunc: func(e event.DeleteEvent) bool {
 		return true
+	},
+}
+
+// watch globalhub applied services
+var GeneralPredicate = predicate.Funcs{
+	CreateFunc: func(e event.CreateEvent) bool {
+		return false
+	},
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		if e.ObjectNew.GetLabels()[constants.GlobalHubOwnerLabelKey] !=
+			constants.GHOperatorOwnerLabelVal {
+			return false
+		}
+		return e.ObjectNew.GetGeneration() != e.ObjectOld.GetGeneration()
+	},
+	DeleteFunc: func(e event.DeleteEvent) bool {
+		if e.Object.GetLabels()[constants.GlobalHubOwnerLabelKey] ==
+			constants.GHOperatorOwnerLabelVal {
+			return true
+		}
+		return false
 	},
 }
 

--- a/operator/pkg/controllers/acm/resources.go
+++ b/operator/pkg/controllers/acm/resources.go
@@ -90,10 +90,11 @@ func (r *ACMResourceController) readyToWatchACMResources() bool {
 }
 
 func StartController(opts config.ControllerOption) (config.ControllerInterface, error) {
-	log.Info("start acm controller")
 	if acmResourceController != nil {
 		return acmResourceController, nil
 	}
+	log.Info("start acm controller")
+
 	acmController := &ACMResourceController{
 		Manager:   opts.Manager,
 		Resources: make(map[string]bool),

--- a/operator/pkg/controllers/agent/addon_manager.go
+++ b/operator/pkg/controllers/agent/addon_manager.go
@@ -61,11 +61,11 @@ func ReadyToEnableAddonManager(mgh *v1alpha4.MulticlusterGlobalHub) bool {
 }
 
 func StartAddonManagerController(initOption config.ControllerOption) (config.ControllerInterface, error) {
-	log.Info("start addon manager controller")
-
 	if addonManagerController != nil {
 		return addonManagerController, nil
 	}
+	log.Info("start addon manager controller")
+
 	if !ReadyToEnableAddonManager(initOption.MulticlusterGlobalHub) {
 		return nil, nil
 	}

--- a/operator/pkg/controllers/agent/default_agent_controller.go
+++ b/operator/pkg/controllers/agent/default_agent_controller.go
@@ -128,10 +128,11 @@ func NewDefaultAgentController(c client.Client) *DefaultAgentController {
 }
 
 func StartDefaultAgentController(initOption config.ControllerOption) (config.ControllerInterface, error) {
-	log.Info("start default agent controller")
 	if defaultAgentController != nil {
 		return defaultAgentController, nil
 	}
+	log.Info("start default agent controller")
+
 	if !ReadyToEnableAddonManager(initOption.MulticlusterGlobalHub) {
 		return nil, nil
 	}

--- a/operator/pkg/controllers/agent/hosted_agent_controller.go
+++ b/operator/pkg/controllers/agent/hosted_agent_controller.go
@@ -56,14 +56,18 @@ var (
 )
 
 func StartHostedAgentController(initOption config.ControllerOption) (config.ControllerInterface, error) {
-	log.Info("start hosted agent  controller")
-
 	if hostedAgentController != nil {
 		return hostedAgentController, nil
+	}
+	if !config.IsACMResourceReady() {
+		return nil, nil
 	}
 	if !config.GetImportClusterInHosted() {
 		return nil, nil
 	}
+
+	log.Info("start hosted agent  controller")
+
 	if !ReadyToEnableAddonManager(initOption.MulticlusterGlobalHub) {
 		return nil, nil
 	}

--- a/operator/pkg/controllers/backup/backup_start.go
+++ b/operator/pkg/controllers/backup/backup_start.go
@@ -69,13 +69,14 @@ func GetBackupController() *BackupReconciler {
 }
 
 func StartController(initOption config.ControllerOption) (config.ControllerInterface, error) {
-	log.Infof("start backup controller")
 	if backupController != nil {
 		return backupController, nil
 	}
 	if !config.IsACMResourceReady() {
 		return nil, nil
 	}
+	log.Infof("start backup controller")
+
 	c := &BackupReconciler{
 		Manager: initOption.Manager,
 		Client:  initOption.Manager.GetClient(),

--- a/operator/pkg/controllers/inventory/inventory_reconciler.go
+++ b/operator/pkg/controllers/inventory/inventory_reconciler.go
@@ -68,7 +68,6 @@ func (r *InventoryReconciler) IsResourceRemoved() bool {
 }
 
 func StartController(initOption config.ControllerOption) (config.ControllerInterface, error) {
-	log.Info("start inventory controller")
 	if inventoryReconciler != nil {
 		return inventoryReconciler, nil
 	}
@@ -81,6 +80,7 @@ func StartController(initOption config.ControllerOption) (config.ControllerInter
 	if config.GetStorageConnection() == nil {
 		return nil, nil
 	}
+	log.Info("start inventory controller")
 
 	inventoryReconciler = NewInventoryReconciler(initOption.Manager,
 		initOption.KubeClient)
@@ -100,6 +100,12 @@ func (r *InventoryReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			builder.WithPredicates(config.MGHPred)).
 		Watches(&appsv1.Deployment{},
 			&handler.EnqueueRequestForObject{}, builder.WithPredicates(deploymentPred)).
+		Watches(&corev1.Secret{},
+			&handler.EnqueueRequestForObject{}, builder.WithPredicates(config.GeneralPredicate)).
+		Watches(&corev1.Service{},
+			&handler.EnqueueRequestForObject{}, builder.WithPredicates(config.GeneralPredicate)).
+		Watches(&corev1.ServiceAccount{},
+			&handler.EnqueueRequestForObject{}, builder.WithPredicates(config.GeneralPredicate)).
 		Complete(r)
 }
 

--- a/operator/pkg/controllers/managedhub/managedhub_controller.go
+++ b/operator/pkg/controllers/managedhub/managedhub_controller.go
@@ -55,13 +55,14 @@ func (r *ManagedHubController) IsResourceRemoved() bool {
 }
 
 func StartController(initOption config.ControllerOption) (config.ControllerInterface, error) {
-	log.Info("start managedhub controller")
 	if managedHubController != nil {
 		return managedHubController, nil
 	}
 	if !config.IsACMResourceReady() {
 		return nil, nil
 	}
+	log.Info("start managedhub controller")
+
 	managedHubController = NewManagedHubController(initOption.Manager)
 	err := managedHubController.SetupWithManager(initOption.Manager)
 	if err != nil {

--- a/operator/pkg/controllers/transporter/protocol/strimzi_kafka_controller.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_kafka_controller.go
@@ -148,10 +148,10 @@ var kafkaPred = predicate.Funcs{
 }
 
 func StartKafkaController(ctx context.Context, mgr ctrl.Manager, transporter transport.Transporter) error {
-	log.Info("start kafka controller")
 	if startedKafkaController {
 		return nil
 	}
+	log.Info("start kafka controller")
 	r := &KafkaController{
 		c:     mgr.GetClient(),
 		trans: transporter.(*strimziTransporter),

--- a/operator/pkg/controllers/transporter/transport_reconciler.go
+++ b/operator/pkg/controllers/transporter/transport_reconciler.go
@@ -51,10 +51,11 @@ func (c *TransportReconciler) IsResourceRemoved() bool {
 }
 
 func StartController(controllerOption config.ControllerOption) (config.ControllerInterface, error) {
-	log.Info("start transport controller")
 	if transportReconciler != nil {
 		return transportReconciler, nil
 	}
+	log.Info("start transport controller")
+
 	transportReconciler = NewTransportReconciler(controllerOption.Manager)
 	err := transportReconciler.SetupWithManager(controllerOption.Manager)
 	if err != nil {

--- a/test/integration/operator/controllers/grafana_test.go
+++ b/test/integration/operator/controllers/grafana_test.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
@@ -57,13 +56,9 @@ var _ = Describe("grafana", Ordered, func() {
 
 		grafanaReconciler := grafana.NewGrafanaReconciler(runtimeManager, kubeClient)
 
-		_, err := grafanaReconciler.Reconcile(ctx, reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Namespace: mgh.Namespace,
-				Name:      mgh.Name,
-			},
-		})
+		err := grafanaReconciler.SetupWithManager(runtimeManager)
 		Expect(err).To(Succeed())
+
 		// deployment
 		Eventually(func() error {
 			deployment := &appsv1.Deployment{}

--- a/test/integration/operator/controllers/inventory_test.go
+++ b/test/integration/operator/controllers/inventory_test.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
@@ -62,12 +61,7 @@ var _ = Describe("inventory-api", Ordered, func() {
 
 	It("should generate the inventory resources", func() {
 		reconciler := inventory.NewInventoryReconciler(runtimeManager, kubeClient)
-		_, err := reconciler.Reconcile(ctx, reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Namespace: mgh.Namespace,
-				Name:      mgh.Name,
-			},
-		})
+		err := reconciler.SetupWithManager(runtimeManager)
 		Expect(err).To(Succeed())
 
 		// deployment

--- a/test/integration/operator/controllers/storage_test.go
+++ b/test/integration/operator/controllers/storage_test.go
@@ -68,7 +68,9 @@ var _ = Describe("storage", Ordered, func() {
 		}
 		Expect(runtimeClient.Create(ctx, storageSecret)).To(Succeed())
 
-		storageReconciler := storage.NewStorageReconciler(runtimeManager, true)
+		storageReconciler := storage.NewStorageReconciler(runtimeManager, true, false)
+		Expect(err).To(Succeed())
+		err = storageReconciler.SetupWithManager(runtimeManager)
 		Expect(err).To(Succeed())
 
 		// the subscription
@@ -123,7 +125,7 @@ var _ = Describe("storage", Ordered, func() {
 		Expect(runtimeClient.Create(ctx, mgh)).To(Succeed())
 		Expect(runtimeClient.Get(ctx, client.ObjectKeyFromObject(mgh), mgh)).To(Succeed())
 
-		storageReconciler := storage.NewStorageReconciler(runtimeManager, true)
+		storageReconciler := storage.NewStorageReconciler(runtimeManager, true, false)
 
 		// blocking until get the connection
 		go func() {
@@ -192,7 +194,7 @@ var _ = Describe("storage", Ordered, func() {
 		Expect(runtimeClient.Create(ctx, mgh)).To(Succeed())
 		Expect(runtimeClient.Get(ctx, client.ObjectKeyFromObject(mgh), mgh)).To(Succeed())
 
-		storageReconciler := storage.NewStorageReconciler(runtimeManager, true)
+		storageReconciler := storage.NewStorageReconciler(runtimeManager, true, false)
 
 		// blocking until get the connection
 		go func() {

--- a/test/script/util.sh
+++ b/test/script/util.sh
@@ -376,8 +376,9 @@ install_crds() {
   # cluster managers
   kubectl --context "$ctx" apply -f ${CURRENT_DIR}/../manifest/crd/0000_01_operator.open-cluster-management.io_clustermanagers.crd.yaml
 
-  # service monitor
+  # monitor
   kubectl --context "$1" apply -f "$CURRENT_DIR"/../manifest/crd/0000_04_monitoring.coreos.com_servicemonitors.crd.yaml
+  kubectl --context "$1" apply -f "$CURRENT_DIR"/../manifest/crd/0000_04_monitoring.coreos.com_prometheusrules.yaml
 
   # addons
   kubectl --context "$1" apply -f "$CURRENT_DIR"/../manifest/crd/0000_01_addon.open-cluster-management.io_managedclusteraddons.crd.yaml


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
We did not watch globalhub applied resources previously,  if user changed these resources, we should rollback them.
## Related issue(s)

Fixes #

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [x] List other manual tests you have done.
  - manually removed the manager role/rolebinding, they will be recreated.
