### PR TITLE
:bug: Fix cannot start manager

### DIFF
--- a/manager/cmd/main.go
+++ b/manager/cmd/main.go
@@ -18,7 +18,6 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
-	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -338,13 +337,6 @@ func initCache(config *rest.Config, cacheOpts cache.Options) (cache.Cache, error
 		},
 		&corev1.PersistentVolumeClaim{}: {
 			Field: fields.OneTermEqualSelector(namespacePath, managerNamespace),
-		},
-		&addonv1alpha1.ManagedClusterAddOn{}: {
-			Field: fields.SelectorFromSet(
-				fields.Set{
-					"metadata.name": constants.GHManagedClusterAddonName,
-				},
-			),
 		},
 	}
 	return cache.New(config, cacheOpts)

--- a/operator/pkg/config/multiclusterglobalhub_config.go
+++ b/operator/pkg/config/multiclusterglobalhub_config.go
@@ -408,7 +408,7 @@ func GetMulticlusterGlobalHub(ctx context.Context, c client.Client) (*v1alpha4.M
 		return nil, err
 	}
 	if len(mghList.Items) != 1 {
-		log.Infof("mgh should have 1 instance, but got %v", len(mghList.Items))
+		log.Debugf("mgh may have 1 instance, but got %v", len(mghList.Items))
 		return nil, nil
 	}
 	return &mghList.Items[0], nil
@@ -421,7 +421,7 @@ func GetMulticlusterGlobalHubAgent(ctx context.Context, c client.Client) (*v1alp
 		return nil, err
 	}
 	if len(mghaList.Items) != 1 {
-		log.Infof("mgha should have 1 instance, but got %v", len(mghaList.Items))
+		log.Debugf("mgha may have 1 instance, but got %v", len(mghaList.Items))
 		return nil, nil
 	}
 	return &mghaList.Items[0], nil

--- a/test/script/kessel_e2e_setup.sh
+++ b/test/script/kessel_e2e_setup.sh
@@ -14,7 +14,7 @@ source "$CURRENT_DIR/util.sh"
 cluster_name="global-hub-kessel"
 
 kind_cluster $cluster_name
-install_crds $cluster_name
+install_crds $cluster_name false
 enable_service_ca $cluster_name "$TEST_DIR/manifest"
 enable_olm $cluster_name
 

--- a/test/script/util.sh
+++ b/test/script/util.sh
@@ -363,18 +363,18 @@ enable_router() {
 
 install_crds() {
   local ctx=$1
-  local install_acm_crds=$2
+  local install_acm_crds=${2:-true}
   # router
   kubectl create ns openshift-ingress --dry-run=client -o yaml | kubectl --context "$ctx" apply -f -
   path="https://raw.githubusercontent.com/openshift/router/$ROUTE_VERSION"
   kubectl --context "$ctx" apply -f $path/deploy/route_crd.yaml
 
   #proxy crd. required by olm
-  kubectl --context "$1" apply -f ${CURRENT_DIR}/../manifest/crd/0000_03_config-operator_01_proxies.crd.yaml
+  kubectl --context "$ctx" apply -f ${CURRENT_DIR}/../manifest/crd/0000_03_config-operator_01_proxies.crd.yaml
 
   # monitor
-  kubectl --context "$1" apply -f "$CURRENT_DIR"/../manifest/crd/0000_04_monitoring.coreos.com_servicemonitors.crd.yaml
-  kubectl --context "$1" apply -f "$CURRENT_DIR"/../manifest/crd/0000_04_monitoring.coreos.com_prometheusrules.yaml
+  kubectl --context "$ctx" apply -f "$CURRENT_DIR"/../manifest/crd/0000_04_monitoring.coreos.com_servicemonitors.crd.yaml
+  kubectl --context "$ctx" apply -f "$CURRENT_DIR"/../manifest/crd/0000_04_monitoring.coreos.com_prometheusrules.yaml
 
   # clusterID from clusterversion
   kubectl --context "$ctx" apply -f ${CURRENT_DIR}/../manifest/crd/clusterversion.crd.yaml
@@ -398,12 +398,12 @@ install_crds() {
   kubectl --context "$ctx" apply -f ${CURRENT_DIR}/../manifest/crd/0000_01_operator.open-cluster-management.io_clustermanagers.crd.yaml
 
   # addons
-  kubectl --context "$1" apply -f "$CURRENT_DIR"/../manifest/crd/0000_01_addon.open-cluster-management.io_managedclusteraddons.crd.yaml
-  kubectl --context "$1" apply -f "$CURRENT_DIR"/../manifest/crd/0000_00_addon.open-cluster-management.io_clustermanagementaddons.crd.yaml
-  kubectl --context "$1" apply -f "$CURRENT_DIR"/../manifest/crd/0000_02_addon.open-cluster-management.io_addondeploymentconfigs.crd.yaml
+  kubectl --context "$ctx" apply -f "$CURRENT_DIR"/../manifest/crd/0000_01_addon.open-cluster-management.io_managedclusteraddons.crd.yaml
+  kubectl --context "$ctx" apply -f "$CURRENT_DIR"/../manifest/crd/0000_00_addon.open-cluster-management.io_clustermanagementaddons.crd.yaml
+  kubectl --context "$ctx" apply -f "$CURRENT_DIR"/../manifest/crd/0000_02_addon.open-cluster-management.io_addondeploymentconfigs.crd.yaml
 
   # cluster
-  kubectl --context "$1" apply -f "$CURRENT_DIR"/../manifest/crd/0000_00_cluster.open-cluster-management.io_managedclusters.crd.yaml
+  kubectl --context "$ctx" apply -f "$CURRENT_DIR"/../manifest/crd/0000_00_cluster.open-cluster-management.io_managedclusters.crd.yaml
 }
 
 install_mch() {

--- a/test/script/util.sh
+++ b/test/script/util.sh
@@ -133,7 +133,7 @@ ensure_cluster() {
     docker rm -f "$cluster_name-control-plane"
   fi
 
-  kind create cluster --name "$cluster_name" --wait 5m
+  kind create cluster --name "$cluster_name" --image=kindest/node:v1.23.0 --wait 5m
 
   # modify the context = KinD cluster name = kubeconfig name
   kubectl config delete-context "$cluster_name" 2>/dev/null || true


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
1. in kessel inventory, we should not install ACM related CRDs
2. for manager, we should not watch any ACM resource initially.

## Related issue(s)

Fixes # https://issues.redhat.com/browse/ACM-17820

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [x] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
