### PR TITLE
Cloud Events emitter from cluster-group-upgrades-operator events

### DIFF
--- a/agent/pkg/status/syncers/events/event_syncer.go
+++ b/agent/pkg/status/syncers/events/event_syncer.go
@@ -30,7 +30,8 @@ func LaunchEventSyncer(ctx context.Context, mgr ctrl.Manager,
 		}
 		// only sync the policy event || extend other InvolvedObject kind
 		return event.InvolvedObject.Kind == policiesv1.Kind ||
-			event.InvolvedObject.Kind == constants.ManagedClusterKind
+			event.InvolvedObject.Kind == constants.ManagedClusterKind ||
+			event.InvolvedObject.Kind == constants.ClusterGroupUpgradeKind
 	})
 
 	return generic.LaunchMultiEventSyncer(
@@ -47,6 +48,10 @@ func LaunchEventSyncer(ctx context.Context, mgr ctrl.Manager,
 			{
 				Handler: handlers.NewManagedClusterEventHandler(ctx, mgr.GetClient()),
 				Emitter: handlers.NewManagedClusterEventEmitter(),
+			},
+			{
+				Handler: handlers.NewClusterGroupUpgradeEventHandler(ctx, mgr.GetClient()),
+				Emitter: handlers.NewClusterGroupUpgradeEventEmitter(),
 			},
 		})
 }

