### PR TITLE
fix deployment always update

### DIFF
--- a/operator/pkg/controllers/agent/manifests/templates/agent/multicluster-global-hub-agent-deployment.yaml
+++ b/operator/pkg/controllers/agent/manifests/templates/agent/multicluster-global-hub-agent-deployment.yaml
@@ -73,7 +73,9 @@ spec:
         {{- range .Tolerations}}
         - key: "{{.Key}}"
           operator: "{{.Operator}}"
+          {{- if .Value}}
           value: "{{.Value}}"
+          {{- end}}
           effect: "{{.Effect}}"
           {{- if .TolerationSeconds}}
           tolerationSeconds: {{.TolerationSeconds}}

--- a/operator/pkg/controllers/agent/manifests/templates/hostedagent/multicluster-global-hub-hosting-agent-deployment.yaml
+++ b/operator/pkg/controllers/agent/manifests/templates/hostedagent/multicluster-global-hub-hosting-agent-deployment.yaml
@@ -63,7 +63,9 @@ spec:
         {{- range .Tolerations}}
         - key: "{{.Key}}"
           operator: "{{.Operator}}"
+          {{- if .Value}}
           value: "{{.Value}}"
+          {{- end}}
           effect: "{{.Effect}}"
           {{- if .TolerationSeconds}}
           tolerationSeconds: {{.TolerationSeconds}}

--- a/operator/pkg/controllers/agent/manifests/templates/hubcluster/hubcluster-mch.yaml
+++ b/operator/pkg/controllers/agent/manifests/templates/hubcluster/hubcluster-mch.yaml
@@ -20,7 +20,9 @@ spec:
     {{- range .Tolerations}}
     - key: "{{.Key}}"
       operator: "{{.Operator}}"
+      {{- if .Value}}
       value: "{{.Value}}"
+      {{- end}}
       effect: "{{.Effect}}"
       {{ if .TolerationSeconds }} tolerationSeconds: {{ .TolerationSeconds }} {{- end }}
     {{- end}}

--- a/operator/pkg/controllers/grafana/manifests/deployment.yaml
+++ b/operator/pkg/controllers/grafana/manifests/deployment.yaml
@@ -167,7 +167,9 @@ spec:
         {{- range .Tolerations}}
         - key: "{{.Key}}"
           operator: "{{.Operator}}"
+          {{- if .Value}}
           value: "{{.Value}}"
+          {{- end}}
           effect: "{{.Effect}}"
           {{- if .TolerationSeconds}}
           tolerationSeconds: {{.TolerationSeconds}}

--- a/operator/pkg/controllers/inventory/manifests/deployment.yaml
+++ b/operator/pkg/controllers/inventory/manifests/deployment.yaml
@@ -102,7 +102,9 @@ spec:
         {{- range .Tolerations}}
         - key: "{{.Key}}"
           operator: "{{.Operator}}"
+          {{- if .Value}}
           value: "{{.Value}}"
+          {{- end}}
           effect: "{{.Effect}}"
           {{- if .TolerationSeconds}}
           tolerationSeconds: {{.TolerationSeconds}}

--- a/operator/pkg/controllers/manager/manifests/deployment.yaml
+++ b/operator/pkg/controllers/manager/manifests/deployment.yaml
@@ -151,7 +151,9 @@ spec:
         {{- range .Tolerations}}
         - key: "{{.Key}}"
           operator: "{{.Operator}}"
+          {{- if .Value}}
           value: "{{.Value}}"
+          {{- end}}
           effect: "{{.Effect}}"
           {{- if .TolerationSeconds}}
           tolerationSeconds: {{.TolerationSeconds}}

--- a/operator/pkg/controllers/storage/manifests.sts/postgres-statefulset.yaml
+++ b/operator/pkg/controllers/storage/manifests.sts/postgres-statefulset.yaml
@@ -130,7 +130,9 @@ spec:
         {{- range .Tolerations}}
         - key: "{{.Key}}"
           operator: "{{.Operator}}"
+          {{- if .Value}}
           value: "{{.Value}}"
+          {{- end}}
           effect: "{{.Effect}}"
           {{- if .TolerationSeconds}}
           tolerationSeconds: {{.TolerationSeconds}}

--- a/operator/pkg/renderer/testdata/app/nginx-deployment.yaml
+++ b/operator/pkg/renderer/testdata/app/nginx-deployment.yaml
@@ -74,7 +74,9 @@ spec:
         {{- range .Tolerations}}
         - key: "{{.Key}}"
           operator: "{{.Operator}}"
+          {{- if .Value}}
           value: "{{.Value}}"
+          {{- end}}
           effect: "{{.Effect}}"
           {{- if .TolerationSeconds}}
           tolerationSeconds: {{.TolerationSeconds}}

--- a/operator/pkg/renderer/testdata/output/all-nginx.golden.yaml
+++ b/operator/pkg/renderer/testdata/output/all-nginx.golden.yaml
@@ -49,7 +49,6 @@ spec:
       serviceAccountName: nginx
       tolerations:
       - key: node.kubernetes.io/unreachable
-        value: ""
         operator: Exists
         effect: NoExecute
         tolerationSeconds: 6000

--- a/operator/pkg/renderer/testdata/output/all.golden.yaml
+++ b/operator/pkg/renderer/testdata/output/all.golden.yaml
@@ -49,7 +49,6 @@ spec:
       serviceAccountName: nginx
       tolerations:
       - key: node.kubernetes.io/unreachable
-        value: ""
         operator: Exists
         effect: NoExecute
         tolerationSeconds: 6000

--- a/operator/pkg/renderer/testdata/output/default.golden.yaml
+++ b/operator/pkg/renderer/testdata/output/default.golden.yaml
@@ -61,7 +61,6 @@ spec:
       serviceAccountName: nginx
       tolerations:
       - key: node.kubernetes.io/unreachable
-        value: ""
         operator: Exists
         effect: NoExecute
         tolerationSeconds: 6000

--- a/operator/pkg/renderer/testdata/output/external.golden.yaml
+++ b/operator/pkg/renderer/testdata/output/external.golden.yaml
@@ -50,7 +50,6 @@ spec:
       serviceAccountName: nginx
       tolerations:
       - key: node.kubernetes.io/unreachable
-        value: ""
         operator: Exists
         effect: NoExecute
         tolerationSeconds: 6000

--- a/operator/pkg/renderer/testdata/output/ha.golden.yaml
+++ b/operator/pkg/renderer/testdata/output/ha.golden.yaml
@@ -60,7 +60,6 @@ spec:
       serviceAccountName: nginx
       tolerations:
       - key: node.kubernetes.io/unreachable
-        value: ""
         operator: Exists
         effect: NoExecute
         tolerationSeconds: 6000


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
When set tolerations in mgh like the following, manager and grafana deploy will always update quickly.
    tolerations:
    - effect: NoExecute
      key: node.kubernetes.io/not-ready
      operator: Exists


## Related issue(s)

Fixes #

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
