### PR TITLE
:bug: Watch secret

### DIFF
--- a/agent/pkg/spec/syncers/migration_from_syncer.go
+++ b/agent/pkg/spec/syncers/migration_from_syncer.go
@@ -64,6 +64,7 @@ func (s *managedClusterMigrationFromSyncer) Sync(ctx context.Context, payload []
 		}, foundBootstrapSecret); err != nil {
 		if apierrors.IsNotFound(err) {
 			s.log.Infof("creating bootstrap secret %s", bootstrapSecret.GetName())
+			s.log.Debugf("creating bootstrap secret %v", bootstrapSecret)
 			if err := s.client.Create(ctx, bootstrapSecret); err != nil {
 				return err
 			}
@@ -73,6 +74,7 @@ func (s *managedClusterMigrationFromSyncer) Sync(ctx context.Context, payload []
 	} else {
 		// update the bootstrap secret if it already exists
 		s.log.Infof("updating bootstrap secret %s", bootstrapSecret.GetName())
+		s.log.Debugf("updating bootstrap secret %v", bootstrapSecret)
 		if err := s.client.Update(ctx, bootstrapSecret); err != nil {
 			return err
 		}

--- a/agent/pkg/spec/syncers/migration_from_syncer.go
+++ b/agent/pkg/spec/syncers/migration_from_syncer.go
@@ -53,6 +53,7 @@ func (s *managedClusterMigrationFromSyncer) Sync(ctx context.Context, payload []
 	if err := json.Unmarshal(payload, managedClusterMigrationEvent); err != nil {
 		return err
 	}
+	s.log.Debugf("received managed cluster migration event %s", string(payload))
 
 	// create or update bootstrap secret
 	bootstrapSecret := managedClusterMigrationEvent.BootstrapSecret
@@ -64,7 +65,6 @@ func (s *managedClusterMigrationFromSyncer) Sync(ctx context.Context, payload []
 		}, foundBootstrapSecret); err != nil {
 		if apierrors.IsNotFound(err) {
 			s.log.Infof("creating bootstrap secret %s", bootstrapSecret.GetName())
-			s.log.Debugf("creating bootstrap secret %v", bootstrapSecret)
 			if err := s.client.Create(ctx, bootstrapSecret); err != nil {
 				return err
 			}
@@ -74,7 +74,6 @@ func (s *managedClusterMigrationFromSyncer) Sync(ctx context.Context, payload []
 	} else {
 		// update the bootstrap secret if it already exists
 		s.log.Infof("updating bootstrap secret %s", bootstrapSecret.GetName())
-		s.log.Debugf("updating bootstrap secret %v", bootstrapSecret)
 		if err := s.client.Update(ctx, bootstrapSecret); err != nil {
 			return err
 		}

--- a/agent/pkg/spec/syncers/migration_to_syncer.go
+++ b/agent/pkg/spec/syncers/migration_to_syncer.go
@@ -209,7 +209,7 @@ func (s *managedClusterMigrationToSyncer) ensureMigrationClusterRole(ctx context
 func (s *managedClusterMigrationToSyncer) ensureRegistrationClusterRoleBinding(ctx context.Context,
 	msaName, msaNamespace string,
 ) error {
-	registrationClusterRoleName := "system:open-cluster-management:managedcluster:bootstrap:agent-registration"
+	registrationClusterRoleName := "open-cluster-management:managedcluster:bootstrap:agent-registration"
 	registrationClusterRoleBindingName := fmt.Sprintf("agent-registration-clusterrolebinding:%s", msaName)
 	registrationClusterRoleBinding := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{

--- a/agent/pkg/spec/syncers/migration_to_syncer.go
+++ b/agent/pkg/spec/syncers/migration_to_syncer.go
@@ -38,10 +38,12 @@ func NewManagedClusterMigrationToSyncer(client client.Client) *managedClusterMig
 
 func (s *managedClusterMigrationToSyncer) Sync(ctx context.Context, payload []byte) error {
 	// handle migration.to cloud event
+	s.log.Info("received cloudevent from the global hub")
 	managedClusterMigrationToEvent := &bundleevent.ManagedClusterMigrationToEvent{}
 	if err := json.Unmarshal(payload, managedClusterMigrationToEvent); err != nil {
 		return err
 	}
+	s.log.Debugf("received cloudevent %v", string(payload))
 
 	msaName := managedClusterMigrationToEvent.ManagedServiceAccountName
 	msaNamespace := managedClusterMigrationToEvent.ManagedServiceAccountInstallNamespace

--- a/agent/pkg/spec/syncers/migration_to_syncer_test.go
+++ b/agent/pkg/spec/syncers/migration_to_syncer_test.go
@@ -108,7 +108,7 @@ func TestMigrationToSyncer(t *testing.T) {
 				},
 				RoleRef: rbacv1.RoleRef{
 					Kind:     "ClusterRole",
-					Name:     "system:open-cluster-management:managedcluster:bootstrap:agent-registration",
+					Name:     "open-cluster-management:managedcluster:bootstrap:agent-registration",
 					APIGroup: "rbac.authorization.k8s.io",
 				},
 			},
@@ -330,7 +330,7 @@ func TestMigrationToSyncer(t *testing.T) {
 					},
 					RoleRef: rbacv1.RoleRef{
 						Kind:     "ClusterRole",
-						Name:     "system:open-cluster-management:managedcluster:bootstrap:agent-registration",
+						Name:     "open-cluster-management:managedcluster:bootstrap:agent-registration",
 						APIGroup: "rbac.authorization.k8s.io",
 					},
 				},
@@ -395,7 +395,7 @@ func TestMigrationToSyncer(t *testing.T) {
 				},
 				RoleRef: rbacv1.RoleRef{
 					Kind:     "ClusterRole",
-					Name:     "system:open-cluster-management:managedcluster:bootstrap:agent-registration",
+					Name:     "open-cluster-management:managedcluster:bootstrap:agent-registration",
 					APIGroup: "rbac.authorization.k8s.io",
 				},
 			},
@@ -454,7 +454,7 @@ func TestMigrationToSyncer(t *testing.T) {
 					},
 					RoleRef: rbacv1.RoleRef{
 						Kind:     "ClusterRole",
-						Name:     "system:open-cluster-management:managedcluster:bootstrap:agent-registration",
+						Name:     "open-cluster-management:managedcluster:bootstrap:agent-registration",
 						APIGroup: "rbac.authorization.k8s.io",
 					},
 				},
@@ -519,7 +519,7 @@ func TestMigrationToSyncer(t *testing.T) {
 				},
 				RoleRef: rbacv1.RoleRef{
 					Kind:     "ClusterRole",
-					Name:     "system:open-cluster-management:managedcluster:bootstrap:agent-registration",
+					Name:     "open-cluster-management:managedcluster:bootstrap:agent-registration",
 					APIGroup: "rbac.authorization.k8s.io",
 				},
 			},

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -196,6 +196,8 @@ const (
 	CloudEventTypeMigrationFrom = "io.open-cluster-management.operator.multiclusterglobalhubs.spec.migration.from"
 	// CloudEventTypeManagedClusterMigrationTo is the cloud event type for managed cluster migration to
 	CloudEventTypeMigrationTo = "io.open-cluster-management.operator.multiclusterglobalhubs.spec.migration.to"
+	// LabelKeyIsManagedServiceAccount is from     managed-serviceaccount/pkg/common/constants.go
+	LabelKeyIsManagedServiceAccount = "authentication.open-cluster-management.io/is-managed-serviceaccount"
 )
 
 const (

--- a/test/integration/manager/controller/migration_test.go
+++ b/test/integration/manager/controller/migration_test.go
@@ -121,6 +121,9 @@ var _ = Describe("migration", Ordered, func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "migration",
 					Namespace: "hub2",
+					Labels: map[string]string{
+						"authentication.open-cluster-management.io/is-managed-serviceaccount": "true",
+					},
 				},
 				Data: map[string][]byte{
 					"ca.crt": []byte("test"),
@@ -148,16 +151,15 @@ var _ = Describe("migration", Ordered, func() {
 			}, 3*time.Second, 100*time.Millisecond).Should(Succeed())
 		})
 
-		It("should have bootstrap secret generated after managedserviceaccount is reconciled", func() {
-			msa := &v1beta1.ManagedServiceAccount{}
+		It("should have bootstrap secret generated if the secret is updated", func() {
+			secret := &corev1.Secret{}
 			Expect(mgr.GetClient().Get(testCtx, types.NamespacedName{
 				Name:      "migration",
 				Namespace: "hub2",
-			}, msa)).To(Succeed())
+			}, secret)).To(Succeed())
 
-			// mimic the managedserviceaccount is reconciled
-			msa.Spec.Rotation.Validity = metav1.Duration{Duration: 3600 * time.Hour}
-			Expect(mgr.GetClient().Update(testCtx, msa)).To(Succeed())
+			secret.Data["ca.crt"] = []byte("updated")
+			Expect(mgr.GetClient().Update(testCtx, secret)).To(Succeed())
 
 			Eventually(func() error {
 				if migrationReconciler.BootstrapSecret == nil {
@@ -400,6 +402,9 @@ var _ = Describe("migration", Ordered, func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "migration",
 					Namespace: "hub3",
+					Labels: map[string]string{
+						"authentication.open-cluster-management.io/is-managed-serviceaccount": "true",
+					},
 				},
 				Data: map[string][]byte{
 					"ca.crt": []byte("test"),
@@ -433,16 +438,15 @@ var _ = Describe("migration", Ordered, func() {
 			}, 3*time.Second, 100*time.Millisecond).Should(Succeed())
 		})
 
-		It("should have bootstrap secret generated after managedserviceaccount is reconciled", func() {
-			msa := &v1beta1.ManagedServiceAccount{}
+		It("should have bootstrap secret generated if the secret is updated", func() {
+			secret := &corev1.Secret{}
 			Expect(mgr.GetClient().Get(testCtx, types.NamespacedName{
 				Name:      "migration",
 				Namespace: "hub3",
-			}, msa)).To(Succeed())
+			}, secret)).To(Succeed())
 
-			// mimic the managedserviceaccount is reconciled
-			msa.Spec.Rotation.Validity = metav1.Duration{Duration: 3600 * time.Hour}
-			Expect(mgr.GetClient().Update(testCtx, msa)).To(Succeed())
+			secret.Data["ca.crt"] = []byte("updated")
+			Expect(mgr.GetClient().Update(testCtx, secret)).To(Succeed())
 
 			Eventually(func() error {
 				if migrationReconciler.BootstrapSecret == nil {
@@ -461,7 +465,7 @@ var _ = Describe("migration", Ordered, func() {
 			}, 3*time.Second, 100*time.Millisecond).Should(Succeed())
 		})
 
-		It("should have received the migration event", func() {
+		It("should have the migration event received", func() {
 			Eventually(func() error {
 				if fromEvent1 == nil {
 					return fmt.Errorf("fromEvent1 is nil")


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
1. the clusterrole name is changed from `system:open-cluster-management:managedcluster:bootstrap:agent-registration` to `open-cluster-management:managedcluster:bootstrap:agent-registration` in foundation so we need to update accordingly.
2. instead of watching the changes for managedserviceaccount, watch secret should be a better solution. if the secret gets update, we can capture it and update the bootstrap kubeconfig.

## Related issue(s)

Fixes # https://issues.redhat.com/browse/ACM-17904

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
