### PR TITLE
:bug: Fix the duplicate key value violates unique constraint of history table restore

### DIFF
--- a/doc/upgrade/restore_event_tables.sh
+++ b/doc/upgrade/restore_event_tables.sh
@@ -39,7 +39,6 @@ for table in "${tables[@]}"; do
     continue
   fi
 
-  echo "> Latest created_at time for $table: $latest_time"
   # Delete records from the target table with a timestamp earlier than the latest time
   echo "> Deleting records from $table with created_at <= $latest_time"
   kubectl exec -it -c $TARGET_CONTAINER $TARGET_POD -n $NAMESPACE -- psql -U $DB_USER -d $DB_NAME -c "DELETE FROM $table WHERE created_at <= '$latest_time';"


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes # https://issues.redhat.com/browse/ACM-16799

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [x] List other manual tests you have done.

```bash
❯ ./doc/upgrade/restore_history_tables.sh mgh
Using namespace: mgh
>> Backing up history tables from multicluster-global-hub-postgres-0 (multicluster-global-hub-postgres)...
>> Backup completed.
>> Removing duplicated history records from the target tables
> Processing table: history.local_compliance
  Deleting records from history.local_compliance with compliance_date <= 2025-01-02
DELETE 4
>> Completed removing duplicated history records.
>> Restoring history tables to multicluster-global-hub-postgresql-0 (multicluster-global-hub-postgresql)...
SET
SET
SET
SET
SET
 set_config 
------------
 
(1 row)

SET
SET
SET
SET
COPY 0
COPY 4
COPY 0
>> Restore completed.
>> Cleaning up temporary files...
>> Local and remote backup files removed. Done!
```
