### PR TITLE
:bug: Fix integration

### DIFF
--- a/operator/pkg/config/condition_test.go
+++ b/operator/pkg/config/condition_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
@@ -28,9 +29,12 @@ func TestMain(m *testing.M) {
 	ctx = context.TODO()
 	// start testenv
 	testenv := &envtest.Environment{
-		CRDDirectoryPaths: []string{
-			filepath.Join("..", "..", "config", "crd", "bases"),
-			filepath.Join("..", "..", "..", "test", "manifest", "crd"),
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Paths: []string{
+				filepath.Join("..", "..", "config", "crd", "bases"),
+				filepath.Join("..", "..", "..", "test", "manifest", "crd"),
+			},
+			MaxTime: 1 * time.Minute,
 		},
 		ErrorIfCRDPathMissing: true,
 	}

--- a/operator/pkg/controllers/backup/suite_test.go
+++ b/operator/pkg/controllers/backup/suite_test.go
@@ -82,9 +82,12 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths: []string{
-			filepath.Join("..", "..", "..", "config", "crd", "bases"),
-			filepath.Join("..", "..", "..", "..", "test", "manifest", "crd"),
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Paths: []string{
+				filepath.Join("..", "..", "..", "config", "crd", "bases"),
+				filepath.Join("..", "..", "..", "..", "test", "manifest", "crd"),
+			},
+			MaxTime: 1 * time.Minute,
 		},
 		ErrorIfCRDPathMissing: true,
 	}

