### PR TITLE
fix agent log level

### DIFF
--- a/agent/pkg/status/syncers/configmap/config_controller.go
+++ b/agent/pkg/status/syncers/configmap/config_controller.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/configs"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/logger"
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
 const (
@@ -35,7 +36,7 @@ func AddConfigMapController(mgr ctrl.Manager, agentConfig *configs.AgentConfig) 
 	}
 
 	configMapPredicate := predicate.NewPredicateFuncs(func(object client.Object) bool {
-		return object.GetNamespace() == constants.GHAgentNamespace &&
+		return (object.GetNamespace() == constants.GHAgentNamespace || object.GetNamespace() == utils.GetDefaultNamespace()) &&
 			object.GetName() == constants.GHAgentConfigCMName
 	})
 	if err := ctrl.NewControllerManagedBy(mgr).

--- a/operator/pkg/controllers/agent/local_agent_controller.go
+++ b/operator/pkg/controllers/agent/local_agent_controller.go
@@ -59,7 +59,7 @@ func StartLocalAgentController(initOption config.ControllerOption) (config.Contr
 		Watches(&appsv1.Deployment{},
 			&handler.EnqueueRequestForObject{}, builder.WithPredicates(deplomentPred)).
 		Watches(&corev1.ConfigMap{},
-			&handler.EnqueueRequestForObject{}, builder.WithPredicates(config.GeneralPredicate)).
+			&handler.EnqueueRequestForObject{}, builder.WithPredicates(configMapPredicate)).
 		Watches(&corev1.ServiceAccount{},
 			&handler.EnqueueRequestForObject{}, builder.WithPredicates(config.GeneralPredicate)).
 		Watches(&rbacv1.ClusterRole{},

--- a/operator/pkg/controllers/agent/manifests/configmap.yaml
+++ b/operator/pkg/controllers/agent/manifests/configmap.yaml
@@ -12,4 +12,4 @@ data:
   hubClusterHeartbeat: "60s"
   aggregationLevel: full
   enableLocalPolicies: "true"
-  logLevel: "info"
+  logLevel: {{.LogLevel}}

--- a/operator/pkg/controllers/agent/standalone_agent_controller_test.go
+++ b/operator/pkg/controllers/agent/standalone_agent_controller_test.go
@@ -1,0 +1,84 @@
+package agent
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
+	commonutils "github.com/stolostron/multicluster-global-hub/pkg/utils"
+)
+
+func TestGetLogLevel(t *testing.T) {
+	s := scheme.Scheme
+
+	tests := []struct {
+		name          string
+		configMap     *corev1.ConfigMap
+		expectedLevel string
+		expectedError bool
+		notFoundError bool
+	}{
+		{
+			name: "config map exists with log level",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.GHConfigCMName,
+					Namespace: commonutils.GetDefaultNamespace(),
+				},
+				Data: map[string]string{
+					logger.LogLevelKey: "debug",
+				},
+			},
+			expectedLevel: "debug",
+			expectedError: false,
+		},
+		{
+			name: "config map exists without log level",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.GHConfigCMName,
+					Namespace: commonutils.GetDefaultNamespace(),
+				},
+				Data: map[string]string{},
+			},
+			expectedLevel: "",
+			expectedError: false,
+		},
+		{
+			name:          "config map not found",
+			configMap:     nil,
+			expectedLevel: string(logger.Info),
+			expectedError: false,
+			notFoundError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var objects []runtime.Object
+			if test.configMap != nil {
+				objects = append(objects, test.configMap)
+			}
+
+			fakeClient := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objects...).Build()
+
+			level, err := getLogLevel(fakeClient)
+
+			if test.expectedError && err == nil {
+				t.Error("expected error but got none")
+			}
+			if !test.expectedError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if level != test.expectedLevel {
+				t.Errorf("expected log level %s but got %s", test.expectedLevel, level)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Root cause: 
In operator part, we do not set the log level to agent configmap `multicluster-global-hub-agent-config`
In agent part, we do not watch the globalhub namespace to change log level.

## Related issue(s)

Fixes #
https://issues.redhat.com/browse/ACM-19942
## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
