### PR TITLE
[release-2.12] fix postgres databse has no data when install globalhub in other ns

### DIFF
--- a/operator/pkg/controllers/hubofhubs/storage/manifests.sts/service-monitor.yaml
+++ b/operator/pkg/controllers/hubofhubs/storage/manifests.sts/service-monitor.yaml
@@ -12,7 +12,7 @@ spec:
   jobLabel: prometheus-postgres-exporter
   namespaceSelector:
     matchNames:
-    - multicluster-global-hub
+    - {{.Namespace}}
   selector:
     matchLabels:
       name: multicluster-global-hub-postgres


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