--- a/agent/pkg/status/syncers/events/handlers/clustergroupupgrade_handler.go
+++ b/agent/pkg/status/syncers/events/handlers/clustergroupupgrade_handler.go
@@ -19,8 +19,8 @@ import (
 )
 
 func NewClusterGroupUpgradeEventEmitter() interfaces.Emitter {
-	name := strings.Replace(string(enum.CGUEventType), enum.EventTypePrefix, "", -1)
-	return generic.NewGenericEmitter(enum.CGUEventType, generic.WithPostSend(
+	name := strings.Replace(string(enum.ClusterGroupUpgradesEventType), enum.EventTypePrefix, "", -1)
+	return generic.NewGenericEmitter(enum.ClusterGroupUpgradesEventType, generic.WithPostSend(
 		// After sending the event, update the filter cache and clear the bundle from the handler cache.
 		func(data interface{}) {
 			events, ok := data.(*event.ClusterGroupUpgradeEventBundle)
@@ -46,12 +46,12 @@ type clusterGroupUpgradeEventHandler struct {
 }
 
 func NewClusterGroupUpgradeEventHandler(ctx context.Context, c client.Client) *clusterGroupUpgradeEventHandler {
-	name := strings.Replace(string(enum.CGUEventType), enum.EventTypePrefix, "", -1)
+	name := strings.Replace(string(enum.ClusterGroupUpgradesEventType), enum.EventTypePrefix, "", -1)
 	filter.RegisterTimeFilter(name)
 	return &clusterGroupUpgradeEventHandler{
 		ctx:           ctx,
 		name:          name,
-		eventType:     string(enum.CGUEventType),
+		eventType:     string(enum.ClusterGroupUpgradesEventType),
 		runtimeClient: c,
 		payload:       &event.ClusterGroupUpgradeEventBundle{},
 	}

--- a/agent/pkg/status/syncers/events/handlers/clustergroupupgrade_handler.go
+++ b/agent/pkg/status/syncers/events/handlers/clustergroupupgrade_handler.go
@@ -1,0 +1,118 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/configs"
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/filter"
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/generic"
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/interfaces"
+	"github.com/stolostron/multicluster-global-hub/pkg/bundle/event"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/database/models"
+	"github.com/stolostron/multicluster-global-hub/pkg/enum"
+)
+
+func NewClusterGroupUpgradeEventEmitter() interfaces.Emitter {
+	name := strings.Replace(string(enum.CGUEventType), enum.EventTypePrefix, "", -1)
+	return generic.NewGenericEmitter(enum.CGUEventType, generic.WithPostSend(
+		// After sending the event, update the filter cache and clear the bundle from the handler cache.
+		func(data interface{}) {
+			events, ok := data.(*event.ClusterGroupUpgradeEventBundle)
+			if !ok {
+				return
+			}
+			// update the time filter: with latest event
+			for _, evt := range *events {
+				filter.CacheTime(name, evt.CreatedAt)
+			}
+			// reset the payload
+			*events = (*events)[:0]
+		}),
+	)
+}
+
+type clusterGroupUpgradeEventHandler struct {
+	ctx           context.Context
+	name          string
+	runtimeClient client.Client
+	eventType     string
+	payload       *event.ClusterGroupUpgradeEventBundle
+}
+
+func NewClusterGroupUpgradeEventHandler(ctx context.Context, c client.Client) *clusterGroupUpgradeEventHandler {
+	name := strings.Replace(string(enum.CGUEventType), enum.EventTypePrefix, "", -1)
+	filter.RegisterTimeFilter(name)
+	return &clusterGroupUpgradeEventHandler{
+		ctx:           ctx,
+		name:          name,
+		eventType:     string(enum.CGUEventType),
+		runtimeClient: c,
+		payload:       &event.ClusterGroupUpgradeEventBundle{},
+	}
+}
+
+func (h *clusterGroupUpgradeEventHandler) shouldUpdate(obj client.Object) bool {
+	evt, ok := obj.(*corev1.Event)
+	if !ok {
+		return false
+	}
+
+	if evt.InvolvedObject.Kind != constants.ClusterGroupUpgradeKind {
+		return false
+	}
+
+	// if it's a older event, then return false
+	if !filter.Newer(h.name, getEventLastTime(evt).Time) {
+		return false
+	}
+
+	return true
+}
+
+func (h *clusterGroupUpgradeEventHandler) Update(obj client.Object) bool {
+	if !h.shouldUpdate(obj) {
+		return false
+	}
+
+	evt, ok := obj.(*corev1.Event)
+	if !ok {
+		return false
+	}
+
+	annsJSONB, err := json.Marshal(evt.Annotations)
+	if err != nil {
+		log.Error("failed to parse the event annotations %+v: %s", evt.Annotations, err.Error())
+	}
+
+	clusterEvent := models.ClusterGroupUpgradeEvent{
+		EventName:           evt.Name,
+		EventNamespace:      evt.Namespace,
+		EventAnns:           annsJSONB,
+		Message:             evt.Message,
+		Reason:              evt.Reason,
+		CGUName:             evt.InvolvedObject.Name,
+		LeafHubName:         configs.GetLeafHubName(),
+		ReportingController: evt.ReportingController,
+		ReportingInstance:   evt.ReportingInstance,
+		EventType:           evt.Type,
+		CreatedAt:           getEventLastTime(evt).Time,
+	}
+
+	*h.payload = append(*h.payload, clusterEvent)
+	return true
+}
+
+func (*clusterGroupUpgradeEventHandler) Delete(client.Object) bool {
+	// do nothing
+	return false
+}
+
+func (h *clusterGroupUpgradeEventHandler) Get() interface{} {
+	return h.payload
+}

--- a/pkg/bundle/event/clustergroupupgrades_event_bundle.go
+++ b/pkg/bundle/event/clustergroupupgrades_event_bundle.go
@@ -1,0 +1,5 @@
+package event
+
+import "github.com/stolostron/multicluster-global-hub/pkg/database/models"
+
+type ClusterGroupUpgradeEventBundle []models.ClusterGroupUpgradeEvent

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -137,6 +137,7 @@ const (
 	MultiClusterHubKind         = "MultiClusterHub"
 	ManagedClusterKind          = "ManagedCluster"
 	ManagedClusterMigrationKind = "ManagedClusterMigration"
+	ClusterGroupUpgradeKind     = "ClusterGroupUpgrade"
 
 	// VersionClusterClaimName is a claim to record the ACM version
 	VersionClusterClaimName = "version.open-cluster-management.io"

--- a/pkg/database/models/event.go
+++ b/pkg/database/models/event.go
@@ -68,3 +68,21 @@ type ManagedClusterEvent struct {
 func (ManagedClusterEvent) TableName() string {
 	return "event.managed_clusters"
 }
+
+type ClusterGroupUpgradeEvent struct {
+	EventNamespace      string         `gorm:"column:event_namespace;type:varchar(63);not null" json:"eventNamespace"`
+	EventName           string         `gorm:"column:event_name;type:varchar(63);not null" json:"eventName"`
+	EventAnns           datatypes.JSON `gorm:"column:event_annotations;type:jsonb" json:"eventAnnotations,omitempty"`
+	CGUName             string         `gorm:"column:cgu_name;type:varchar(63);not null" json:"cguName"`
+	LeafHubName         string         `gorm:"column:leaf_hub_name;type:varchar(256);not null" json:"leafHubName"`
+	Message             string         `gorm:"column:message;type:text" json:"message"`
+	Reason              string         `gorm:"column:reason;type:text" json:"reason"`
+	ReportingController string         `gorm:"column:reporting_controller;type:text" json:"reportingController"`
+	ReportingInstance   string         `gorm:"column:reporting_instance;type:text" json:"reportingInstance"`
+	EventType           string         `gorm:"column:event_type;type:varchar(63);not null" json:"type"`
+	CreatedAt           time.Time      `gorm:"column:created_at;default:now();not null" json:"createdAt"`
+}
+
+func (ClusterGroupUpgradeEvent) TableName() string {
+	return "event.clustergroup_upgrades"
+}

--- a/pkg/enum/event_type.go
+++ b/pkg/enum/event_type.go
@@ -32,9 +32,9 @@ const (
 	//nolint: go:S103
 	LocalReplicatedPolicyEventType EventType = "io.open-cluster-management.operator.multiclusterglobalhubs.event.localreplicatedpolicy"
 	//nolint: go:S103
-	LocalRootPolicyEventType EventType = "io.open-cluster-management.operator.multiclusterglobalhubs.event.localrootpolicy"
-	ManagedClusterEventType  EventType = "io.open-cluster-management.operator.multiclusterglobalhubs.event.managedcluster"
-	CGUEventType             EventType = "io.open-cluster-management.operator.multiclusterglobalhubs.event.clustergroupupgrade"
+	LocalRootPolicyEventType      EventType = "io.open-cluster-management.operator.multiclusterglobalhubs.event.localrootpolicy"
+	ManagedClusterEventType       EventType = "io.open-cluster-management.operator.multiclusterglobalhubs.event.managedcluster"
+	ClusterGroupUpgradesEventType EventType = "io.open-cluster-management.operator.multiclusterglobalhubs.event.clustergroupupgrade"
 
 	PlacementDecisionType EventType = "io.open-cluster-management.operator.multiclusterglobalhubs.placementdecision"
 	//nolint: go:S103

--- a/pkg/enum/event_type.go
+++ b/pkg/enum/event_type.go
@@ -34,6 +34,7 @@ const (
 	//nolint: go:S103
 	LocalRootPolicyEventType EventType = "io.open-cluster-management.operator.multiclusterglobalhubs.event.localrootpolicy"
 	ManagedClusterEventType  EventType = "io.open-cluster-management.operator.multiclusterglobalhubs.event.managedcluster"
+	CGUEventType             EventType = "io.open-cluster-management.operator.multiclusterglobalhubs.event.clustergroupupgrade"
 
 	PlacementDecisionType EventType = "io.open-cluster-management.operator.multiclusterglobalhubs.placementdecision"
 	//nolint: go:S103

--- a/test/integration/agent/status/clustergroupupgrade_event_test.go
+++ b/test/integration/agent/status/clustergroupupgrade_event_test.go
@@ -1,0 +1,89 @@
+package status
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/bundle/event"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/enum"
+)
+
+// go test ./test/integration/agent/status -v -ginkgo.focus "ClusterGroupUpgradeEventEmitter"
+var _ = Describe("ClusterGroupUpgradeEventEmitter", Ordered, func() {
+	It("should pass the managed cluster event", func() {
+		By("Create namespace for cgu events")
+		err := runtimeClient.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cgu-ns1",
+			},
+		}, &client.CreateOptions{})
+		Expect(err).Should(Succeed())
+
+		By("Create the cgu event")
+		evt := &corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cgu-ns1.event.17cd34e8c8b27fdd",
+				Namespace: "cgu-ns1",
+				Annotations: map[string]string{
+					"cgu.openshift.io/event-type":           "global",
+					"cgu.openshift.io/total-clusters-count": "2",
+				},
+			},
+			InvolvedObject: corev1.ObjectReference{
+				Kind: constants.ClusterGroupUpgradeKind,
+				// TODO: the cluster namespace should be empty! but if not set the namespace,
+				// it will throw the error: involvedObject.namespace: Invalid value: "": does not match event.namespace
+				Namespace: "cgu-ns1",
+				Name:      "test-cgu1",
+			},
+			Reason:              "CguSuccess",
+			Message:             "ClusterGroupUpgrade test-cgu1 succeeded remediating policies",
+			ReportingController: "cgu-controller",
+			ReportingInstance:   "cgu-controller-6794cf54d9-j7lgm",
+			Type:                "Normal",
+		}
+		Expect(runtimeClient.Create(ctx, evt)).NotTo(HaveOccurred())
+
+		Eventually(func() error {
+			key := string(enum.ClusterGroupUpgradesEventType)
+			receivedEvent, ok := receivedEvents[key]
+			if !ok {
+				return fmt.Errorf("not get the event: %s", key)
+			}
+			fmt.Println(">>>>>>>>>>>>>>>>>>> cgu event", receivedEvent)
+			outEvents := event.ClusterGroupUpgradeEventBundle{}
+			err = json.Unmarshal(receivedEvent.Data(), &outEvents)
+			if err != nil {
+				return err
+			}
+			if len(outEvents) == 0 {
+				return fmt.Errorf("got an empty event payload %s", key)
+			}
+
+			if outEvents[0].EventName != evt.Name {
+				return fmt.Errorf("want %v, but got %v", evt, outEvents[0])
+			}
+
+			Expect(outEvents[0].EventType).To(Equal("Normal"))
+			Expect(outEvents[0].Reason).To(Equal("CguSuccess"))
+			Expect(outEvents[0].Message).To(Equal("ClusterGroupUpgrade test-cgu1 succeeded remediating policies"))
+			Expect(outEvents[0].ReportingController).To(Equal("cgu-controller"))
+			Expect(outEvents[0].ReportingInstance).To(Equal("cgu-controller-6794cf54d9-j7lgm"))
+
+			annsJSONB, err := json.Marshal(evt.Annotations)
+			Expect(err).ToNot(HaveOccurred(), "failed marshalling evt annotations")
+
+			Expect([]byte(outEvents[0].EventAnns)).To(Equal(annsJSONB))
+
+			return nil
+		}, 30*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
+	})
+})


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Implements a simple cloud events emitter from TALM k8s' ones, which may have some extra (structured) information encoded in the event's annotations.
## Related issue(s)
https://issues.redhat.com/browse/ACM-12511

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
