### PR TITLE
:sparkles: Enable the builtin postgres configuration

### DIFF
--- a/operator/pkg/controllers/storage/manifests.sts/postgres-config-configmap.yaml
+++ b/operator/pkg/controllers/storage/manifests.sts/postgres-config-configmap.yaml
@@ -14,3 +14,4 @@ data:
     pg_stat_statements.max = 10000
     pg_stat_statements.track = all
     {{- end }}
+    {{.PostgresCustomizedConfig }}

--- a/operator/pkg/controllers/storage/manifests.sts/postgres-config-configmap.yaml
+++ b/operator/pkg/controllers/storage/manifests.sts/postgres-config-configmap.yaml
@@ -14,4 +14,4 @@ data:
     pg_stat_statements.max = 10000
     pg_stat_statements.track = all
     {{- end }}
-    {{.PostgresCustomizedConfig }}
+    {{- .PostgresCustomizedConfig | indent 4 }}

--- a/operator/pkg/controllers/storage/postgres_statefulset.go
+++ b/operator/pkg/controllers/storage/postgres_statefulset.go
@@ -89,7 +89,7 @@ func InitPostgresByStatefulset(ctx context.Context, mgh *globalhubv1alpha4.Multi
 				EnableMetrics                bool
 				EnablePostgresMetrics        bool
 				EnableInventoryAPI           bool
-				PostgresCustomizedConfig     string
+				PostgresCustomizedConfig     []byte
 			}{
 				Name:                         BuiltinPostgresName,
 				Namespace:                    mgh.GetNamespace(),
@@ -117,7 +117,7 @@ func InitPostgresByStatefulset(ctx context.Context, mgh *globalhubv1alpha4.Multi
 				EnableMetrics:            mgh.Spec.EnableMetrics,
 				EnablePostgresMetrics:    (!config.IsBYOPostgres()) && mgh.Spec.EnableMetrics,
 				EnableInventoryAPI:       config.WithInventory(mgh),
-				PostgresCustomizedConfig: customizedConfig,
+				PostgresCustomizedConfig: []byte(customizedConfig),
 			}, nil
 		})
 	if err != nil {
@@ -188,7 +188,7 @@ func getPostgresCustomizedConfig(ctx context.Context, mgh *globalhubv1alpha4.Mul
 	}
 	customizedConfig := ""
 	if !errors.IsNotFound(err) {
-		customizedConfig = cm.Data["postgresql.conf"]
+		customizedConfig = fmt.Sprintf("\n%s", cm.Data["postgresql.conf"])
 	}
 	return customizedConfig, nil
 }