--- a/operator/pkg/controllers/crd/crd_controller_test.go
+++ b/operator/pkg/controllers/crd/crd_controller_test.go
@@ -56,9 +56,12 @@ func TestMain(m *testing.M) {
 
 	// start testenv
 	testenv := &envtest.Environment{
-		CRDDirectoryPaths: []string{
-			filepath.Join("..", "..", "..", "..", "test", "manifest", "crd"),
-			filepath.Join("..", "..", "..", "config", "crd", "bases", clusterResourceFile),
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Paths: []string{
+				filepath.Join("..", "..", "..", "..", "test", "manifest", "crd"),
+				filepath.Join("..", "..", "..", "config", "crd", "bases", clusterResourceFile),
+			},
+			MaxTime: 1 * time.Minute,
 		},
 		ErrorIfCRDPathMissing: true,
 	}

--- a/operator/pkg/controllers/hubofhubs/controller_test.go
+++ b/operator/pkg/controllers/hubofhubs/controller_test.go
@@ -45,9 +45,12 @@ func TestMain(m *testing.M) {
 	}
 
 	testenv := &envtest.Environment{
-		CRDDirectoryPaths: []string{
-			filepath.Join("..", "..", "..", "config", "crd", "bases"),
-			filepath.Join("..", "..", "..", "..", "test", "manifest", "crd"),
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Paths: []string{
+				filepath.Join("..", "..", "..", "config", "crd", "bases"),
+				filepath.Join("..", "..", "..", "..", "test", "manifest", "crd"),
+			},
+			MaxTime: 1 * time.Minute,
 		},
 		ErrorIfCRDPathMissing: true,
 	}

--- a/operator/pkg/deployer/hoh_deployer_suite_test.go
+++ b/operator/pkg/deployer/hoh_deployer_suite_test.go
@@ -3,6 +3,7 @@ package deployer_test
 import (
 	"path/filepath"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -33,9 +34,12 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths: []string{
-			filepath.Join("..", "..", "config", "crd", "bases"),
-			filepath.Join("..", "..", "..", "test", "manifest", "crd"),
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Paths: []string{
+				filepath.Join("..", "..", "config", "crd", "bases"),
+				filepath.Join("..", "..", "..", "test", "manifest", "crd"),
+			},
+			MaxTime: 1 * time.Minute,
 		},
 		ErrorIfCRDPathMissing: true,
 	}

--- a/pkg/jobs/jobs_suite_test.go
+++ b/pkg/jobs/jobs_suite_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -44,8 +45,11 @@ var (
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 	testenv = &envtest.Environment{
-		CRDDirectoryPaths: []string{
-			filepath.Join("..", "..", "test", "manifest", "crd"),
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Paths: []string{
+				filepath.Join("..", "..", "test", "manifest", "crd"),
+			},
+			MaxTime: 1 * time.Minute,
 		},
 	}
 

--- a/test/integration/agent/controller/suite_test.go
+++ b/test/integration/agent/controller/suite_test.go
@@ -42,8 +42,11 @@ var _ = BeforeSuite(func() {
 	ctx, cancel = context.WithCancel(context.Background())
 
 	testenv = &envtest.Environment{
-		CRDDirectoryPaths: []string{
-			filepath.Join("..", "..", "..", "manifest", "crd"),
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Paths: []string{
+				filepath.Join("..", "..", "..", "manifest", "crd"),
+			},
+			MaxTime: 1 * time.Minute,
 		},
 	}
 

--- a/test/integration/agent/spec/suite_test.go
+++ b/test/integration/agent/spec/suite_test.go
@@ -61,8 +61,11 @@ var _ = BeforeSuite(func() {
 	}
 
 	testenv = &envtest.Environment{
-		CRDDirectoryPaths: []string{
-			filepath.Join("..", "..", "..", "manifest", "crd"),
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Paths: []string{
+				filepath.Join("..", "..", "..", "manifest", "crd"),
+			},
+			MaxTime: 1 * time.Minute,
 		},
 	}
 

--- a/test/integration/agent/status/suite_test.go
+++ b/test/integration/agent/status/suite_test.go
@@ -64,8 +64,11 @@ var _ = BeforeSuite(func() {
 	ctx, cancel = context.WithCancel(context.Background())
 
 	testenv = &envtest.Environment{
-		CRDDirectoryPaths: []string{
-			filepath.Join("..", "..", "..", "manifest", "crd"),
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Paths: []string{
+				filepath.Join("..", "..", "..", "manifest", "crd"),
+			},
+			MaxTime: 1 * time.Minute,
 		},
 		ErrorIfCRDPathMissing: true,
 	}

--- a/test/integration/manager/controller/suite_test.go
+++ b/test/integration/manager/controller/suite_test.go
@@ -62,9 +62,12 @@ var _ = BeforeSuite(func() {
 	By("Prepare envtest environment")
 	var err error
 	testenv = &envtest.Environment{
-		CRDDirectoryPaths: []string{
-			filepath.Join("..", "..", "..", "manifest", "crd"),
-			filepath.Join("..", "..", "..", "..", "operator", "config", "crd", "bases"),
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Paths: []string{
+				filepath.Join("..", "..", "..", "manifest", "crd"),
+				filepath.Join("..", "..", "..", "..", "operator", "config", "crd", "bases"),
+			},
+			MaxTime: 1 * time.Minute,
 		},
 		ErrorIfCRDPathMissing: true,
 	}

--- a/test/integration/manager/spec/suite_test.go
+++ b/test/integration/manager/spec/suite_test.go
@@ -64,8 +64,11 @@ var _ = BeforeSuite(func() {
 	By("Prepare envtest environment")
 	var err error
 	testenv = &envtest.Environment{
-		CRDDirectoryPaths: []string{
-			filepath.Join("..", "..", "..", "manifest", "crd"),
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Paths: []string{
+				filepath.Join("..", "..", "..", "manifest", "crd"),
+			},
+			MaxTime: 1 * time.Minute,
 		},
 		ErrorIfCRDPathMissing: true,
 	}

--- a/test/integration/manager/status/suite_test.go
+++ b/test/integration/manager/status/suite_test.go
@@ -51,8 +51,11 @@ var _ = BeforeSuite(func() {
 	By("Prepare envtest environment")
 	var err error
 	testenv = &envtest.Environment{
-		CRDDirectoryPaths: []string{
-			filepath.Join("..", "..", "..", "manifest", "crd"),
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Paths: []string{
+				filepath.Join("..", "..", "..", "manifest", "crd"),
+			},
+			MaxTime: 1 * time.Minute,
 		},
 		ErrorIfCRDPathMissing: true,
 	}

--- a/test/integration/manager/webhook/admission_suite_test.go
+++ b/test/integration/manager/webhook/admission_suite_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -65,8 +66,11 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths: []string{
-			filepath.Join("..", "..", "..", "manifest", "crd"),
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Paths: []string{
+				filepath.Join("..", "..", "..", "manifest", "crd"),
+			},
+			MaxTime: 1 * time.Minute,
 		},
 		ErrorIfCRDPathMissing: true,
 	}

--- a/test/integration/operator/addons/suite_test.go
+++ b/test/integration/operator/addons/suite_test.go
@@ -43,9 +43,12 @@ var _ = BeforeSuite(func() {
 	By("Prepare envtest environment")
 	var err error
 	testenv = &envtest.Environment{
-		CRDDirectoryPaths: []string{
-			filepath.Join("..", "..", "..", "manifest", "crd"),
-			filepath.Join("..", "..", "..", "..", "operator", "config", "crd", "bases"),
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Paths: []string{
+				filepath.Join("..", "..", "..", "manifest", "crd"),
+				filepath.Join("..", "..", "..", "..", "operator", "config", "crd", "bases"),
+			},
+			MaxTime: 1 * time.Minute,
 		},
 		ErrorIfCRDPathMissing: true,
 	}

--- a/test/integration/operator/agent/suite_test.go
+++ b/test/integration/operator/agent/suite_test.go
@@ -69,9 +69,12 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths: []string{
-			filepath.Join("..", "..", "..", "..", "operator", "config", "crd", "bases"),
-			filepath.Join("..", "..", "..", "manifest", "crd"),
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Paths: []string{
+				filepath.Join("..", "..", "..", "..", "operator", "config", "crd", "bases"),
+				filepath.Join("..", "..", "..", "manifest", "crd"),
+			},
+			MaxTime: 1 * time.Minute,
 		},
 		ErrorIfCRDPathMissing: true,
 	}

--- a/test/integration/operator/hubofhubs/suite_test.go
+++ b/test/integration/operator/hubofhubs/suite_test.go
@@ -66,9 +66,12 @@ var _ = BeforeSuite(func() {
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
 		ControlPlane: envtest.ControlPlane{},
-		CRDDirectoryPaths: []string{
-			filepath.Join("..", "..", "..", "..", "operator", "config", "crd", "bases"),
-			filepath.Join("..", "..", "..", "manifest", "crd"),
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Paths: []string{
+				filepath.Join("..", "..", "..", "..", "operator", "config", "crd", "bases"),
+				filepath.Join("..", "..", "..", "manifest", "crd"),
+			},
+			MaxTime: 1 * time.Minute,
 		},
 		ErrorIfCRDPathMissing: true,
 	}

--- a/test/integration/operator/webhook/admission_suite_test.go
+++ b/test/integration/operator/webhook/admission_suite_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -64,8 +65,11 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths: []string{
-			filepath.Join("..", "..", "..", "manifest", "crd"),
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Paths: []string{
+				filepath.Join("..", "..", "..", "manifest", "crd"),
+			},
+			MaxTime: 1 * time.Minute,
 		},
 		ErrorIfCRDPathMissing: true,
 	}

--- a/test/manifest/kafka/kafka-cluster/kafka-cluster.yaml
+++ b/test/manifest/kafka/kafka-cluster/kafka-cluster.yaml
@@ -27,8 +27,8 @@ metadata:
     strimzi.io/kraft: enabled
 spec:
   kafka:
-    version: 3.7.0
-    metadataVersion: 3.7-IV4
+    version: 3.8.0
+    metadataVersion: 3.8-IV0
     listeners:
     - configuration:
         useServiceDnsDomain: true


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

the default timeout is 10s which is not enough for the envtest environment sometimes. set it as 1 minute

## Related issue(s)

Fixes #

```
       unable to install CRDs onto control plane: unable to create CRD instances: unable to create CRD "managedserviceaccounts.authentication.open-cluster-management.io": etcdserver: request timed out
      {
          msg: "unable to install CRDs onto control plane: unable to create CRD instances: unable to create CRD \"managedserviceaccounts.authentication.open-cluster-management.io\": etcdserver: request timed out", 
```

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
