### PR TITLE
update backup script to use https to clone repo

### DIFF
--- a/doc/simulation/backup_restore/backupenv.sh
+++ b/doc/simulation/backup_restore/backupenv.sh
@@ -6,7 +6,7 @@ cd run
 cp -r ../backup ./
 cp -r ../common ./
 
-git clone git@github.com:open-cluster-management-io/policy-collection.git
+git clone https://github.com/open-cluster-management-io/policy-collection.git
 
 sed -i 's/<AWS_BUCKET>/'$AWS_BUCKET'/g' common/data-protection-app.yaml
 

--- a/doc/simulation/backup_restore/restoreenv.sh
+++ b/doc/simulation/backup_restore/restoreenv.sh
@@ -13,7 +13,7 @@ sed -i 's/<AWS_ACCESS_KEY_ID>/'$AWS_ACCESS_KEY_ID'/g' common/credentials-velero
 sed -i 's/<AWS_ACCESS_KEY_SECRET>/'$AWS_SECRET_ACCESS_KEY'/g' common/credentials-velero
 sed -i 's/<AWS_BUCKET>/'$AWS_BUCKET'/g' common/data-protection-app.yaml
 
-git clone git@github.com:open-cluster-management-io/policy-collection.git
+git clone https://github.com/open-cluster-management-io/policy-collection.git
 
 
 ##clean up


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
QE need to run backup script in jenkins, so we should use https to clone code.
## Related issue(s)

Fixes #

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