--- a/operator/pkg/controllers/storage/storage_reconciler.go
+++ b/operator/pkg/controllers/storage/storage_reconciler.go
@@ -75,6 +75,7 @@ var WatchedSecret = sets.NewString(
 
 var WatchedConfigMap = sets.NewString(
 	BuiltinPostgresCAName,
+	BuiltinPostgresCustomizedConfigName,
 )
 
 var (
@@ -120,7 +121,7 @@ func (r *StorageReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&corev1.Secret{},
 			&handler.EnqueueRequestForObject{}, builder.WithPredicates(secretPred)).
 		Watches(&corev1.ConfigMap{},
-			&handler.EnqueueRequestForObject{}, builder.WithPredicates(config.GeneralPredicate)).
+			&handler.EnqueueRequestForObject{}, builder.WithPredicates(configMapPredicate)).
 		Watches(&appsv1.StatefulSet{},
 			&handler.EnqueueRequestForObject{}, builder.WithPredicates(statefulSetPred)).
 		Watches(&corev1.ServiceAccount{},
@@ -130,6 +131,20 @@ func (r *StorageReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&promv1.ServiceMonitor{},
 			&handler.EnqueueRequestForObject{}, builder.WithPredicates(config.GeneralPredicate)).
 		Complete(r)
+}
+
+var configMapPredicate = predicate.Funcs{
+	CreateFunc: func(e event.CreateEvent) bool {
+		return WatchedConfigMap.Has(e.Object.GetName())
+	},
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		return WatchedConfigMap.Has(e.ObjectNew.GetName()) ||
+			e.ObjectNew.GetLabels()[constants.GlobalHubOwnerLabelKey] == constants.GHOperatorOwnerLabelVal
+	},
+	DeleteFunc: func(e event.DeleteEvent) bool {
+		return WatchedConfigMap.Has(e.Object.GetName()) ||
+			e.Object.GetLabels()[constants.GlobalHubOwnerLabelKey] == constants.GHOperatorOwnerLabelVal
+	},
 }
 
 var statefulSetPred = predicate.Funcs{

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -91,9 +91,8 @@ const (
 
 // global hub console secret/configmap names
 const (
-	CustomAlertName              = "multicluster-global-hub-custom-alerting"
-	CustomGrafanaIniName         = "multicluster-global-hub-custom-grafana-config"
-	PostgresCustomizedConfigName = "multicluster-global-hub-custom-postgres-config"
+	CustomAlertName      = "multicluster-global-hub-custom-alerting"
+	CustomGrafanaIniName = "multicluster-global-hub-custom-grafana-config"
 )
 
 const (

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -91,8 +91,9 @@ const (
 
 // global hub console secret/configmap names
 const (
-	CustomAlertName      = "multicluster-global-hub-custom-alerting"
-	CustomGrafanaIniName = "multicluster-global-hub-custom-grafana-config"
+	CustomAlertName              = "multicluster-global-hub-custom-alerting"
+	CustomGrafanaIniName         = "multicluster-global-hub-custom-grafana-config"
+	PostgresCustomizedConfigName = "multicluster-global-hub-custom-postgres-config"
 )
 
 const (


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

You need to restart the Postgres instance for the configuration to take effect!

Fixed: https://issues.redhat.com/browse/ACM-16887

Resolved: https://github.com/stolostron/multicluster-global-hub/issues/1320, which provides the details for addressing the aforementioned Jira issue.


## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [x] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [x] List other manual tests you have done.

- Check the configuration before 
```bash
❯ kubectl exec -it multicluster-global-hub-postgresql-0 -n multicluster-global-hub -- psql -U postgres -d hoh;

Defaulted container "multicluster-global-hub-postgresql" out of: multicluster-global-hub-postgresql, prometheus-postgres-exporter
psql (16.4)
Type "help" for help.

hoh=# SHOW wal_level;
 wal_level
-----------
 replica
(1 row)

hoh=# SHOW max_wal_size;
 max_wal_size
--------------
 1GB
(1 row)

hoh=# exit
```
- Change the configuration
```bash
❯ oc get cm multicluster-global-hub-custom-postgresql-config -oyaml
apiVersion: v1
data:
  postgresql.conf: |
    wal_level = logical
    max_wal_size = 2GB
kind: ConfigMap
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","data":{"postgresql.conf":"wal_level = logical\nmax_wal_size = 2GB\n"},"kind":"ConfigMap","metadata":{"annotations":{},"name":"multicluster-global-hub-custom-postgresql-config","namespace":"multicluster-global-hub"}}
  creationTimestamp: "2025-01-13T08:40:51Z"
  name: multicluster-global-hub-custom-postgresql-config
  namespace: multicluster-global-hub
  resourceVersion: "41591561"
  uid: 2b292e02-bab9-479f-a8b9-128e70a8a119
❯ oc get cm multicluster-global-hub-postgresql-config -oyaml
apiVersion: v1
data:
  postgresql.conf: |
    ssl = on
    ssl_cert_file = '/opt/app-root/src/certs/tls.crt' # server certificate
    ssl_key_file =  '/opt/app-root/src/certs/tls.key' # server private key
    ssl_min_protocol_version = TLSv1.3
    shared_preload_libraries = 'pg_stat_statements'
    pg_stat_statements.max = 10000
    pg_stat_statements.track = all
    wal_level = logical
    max_wal_size = 2GB
kind: ConfigMap
metadata:
  creationTimestamp: "2025-01-08T11:04:23Z"
  labels:
    global-hub.open-cluster-management.io/managed-by: global-hub-operator
  name: multicluster-global-hub-postgresql-config
  namespace: multicluster-global-hub
  ownerReferences:
  - apiVersion: operator.open-cluster-management.io/v1alpha4
    blockOwnerDeletion: true
    controller: true
    kind: MulticlusterGlobalHub
    name: multiclusterglobalhub
    uid: 1522175f-8e05-46cd-b8b5-17c65a72e20b
  resourceVersion: "41603005"
  uid: c496c5aa-37e5-4d82-8a6c-45a570ecbfdb
```
- Restart the instance and verify the configuration has been applied successfully
```bash
❯ oc get pods
NAME                                                READY   STATUS    RESTARTS      AGE
kafka-entity-operator-c5d866b4b-s9p2r               2/2     Running   0             4d21h
kafka-kraft-0                                       1/1     Running   0             4d22h
multicluster-global-hub-grafana-79bd77df4f-t92mh    2/2     Running   0             4d22h
multicluster-global-hub-manager-65945b9d89-74fln    1/1     Running   0             3m15s
multicluster-global-hub-operator-6ccd7577fd-8ktrk   1/1     Running   0             3m24s
multicluster-global-hub-postgresql-0                2/2     Running   0             4d3h
strimzi-cluster-operator-v0.43.0-76f57fb5b7-ks9kk   1/1     Running   1 (12h ago)   4d22h
❯ oc delete pods multicluster-global-hub-postgresql-0
pod "multicluster-global-hub-postgresql-0" deleted
❯ oc get pods
NAME                                                READY   STATUS    RESTARTS      AGE
kafka-entity-operator-c5d866b4b-s9p2r               2/2     Running   0             4d21h
kafka-kraft-0                                       1/1     Running   0             4d22h
multicluster-global-hub-grafana-79bd77df4f-t92mh    2/2     Running   0             4d22h
multicluster-global-hub-manager-65945b9d89-74fln    1/1     Running   0             4m9s
multicluster-global-hub-operator-6ccd7577fd-8ktrk   1/1     Running   0             4m18s
multicluster-global-hub-postgresql-0                2/2     Running   0             13s
strimzi-cluster-operator-v0.43.0-76f57fb5b7-ks9kk   1/1     Running   1 (12h ago)   4d22h
❯ kubectl exec -it multicluster-global-hub-postgresql-0 -n multicluster-global-hub -- psql -U postgres -d hoh;

Defaulted container "multicluster-global-hub-postgresql" out of: multicluster-global-hub-postgresql, prometheus-postgres-exporter
psql (16.4)
Type "help" for help.

hoh=# SHOW wal_level;
 wal_level
-----------
 logical
(1 row)

hoh=# SHOW max_wal_size;
 max_wal_size
--------------
 2GB
(1 row)

hoh=# exit
```