### PR TITLE
:bug: Get clusterId from managedcluster

### DIFF
--- a/agent/pkg/status/controller/managedclusters/k8s_cluster_test.go
+++ b/agent/pkg/status/controller/managedclusters/k8s_cluster_test.go
@@ -16,7 +16,7 @@ func TestGetK8SClusterInfo(t *testing.T) {
 		clusterinfov1beta1.CloudVendorAWS)
 
 	// Call the function
-	k8sCluster := GetK8SCluster(clusterInfo, "guest")
+	k8sCluster := GetK8SCluster(clusterInfo, clusterInfo.Status.ClusterID, "guest")
 
 	// Assert the results
 	assert.NotNil(t, k8sCluster)
@@ -51,27 +51,27 @@ func TestKubeVendorK8SCluster(t *testing.T) {
 			clusterInfo: createMockClusterInfo("eks-cluster", clusterinfov1beta1.KubeVendorEKS, "",
 				clusterinfov1beta1.CloudVendorAzure),
 			expectedVendor:  kessel.K8SClusterDetail_EKS,
-			expectedVersion: "",
+			expectedVersion: "1.23.0",
 		},
 		{
 			name: "GKE Cluster",
 			clusterInfo: createMockClusterInfo("gke-cluster", clusterinfov1beta1.KubeVendorGKE, "",
 				clusterinfov1beta1.CloudVendorGoogle),
 			expectedVendor:  kessel.K8SClusterDetail_GKE,
-			expectedVersion: "",
+			expectedVersion: "1.23.0",
 		},
 		{
 			name: "Other Kubernetes Vendor",
 			clusterInfo: createMockClusterInfo("other-cluster", "SomeOtherVendor", "",
 				clusterinfov1beta1.CloudVendorBareMetal),
 			expectedVendor:  kessel.K8SClusterDetail_KUBE_VENDOR_OTHER,
-			expectedVersion: "",
+			expectedVersion: "1.23.0",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			k8sCluster := GetK8SCluster(tc.clusterInfo, "guest")
+			k8sCluster := GetK8SCluster(tc.clusterInfo, tc.clusterInfo.Status.ClusterID, "guest")
 
 			assert.NotNil(t, k8sCluster)
 			assert.Equal(t, tc.expectedVendor, k8sCluster.ResourceData.KubeVendor)

--- a/samples/inventory/requester/global_hub.go
+++ b/samples/inventory/requester/global_hub.go
@@ -41,7 +41,7 @@ func globalHub(ctx context.Context) error {
 	}
 
 	clusterInfo := createMockClusterInfo("local-cluster")
-	k8sCluster := managedclusters.GetK8SCluster(clusterInfo, "guest")
+	k8sCluster := managedclusters.GetK8SCluster(clusterInfo, clusterInfo.Status.ClusterID, "guest")
 	createResp, err := requesterClient.GetHttpClient().K8sClusterService.CreateK8SCluster(ctx,
 		&kessel.CreateK8SClusterRequest{K8SCluster: k8sCluster})
 	if err != nil {
@@ -50,7 +50,7 @@ func globalHub(ctx context.Context) error {
 	fmt.Println("creating response", createResp)
 
 	clusterInfo = createMockClusterInfo("local-cluster")
-	k8sCluster = managedclusters.GetK8SCluster(clusterInfo, "guest")
+	k8sCluster = managedclusters.GetK8SCluster(clusterInfo, clusterInfo.Status.ClusterID, "guest")
 	updatingResponse, err := requesterClient.GetHttpClient().K8sClusterService.UpdateK8SCluster(ctx,
 		&kessel.UpdateK8SClusterRequest{K8SCluster: k8sCluster})
 	if err != nil {
@@ -59,7 +59,7 @@ func globalHub(ctx context.Context) error {
 	fmt.Println("updating response", updatingResponse)
 
 	clusterInfo = createMockClusterInfo("local-cluster")
-	k8sCluster = managedclusters.GetK8SCluster(clusterInfo, "guest")
+	k8sCluster = managedclusters.GetK8SCluster(clusterInfo, clusterInfo.Status.ClusterID, "guest")
 	deletingResponse, err := requesterClient.GetHttpClient().K8sClusterService.DeleteK8SCluster(ctx,
 		&kessel.DeleteK8SClusterRequest{ReporterData: k8sCluster.ReporterData})
 	if err != nil {

--- a/samples/inventory/requester/managed_hub.go
+++ b/samples/inventory/requester/managed_hub.go
@@ -40,7 +40,8 @@ func managedHub(ctx context.Context, leafHubName string) error {
 		return err
 	}
 
-	k8sCluster := managedclusters.GetK8SCluster(&clusterInfoList[0], requester.GetInventoryClientName(leafHubName))
+	k8sCluster := managedclusters.GetK8SCluster(&clusterInfoList[0], clusterInfoList[0].Status.ClusterID,
+		requester.GetInventoryClientName(leafHubName))
 
 	resp, err := requesterClient.GetHttpClient().K8sClusterService.CreateK8SCluster(ctx,
 		&kessel.CreateK8SClusterRequest{K8SCluster: k8sCluster},


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Get ClusterId from managedcluster, because there is no clusterId in managedclusterinfo object for non-OpenShift Cluster.

## Related issue(s)

main branch PR: https://github.com/stolostron/multicluster-global-hub/pull/1290

Fixes # https://issues.redhat.com/browse/ACM-16468

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
