### PR TITLE
:bug: Get clusterId from managedcluster

### DIFF
--- a/agent/pkg/controllers/inventory/managedclusterinfo/managed_cluster_info_controller.go
+++ b/agent/pkg/controllers/inventory/managedclusterinfo/managed_cluster_info_controller.go
@@ -180,10 +180,13 @@ func GetK8SCluster(clusterInfo *clusterinfov1beta1.ManagedClusterInfo,
 		k8sCluster.ResourceData.VendorVersion = clusterInfo.Status.DistributionInfo.OCP.Version
 	case clusterinfov1beta1.KubeVendorEKS:
 		k8sCluster.ResourceData.KubeVendor = kessel.K8SClusterDetail_EKS
+		k8sCluster.ResourceData.VendorVersion = clusterInfo.Status.Version
 	case clusterinfov1beta1.KubeVendorGKE:
 		k8sCluster.ResourceData.KubeVendor = kessel.K8SClusterDetail_GKE
+		k8sCluster.ResourceData.VendorVersion = clusterInfo.Status.Version
 	default:
 		k8sCluster.ResourceData.KubeVendor = kessel.K8SClusterDetail_KUBE_VENDOR_OTHER
+		k8sCluster.ResourceData.VendorVersion = clusterInfo.Status.Version
 	}
 
 	// cluster status

--- a/agent/pkg/controllers/inventory/managedclusterinfo/managed_cluster_info_controller_test.go
+++ b/agent/pkg/controllers/inventory/managedclusterinfo/managed_cluster_info_controller_test.go
@@ -144,7 +144,7 @@ func TestGetK8SClusterInfo(t *testing.T) {
 		clusterinfov1beta1.CloudVendorAWS)
 
 	// Call the function
-	k8sCluster := GetK8SCluster(clusterInfo, "guest")
+	k8sCluster := GetK8SCluster(clusterInfo, clusterInfo.Status.ClusterID, "guest")
 
 	// Assert the results
 	assert.NotNil(t, k8sCluster)
@@ -199,7 +199,7 @@ func TestKubeVendorK8SCluster(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			k8sCluster := GetK8SCluster(tc.clusterInfo, "guest")
+			k8sCluster := GetK8SCluster(tc.clusterInfo, tc.clusterInfo.Status.ClusterID, "guest")
 
 			assert.NotNil(t, k8sCluster)
 			assert.Equal(t, tc.expectedVendor, k8sCluster.ResourceData.KubeVendor)

--- a/operator/pkg/controllers/agent/addon_manager.go
+++ b/operator/pkg/controllers/agent/addon_manager.go
@@ -54,9 +54,6 @@ func ReadyToEnableAddonManager(mgh *v1alpha4.MulticlusterGlobalHub) bool {
 	if !meta.IsStatusConditionTrue(mgh.Status.Conditions, config.CONDITION_TYPE_GLOBALHUB_READY) {
 		return false
 	}
-	if config.EnableInventory() {
-		return false
-	}
 	return true
 }
 

--- a/samples/inventory/requester/global_hub.go
+++ b/samples/inventory/requester/global_hub.go
@@ -41,7 +41,7 @@ func globalHub(ctx context.Context) error {
 	}
 
 	clusterInfo := createMockClusterInfo("local-cluster")
-	k8sCluster := managedclusterinfo.GetK8SCluster(clusterInfo, "guest")
+	k8sCluster := managedclusterinfo.GetK8SCluster(clusterInfo, clusterInfo.Status.ClusterID, "guest")
 	createResp, err := requesterClient.GetHttpClient().K8sClusterService.CreateK8SCluster(ctx,
 		&kessel.CreateK8SClusterRequest{K8SCluster: k8sCluster})
 	if err != nil {
@@ -50,7 +50,7 @@ func globalHub(ctx context.Context) error {
 	fmt.Println("creating response", createResp)
 
 	clusterInfo = createMockClusterInfo("local-cluster")
-	k8sCluster = managedclusterinfo.GetK8SCluster(clusterInfo, "guest")
+	k8sCluster = managedclusterinfo.GetK8SCluster(clusterInfo, clusterInfo.Status.ClusterID, "guest")
 	updatingResponse, err := requesterClient.GetHttpClient().K8sClusterService.UpdateK8SCluster(ctx,
 		&kessel.UpdateK8SClusterRequest{K8SCluster: k8sCluster})
 	if err != nil {
@@ -59,7 +59,7 @@ func globalHub(ctx context.Context) error {
 	fmt.Println("updating response", updatingResponse)
 
 	clusterInfo = createMockClusterInfo("local-cluster")
-	k8sCluster = managedclusterinfo.GetK8SCluster(clusterInfo, "guest")
+	k8sCluster = managedclusterinfo.GetK8SCluster(clusterInfo, clusterInfo.Status.ClusterID, "guest")
 	deletingResponse, err := requesterClient.GetHttpClient().K8sClusterService.DeleteK8SCluster(ctx,
 		&kessel.DeleteK8SClusterRequest{ReporterData: k8sCluster.ReporterData})
 	if err != nil {

--- a/samples/inventory/requester/managed_hub.go
+++ b/samples/inventory/requester/managed_hub.go
@@ -40,7 +40,8 @@ func managedHub(ctx context.Context, leafHubName string) error {
 		return err
 	}
 
-	k8sCluster := managedclusterinfo.GetK8SCluster(&clusterInfoList[0], requester.GetInventoryClientName(leafHubName))
+	k8sCluster := managedclusterinfo.GetK8SCluster(&clusterInfoList[0], clusterInfoList[0].Status.ClusterID,
+		requester.GetInventoryClientName(leafHubName))
 
 	resp, err := requesterClient.GetHttpClient().K8sClusterService.CreateK8SCluster(ctx,
 		&kessel.CreateK8SClusterRequest{K8SCluster: k8sCluster},

--- a/test/e2e/kessel/cluster_test.go
+++ b/test/e2e/kessel/cluster_test.go
@@ -24,7 +24,7 @@ var _ = Describe("kafka-event: cluster API", Ordered, func() {
 		localResourceId = fmt.Sprintf("test-cluster-%d", rand.Intn(100000))
 		clusterInfo := mockManagedClusterInfo(localResourceId, clusterinfov1beta1.KubeVendorOpenShift, "4.10.0",
 			clusterinfov1beta1.CloudVendorAWS)
-		k8sCluster = managedclusterinfo.GetK8SCluster(clusterInfo, "guest")
+		k8sCluster = managedclusterinfo.GetK8SCluster(clusterInfo, clusterInfo.Status.ClusterID, "guest")
 	})
 
 	It("Create", func() {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Get ClusterId from managedcluster, because there is no clusterId in managedclusterinfo object for non-OpenShift Cluster.

## Related issue(s)

Fixes # https://issues.redhat.com/browse/ACM-15814

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
