### PR TITLE
:sparkles: Init postgres user and database from annotation

### DIFF
--- a/operator/pkg/config/storage_config.go
+++ b/operator/pkg/config/storage_config.go
@@ -65,6 +65,10 @@ func IsBYOPostgres() bool {
 	return isBYOPostgres
 }
 
+func SetBYOPostgres(byo bool) {
+	isBYOPostgres = byo
+}
+
 func SetDatabaseReady(ready bool) {
 	databaseReady = ready
 }

--- a/operator/pkg/constants/constants.go
+++ b/operator/pkg/constants/constants.go
@@ -75,6 +75,9 @@ const (
 	// development environments, where is is convenient to reduce the poll interval. The value should be a string
 	// that can be parsed with the time.ParseDuration function.
 	AnnotationMGHWithStackroxPollInterval = "global-hub.open-cluster-management.io/with-stackrox-poll-interval"
+
+	// AnnotationBuiltInPostgresUser indicates to create the postgres users and databases based on the value configuration
+	AnnotationBuiltInPostgresUsers = "global-hub.open-cluster-management.io/postgres-users"
 )
 
 // hub installation constants

--- a/operator/pkg/controllers/storage/storage_reconciler.go
+++ b/operator/pkg/controllers/storage/storage_reconciler.go
@@ -80,10 +80,10 @@ var WatchedConfigMap = sets.NewString(
 )
 
 var (
-	storageReconciler          *StorageReconciler
-	updateConnection           bool
-	appliedPgUserValue         string
-	postgresUserSecretTemplate = "postgresql-user-%s"
+	storageReconciler        *StorageReconciler
+	updateConnection         bool
+	appliedPgUserValue       string
+	postgresUserNameTemplate = "postgresql-user-%s"
 )
 
 func (r *StorageReconciler) IsResourceRemoved() bool {
@@ -391,7 +391,7 @@ func (r *StorageReconciler) createPostgresUser(ctx context.Context, conn *pgx.Co
 ) error {
 	userSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf(postgresUserSecretTemplate, user.Name),
+			Name:      fmt.Sprintf(postgresUserNameTemplate, user.Name),
 			Namespace: ns,
 		},
 	}

