### PR TITLE
:bug: Provide the valid secret name for postgres user

### DIFF
--- a/doc/global_hub_builtin_postgresql.md
+++ b/doc/global_hub_builtin_postgresql.md
@@ -41,6 +41,8 @@ metadata:
 ...
 ```
 
+Note: If the `<username>` contains characters '_', they will be replaced with '-' in the secret name. For example, if the `<username>` is `test_user`, the secret name will be `postgresql-user-test-user`.
+
 ## Custom PostgreSQL Server Configuration
 
 The Global Hub also provides a way to customize the configuration of the built-in PostgreSQL server (refer to [PostgreSQL Configuration Settings](https://www.postgresql.org/docs/16/config-setting.html#CONFIG-SETTING-CONFIGURATION-FILE)). Follow these steps to achieve it:

--- a/operator/pkg/controllers/storage/postgres_statefulset.go
+++ b/operator/pkg/controllers/storage/postgres_statefulset.go
@@ -31,8 +31,13 @@ var (
 	builtinPostgresInitName   = fmt.Sprintf("%s-init", BuiltinPostgresName)
 	builtinPartialPostgresURI = fmt.Sprintf("%s.%s.svc:5432/hoh?sslmode=verify-ca", BuiltinPostgresName,
 		utils.GetDefaultNamespace())
-	BuiltinPostgresCustomizedConfigName = "multicluster-global-hub-custom-postgresql-config"
-	BuiltinPostgresCustomizedUsersName  = "multicluster-global-hub-custom-postgresql-users"
+)
+
+const (
+	BuiltinPostgresCustomizedConfigName        = "multicluster-global-hub-custom-postgresql-config"
+	BuiltinPostgresCustomizedUsersName         = "multicluster-global-hub-custom-postgresql-users"
+	BuiltinPostgresCustomizedUserSecretDBKey   = "databases"
+	BuiltinPostgresCustomizedUserSecretUserKey = "db.user"
 )
 
 type postgresCredential struct {

--- a/operator/pkg/controllers/storage/storage_reconciler.go
+++ b/operator/pkg/controllers/storage/storage_reconciler.go
@@ -502,9 +502,10 @@ func (r *StorageReconciler) createPostgresUserSecret(ctx context.Context, userNa
 	// update the databases if exists
 	if err == nil {
 		log.Infof("the postgresql user secret already exists: %s", userSecret.Name)
-		if string(userSecret.Data["databases"]) != dbs || string(userSecret.Data["db.user"]) != userName {
-			userSecret.Data["databases"] = []byte(dbs)
-			userSecret.Data["db.user"] = []byte(userName)
+		if string(userSecret.Data[BuiltinPostgresCustomizedUserSecretDBKey]) != dbs ||
+			string(userSecret.Data[BuiltinPostgresCustomizedUserSecretUserKey]) != userName {
+			userSecret.Data[BuiltinPostgresCustomizedUserSecretDBKey] = []byte(dbs)
+			userSecret.Data[BuiltinPostgresCustomizedUserSecretUserKey] = []byte(userName)
 			err = r.GetClient().Update(ctx, userSecret)
 			if err != nil {
 				return fmt.Errorf("failed to updating postgres user secret %s, err %v", userName, err)
@@ -521,11 +522,11 @@ func (r *StorageReconciler) createPostgresUserSecret(ctx context.Context, userNa
 		return fmt.Errorf("failed the parse the supper user database URI")
 	}
 	userSecret.Data = map[string][]byte{
-		"db.host":   []byte(pgConfig.Host),
-		"db.port":   []byte(fmt.Sprintf("%d", pgConfig.Port)),
-		"db.user":   []byte(userName),
-		"databases": []byte(dbs),
-		"ca":        storageConn.CACert,
+		"db.host": []byte(pgConfig.Host),
+		"db.port": []byte(fmt.Sprintf("%d", pgConfig.Port)),
+		BuiltinPostgresCustomizedUserSecretUserKey: []byte(userName),
+		BuiltinPostgresCustomizedUserSecretDBKey:   []byte(dbs),
+		"ca":                                       storageConn.CACert,
 	}
 	if password != "" {
 		userSecret.Data["db.password"] = []byte(password)

--- a/operator/pkg/controllers/storage/storage_reconciler.go
+++ b/operator/pkg/controllers/storage/storage_reconciler.go
@@ -502,16 +502,14 @@ func (r *StorageReconciler) createPostgresUserSecret(ctx context.Context, userNa
 	// update the databases if exists
 	if err == nil {
 		log.Infof("the postgresql user secret already exists: %s", userSecret.Name)
-		previousDatabases := userSecret.Data["databases"]
-		previousUser := userSecret.Data["db.user"]
-		if string(previousDatabases) != dbs || string(previousUser) != userName {
+		if string(userSecret.Data["databases"]) != dbs || string(userSecret.Data["db.user"]) != userName {
 			userSecret.Data["databases"] = []byte(dbs)
 			userSecret.Data["db.user"] = []byte(userName)
 			err = r.GetClient().Update(ctx, userSecret)
 			if err != nil {
 				return fmt.Errorf("failed to updating postgres user secret %s, err %v", userName, err)
 			}
-			log.Infof("update the postgres user secret databases: %s", userSecret.Name)
+			log.Infof("update the postgres user secret user: %s", userSecret.Name)
 		}
 		return nil
 	}

--- a/operator/pkg/controllers/storage/storage_reconciler.go
+++ b/operator/pkg/controllers/storage/storage_reconciler.go
@@ -503,8 +503,10 @@ func (r *StorageReconciler) createPostgresUserSecret(ctx context.Context, userNa
 	if err == nil {
 		log.Infof("the postgresql user secret already exists: %s", userSecret.Name)
 		previousDatabases := userSecret.Data["databases"]
-		if string(previousDatabases) != dbs {
+		previousUser := userSecret.Data["db.user"]
+		if string(previousDatabases) != dbs || string(previousUser) != userName {
 			userSecret.Data["databases"] = []byte(dbs)
+			userSecret.Data["db.user"] = []byte(userName)
 			err = r.GetClient().Update(ctx, userSecret)
 			if err != nil {
 				return fmt.Errorf("failed to updating postgres user secret %s, err %v", userName, err)

--- a/operator/pkg/controllers/storage/storage_reconciler.go
+++ b/operator/pkg/controllers/storage/storage_reconciler.go
@@ -342,7 +342,7 @@ func (r *StorageReconciler) ReconcileDatabase(ctx context.Context, mgh *v1alpha4
 		if err = r.applyPostgresUsers(ctx, conn, pgUsers.Data, mgh); err != nil {
 			return false, err
 		}
-		log.Info("applied the annotation postgres users successfully!")
+		log.Infof("applied the postgresql users from ConfigMap(%s) successfully!", pgUsers.Name)
 		appliedConfigMapUsers = pgUsers.Data
 	}
 
@@ -510,7 +510,7 @@ func (r *StorageReconciler) createPostgresUserSecret(ctx context.Context, userNa
 			if err != nil {
 				return fmt.Errorf("failed to updating postgres user secret %s, err %v", userName, err)
 			}
-			log.Infof("update the postgres user secret user: %s", userSecret.Name)
+			log.Infof("update the postgres user secret: %s", userSecret.Name)
 		}
 		return nil
 	}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

As @hchenxa pointed out, the secret cannot contain the `_` character. it will replace `_` with `-`  when generating the secret. That means both `test_user`  and `test-user` will share the same postures secret `postgresql-user-test-user`

## Related issue(s)

Fixes # https://issues.redhat.com/browse/ACM-17609

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [x] List other manual tests you have done.

- configmap data: `chrome_service_user: '["chrome_service_db"]'`
```bash
2025-02-05T07:37:21.511Z        INFO    storage/storage_reconciler.go:471       postgres user already exist: chrome_service_user
2025-02-05T07:37:21.512Z        INFO    storage/storage_reconciler.go:448       database chrome_service_db already exists.
2025-02-05T07:37:21.513Z        INFO    storage/storage_reconciler.go:554       granted all privileges to user chrome_service_user on database chrome_service_db.

