### PR TITLE
:sparkles: Install GH into a brownfield

### DIFF
--- a/operator/api/operator/v1alpha4/multiclusterglobalhub_types.go
+++ b/operator/api/operator/v1alpha4/multiclusterglobalhub_types.go
@@ -107,13 +107,13 @@ type MulticlusterGlobalHubSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	// +optional
 	EnableMetrics bool `json:"enableMetrics"`
-	// InstallAgentOnHub determines whether deploy the Global Hub Agent on hub cluster.
-	// If set to true, the Global Hub Agent will be installed on the hub cluster only.
-	// If set to false, the Global Hub Agent will not be installed on the hub cluster.
+	// InstallAgentOnLocal determines whether deploy the Global Hub Agent on the local hub cluster or not.
+	// If set to true, the Global Hub Agent will be installed on the local hub cluster only.
+	// If set to false, the Global Hub Agent will not be installed on the local hub cluster.
 	// Currently, switching the value of this field is not supported after the Global Hub is installed.
 	// +kubebuilder:default=false
 	// +optional
-	InstallAgentOnHub bool `json:"installAgentOnHub,omitempty"`
+	InstallAgentOnLocal bool `json:"InstallAgentOnLocal,omitempty"`
 }
 
 type AdvancedSpec struct {

--- a/operator/api/operator/v1alpha4/multiclusterglobalhub_types.go
+++ b/operator/api/operator/v1alpha4/multiclusterglobalhub_types.go
@@ -107,6 +107,13 @@ type MulticlusterGlobalHubSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	// +optional
 	EnableMetrics bool `json:"enableMetrics"`
+	// InstallAgentOnHub determines whether deploy the Global Hub Agent on hub cluster.
+	// If set to true, the Global Hub Agent will be installed on the hub cluster only.
+	// If set to false, the Global Hub Agent will not be installed on the hub cluster.
+	// Currently, switching the value of this field is not supported after the Global Hub is installed.
+	// +kubebuilder:default=false
+	// +optional
+	InstallAgentOnHub bool `json:"installAgentOnHub,omitempty"`
 }
 
 type AdvancedSpec struct {

--- a/operator/bundle/manifests/operator.open-cluster-management.io_multiclusterglobalhubs.yaml
+++ b/operator/bundle/manifests/operator.open-cluster-management.io_multiclusterglobalhubs.yaml
@@ -55,6 +55,14 @@ spec:
                   retention: 18m
             description: Spec specifies the desired state of multicluster global hub
             properties:
+              InstallAgentOnLocal:
+                default: false
+                description: |-
+                  InstallAgentOnLocal determines whether deploy the Global Hub Agent on the local hub cluster or not.
+                  If set to true, the Global Hub Agent will be installed on the local hub cluster only.
+                  If set to false, the Global Hub Agent will not be installed on the local hub cluster.
+                  Currently, switching the value of this field is not supported after the Global Hub is installed.
+                type: boolean
               advanced:
                 description: AdvancedSpec specifies the advanced configurations for
                   the multicluster global hub
@@ -248,14 +256,6 @@ spec:
                 description: ImagePullSecret specifies the pull secret of the multicluster
                   global hub images
                 type: string
-              installAgentOnHub:
-                default: false
-                description: |-
-                  InstallAgentOnHub determines whether deploy the Global Hub Agent on hub cluster.
-                  If set to true, the Global Hub Agent will be installed on the hub cluster only.
-                  If set to false, the Global Hub Agent will not be installed on the hub cluster.
-                  Currently, switching the value of this field is not supported after the Global Hub is installed.
-                type: boolean
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/operator/bundle/manifests/operator.open-cluster-management.io_multiclusterglobalhubs.yaml
+++ b/operator/bundle/manifests/operator.open-cluster-management.io_multiclusterglobalhubs.yaml
@@ -248,6 +248,14 @@ spec:
                 description: ImagePullSecret specifies the pull secret of the multicluster
                   global hub images
                 type: string
+              installAgentOnHub:
+                default: false
+                description: |-
+                  InstallAgentOnHub determines whether deploy the Global Hub Agent on hub cluster.
+                  If set to true, the Global Hub Agent will be installed on the hub cluster only.
+                  If set to false, the Global Hub Agent will not be installed on the hub cluster.
+                  Currently, switching the value of this field is not supported after the Global Hub is installed.
+                type: boolean
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/operator/config/crd/bases/operator.open-cluster-management.io_multiclusterglobalhubs.yaml
+++ b/operator/config/crd/bases/operator.open-cluster-management.io_multiclusterglobalhubs.yaml
@@ -55,6 +55,14 @@ spec:
                   retention: 18m
             description: Spec specifies the desired state of multicluster global hub
             properties:
+              InstallAgentOnLocal:
+                default: false
+                description: |-
+                  InstallAgentOnLocal determines whether deploy the Global Hub Agent on the local hub cluster or not.
+                  If set to true, the Global Hub Agent will be installed on the local hub cluster only.
+                  If set to false, the Global Hub Agent will not be installed on the local hub cluster.
+                  Currently, switching the value of this field is not supported after the Global Hub is installed.
+                type: boolean
               advanced:
                 description: AdvancedSpec specifies the advanced configurations for
                   the multicluster global hub
@@ -248,14 +256,6 @@ spec:
                 description: ImagePullSecret specifies the pull secret of the multicluster
                   global hub images
                 type: string
-              installAgentOnHub:
-                default: false
-                description: |-
-                  InstallAgentOnHub determines whether deploy the Global Hub Agent on hub cluster.
-                  If set to true, the Global Hub Agent will be installed on the hub cluster only.
-                  If set to false, the Global Hub Agent will not be installed on the hub cluster.
-                  Currently, switching the value of this field is not supported after the Global Hub is installed.
-                type: boolean
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/operator/config/crd/bases/operator.open-cluster-management.io_multiclusterglobalhubs.yaml
+++ b/operator/config/crd/bases/operator.open-cluster-management.io_multiclusterglobalhubs.yaml
@@ -248,6 +248,14 @@ spec:
                 description: ImagePullSecret specifies the pull secret of the multicluster
                   global hub images
                 type: string
+              installAgentOnHub:
+                default: false
+                description: |-
+                  InstallAgentOnHub determines whether deploy the Global Hub Agent on hub cluster.
+                  If set to true, the Global Hub Agent will be installed on the hub cluster only.
+                  If set to false, the Global Hub Agent will not be installed on the hub cluster.
+                  Currently, switching the value of this field is not supported after the Global Hub is installed.
+                type: boolean
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/operator/pkg/controllers/agent/default_agent_controller.go
+++ b/operator/pkg/controllers/agent/default_agent_controller.go
@@ -261,7 +261,7 @@ func (r *DefaultAgentController) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, nil
 	}
 
