### PR TITLE
fix some issue about upgrade

### DIFF
--- a/operator/pkg/controllers/agent/addon_manager.go
+++ b/operator/pkg/controllers/agent/addon_manager.go
@@ -50,7 +50,9 @@ func ReadyToEnableAddonManager(mgh *v1alpha4.MulticlusterGlobalHub) bool {
 	if !config.IsACMResourceReady() {
 		return false
 	}
-
+	if config.GetTransporterConn() == nil {
+		return false
+	}
 	if !meta.IsStatusConditionTrue(mgh.Status.Conditions, config.CONDITION_TYPE_GLOBALHUB_READY) {
 		return false
 	}

--- a/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
@@ -33,6 +33,7 @@ import (
 	operatorutils "github.com/stolostron/multicluster-global-hub/operator/pkg/utils"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
 const (
@@ -629,6 +630,8 @@ func (k *strimziTransporter) kafkaClusterReady() (KafkaStatus, error) {
 		return kafkaStatus, nil
 	}
 
+	k.isNewKafkaCluster = utils.HasAnnotation(kafkaCluster, constants.UpgradeKafkaFromZookeeperAnnotation)
+
 	if kafkaCluster.Spec != nil && kafkaCluster.Spec.Kafka.Listeners != nil {
 		// if the kafka cluster is already created, check if the tls is enabled
 		enableTLS := false
@@ -780,6 +783,9 @@ func (k *strimziTransporter) newKafkaCluster(mgh *operatorv1alpha4.MulticlusterG
 				UserOperator:  &kafkav1beta2.KafkaSpecEntityOperatorUserOperator{},
 			},
 		},
+	}
+	if k.isNewKafkaCluster {
+		kafkaCluster.Annotations[constants.UpgradeKafkaFromZookeeperAnnotation] = "true"
 	}
 
 	k.setAffinity(mgh, kafkaCluster)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -115,7 +115,8 @@ const (
 	ManagedClusterManagedByAnnotation = "global-hub.open-cluster-management.io/managed-by"
 	// identify the resource is from the global hub cluster
 	OriginOwnerReferenceAnnotation = "global-hub.open-cluster-management.io/origin-ownerreference-uid"
-
+	// identy the kafka is upgrade from zookeeper mode
+	UpgradeKafkaFromZookeeperAnnotation = "global-hub.open-cluster-management.io/upgrade-from-zookeeper"
 	// resync the kafka client secret in agent
 	ResyncKafkaClientSecretAnnotation = "global-hub.open-cluster-management.io/resign-kafka-client-secret" // #nosec G101
 )

--- a/test/integration/operator/controllers/agent/suite_test.go
+++ b/test/integration/operator/controllers/agent/suite_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/agent"
 	operatortrans "github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/transporter/protocol"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
@@ -122,6 +123,11 @@ var _ = BeforeSuite(func() {
 			EnablePprof:           false,
 		},
 	}
+	config.SetTransporterConn(&transport.KafkaConfig{
+		ClusterID:         "fake",
+		IsNewKafkaCluster: true,
+	})
+
 	By("start the addon manager and add addon controller to manager")
 	_, err = agent.StartAddonManagerController(controllerOption)
 	Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
1. Agent should start after transport ready
2. Add an annotation in kafka cr in upgrade case. then identify the `isNewKafkaCluster` based on this annotation. With this, operator restart will not impact this field.

## Related issue(s)

Fixes #
https://issues.redhat.com/browse/ACM-16797
## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