2025-02-05T07:37:21.513Z        INFO    storage/storage_reconciler.go:504       the postgresql user secret already exists: postgresql-user-chrome-service-user
2025-02-05T07:37:21.518Z        INFO    storage/storage_reconciler.go:514       update the postgres user secret user: postgresql-user-chrome-service-user
2025-02-05T07:37:21.518Z        INFO    storage/storage_reconciler.go:345       applied the annotation postgres users successfully!

❯ oc get secret postgresql-user-chrome-service-user -ojsonpath='{.data.db\.user}' | base64 -d
chrome_service_user%                                                                                                                                    
❯ oc get secret postgresql-user-chrome-service-user -ojsonpath='{.data.databases}' | base64 -d
["chrome_service_db"]% 
```
- configmap data: `chrome-service-user: '["chrome_service_db"]'`
```bash
2025-02-05T07:39:15.165Z        INFO    storage/storage_reconciler.go:471       postgres user already exist: chrome-service-user
2025-02-05T07:39:15.165Z        INFO    storage/storage_reconciler.go:448       database chrome_service_db already exists.
2025-02-05T07:39:15.167Z        INFO    storage/storage_reconciler.go:554       granted all privileges to user chrome-service-user on database chrome_service_db.

2025-02-05T07:39:15.167Z        INFO    storage/storage_reconciler.go:504       the postgresql user secret already exists: postgresql-user-chrome-service-user
2025-02-05T07:39:15.173Z        INFO    storage/storage_reconciler.go:514       update the postgres user secret user: postgresql-user-chrome-service-user
2025-02-05T07:39:15.174Z        INFO    storage/storage_reconciler.go:345       applied the annotation postgres users successfully!

❯ oc get secret postgresql-user-chrome-service-user -ojsonpath='{.data.db\.user}' | base64 -d
chrome-service-user%                                                                                                                                    
❯ oc get secret postgresql-user-chrome-service-user -ojsonpath='{.data.databases}' | base64 -d
["chrome_service_db"]% 
```
- configmap data: `chrome-service-user: '["chrome-service-db"]'`
```bash
2025-02-05T07:41:00.619Z        INFO    storage/storage_reconciler.go:471       postgres user already exist: chrome-service-user
2025-02-05T07:41:00.620Z        INFO    storage/storage_reconciler.go:448       database chrome-service-db already exists.
2025-02-05T07:41:00.621Z        INFO    storage/storage_reconciler.go:554       granted all privileges to user chrome-service-user on database chrome-service-db.

2025-02-05T07:41:00.621Z        INFO    storage/storage_reconciler.go:504       the postgresql user secret already exists: postgresql-user-chrome-service-user
2025-02-05T07:41:00.627Z        INFO    storage/storage_reconciler.go:514       update the postgres user secret user: postgresql-user-chrome-service-user
2025-02-05T07:41:00.627Z        INFO    storage/storage_reconciler.go:345       applied the annotation postgres users successfully!

❯ oc get secret postgresql-user-chrome-service-user -ojsonpath='{.data.databases}' | base64 -d
["chrome-service-db"]%                                                                                                                                  
❯ oc get secret postgresql-user-chrome-service-user -ojsonpath='{.data.db\.user}' | base64 -d
chrome-service-user%                                                                                                                          
```