-	if mgh.Spec.InstallAgentOnHub {
+	if mgh.Spec.InstallAgentOnLocal {
 		// if installed agent on hub cluster, global hub is installed in a brownfield cluster
 		if cluster.GetName() == constants.LocalClusterName ||
 			cluster.Labels[constants.LocalClusterName] == "true" ||

--- a/operator/pkg/controllers/agent/default_agent_controller.go
+++ b/operator/pkg/controllers/agent/default_agent_controller.go
@@ -265,7 +265,8 @@ func (r *DefaultAgentController) Reconcile(ctx context.Context, req ctrl.Request
 		// if installed agent on hub cluster, global hub is installed in a brownfield cluster
 		if cluster.GetName() == constants.LocalClusterName ||
 			cluster.Labels[constants.LocalClusterName] == "true" ||
-			deployMode != operatorconstants.GHAgentDeployModeNone {
+			deployMode == operatorconstants.GHAgentDeployModeDefault ||
+			deployMode == operatorconstants.GHAgentDeployModeHosted {
 			return ctrl.Result{}, r.reconcileAddonAndResources(ctx, cluster, clusterManagementAddOn)
 		}
 	} else {

--- a/test/integration/operator/controllers/agent/cluster_default_addon_test.go
+++ b/test/integration/operator/controllers/agent/cluster_default_addon_test.go
@@ -11,11 +11,12 @@ import (
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	workv1 "open-cluster-management.io/api/work/v1"
 
+	globalhubv1alpha4 "github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
 	operatorconstants "github.com/stolostron/multicluster-global-hub/operator/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 )
 
-// go test ./test/integration/operator/agent -ginkgo.focus "deploy default addon" -v
+// go test ./test/integration/operator/controllers/agent -ginkgo.focus "deploy default addon" -v
 var _ = Describe("deploy default addon", func() {
 	It("Should create agent when importing an bare OCP", func() {
 		clusterName := fmt.Sprintf("hub-%s", rand.String(6))
@@ -131,5 +132,58 @@ var _ = Describe("deploy default addon", func() {
 
 		// contains both the ACM and the Global Hub manifests
 		Expect(len(work.Spec.Workload.Manifests)).Should(Equal(17))
+	})
+
+	It("Should create agent for the local-cluster", func() {
+		By("set InstallAgentOnHub to true")
+		mghLookupKey := types.NamespacedName{Namespace: "default", Name: MGHName}
+		existingMGH := &globalhubv1alpha4.MulticlusterGlobalHub{}
+		Eventually(func() bool {
+			err := runtimeClient.Get(ctx, mghLookupKey, existingMGH)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+		existingMGH.Spec.InstallAgentOnHub = true
+		Expect(runtimeClient.Update(ctx, existingMGH)).Should(Succeed())
+
+		clusterName := fmt.Sprintf("hub-%s", rand.String(6))
+		workName := fmt.Sprintf("addon-%s-deploy-0",
+			constants.GHManagedClusterAddonName)
+
+		By("By preparing an OCP Managed Clusters")
+		prepareCluster(clusterName,
+			map[string]string{"vendor": "OpenShift", "local-cluster": "true"},
+			map[string]string{},
+			[]clusterv1.ManagedClusterClaim{},
+			clusterAvailableCondition)
+
+		By("By checking the addon CR is is created in the cluster ns")
+		addon := &addonv1alpha1.ManagedClusterAddOn{}
+		Eventually(func() error {
+			return runtimeClient.Get(ctx, types.NamespacedName{
+				Name:      constants.GHManagedClusterAddonName,
+				Namespace: clusterName,
+			}, addon)
+		}, timeout, interval).ShouldNot(HaveOccurred())
+
+		Expect(len(addon.GetAnnotations())).Should(Equal(0))
+
+		By("By checking the agent manifestworks are created for the local cluster")
+		work := &workv1.ManifestWork{}
+		Eventually(func() error {
+			return runtimeClient.Get(ctx, types.NamespacedName{
+				Name:      workName,
+				Namespace: clusterName,
+			}, work)
+		}, timeout, interval).ShouldNot(HaveOccurred())
+
+		Expect(len(work.Spec.Workload.Manifests)).Should(Equal(8))
+
+		By("set InstallAgentOnHub to false as a default value")
+		Eventually(func() bool {
+			err := runtimeClient.Get(ctx, mghLookupKey, existingMGH)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+		existingMGH.Spec.InstallAgentOnHub = false
+		Expect(runtimeClient.Update(ctx, existingMGH)).Should(Succeed())
 	})
 })

--- a/test/integration/operator/controllers/agent/cluster_default_addon_test.go
+++ b/test/integration/operator/controllers/agent/cluster_default_addon_test.go
@@ -135,14 +135,14 @@ var _ = Describe("deploy default addon", func() {
 	})
 
 	It("Should create agent for the local-cluster", func() {
-		By("set InstallAgentOnHub to true")
+		By("set InstallAgentOnLocal to true")
 		mghLookupKey := types.NamespacedName{Namespace: "default", Name: MGHName}
 		existingMGH := &globalhubv1alpha4.MulticlusterGlobalHub{}
 		Eventually(func() bool {
 			err := runtimeClient.Get(ctx, mghLookupKey, existingMGH)
 			return err == nil
 		}, timeout, interval).Should(BeTrue())
-		existingMGH.Spec.InstallAgentOnHub = true
+		existingMGH.Spec.InstallAgentOnLocal = true
 		Expect(runtimeClient.Update(ctx, existingMGH)).Should(Succeed())
 
 		clusterName := fmt.Sprintf("hub-%s", rand.String(6))
@@ -178,12 +178,12 @@ var _ = Describe("deploy default addon", func() {
 
 		Expect(len(work.Spec.Workload.Manifests)).Should(Equal(8))
 
-		By("set InstallAgentOnHub to false as a default value")
+		By("set InstallAgentOnLocal to false as a default value")
 		Eventually(func() bool {
 			err := runtimeClient.Get(ctx, mghLookupKey, existingMGH)
 			return err == nil
 		}, timeout, interval).Should(BeTrue())
-		existingMGH.Spec.InstallAgentOnHub = false
+		existingMGH.Spec.InstallAgentOnLocal = false
 		Expect(runtimeClient.Update(ctx, existingMGH)).Should(Succeed())
 	})
 })

--- a/test/integration/operator/controllers/agent/cluster_hosted_addon_test.go
+++ b/test/integration/operator/controllers/agent/cluster_hosted_addon_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 )
 
-// go test ./test/integration/operator/agent -ginkgo.focus "deploy hosted addon" -v
+// go test ./test/integration/operator/controllers/agent -ginkgo.focus "deploy hosted addon" -v
 var _ = Describe("deploy hosted addon", func() {
 	It("Should create hosted addon in OCP", func() {
 		clusterName := fmt.Sprintf("hub-%s", rand.String(6))                // managed hub cluster -> enable local cluster

--- a/test/integration/operator/controllers/agent/hosted_managedhub/mgh_hosted_test.go
+++ b/test/integration/operator/controllers/agent/hosted_managedhub/mgh_hosted_test.go
@@ -90,7 +90,7 @@ var hostedMGH = globalhubv1alpha4.MulticlusterGlobalHub{
 // hosted: put the acm agent cluster control plane into acm hub cluster
 // global hub -> managed-hub(local-cluster)
 
-// go test ./test/integration/operator/agent -ginkgo.focus "other addons in hosted mode test" -v
+// go test ./test/integration/operator/controllers/agent -ginkgo.focus "other addons in hosted mode test" -v
 var _ = Describe("other addons in hosted mode test", Ordered, func() {
 	var hostedAddonReconciler *agent.HostedAgentController
 	BeforeAll(func() {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

InstallAgentOnHub determines whether deploy the Global Hub Agent on hub cluster.
If set to true, the Global Hub Agent will be installed on the hub cluster only.
If set to false, the Global Hub Agent will not be installed on the hub cluster.
Currently, switching the value of this field is not supported after the Global Hub is installed.

## Related issue(s)

Fixes # https://issues.redhat.com/browse/ACM-15099

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [x] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [x] List other manual tests you have done.
- tested deploy the agent into local-cluster
- tested deploy the agent into hub cluster which has local-cluster="true" label

