### PR TITLE
:bug: Enhance e2e

### DIFF
--- a/agent/pkg/spec/dispatcher.go
+++ b/agent/pkg/spec/dispatcher.go
@@ -91,7 +91,7 @@ func (d *genericDispatcher) dispatch(ctx context.Context) {
 				continue
 			}
 			if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-				d.log.Debug("sync data: %v", evt.Data())
+				d.log.Debugf("sync data: %+v", evt.Data())
 				if err := syncer.Sync(ctx, evt.Data()); err != nil {
 					return err
 				}

--- a/test/e2e/localpolicy_test.go
+++ b/test/e2e/localpolicy_test.go
@@ -274,6 +274,11 @@ var _ = Describe("Local Policy", Ordered, Label("e2e-test-localpolicy"), func() 
 				return err
 			}
 			for _, p := range localPolicies {
+				// since we have local agent enabled, so that localPolicies has local-cluster.
+				// but hubToPolicyMap does not have local-cluster
+				if _, found := hubToPolicyMap[p.LeafHubName]; !found {
+					continue
+				}
 				if string(hubToPolicyMap[p.LeafHubName].UID) == p.PolicyID {
 					return fmt.Errorf("the policy(%s) is not deleted from local_spec.policies", p.PolicyName)
 				}

--- a/test/script/e2e_prow.sh
+++ b/test/script/e2e_prow.sh
@@ -24,8 +24,8 @@ scp "${OPT[@]}" -r ../multicluster-global-hub "$HOST:$HOST_DIR"
 
 ssh "${OPT[@]}" "$HOST" sudo yum install git wget jq librdkafka gcc -y
 # Insufficient resources creating kind clusters, modify parameters to expand
-ssh "${OPT[@]}" "$HOST" "sudo sh -c 'echo \"fs.inotify.max_user_watches=524288\" >> /etc/sysctl.conf && \
-                                     echo \"fs.inotify.max_user_instances=8192\" >> /etc/sysctl.conf && \
+ssh "${OPT[@]}" "$HOST" "sudo sh -c 'echo fs.inotify.max_user_watches=524288 >> /etc/sysctl.conf && \
+                                     echo fs.inotify.max_user_instances=8192 >> /etc/sysctl.conf && \
                                      sysctl -p /etc/sysctl.conf'"
 
 echo "setup e2e environment"

--- a/test/script/e2e_run.sh
+++ b/test/script/e2e_run.sh
@@ -82,7 +82,6 @@ for i in $(seq 1 "${MH_NUM}"); do
 EOF
 
   docker pull "$MULTICLUSTER_GLOBAL_HUB_AGENT_IMAGE_REF"
-  kind load docker-image "$MULTICLUSTER_GLOBAL_HUB_AGENT_IMAGE_REF" --name "hub$i"
   for j in $(seq 1 "${MC_NUM}"); do
     # imported managedcluster
     mc_kubeconfig="${CONFIG_DIR}/hub$i-cluster$j"

--- a/test/script/e2e_setup.sh
+++ b/test/script/e2e_setup.sh
@@ -47,8 +47,12 @@ done
 # it reports `CSV "packageserver" failed to reach phase succeeded` if create service ca before enable olm
 enable_service_ca "$GH_NAME" "$TEST_DIR/manifest" 2>&1 || true
 
-# install the mch on the global hub
+# install the mch on the global hub and managed hubs
 install_mch "$GH_NAME"
+for i in $(seq 1 "${MH_NUM}"); do
+  # install the mch on the managed hub
+  install_mch "hub$i"
+done
 echo -e "${YELLOW} initializing hubs:${NC} $(($(date +%s) - start_time)) seconds"
 
 # async ocm, policy and app

--- a/test/script/e2e_setup.sh
+++ b/test/script/e2e_setup.sh
@@ -25,9 +25,6 @@ done
 
 echo -e "${YELLOW} creating clusters:${NC} $(($(date +%s) - start_time)) seconds"
 
-# service-ca
-enable_service_ca "$GH_NAME" "$TEST_DIR/manifest" 2>&1 || true
-
 # Init hubs
 start_time=$(date +%s)
 pids=()
@@ -45,6 +42,10 @@ done
 for pid in "${pids[@]}"; do
   wait "$pid" || true
 done
+
+# service-ca
+# it reports `CSV "packageserver" failed to reach phase succeeded` if create service ca before enable olm
+enable_service_ca "$GH_NAME" "$TEST_DIR/manifest" 2>&1 || true
 
 # install the mch on the global hub
 install_mch "$GH_NAME"

--- a/test/script/util.sh
+++ b/test/script/util.sh
@@ -411,6 +411,9 @@ install_crds() {
 
 install_mch() {
   local ctx=$1
+  # create open-cluster-management namespace
+  kubectl create ns open-cluster-management --dry-run=client -o yaml | kubectl --context "$ctx" apply -f -
+
   # mch
   kubectl --context "$ctx" apply -f ${CURRENT_DIR}/../manifest/crd/0000_01_operator.open-cluster-management.io_multiclusterhubs.crd.yaml
 
@@ -418,7 +421,7 @@ install_mch() {
   kubectl --context "$ctx" apply -f ${CURRENT_DIR}/../manifest/mch/multiclusterhub.yaml
 
   # patch it to ready
-  kubectl --context "$ctx" patch multiclusterhub multiclusterhub -n open-cluster-management --type='merge' -p='{"status": {"phase": "Running"}}' --subresource=status
+  kubectl --context "$ctx" patch multiclusterhub multiclusterhub -n open-cluster-management --type='merge' -p='{"status": {"phase": "Running", "currentVersion": "2.13.1", "desiredVersion": "2.13.1"}}' --subresource=status
 }
 
 enable_service_ca() {

--- a/test/script/util.sh
+++ b/test/script/util.sh
@@ -2,13 +2,13 @@
 
 # Version
 export INSTALL_DIR=/usr/local/bin
-export PATH=$PATH:$INSTALL_DIR
+export PATH=$INSTALL_DIR:$PATH
 export GRC_VERSION=v0.15.0
 export KUBECTL_VERSION=v1.28.1
-export CLUSTERADM_VERSION=0.8.2
+export CLUSTERADM_VERSION=0.10.1
 export KIND_VERSION=v0.19.0
 export ROUTE_VERSION=release-4.12
-export GO_VERSION=go1.23.2
+export GO_VERSION=go1.23.6
 export GINKGO_VERSION=v2.17.2
 
 # Environment Variables
@@ -101,6 +101,12 @@ check_kind() {
     chmod +x ./kind-amd64
     sudo mv ./kind-amd64 $INSTALL_DIR/kind
   fi
+  if [[ $(kind version) < "kind v0.19.0" ]]; then
+    echo "KinD version is less than 0.19, update to $KIND_VERSION"
+    curl -Lo ./kind-amd64 "https://kind.sigs.k8s.io/dl/$KIND_VERSION/kind-$(uname)-amd64"
+    chmod +x ./kind-amd64
+    sudo mv ./kind-amd64 $INSTALL_DIR/kind
+  fi
   echo "kind version: $(kind version)"
 }
 
@@ -130,7 +136,7 @@ ensure_cluster() {
     kind delete cluster --name="$cluster_name"
   fi
 
-  kind create cluster --name "$cluster_name" --image=kindest/node:v1.23.0 --wait 5m
+  kind create cluster --name "$cluster_name" --wait 5m
 
   # modify the context = KinD cluster name = kubeconfig name
   kubectl config delete-context "$cluster_name" 2>/dev/null || true
@@ -430,7 +436,7 @@ enable_olm() {
   kubectl config use-context "$1"
   curl -L https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.28.0/install.sh -o install.sh
   chmod +x install.sh
-  ./install.sh v0.30.0
+  ./install.sh v0.28.0
 }
 
 wait_secret_ready() {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
e2e is not stable in main branch is mainly due to the memory is not sufficient to support enable/disable agent. use `m5ad.2xlarge` instead - https://github.com/openshift/release/pull/63567
some minor fixes:
1.  do not enable service ca before enable olm to fix this error:
```
CSV "packageserver" failed to reach phase succeeded
customresourcedefinition.apiextensions.k8s.io/multiclusterhubs.operator.open-cluster-management.io created
multiclusterhub.operator.open-cluster-management.io/multiclusterhub created
multiclusterhub.operator.open-cluster-management.io/multiclusterhub patched
 initializing hubs: 331 seconds
```
2. update KinD version to 0.19.0 to support kubernetes 1.27 so that it can be used by https://github.com/stolostron/multicluster-global-hub/pull/1499
3. remove double quote to correct the settings
4. fix the panic error introduced by local agent
```
• [PANICKED] [10.880 seconds]
Local Policy [AfterAll] Global Hub Cleanup Finalizer check the placementrule [e2e-test-localpolicy]
  [AfterAll] /tmp/multicluster-global-hub/test/e2e/localpolicy_test.go:241
  [It] /tmp/multicluster-global-hub/test/e2e/localpolicy_test.go:219

  Timeline >>
  STEP: Delete the policy from leafhub @ 04/07/25 14:43:41.866
  STEP: Verify the policy is delete from the leafhub @ 04/07/25 14:43:52.729
  STEP: Verify the policy is delete from the spec table @ 04/07/25 14:43:52.735
  [PANICKED] in [AfterAll] - /tmp/multicluster-global-hub/vendor/github.com/onsi/gomega/internal/async_assertion.go:333 @ 04/07/25 14:43:52.736
  << Timeline

  [PANICKED] Test Panicked
  In [AfterAll] at: /tmp/multicluster-global-hub/vendor/github.com/onsi/gomega/internal/async_assertion.go:333 @ 04/07/25 14:43:52.736

  runtime error: invalid memory address or nil pointer dereference

  Full Stack Trace
    github.com/onsi/gomega/internal.(*AsyncAssertion).buildActualPoller.func3.1()
    	/tmp/multicluster-global-hub/vendor/github.com/onsi/gomega/internal/async_assertion.go:333 +0x186
    panic({0x49bd5e0?, 0x7637730?})
    	/usr/local/go/src/runtime/panic.go:785 +0x132
    github.com/stolostron/multicluster-global-hub/test/e2e.init.func9.4.2()
```
5. Do not load the image because we met the same problem described https://github.com/kubernetes/kubernetes/issues/126473#issuecomment-2375552906
## Related issue(s)

Fixes #

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
