### PR TITLE
:bug: Prevent conflicts with custom PostgreSQL usernames.

### DIFF
--- a/doc/global_hub_builtin_postgresql.md
+++ b/doc/global_hub_builtin_postgresql.md
@@ -41,7 +41,11 @@ metadata:
 ...
 ```
 
-Note: If the `<username>` contains characters '_', they will be replaced with '-' in the secret name. For example, if the `<username>` is `test_user`, the secret name will be `postgresql-user-test-user`.
+**Note**
+
+1. If the `<username>` contains characters '_', they will be replaced with '-' in the secret name. For example, if the `<username>` is `test_user`, the secret name will be `postgresql-user-test-user`.
+
+2. `test_user` and `test-user` are distinct in the database but identical(`postgresql-user-test-user`) in the Kubernetes secret name. Avoid using both in the ConfigMap, as the secret data (user, password, databases) will be overwritten by the last applied entry.
 
 ## Custom PostgreSQL Server Configuration
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [x] List other manual tests you have done.

The verification confirms that the secret name remains unchanged, but there is a username conflict. All usernames and passwords have been overridden.

```bash
cat <<EOF | kubectl apply -f -
apiVersion: v1
kind: ConfigMap
metadata:
  name: multicluster-global-hub-custom-postgresql-users
  namespace: multicluster-global-hub
data:
  "mock-user": '["test1", "test2"]'
EOF

❯ oc get secret postgresql-user-mock-user -ojsonpath='{.data.db\.user}' | base64 -d
mock-user%
❯ oc get secret postgresql-user-mock-user -ojsonpath='{.data.db\.password}' | base64 -d
rUXQvCfsGiE1teLW%
❯ oc get secret postgresql-user-mock-user -ojsonpath='{.data.db\.names}' | base64 -d
["test1", "test2"]%
```

```bash
❯ cat <<EOF | kubectl apply -f -
apiVersion: v1
kind: ConfigMap
metadata:
  name: multicluster-global-hub-custom-postgresql-users
  namespace: multicluster-global-hub
data:
  "mock_user": '["test3", "test4"]'
EOF
configmap/multicluster-global-hub-custom-postgresql-users configured
❯ oc get secret postgresql-user-mock-user -ojsonpath='{.data.db\.user}' | base64 -d
mock_user%
❯ oc get secret postgresql-user-mock-user -ojsonpath='{.data.db\.password}' | base64 -d
H6nblX0phiKQwwjj%
❯ oc get secret postgresql-user-mock-user -ojsonpath='{.data.db\.names}' | base64 -d
["test3", "test4"]%
```