--- a/operator/pkg/controllers/storage/storage_reconciler.go
+++ b/operator/pkg/controllers/storage/storage_reconciler.go
@@ -211,7 +211,7 @@ func (r *StorageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 	updateConnection = config.SetStorageConnection(storageConn)
 
-	needRequeue, err := r.reconcileDatabase(ctx, mgh)
+	needRequeue, err := r.ReconcileDatabase(ctx, mgh)
 	if err != nil {
 		reconcileErr = fmt.Errorf("database not ready, Error: %v", err)
 		return ctrl.Result{}, reconcileErr
@@ -286,7 +286,7 @@ func (r *StorageReconciler) ReconcileStorage(ctx context.Context,
 	return pgConnection, nil
 }
 
-func (r *StorageReconciler) reconcileDatabase(ctx context.Context, mgh *v1alpha4.MulticlusterGlobalHub) (bool, error) {
+func (r *StorageReconciler) ReconcileDatabase(ctx context.Context, mgh *v1alpha4.MulticlusterGlobalHub) (bool, error) {
 	var conn *pgx.Conn
 	var err error
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes # https://issues.redhat.com/browse/ACM-16818

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [x] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [x] List other manual tests you have done.

1. create
```bash
❯ oc get secret postgresql-user-testuser
Error from server (NotFound): secrets "postgresql-user-testuser" not found
❯ kubectl patch mgh multiclusterglobalhub -n multicluster-global-hub --type='merge' \
  -p '{"metadata": {"annotations": {"global-hub.open-cluster-management.io/postgres-users": "[{\"name\": \"testuser\", \"databases\": [\"test1\"]}]"}}}'
multiclusterglobalhub.operator.open-cluster-management.io/multiclusterglobalhub patched
❯ kubectl exec -it multicluster-global-hub-postgresql-0 -n multicluster-global-hub -- psql -U postgres -d hoh;

Defaulted container "multicluster-global-hub-postgresql" out of: multicluster-global-hub-postgresql, prometheus-postgres-exporter
psql (16.4)
Type "help" for help.

hoh=# \l
                                                      List of databases
   Name    |  Owner   | Encoding | Locale Provider |  Collate   |   Ctype    | ICU Locale | ICU Rules |   Access privileges
-----------+----------+----------+-----------------+------------+------------+------------+-----------+-----------------------
...
 template0 | postgres | UTF8     | libc            | en_US.utf8 | en_US.utf8 |            |           | =..
 test1     | postgres | UTF8     | libc            | en_US.utf8 | en_US.utf8 |            |           | =Tc/postgres         +
           |          |          |                 |            |            |            |           | testuser=CTc/postgres
(6 rows)

hoh=# select * from pg_catalog.pg_user;
         usename          | usesysid | usecreatedb | usesuper | userepl | usebypassrls |  passwd  | valuntil | useconfig
--------------------------+----------+-------------+----------+---------+--------------+----------+----------+-----------
...
 testuser                 |    24657 | f           | f        | f       | f            | ******** |          |
(3 rows)

hoh=# SELECT
    rolname AS role_name,
    datname AS database_name,
    has_database_privilege(rolname, datname, 'CONNECT') AS can_connect,
    has_database_privilege(rolname, datname, 'CREATE') AS can_create
FROM
    pg_roles,
    pg_database
WHERE rolname = 'testuser';
 role_name | database_name | can_connect | can_create
-----------+---------------+-------------+------------
 testuser  | other1      | t           | f
 testuser  | ohter2           | t           | f
 testuser  | test1         | t           | t
(6 rows)

hoh=# exit
❯ oc get secret postgresql-user-testuser -oyaml
apiVersion: v1
data:
  ca: L...K
  databases: dGVzdDE=
  db.host: **
  db.password: **
  db.port: **
  db.user: dGVzdHVzZXI=
kind: Secret
metadata:
  creationTimestamp: "2025-01-10T09:55:32Z"
  name: postgresql-user-testuser
  namespace: multicluster-global-hub
  resourceVersion: "39342680"
  uid: 4d8996d7-8afc-4094-b0e2-34849ff6f347
type: Opaque
❯ echo "dGVzdDE=" | base64 -d
test1%
❯ echo "L...K" | base64 -d
-----BEGIN CERTIFICATE-----
...
-----END CERTIFICATE-----
```

2. update 
```bash
❯ kubectl patch mgh multiclusterglobalhub -n multicluster-global-hub --type='merge' \
  -p '{"metadata": {"annotations": {"global-hub.open-cluster-management.io/postgres-users": "[{\"name\": \"testuser\", \"databases\": [\"test1\", \"test2\"]}]"}}}'

multiclusterglobalhub.operator.open-cluster-management.io/multiclusterglobalhub patched
❯ kubectl exec -it multicluster-global-hub-postgresql-0 -n multicluster-global-hub -- psql -U postgres -d hoh;

Defaulted container "multicluster-global-hub-postgresql" out of: multicluster-global-hub-postgresql, prometheus-postgres-exporter
psql (16.4)
Type "help" for help.

hoh=# \l
                                                      List of databases
   Name    |  Owner   | Encoding | Locale Provider |  Collate   |   Ctype    | ICU Locale | ICU Rules |   Access privileges
-----------+----------+----------+-----------------+------------+------------+------------+-----------+-----------------------
...      
           |          |          |                 |            |            |            |           | postgres=CTc/postgres
 test1     | postgres | UTF8     | libc            | en_US.utf8 | en_US.utf8 |            |           | =Tc/postgres         +
           |          |          |                 |            |            |            |           | postgres=CTc/postgres+
           |          |          |                 |            |            |            |           | testuser=CTc/postgres
 test2     | postgres | UTF8     | libc            | en_US.utf8 | en_US.utf8 |            |           | =Tc/postgres         +
           |          |          |                 |            |            |            |           | postgres=CTc/postgres+
           |          |          |                 |            |            |            |           | testuser=CTc/postgres
(7 rows)

hoh=# select * from pg_catalog.pg_user;
         usename          | usesysid | usecreatedb | usesuper | userepl | usebypassrls |  passwd  | valuntil | useconfig
--------------------------+----------+-------------+----------+---------+--------------+----------+----------+-----------
 ...
 testuser                 |    24657 | f           | f        | f       | f            | ******** |          |
(3 rows)

hoh=# SELECT
    rolname AS role_name,
    datname AS database_name,
    has_database_privilege(rolname, datname, 'CONNECT') AS can_connect,
    has_database_privilege(rolname, datname, 'CREATE') AS can_create
FROM
    pg_roles,
    pg_database
WHERE rolname = 'testuser';
 role_name | database_name | can_connect | can_create
-----------+---------------+-------------+------------
 testuser  | ...     | t           | f
 testuser  | test1         | t           | t
 testuser  | test2         | t           | t
(7 rows)

hoh=# exit
❯ oc get secret postgresql-user-testuser -oyaml
apiVersion: v1
data:
  ca: L...K
  databases: dGVzdDEsdGVzdDI=
  ...
kind: Secret
metadata:
  creationTimestamp: "2025-01-10T09:55:32Z"
  name: postgresql-user-testuser
  namespace: multicluster-global-hub
  resourceVersion: "39347390"
  uid: 4d8996d7-8afc-4094-b0e2-34849ff6f347
type: Opaque
❯ echo "dGVzdDEsdGVzdDI=" | base64 -d
test1,test2%
```

3. dashboard

<img width="1903" alt="image" src="https://github.com/user-attachments/assets/3dfdd237-6b30-4646-8a95-1474b22c41ce" />
