### PR TITLE
:sparkles: Refactor generic producer and consumer so that it can be used by migration controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ push-agent-image:
 unit-tests: unit-tests-pkg unit-tests-operator unit-tests-manager unit-tests-agent
 
 setup_envtest:
-	GOBIN=${TMP_BIN} go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	GOBIN=${TMP_BIN} go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.20
 
 unit-tests-operator: setup_envtest
 	KUBEBUILDER_ASSETS="$(shell ${TMP_BIN}/setup-envtest use --use-env -p path)" ${GO_TEST} `go list ./operator/... | grep -v test`

--- a/agent/cmd/main.go
+++ b/agent/cmd/main.go
@@ -97,6 +97,7 @@ func doMain(ctx context.Context, agentConfig *configs.AgentConfig, restConfig *r
 		transportSecretName,
 		transportCallback(mgr, agentConfig),
 		agentConfig.TransportConfig,
+		false,
 	).SetupWithManager(mgr)
 	if err != nil {
 		return fmt.Errorf("failed to add transport to manager: %w", err)

--- a/agent/cmd/main.go
+++ b/agent/cmd/main.go
@@ -112,9 +112,6 @@ func parseFlags() *configs.AgentConfig {
 	agentConfig := &configs.AgentConfig{
 		ElectionConfig: &commonobjects.LeaderElectionConfig{},
 		TransportConfig: &transport.TransportInternalConfig{
-			// IsManager specifies the send/receive topics from specTopic and statusTopic
-			// For example, SpecTopic sends and statusTopic receives on the manager; the agent is the opposite
-			IsManager: false,
 			// EnableDatabaseOffset affects only the manager, deciding if consumption starts from a database-stored offset
 			EnableDatabaseOffset: false,
 		},

--- a/agent/pkg/spec/syncers/migration_from_syncer_test.go
+++ b/agent/pkg/spec/syncers/migration_from_syncer_test.go
@@ -231,6 +231,6 @@ func (m *ProducerMock) SendEvent(ctx context.Context, evt cloudevents.Event) err
 	return nil
 }
 
-func (m *ProducerMock) Reconnect(config *transport.TransportInternalConfig) error {
+func (m *ProducerMock) Reconnect(config *transport.TransportInternalConfig, topic string) error {
 	return nil
 }

--- a/manager/cmd/main.go
+++ b/manager/cmd/main.go
@@ -208,7 +208,7 @@ func createManager(ctx context.Context,
 
 	err = controller.NewTransportCtrl(managerConfig.ManagerNamespace, constants.GHTransportConfigSecret,
 		transportCallback(mgr, managerConfig),
-		managerConfig.TransportConfig,
+		managerConfig.TransportConfig, true,
 	).SetupWithManager(mgr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to add the transport controller")

--- a/manager/cmd/main.go
+++ b/manager/cmd/main.go
@@ -66,7 +66,6 @@ func parseFlags() *configs.ManagerConfig {
 		SyncerConfig:   &configs.SyncerConfig{},
 		DatabaseConfig: &configs.DatabaseConfig{},
 		TransportConfig: &transport.TransportInternalConfig{
-			IsManager:            true,
 			ConsumerGroupId:      "global-hub-manager",
 			EnableDatabaseOffset: true,
 		},

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -200,7 +200,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.20
 
 .PHONY: operator-sdk
 OPERATOR_SDK ?= $(LOCALBIN)/operator-sdk

--- a/operator/api/operator/v1alpha4/multiclusterglobalhub_types.go
+++ b/operator/api/operator/v1alpha4/multiclusterglobalhub_types.go
@@ -151,7 +151,7 @@ type CommonSpec struct {
 // DataLayerSpec is a discriminated union of data layer specific configuration.
 type DataLayerSpec struct {
 	// Kafka specifies the desired state of kafka
-	// +kubebuilder:default={"topics": {"specTopic": "gh-spec", "statusTopic": "gh-status.*"}}
+	// +kubebuilder:default={"topics": {"migrationTopic": "gh-migration", "specTopic": "gh-spec", "statusTopic": "gh-status.*"}}
 	Kafka KafkaSpec `json:"kafka,omitempty"`
 	// Postgres specifies the desired state of postgres
 	// +kubebuilder:default={retention: "18m"}
@@ -179,7 +179,7 @@ type PostgresSpec struct {
 // KafkaSpec defines the desired state of kafka
 type KafkaSpec struct {
 	// KafkaTopics specify the desired topics
-	// +kubebuilder:default={"specTopic": "gh-spec", "statusTopic": "gh-status.*"}
+	// +kubebuilder:default={"migrationTopic": "gh-migration", "specTopic": "gh-spec", "statusTopic": "gh-status.*"}
 	KafkaTopics KafkaTopics `json:"topics,omitempty"`
 
 	// StorageSize specifies the size for storage
@@ -192,6 +192,10 @@ type KafkaTopics struct {
 	// SpecTopic is the topic to distribute workloads from global hub to managed hubs. The default value is "gh-spec"
 	// +kubebuilder:default="gh-spec"
 	SpecTopic string `json:"specTopic,omitempty"`
+
+	// MigrationTopic is the topic for the managed cluster migration purpose. The default value is "gh-migration"
+	// +kubebuilder:default="gh-migration"
+	MigrationTopic string `json:"migrationTopic,omitempty"`
 
 	// StatusTopic specifies the topic where an agent reports events and status updates to a manager.
 	// Specifically, the topic can end up with an asterisk (*), indicating topics for individual managed hubs.

--- a/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -41,7 +41,7 @@ metadata:
     categories: Integration & Delivery,OpenShift Optional
     certified: "false"
     containerImage: quay.io/stolostron/multicluster-global-hub-operator:latest
-    createdAt: "2025-03-26T13:12:03Z"
+    createdAt: "2025-04-03T01:43:04Z"
     description: Manages the installation and upgrade of the Multicluster Global Hub.
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"

--- a/operator/bundle/manifests/operator.open-cluster-management.io_multiclusterglobalhubs.yaml
+++ b/operator/bundle/manifests/operator.open-cluster-management.io_multiclusterglobalhubs.yaml
@@ -182,6 +182,7 @@ spec:
                   kafka:
                     default:
                       topics:
+                        migrationTopic: gh-migration
                         specTopic: gh-spec
                         statusTopic: gh-status.*
                     description: Kafka specifies the desired state of kafka
@@ -191,10 +192,16 @@ spec:
                         type: string
                       topics:
                         default:
+                          migrationTopic: gh-migration
                           specTopic: gh-spec
                           statusTopic: gh-status.*
                         description: KafkaTopics specify the desired topics
                         properties:
+                          migrationTopic:
+                            default: gh-migration
+                            description: MigrationTopic is the topic for the managed
+                              cluster migration purpose. The default value is "gh-migration"
+                            type: string
                           specTopic:
                             default: gh-spec
                             description: SpecTopic is the topic to distribute workloads

--- a/operator/config/crd/bases/operator.open-cluster-management.io_multiclusterglobalhubs.yaml
+++ b/operator/config/crd/bases/operator.open-cluster-management.io_multiclusterglobalhubs.yaml
@@ -182,6 +182,7 @@ spec:
                   kafka:
                     default:
                       topics:
+                        migrationTopic: gh-migration
                         specTopic: gh-spec
                         statusTopic: gh-status.*
                     description: Kafka specifies the desired state of kafka
@@ -191,10 +192,16 @@ spec:
                         type: string
                       topics:
                         default:
+                          migrationTopic: gh-migration
                           specTopic: gh-spec
                           statusTopic: gh-status.*
                         description: KafkaTopics specify the desired topics
                         properties:
+                          migrationTopic:
+                            default: gh-migration
+                            description: MigrationTopic is the topic for the managed
+                              cluster migration purpose. The default value is "gh-migration"
+                            type: string
                           specTopic:
                             default: gh-spec
                             description: SpecTopic is the topic to distribute workloads

--- a/operator/pkg/config/transport_config.go
+++ b/operator/pkg/config/transport_config.go
@@ -33,6 +33,7 @@ var (
 	isBYOKafka            = false
 	specTopic             = ""
 	statusTopic           = ""
+	migrationTopic        = ""
 	kafkaResourceReady    = false
 	acmResourceReady      = false
 	kafkaClientCAKey      []byte
@@ -107,11 +108,15 @@ func SetTransportConfig(ctx context.Context, runtimeClient client.Client, mgh *v
 	// set the topic
 	specTopic = mgh.Spec.DataLayerSpec.Kafka.KafkaTopics.SpecTopic
 	statusTopic = mgh.Spec.DataLayerSpec.Kafka.KafkaTopics.StatusTopic
+	migrationTopic = mgh.Spec.DataLayerSpec.Kafka.KafkaTopics.MigrationTopic
 	if !isValidKafkaTopicName(specTopic) {
 		return fmt.Errorf("the specTopic is invalid: %s", specTopic)
 	}
 	if !isValidKafkaTopicName(statusTopic) {
 		return fmt.Errorf("the specTopic is invalid: %s", statusTopic)
+	}
+	if !isValidKafkaTopicName(migrationTopic) {
+		return fmt.Errorf("the migrationTopic is invalid: %s", migrationTopic)
 	}
 
 	// BYO Case:
@@ -156,6 +161,10 @@ func isValidKafkaTopicName(name string) bool {
 
 func GetSpecTopic() string {
 	return specTopic
+}
+
+func GetMigrationTopic() string {
+	return migrationTopic
 }
 
 // GetStatusTopic return the status topic with clusterName, like 'gh-status.<clusterName>'

--- a/operator/pkg/controllers/transporter/protocol/byo_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/byo_transporter.go
@@ -50,8 +50,9 @@ func (s *BYOTransporter) EnsureUser(clusterName string) (string, error) {
 
 func (s *BYOTransporter) EnsureTopic(clusterName string) (*transport.ClusterTopic, error) {
 	return &transport.ClusterTopic{
-		SpecTopic:   config.GetSpecTopic(),
-		StatusTopic: config.GetStatusTopic(clusterName),
+		SpecTopic:      config.GetSpecTopic(),
+		StatusTopic:    config.GetStatusTopic(clusterName),
+		MigrationTopic: config.GetMigrationTopic(),
 	}, nil
 }
 
@@ -78,10 +79,11 @@ func (s *BYOTransporter) GetConnCredential(clusterName string) (*transport.Kafka
 		BootstrapServer: string(kafkaSecret.Data[filepath.Join("bootstrap_server")]),
 
 		// for the byo case, the status topic isn't change by the clusterName
-		StatusTopic: config.GetStatusTopic(""),
-		SpecTopic:   config.GetSpecTopic(),
-		CACert:      base64.StdEncoding.EncodeToString(kafkaSecret.Data[filepath.Join("ca.crt")]),
-		ClientCert:  base64.StdEncoding.EncodeToString(kafkaSecret.Data[filepath.Join("client.crt")]),
-		ClientKey:   base64.StdEncoding.EncodeToString(kafkaSecret.Data[filepath.Join("client.key")]),
+		StatusTopic:    config.GetStatusTopic(""),
+		SpecTopic:      config.GetSpecTopic(),
+		MigrationTopic: config.GetMigrationTopic(),
+		CACert:         base64.StdEncoding.EncodeToString(kafkaSecret.Data[filepath.Join("ca.crt")]),
+		ClientCert:     base64.StdEncoding.EncodeToString(kafkaSecret.Data[filepath.Join("client.crt")]),
+		ClientKey:      base64.StdEncoding.EncodeToString(kafkaSecret.Data[filepath.Join("client.key")]),
 	}, nil
 }

--- a/operator/pkg/controllers/transporter/protocol/manifests/global-hub-kafka-user.yaml
+++ b/operator/pkg/controllers/transporter/protocol/manifests/global-hub-kafka-user.yaml
@@ -20,6 +20,15 @@ spec:
     - host: '*'
       operations:
       - Write
+      - Describe
+      - Read
+      resource:
+        name: {{.MigrationTopic}}
+        patternType: literal
+        type: topic
+    - host: '*'
+      operations:
+      - Write
       resource:
         name: {{.SpecTopic}}
         patternType: literal

--- a/operator/pkg/controllers/transporter/protocol/strimzi_kafka_controller.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_kafka_controller.go
@@ -192,6 +192,7 @@ func getManagerTransportConn(trans *strimziTransporter, kafkaUserSecret string) 
 	}
 	// topics
 	conn.SpecTopic = config.GetSpecTopic()
+	conn.MigrationTopic = config.GetMigrationTopic()
 	conn.StatusTopic = config.ManagerStatusTopic()
 	// clientCert and clientCA
 	if err := trans.loadUserCredentail(kafkaUserSecret, conn); err != nil {

--- a/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
@@ -298,6 +298,7 @@ func (k *strimziTransporter) renderKafkaResources(mgh *operatorv1alpha4.Multiclu
 				GlobalHubKafkaUser     string
 				SpecTopic              string
 				StatusTopic            string
+				MigrationTopic         string
 				StatusTopicParttern    string
 				StatusPlaceholderTopic string
 				TopicPartition         int32
@@ -312,6 +313,7 @@ func (k *strimziTransporter) renderKafkaResources(mgh *operatorv1alpha4.Multiclu
 				KafkaCluster:           KafkaClusterName,
 				GlobalHubKafkaUser:     DefaultGlobalHubKafkaUserName,
 				SpecTopic:              config.GetSpecTopic(),
+				MigrationTopic:         config.GetMigrationTopic(),
 				StatusTopic:            statusTopic,
 				StatusTopicParttern:    string(topicParttern),
 				StatusPlaceholderTopic: statusPlaceholderTopic,
@@ -415,7 +417,7 @@ func (k *strimziTransporter) EnsureUser(clusterName string) (string, error) {
 func (k *strimziTransporter) EnsureTopic(clusterName string) (*transport.ClusterTopic, error) {
 	clusterTopic := k.getClusterTopic(clusterName)
 
-	topicNames := []string{clusterTopic.SpecTopic, clusterTopic.StatusTopic}
+	topicNames := []string{clusterTopic.MigrationTopic, clusterTopic.SpecTopic, clusterTopic.StatusTopic}
 
 	for _, topicName := range topicNames {
 		kafkaTopic := &kafkav1beta2.KafkaTopic{}
@@ -495,8 +497,9 @@ func (k *strimziTransporter) Prune(clusterName string) error {
 
 func (k *strimziTransporter) getClusterTopic(clusterName string) *transport.ClusterTopic {
 	topic := &transport.ClusterTopic{
-		SpecTopic:   config.GetSpecTopic(),
-		StatusTopic: config.GetStatusTopic(clusterName),
+		SpecTopic:      config.GetSpecTopic(),
+		StatusTopic:    config.GetStatusTopic(clusterName),
+		MigrationTopic: config.GetMigrationTopic(),
 	}
 	return topic
 }

--- a/pkg/transport/assembler_test.go
+++ b/pkg/transport/assembler_test.go
@@ -23,13 +23,12 @@ func TestAssembler(t *testing.T) {
 		},
 	}
 
-	transportConfig.IsManager = true
-	genericProducer, err := producer.NewGenericProducer(transportConfig)
+	genericProducer, err := producer.NewGenericProducer(transportConfig, transportConfig.KafkaCredential.SpecTopic)
 	assert.Nil(t, err)
 	genericProducer.SetDataLimit(5)
 
-	transportConfig.IsManager = false
-	genericConsumer, err := consumer.NewGenericConsumer(transportConfig)
+	genericConsumer, err := consumer.NewGenericConsumer(transportConfig,
+		[]string{transportConfig.KafkaCredential.SpecTopic})
 	assert.Nil(t, err)
 	go func() {
 		err = genericConsumer.Start(context.TODO())

--- a/pkg/transport/consumer/generic_consumer_test.go
+++ b/pkg/transport/consumer/generic_consumer_test.go
@@ -24,13 +24,12 @@ func TestGenerateConsumer(t *testing.T) {
 	transportConfig := &transport.TransportInternalConfig{
 		TransportType:   "kafka",
 		ConsumerGroupId: "test-consumer",
-		IsManager:       false,
 		KafkaCredential: &transport.KafkaConfig{
 			BootstrapServer: mockKafkaCluster.BootstrapServers(),
 			SpecTopic:       "test-topic",
 		},
 	}
-	_, err = NewGenericConsumer(transportConfig)
+	_, err = NewGenericConsumer(transportConfig, []string{transportConfig.KafkaCredential.SpecTopic})
 	if err != nil && !strings.Contains(err.Error(), "client has run out of available brokers") {
 		t.Errorf("failed to generate consumer - %v", err)
 	}

--- a/pkg/transport/controller/controller_test.go
+++ b/pkg/transport/controller/controller_test.go
@@ -39,7 +39,7 @@ func TestSecretCtrlReconcile(t *testing.T) {
 			ConsumerGroupId: "test",
 			KafkaCredential: &transport.KafkaConfig{
 				SpecTopic:   "spec",
-				StatusTopic: "status",
+				StatusTopic: "event",
 			},
 			FailureThreshold: 100,
 		},
@@ -52,6 +52,8 @@ func TestSecretCtrlReconcile(t *testing.T) {
 		},
 		transportClient: &TransportClient{},
 		runtimeClient:   fakeClient,
+		producerTopic:   "event",
+		consumerTopics:  []string{"spec"},
 	}
 
 	ctx := context.TODO()

--- a/pkg/transport/interface.go
+++ b/pkg/transport/interface.go
@@ -25,14 +25,14 @@ type Requester interface {
 
 type Producer interface {
 	SendEvent(ctx context.Context, evt cloudevents.Event) error
-	Reconnect(config *TransportInternalConfig) error
+	Reconnect(config *TransportInternalConfig, topic string) error
 }
 
 type Consumer interface {
 	// start the transport to consume message
 	Start(ctx context.Context) error
 	EventChan() chan *cloudevents.Event
-	Reconnect(ctx context.Context, config *TransportInternalConfig) error
+	Reconnect(ctx context.Context, config *TransportInternalConfig, topics []string) error
 }
 
 // Transporter used to innitialize the infras, it has different implementation/protocol:

--- a/pkg/transport/kafka_config.go
+++ b/pkg/transport/kafka_config.go
@@ -8,6 +8,7 @@ type KafkaConfig struct {
 	BootstrapServer   string `yaml:"bootstrap.server"`
 	StatusTopic       string `yaml:"topic.status,omitempty"`
 	SpecTopic         string `yaml:"topic.spec,omitempty"`
+	MigrationTopic    string `yaml:"topic.migration,omitempty"`
 	ClusterID         string `yaml:"cluster.id,omitempty"`
 	CACert            string `yaml:"ca.crt,omitempty"`
 	ClientCert        string `yaml:"client.crt,omitempty"`
@@ -38,6 +39,7 @@ func (k *KafkaConfig) DeepCopy() *KafkaConfig {
 		BootstrapServer:   k.BootstrapServer,
 		StatusTopic:       k.StatusTopic,
 		SpecTopic:         k.SpecTopic,
+		MigrationTopic:    k.MigrationTopic,
 		ClusterID:         k.ClusterID,
 		CACert:            k.CACert,
 		ClientCert:        k.ClientCert,

--- a/pkg/transport/producer/generic_producer_test.go
+++ b/pkg/transport/producer/generic_producer_test.go
@@ -18,11 +18,12 @@ func TestGenericProducer(t *testing.T) {
 	tranConfig := &transport.TransportInternalConfig{
 		TransportType: string(transport.Rest),
 		KafkaCredential: &transport.KafkaConfig{
-			SpecTopic:   "gh-spec",
-			StatusTopic: "gh-status",
+			SpecTopic:      "gh-spec",
+			StatusTopic:    "gh-status",
+			MigrationTopic: "gh-migration",
 		},
 	}
-	err := p.initClient(tranConfig)
+	err := p.initClient(tranConfig, tranConfig.KafkaCredential.StatusTopic)
 	require.Equal(t, "transport-type - rest is not a valid option", err.Error())
 }
 

--- a/pkg/transport/transport_mocks.go
+++ b/pkg/transport/transport_mocks.go
@@ -29,7 +29,7 @@ func (m *ProducerMock) SendEvent(ctx context.Context, evt event.Event) error {
 	return m.SendEventFunc(ctx, evt)
 }
 
-func (m *ProducerMock) Reconnect(config *TransportInternalConfig) error {
+func (m *ProducerMock) Reconnect(config *TransportInternalConfig, topic string) error {
 	if m == nil {
 		panic("nil mock")
 	}

--- a/pkg/transport/type.go
+++ b/pkg/transport/type.go
@@ -34,9 +34,6 @@ const (
 type TransportInternalConfig struct {
 	TransportType     string
 	CommitterInterval time.Duration
-	// IsManager specifies the send/receive topics from specTopic and statusTopic
-	// For example, SpecTopic sends and statusTopic receives on the manager; the agent is the opposite
-	IsManager bool
 	// EnableDatabaseOffset affects only the manager, deciding if consumption starts from a database-stored offset
 	EnableDatabaseOffset bool
 	ConsumerGroupId      string
@@ -71,8 +68,9 @@ type KafkaConsumerConfig struct {
 
 // topics
 type ClusterTopic struct {
-	SpecTopic   string
-	StatusTopic string
+	SpecTopic      string
+	StatusTopic    string
+	MigrationTopic string
 }
 
 type EventPosition struct {

--- a/test/integration/agent/spec/suite_test.go
+++ b/test/integration/agent/spec/suite_test.go
@@ -48,11 +48,9 @@ var _ = BeforeSuite(func() {
 	agentConfig = &configs.AgentConfig{
 		TransportConfig: &transport.TransportInternalConfig{
 			TransportType:   string(transport.Chan),
-			IsManager:       false,
 			ConsumerGroupId: "agent",
 			KafkaCredential: &transport.KafkaConfig{
-				SpecTopic:   "spec",
-				StatusTopic: "spec",
+				StatusTopic: "status",
 			},
 		},
 		SpecWorkPoolSize:     2,
@@ -82,8 +80,10 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	runtimeClient = mgr.GetClient()
 
-	agentConfig.TransportConfig.IsManager = false
-	genericConsumer, err = genericconsumer.NewGenericConsumer(agentConfig.TransportConfig)
+	genericConsumer, err = genericconsumer.NewGenericConsumer(
+		agentConfig.TransportConfig,
+		[]string{agentConfig.TransportConfig.KafkaCredential.StatusTopic},
+	)
 	Expect(err).NotTo(HaveOccurred())
 
 	go func() {
@@ -93,8 +93,10 @@ var _ = BeforeSuite(func() {
 	}()
 	Expect(err).NotTo(HaveOccurred())
 
-	agentConfig.TransportConfig.IsManager = true
-	genericProducer, err = genericproducer.NewGenericProducer(agentConfig.TransportConfig)
+	genericProducer, err = genericproducer.NewGenericProducer(
+		agentConfig.TransportConfig,
+		agentConfig.TransportConfig.KafkaCredential.StatusTopic,
+	)
 	Expect(err).NotTo(HaveOccurred())
 
 	transportClient := controller.TransportClient{}

--- a/test/integration/agent/status/suite_test.go
+++ b/test/integration/agent/status/suite_test.go
@@ -81,10 +81,10 @@ var _ = BeforeSuite(func() {
 		TransportConfig: &transport.TransportInternalConfig{
 			CommitterInterval: 1 * time.Second,
 			TransportType:     string(transport.Chan),
-			IsManager:         false,
 			KafkaCredential: &transport.KafkaConfig{
-				SpecTopic:   "spec",
-				StatusTopic: "event",
+				SpecTopic:      "spec",
+				StatusTopic:    "event",
+				MigrationTopic: "migration",
 			},
 		},
 		EnableGlobalResource: true,
@@ -228,10 +228,9 @@ func NewChanTransport(mgr ctrl.Manager, transConfig *transport.TransportInternal
 	for _, topic := range topics {
 
 		// mock the consumer in manager
-		transConfig.IsManager = true
 		transConfig.EnableDatabaseOffset = false
 		transConfig.KafkaCredential.StatusTopic = topic
-		consumer, err := genericconsumer.NewGenericConsumer(transConfig)
+		consumer, err := genericconsumer.NewGenericConsumer(transConfig, []string{topic})
 		if err != nil {
 			return trans, err
 		}
@@ -243,8 +242,7 @@ func NewChanTransport(mgr ctrl.Manager, transConfig *transport.TransportInternal
 		Expect(err).NotTo(HaveOccurred())
 
 		// mock the producer in agent
-		transConfig.IsManager = false
-		producer, err := genericproducer.NewGenericProducer(transConfig)
+		producer, err := genericproducer.NewGenericProducer(transConfig, topic)
 		if err != nil {
 			return trans, err
 		}

--- a/test/integration/manager/controller/hub_management_test.go
+++ b/test/integration/manager/controller/hub_management_test.go
@@ -104,6 +104,6 @@ func (p *tmpProducer) SendEvent(ctx context.Context, evt cloudevents.Event) erro
 	return nil
 }
 
-func (p *tmpProducer) Reconnect(config *transport.TransportInternalConfig) error {
+func (p *tmpProducer) Reconnect(config *transport.TransportInternalConfig, topic string) error {
 	return nil
 }

--- a/test/integration/manager/controller/migration_test.go
+++ b/test/integration/manager/controller/migration_test.go
@@ -36,7 +36,9 @@ var _ = Describe("migration", Ordered, func() {
 		BeforeAll(func() {
 			testCtx, testCtxCancel = context.WithCancel(ctx)
 			var err error
-			genericConsumer, err = genericconsumer.NewGenericConsumer(transportConfig)
+			genericConsumer, err = genericconsumer.NewGenericConsumer(transportConfig,
+				[]string{transportConfig.KafkaCredential.SpecTopic},
+			)
 			Expect(err).NotTo(HaveOccurred())
 
 			// start the consumer
@@ -315,7 +317,9 @@ var _ = Describe("migration", Ordered, func() {
 		BeforeAll(func() {
 			testCtx, testCtxCancel = context.WithCancel(ctx)
 			var err error
-			genericConsumer, err = genericconsumer.NewGenericConsumer(transportConfig)
+			genericConsumer, err = genericconsumer.NewGenericConsumer(transportConfig,
+				[]string{transportConfig.KafkaCredential.SpecTopic},
+			)
 			Expect(err).NotTo(HaveOccurred())
 
 			// start the consumer

--- a/test/integration/manager/controller/suite_test.go
+++ b/test/integration/manager/controller/suite_test.go
@@ -52,10 +52,8 @@ var _ = BeforeSuite(func() {
 
 	transportConfig = &transport.TransportInternalConfig{
 		TransportType: string(transport.Chan),
-		IsManager:     true,
 		KafkaCredential: &transport.KafkaConfig{
-			SpecTopic:   "spec",
-			StatusTopic: "spec",
+			SpecTopic: "spec",
 		},
 	}
 
@@ -100,7 +98,7 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	genericProducer, err := genericproducer.NewGenericProducer(transportConfig)
+	genericProducer, err := genericproducer.NewGenericProducer(transportConfig, transportConfig.KafkaCredential.SpecTopic)
 	Expect(err).NotTo(HaveOccurred())
 	migrationReconciler = controllers.NewMigrationController(mgr.GetClient(), genericProducer, false)
 	Expect(migrationReconciler.SetupWithManager(mgr)).To(Succeed())

--- a/test/integration/manager/migration/migration_test.go
+++ b/test/integration/manager/migration/migration_test.go
@@ -38,7 +38,10 @@ var _ = Describe("migration", Ordered, func() {
 	BeforeAll(func() {
 		testCtx, testCtxCancel = context.WithCancel(ctx)
 		var err error
-		genericConsumer, err = genericconsumer.NewGenericConsumer(transportConfig)
+		genericConsumer, err = genericconsumer.NewGenericConsumer(
+			transportConfig,
+			[]string{transportConfig.KafkaCredential.SpecTopic},
+		)
 		Expect(err).NotTo(HaveOccurred())
 
 		// start the consumer

--- a/test/integration/manager/migration/suite_test.go
+++ b/test/integration/manager/migration/suite_test.go
@@ -52,10 +52,8 @@ var _ = BeforeSuite(func() {
 
 	transportConfig = &transport.TransportInternalConfig{
 		TransportType: string(transport.Chan),
-		IsManager:     true,
 		KafkaCredential: &transport.KafkaConfig{
-			SpecTopic:   "spec",
-			StatusTopic: "spec",
+			SpecTopic: "spec",
 		},
 	}
 
@@ -100,7 +98,10 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	genericProducer, err := genericproducer.NewGenericProducer(transportConfig)
+	genericProducer, err := genericproducer.NewGenericProducer(
+		transportConfig,
+		transportConfig.KafkaCredential.SpecTopic,
+	)
 	Expect(err).NotTo(HaveOccurred())
 	migrationReconciler = migration.NewMigrationController(mgr.GetClient(), genericProducer, false)
 	Expect(migrationReconciler.SetupWithManager(mgr)).To(Succeed())

--- a/test/integration/manager/spec/suite_test.go
+++ b/test/integration/manager/spec/suite_test.go
@@ -114,8 +114,9 @@ var _ = BeforeSuite(func() {
 			TransportType:     string(transport.Chan),
 			CommitterInterval: 10 * time.Second,
 			KafkaCredential: &transport.KafkaConfig{
-				SpecTopic:   "spec",
-				StatusTopic: "event",
+				SpecTopic:      "spec",
+				StatusTopic:    "event",
+				MigrationTopic: "migration",
 			},
 		},
 		StatisticsConfig:    &statistics.StatisticsConfig{},
@@ -124,11 +125,11 @@ var _ = BeforeSuite(func() {
 	}
 
 	By("Create consumer/producer")
-	managerConfig.TransportConfig.IsManager = true
-	producer, err = genericproducer.NewGenericProducer(managerConfig.TransportConfig)
+	producer, err = genericproducer.NewGenericProducer(managerConfig.TransportConfig,
+		managerConfig.TransportConfig.KafkaCredential.SpecTopic)
 	Expect(err).NotTo(HaveOccurred())
-	managerConfig.TransportConfig.IsManager = false
-	consumer, err := genericconsumer.NewGenericConsumer(managerConfig.TransportConfig)
+	consumer, err := genericconsumer.NewGenericConsumer(managerConfig.TransportConfig,
+		[]string{managerConfig.TransportConfig.KafkaCredential.SpecTopic})
 	Expect(err).NotTo(HaveOccurred())
 	// use the dispatcher to consume events from transport
 	agentDispatcher, err = agentspec.AddGenericDispatcher(mgr, consumer,

--- a/test/integration/manager/status/suite_test.go
+++ b/test/integration/manager/status/suite_test.go
@@ -89,8 +89,9 @@ var _ = BeforeSuite(func() {
 		TransportConfig: &transport.TransportInternalConfig{
 			TransportType: string(transport.Chan),
 			KafkaCredential: &transport.KafkaConfig{
-				SpecTopic:   "spec",
-				StatusTopic: "event",
+				SpecTopic:      "spec",
+				StatusTopic:    "event",
+				MigrationTopic: "migration",
 			},
 		},
 		StatisticsConfig: &statistics.StatisticsConfig{
@@ -100,12 +101,12 @@ var _ = BeforeSuite(func() {
 	}
 
 	By("Start cloudevents producer and consumer")
-	managerConfig.TransportConfig.IsManager = false
-	producer, err = genericproducer.NewGenericProducer(managerConfig.TransportConfig)
+	producer, err = genericproducer.NewGenericProducer(managerConfig.TransportConfig,
+		managerConfig.TransportConfig.KafkaCredential.StatusTopic)
 	Expect(err).NotTo(HaveOccurred())
 
-	managerConfig.TransportConfig.IsManager = true
-	consumer, err := genericconsumer.NewGenericConsumer(managerConfig.TransportConfig)
+	consumer, err := genericconsumer.NewGenericConsumer(managerConfig.TransportConfig,
+		[]string{managerConfig.TransportConfig.KafkaCredential.StatusTopic})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(mgr.Add(consumer)).Should(Succeed())
 

--- a/test/integration/operator/controllers/transporter_test.go
+++ b/test/integration/operator/controllers/transporter_test.go
@@ -84,6 +84,7 @@ var _ = Describe("transporter", Ordered, func() {
 		// verify the type
 		Expect(config.TransporterProtocol()).To(Equal(transport.SecretTransporter))
 		Expect(config.GetSpecTopic()).To(Equal("gh-spec"))
+		Expect(config.GetMigrationTopic()).To(Equal("gh-migration"))
 		Expect(config.GetRawStatusTopic()).To(Equal("gh-status"))
 
 		reconciler := operatortrans.NewTransportReconciler(runtimeManager)
@@ -393,6 +394,7 @@ var _ = Describe("transporter", Ordered, func() {
 		clusterTopic, err := trans.EnsureTopic(clusterName)
 		Expect(err).To(Succeed())
 		Expect("gh-spec").To(Equal(clusterTopic.SpecTopic))
+		Expect("gh-migration").To(Equal(clusterTopic.MigrationTopic))
 		Expect(config.GetStatusTopic(clusterName)).To(Equal(clusterTopic.StatusTopic))
 
 		// topic: update

--- a/test/manifest/kafka/kafka-cluster/kafka-topics.yaml
+++ b/test/manifest/kafka/kafka-cluster/kafka-topics.yaml
@@ -1,6 +1,18 @@
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
+  name: gh-migration
+  labels:
+    strimzi.io/cluster: kafka
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    cleanup.policy: compact
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
   name: gh-spec
   labels:
     strimzi.io/cluster: kafka

--- a/test/script/kessel_e2e_setup.sh
+++ b/test/script/kessel_e2e_setup.sh
@@ -61,6 +61,7 @@ spec:
   dataLayer:
     kafka:
       topics:
+        migrationTopic: gh-migration
         specTopic: gh-spec
         statusTopic: gh-event.*
       storageSize: 1Gi

--- a/test/script/util.sh
+++ b/test/script/util.sh
@@ -526,7 +526,7 @@ wait_cmd() {
     fi
 
     if [ $elapsed -eq 0 ]; then
-      echo -e "\r placeholder will be overwrite by wating message"
+      echo -e "\r placeholder will be overwrite by waitng message"
     fi
     local index=$((elapsed / interval % ${#signs[@]}))
     echo -ne "\r ${signs[$index]} Waiting $elapsed seconds: $1"


### PR DESCRIPTION

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
1. refactor the generic producer and consumer so that it can be used by migration controller
2. introduce `gh-migration` as a new topic for migration purpose

## Related issue(s)

Fixes https://issues.redhat.com/browse/ACM-19539

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
