### PR TITLE
fix error when delete mgh then recreate it

### DIFF
--- a/operator/pkg/config/storage_config.go
+++ b/operator/pkg/config/storage_config.go
@@ -142,7 +142,11 @@ func GetPGConnectionFromBuildInPostgres(ctx context.Context, client client.Clien
 // SetStorageConnection update the postgres connection
 func SetStorageConnection(conn *PostgresConnection) bool {
 	log.Debugf("Set Storage Connection: %v", conn == nil)
-	if conn != nil && !reflect.DeepEqual(conn, postgresConn) {
+	if conn == nil {
+		postgresConn = nil
+		return true
+	}
+	if !reflect.DeepEqual(conn, postgresConn) {
 		postgresConn = conn
 		log.Debugf("Update Storage Connection")
 		return true

--- a/operator/pkg/config/transport_config.go
+++ b/operator/pkg/config/transport_config.go
@@ -45,7 +45,11 @@ var (
 
 func SetTransporterConn(conn *transport.KafkaConfig) bool {
 	log.Debug("set Transporter Conn")
-	if conn != nil && !reflect.DeepEqual(conn, transporterConn) {
+	if conn == nil {
+		transporterConn = nil
+		return true
+	}
+	if !reflect.DeepEqual(conn, transporterConn) {
 		transporterConn = conn
 		log.Debug("update Transporter Conn")
 		return true


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
we should delete kafka pvc when delete mgh, if not, when we recreate mgh, the kafka pod can not start 
```
[root@ip-172-31-15-97 multicluster-global-hub]# oc get po
NAME                                                READY   STATUS             RESTARTS      AGE
kafka-kafka-0                                       0/1     CrashLoopBackOff   2 (9s ago)    41s
kafka-kafka-1                                       0/1     CrashLoopBackOff   2 (11s ago)   41s
kafka-kafka-2                                       0/1     CrashLoopBackOff   2 (9s ago)    40s
multicluster-global-hub-grafana-cc8b57d74-v6fh2     2/2     Running            0             89s
multicluster-global-hub-grafana-cc8b57d74-vvc9c     2/2     Running            0             89s
multicluster-global-hub-manager-698594c9-6tpcp      1/1     Running            2 (90s ago)   92s
multicluster-global-hub-manager-698594c9-jbvjv      1/1     Running            2 (86s ago)   92s
multicluster-global-hub-operator-776678446c-7gksz   1/1     Running            0             6m8s
multicluster-global-hub-postgresql-0                2/2     Running            0             92s
strimzi-cluster-operator-v0.43.0-76f57fb5b7-kgs4d   1/1     Running            0             80s
```

`
 (org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig) [main]
Exception in thread "main" java.lang.RuntimeException: Invalid cluster.id in: /var/lib/kafka/data-0/kafka-log0/meta.properties. Expected PPAVF8rBTuq25YVTs2LT_Q, but read NCsZMgUBSwuPQDozJaC8zg
	at org.apache.kafka.metadata.properties.MetaPropertiesEnsemble.verify(MetaPropertiesEnsemble.java:509)
	at kafka.tools.StorageTool$.formatCommand(StorageTool.scala:531)
	at kafka.tools.StorageTool$.runFormatCommand(StorageTool.scala:140)
	at kafka.tools.StorageTool$.execute(StorageTool.scala:80)
	at kafka.tools.StorageTool$.main(StorageTool.scala:53)
	at kafka.tools.StorageTool.main(StorageTool.scala)
`


## Related issue(s)
https://issues.redhat.com/browse/ACM-16507
Fixes #

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
