### PR TITLE
:seedling:  Restore the history and event tables after upgrading GH to 1.4.0

### DIFF
--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -64,12 +64,12 @@ Depending on the type of service, there are three ways to access the [provisione
             protocol: TCP
             targetPort: 5432
           selector:
-            name: multicluster-global-hub-postgres
+            name: multicluster-global-hub-postgresql
           type: NodePort
         EOF
 
         # get the postgres password
-        kubectl get secret multicluster-global-hub-postgres  -ojsonpath='{.data.database-admin-password}' | base64 -d
+        kubectl get secret multicluster-global-hub-postgresql  -ojsonpath='{.data.database-admin-password}' | base64 -d
         ```
 
 * `LoadBalancer`

--- a/doc/upgrade/cleanup_legacy_postgres.sh
+++ b/doc/upgrade/cleanup_legacy_postgres.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Set the namespace, default to "multicluster-global-hub" if not provided
+NAMESPACE="${1:-multicluster-global-hub}"
+
+echo ">> Starting cleanup of legacy Postgres resources in namespace: $NAMESPACE"
+
+# Remove the StatefulSet
+echo ">> Deleting StatefulSet: multicluster-global-hub-postgres..."
+kubectl delete sts multicluster-global-hub-postgres -n $NAMESPACE
+
+# Remove Services
+echo ">> Deleting ConfigMaps..."
+kubectl delete svc multicluster-global-hub-postgres -n $NAMESPACE
+
+# Remove ConfigMaps
+echo ">> Deleting ConfigMaps..."
+kubectl delete cm multicluster-global-hub-postgres-ca -n $NAMESPACE
+kubectl delete cm multicluster-global-hub-postgres-config -n $NAMESPACE
+kubectl delete cm multicluster-global-hub-postgres-init -n $NAMESPACE
+
+# Remove Secrets
+echo ">> Deleting Secrets..."
+kubectl delete secret postgres-credential-secret -n $NAMESPACE
+kubectl delete secret multicluster-global-hub-postgres -n $NAMESPACE
+kubectl delete secret multicluster-global-hub-postgres-certs -n $NAMESPACE
+
+echo ">> Cleanup completed for namespace: $NAMESPACE"

--- a/doc/upgrade/restore_event_tables.sh
+++ b/doc/upgrade/restore_event_tables.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Tables: event.local_policies , event.local_root_policies, and event.managed_clusters
+
+# Set namespace and pod names
+NAMESPACE="${1:-multicluster-global-hub}"
+SOURCE_POD="multicluster-global-hub-postgres-0"       # Source pod
+SOURCE_CONTAINER="multicluster-global-hub-postgres"   # Source container
+TARGET_POD="multicluster-global-hub-postgresql-0"     # Target pod
+TARGET_CONTAINER="multicluster-global-hub-postgresql" # Target container
+REMOTE_PATH="/tmp/event_tables_backup.sql"            # Without leading `/` to suppress tar warnings
+DB_NAME="hoh"
+DB_USER="postgres"
+
+echo "Using namespace: $NAMESPACE"
+
+# Backup from source pod
+echo ">> Backing up event tables from $SOURCE_POD ($SOURCE_CONTAINER)..."
+kubectl exec -c $SOURCE_CONTAINER $SOURCE_POD -n $NAMESPACE -- pg_dump -U $DB_USER -d $DB_NAME -t 'event.*' --data-only -f $REMOTE_PATH 2>/dev/null
+kubectl cp $NAMESPACE/$SOURCE_POD:$REMOTE_PATH ./event_tables_backup.sql -c $SOURCE_CONTAINER >/dev/null 2>&1
+echo ">> Backup completed."
+
+# List of tables to process
+tables=("event.local_policies" "event.local_root_policies" "event.managed_clusters")
+
+echo ">> Removing duplicated event records from the target tables"
+
+for table in "${tables[@]}"; do
+  echo "> Processing table: $table"
+
+  # Get the latest timestamp from the source table
+  latest_time=$(kubectl exec -it -c $SOURCE_CONTAINER $SOURCE_POD -n $NAMESPACE -- psql -U $DB_USER -d $DB_NAME -t -c "SELECT MAX(created_at) FROM $table;")
+
+  latest_time=$(echo $latest_time | xargs) # Trim whitespace
+
+  # Validate if latest_time is empty, NULL, or not a valid timestamp
+  if [ -z "$latest_time" ] || [ "$latest_time" == "NULL" ] || ! [[ "$latest_time" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2} ]]; then
+    echo "  No records(or invalid) found in $table. Skipping..."
+    continue
+  fi
+
+  echo "> Latest created_at time for $table: $latest_time"
+  # Delete records from the target table with a timestamp earlier than the latest time
+  echo "> Deleting records from $table with created_at <= $latest_time"
+  kubectl exec -it -c $TARGET_CONTAINER $TARGET_POD -n $NAMESPACE -- psql -U $DB_USER -d $DB_NAME -c "DELETE FROM $table WHERE created_at <= '$latest_time';"
+done
+
+echo ">> Completed removing duplicated event records."
+
+# Restore to target pod
+echo ">> Restoring event tables to $TARGET_POD ($TARGET_CONTAINER)..."
+kubectl cp ./event_tables_backup.sql $NAMESPACE/$TARGET_POD:$REMOTE_PATH -c $TARGET_CONTAINER
+kubectl exec -c $TARGET_CONTAINER $TARGET_POD -n $NAMESPACE -- psql -U $DB_USER -d $DB_NAME -f $REMOTE_PATH
+echo ">> Restore completed."
+
+# Cleanup
+echo ">> Cleaning up temporary files..."
+kubectl exec -c $SOURCE_CONTAINER $SOURCE_POD -n $NAMESPACE -- rm $REMOTE_PATH
+kubectl exec -c $TARGET_CONTAINER $TARGET_POD -n $NAMESPACE -- rm $REMOTE_PATH
+rm ./event_tables_backup.sql
+echo ">> Local and remote backup files removed. Done!"

--- a/doc/upgrade/restore_history_tables.sh
+++ b/doc/upgrade/restore_history_tables.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Tables: `history.local_compliance` and `history.local_compliance_job_log`
+
+# Set namespace and pod names
+NAMESPACE="${1:-multicluster-global-hub}"
+SOURCE_POD="multicluster-global-hub-postgres-0"       # Source pod
+SOURCE_CONTAINER="multicluster-global-hub-postgres"   # Source container
+TARGET_POD="multicluster-global-hub-postgresql-0"     # Target pod
+TARGET_CONTAINER="multicluster-global-hub-postgresql" # Target container
+REMOTE_PATH="/tmp/history_tables_backup.sql"          # Without leading `/` to suppress tar warnings
+DB_NAME="hoh"
+DB_USER="postgres"
+
+echo "Using namespace: $NAMESPACE"
+
+# Backup from source pod
+echo ">> Backing up history tables from $SOURCE_POD ($SOURCE_CONTAINER)..."
+kubectl exec -c $SOURCE_CONTAINER $SOURCE_POD -n $NAMESPACE -- pg_dump -U $DB_USER -d $DB_NAME -t 'history.*' --data-only -f $REMOTE_PATH 2>/dev/null
+kubectl cp $NAMESPACE/$SOURCE_POD:$REMOTE_PATH ./history_tables_backup.sql -c $SOURCE_CONTAINER >/dev/null 2>&1
+echo ">> Backup completed."
+
+# Restore to target pod
+echo ">> Restoring history tables to $TARGET_POD ($TARGET_CONTAINER)..."
+kubectl cp ./history_tables_backup.sql $NAMESPACE/$TARGET_POD:$REMOTE_PATH -c $TARGET_CONTAINER
+kubectl exec -c $TARGET_CONTAINER $TARGET_POD -n $NAMESPACE -- psql -U $DB_USER -d $DB_NAME -f $REMOTE_PATH
+echo ">> Restore completed."
+
+# Cleanup
+echo ">> Cleaning up temporary files..."
+kubectl exec -c $SOURCE_CONTAINER $SOURCE_POD -n $NAMESPACE -- rm $REMOTE_PATH
+kubectl exec -c $TARGET_CONTAINER $TARGET_POD -n $NAMESPACE -- rm $REMOTE_PATH
+rm ./history_tables_backup.sql
+echo ">> Local and remote backup files removed. Done!"

--- a/doc/upgrade/upgrade_to_globalhub_1.4.0.md
+++ b/doc/upgrade/upgrade_to_globalhub_1.4.0.md
@@ -1,0 +1,27 @@
+# Upgrade the Built-in Postgres from Global Hub Release-1.3.0 to 1.4.0
+
+With the Global Hub Release 1.4.0, the built-in Postgres database has been upgraded to version 16, replacing the existing statefulset instance `multicluster-global-hub-postgres` (version 13) with a new instance, `multicluster-global-hub-postgresql`. By default, after the upgrade, real-time data such as **policies** and **clusters** will be automatically re-synced to the new Postgres instance.
+
+However, historical data (e.g., **event** and **history** tables) will not be recovered automatically. If retaining historical data is not a concern, you can skip the backup and restore steps below. Otherwise, follow the optional backup and restore instructions.
+
+## Backup and Restore Data(history and event) [Optional]
+
+- Run the following script to restore history tables
+
+```bash
+./doc/upgrade/restore_history_tables.sh
+```
+
+- Run the following script to restore event tables
+
+```bash
+./doc/upgrade/restore_event_tables.sh
+```
+
+## Delete Legacy Built-in Postgres Resources Manually [Optional]
+
+After the upgrade, the Global Hub switches to the new built-in Postgres instance. Resources associated with the legacy Postgres instance are not deleted automatically by the Global Hub operator. To clean up these resources, Use the following script to delete legacy Postgres resources.
+
+ ```bash
+ ./doc/upgrade/cleanup_legacy_postgres.sh
+ ```


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes # https://issues.redhat.com/browse/ACM-16157

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [x] List other manual tests you have done.

```bash
❯ ./doc/upgrade/restore_history_tables.sh
Using namespace: multicluster-global-hub
>> Backing up history tables from multicluster-global-hub-postgres-0 (multicluster-global-hub-postgres)...
>> Backup completed.
>> Restoring history tables to multicluster-global-hub-postgresql-0 (multicluster-global-hub-postgresql)...
SET
SET
SET
SET
SET
 set_config
------------

(1 row)

SET
SET
SET
SET
COPY 0
COPY 1
COPY 0
>> Restore completed.
>> Cleaning up temporary files...
>> Local and remote backup files removed. Done!
```

```bash
❯ kubectl exec -it multicluster-global-hub-postgres-0 -n multicluster-global-hub -- psql -U postgres -d hoh

Defaulted container "multicluster-global-hub-postgres" out of: multicluster-global-hub-postgres, prometheus-postgres-exporter
psql (13.7)
Type "help" for help.

hoh=# select * from event.local_policies;
    event_name     | event_namespace |              policy_id               |              cluster_id              | cluster_name | leaf_hub_name |              message              |    reason    | c
ount |                           source                            |         created_at         |  compliance
-------------------+-----------------+--------------------------------------+--------------------------------------+--------------+---------------+-----------------------------------+--------------+--
-----+-------------------------------------------------------------+----------------------------+---------------
 PolicyViolation   | namespace-a     | 550e8400-e29b-41d4-a716-446655440000 | 660e8400-e29b-41d4-a716-446655440000 | cluster-a    | leaf-hub-1    | Policy violated on resource X.    | NonCompliant |
   1 | {"type": "kubernetes", "component": "policy-engine"}        | 2024-12-18 03:14:21.795684 | non_compliant
 PolicyRemediation | namespace-b     | 750e8400-e29b-41d4-a716-446655440001 | 860e8400-e29b-41d4-a716-446655440002 | cluster-b    | leaf-hub-2    | Remediation applied successfully. | Compliant    |
   1 | {"type": "kubernetes", "component": "remediation-operator"} | 2024-12-18 03:14:21.822416 | compliant
(2 rows)

hoh=# exit

❯ ./doc/upgrade/restore_event_tables.sh
Using namespace: multicluster-global-hub
>> Backing up event tables from multicluster-global-hub-postgres-0 (multicluster-global-hub-postgres)...
>> Backup completed.
>> Removing duplicated event records from the target tables
> Processing table: event.local_policies
  Latest created_at time for event.local_policies: 2024-12-18 03:14:21.822416
  Deleting records from event.local_policies with created_at <= 2024-12-18 03:14:21.822416
DELETE 2
> Processing table: event.local_root_policies
  No records(or invalid) found in event.local_root_policies. Skipping...
> Processing table: event.managed_clusters
  No records(or invalid) found in event.managed_clusters. Skipping...
>> Completed removing duplicated event records.
>> Restoring event tables to multicluster-global-hub-postgresql-0 (multicluster-global-hub-postgresql)...
SET
SET
SET
SET
SET
 set_config
------------

(1 row)

SET
SET
SET
SET
COPY 0
COPY 0
COPY 2
COPY 0
COPY 0
COPY 0
COPY 0
>> Restore completed.
>> Cleaning up temporary files...
>> Local and remote backup files removed. Done!
❯ kubectl exec -it multicluster-global-hub-postgresql-0 -n multicluster-global-hub -- psql -U postgres -d hoh

Defaulted container "multicluster-global-hub-postgresql" out of: multicluster-global-hub-postgresql, prometheus-postgres-exporter
psql (16.4)
Type "help" for help.

hoh=# select * from event.local_policies;
    event_name     | event_namespace |              policy_id               |              cluster_id              | cluster_name | leaf_hub_name |              message              |    reason    | c
ount |                           source                            |         created_at         |  compliance
-------------------+-----------------+--------------------------------------+--------------------------------------+--------------+---------------+-----------------------------------+--------------+--
-----+-------------------------------------------------------------+----------------------------+---------------
 PolicyRemediation | namespace-b     | 750e8400-e29b-41d4-a716-446655440003 | 860e8400-e29b-41d4-a716-446655440003 | cluster-b    | leaf-hub-2    | Remediation applied successfully. | Compliant    |
   1 | {"type": "kubernetes", "component": "remediation-operator"} | 2024-12-18 03:35:18.151348 | compliant
 PolicyViolation   | namespace-a     | 550e8400-e29b-41d4-a716-446655440000 | 660e8400-e29b-41d4-a716-446655440000 | cluster-a    | leaf-hub-1    | Policy violated on resource X.    | NonCompliant |
   1 | {"type": "kubernetes", "component": "policy-engine"}        | 2024-12-18 03:14:21.795684 | non_compliant
 PolicyRemediation | namespace-b     | 750e8400-e29b-41d4-a716-446655440001 | 860e8400-e29b-41d4-a716-446655440002 | cluster-b    | leaf-hub-2    | Remediation applied successfully. | Compliant    |
   1 | {"type": "kubernetes", "component": "remediation-operator"} | 2024-12-18 03:14:21.822416 | compliant
(3 rows)
```

```bash
❯ oc get pods
NAME                                                READY   STATUS    RESTARTS       AGE
kafka-entity-operator-758d57f949-wqw5d              2/2     Running   0              7d19h
kafka-kafka-0                                       1/1     Running   0              7d19h
multicluster-global-hub-grafana-849bcd8756-cb2tj    2/2     Running   0              7d1h
multicluster-global-hub-manager-698594c9-dvf4h      1/1     Running   0              7d1h
multicluster-global-hub-operator-cb8d6585f-2t2k8    1/1     Running   0              7d1h
multicluster-global-hub-postgres-0                  2/2     Running   0              7d19h
multicluster-global-hub-postgresql-0                2/2     Running   0              7d1h
strimzi-cluster-operator-v0.43.0-76f57fb5b7-thbl9   1/1     Running   1 (4d7h ago)   7d19h
❯ oc get secret | grep postgres
multicluster-global-hub-postgres                     Opaque                                5      7d19h
multicluster-global-hub-postgres-certs               kubernetes.io/tls                     2      7d19h
multicluster-global-hub-postgres-dockercfg-6n8kn     kubernetes.io/dockercfg               1      7d19h
multicluster-global-hub-postgresql                   Opaque                                5      7d1h
multicluster-global-hub-postgresql-cert              kubernetes.io/tls                     2      7d1h
multicluster-global-hub-postgresql-dockercfg-zkl8p   kubernetes.io/dockercfg               1      7d1h
postgres-credential-secret                           Opaque                                2      7d19h
❯ oc get cm | grep postgres
grafana-dashboard-acm-global-postgres                            1      7d19h
grafana-dashboard-acm-global-postgres-tables                     1      7d19h
multicluster-global-hub-postgres-ca                              1      7d19h
multicluster-global-hub-postgres-config                          1      7d19h
multicluster-global-hub-postgres-init                            1      7d19h
multicluster-global-hub-postgresql-ca                            1      7d1h
multicluster-global-hub-postgresql-config                        1      7d1h
multicluster-global-hub-postgresql-init                          1      7d1h
❯ ./doc/upgrade/cleanup_legacy_postgres.sh
>> Starting cleanup of legacy Postgres resources in namespace: multicluster-global-hub
>> Deleting StatefulSet: multicluster-global-hub-postgres...
statefulset.apps "multicluster-global-hub-postgres" deleted
>> Deleting ConfigMaps...
configmap "multicluster-global-hub-postgres-ca" deleted
configmap "multicluster-global-hub-postgres-config" deleted
configmap "multicluster-global-hub-postgres-init" deleted
>> Deleting Secrets...
secret "postgres-credential-secret" deleted
secret "multicluster-global-hub-postgres" deleted
secret "multicluster-global-hub-postgres-certs" deleted
>> Cleanup completed for namespace: multicluster-global-hub
❯ oc get pods
NAME                                                READY   STATUS    RESTARTS       AGE
kafka-entity-operator-758d57f949-wqw5d              2/2     Running   0              7d19h
kafka-kafka-0                                       1/1     Running   0              7d19h
multicluster-global-hub-grafana-849bcd8756-cb2tj    2/2     Running   0              7d1h
multicluster-global-hub-manager-698594c9-dvf4h      1/1     Running   0              7d1h
multicluster-global-hub-operator-cb8d6585f-2t2k8    1/1     Running   0              7d1h
multicluster-global-hub-postgresql-0                2/2     Running   0              7d1h
strimzi-cluster-operator-v0.43.0-76f57fb5b7-thbl9   1/1     Running   1 (4d7h ago)   7d19h
❯ oc get secret | grep postgres
multicluster-global-hub-postgres-dockercfg-6n8kn     kubernetes.io/dockercfg               1      7d19h
multicluster-global-hub-postgresql                   Opaque                                5      7d1h
multicluster-global-hub-postgresql-cert              kubernetes.io/tls                     2      7d1h
multicluster-global-hub-postgresql-dockercfg-zkl8p   kubernetes.io/dockercfg               1      7d1h
❯ oc get cm | grep postgres
grafana-dashboard-acm-global-postgres                            1      7d19h
grafana-dashboard-acm-global-postgres-tables                     1      7d19h
multicluster-global-hub-postgresql-ca                            1      7d1h
multicluster-global-hub-postgresql-config                        1      7d1h
multicluster-global-hub-postgresql-init                          1      7d1h
```