### PR TITLE
:sparkles: Migrate managed clusters

### DIFF
--- a/agent/cmd/main.go
+++ b/agent/cmd/main.go
@@ -171,16 +171,12 @@ func completeConfig(ctx context.Context, c client.Client, agentConfig *configs.A
 	if agentConfig.MetricsAddress == "" {
 		agentConfig.MetricsAddress = fmt.Sprintf("%s:%d", metricsHost, metricsPort)
 	}
-	// if deploy the agent as a event exporter, then disable the consumer features
-	if agentConfig.Standalone {
-		agentConfig.TransportConfig.ConsumerGroupId = ""
-		agentConfig.SpecWorkPoolSize = 0
-	} else {
-		agentConfig.TransportConfig.ConsumerGroupId = agentConfig.LeafHubName
-		if agentConfig.SpecWorkPoolSize < 1 || agentConfig.SpecWorkPoolSize > 100 {
-			return fmt.Errorf("flag consumer-worker-pool-size should be in the scope [1, 100]")
-		}
+	agentConfig.TransportConfig.ConsumerGroupId = agentConfig.LeafHubName
+
+	if agentConfig.SpecWorkPoolSize < 1 || agentConfig.SpecWorkPoolSize > 100 {
+		return fmt.Errorf("flag consumer-worker-pool-size should be in the scope [1, 100]")
 	}
+
 	configs.SetAgentConfig(agentConfig)
 	return nil
 }

--- a/agent/cmd/main_test.go
+++ b/agent/cmd/main_test.go
@@ -80,8 +80,9 @@ func TestCompleteConfig(t *testing.T) {
 		{
 			name: "Valid configuration under standalone mode",
 			agentConfig: &configs.AgentConfig{
-				LeafHubName: "",
-				Standalone:  true,
+				LeafHubName:      "",
+				Standalone:       true,
+				SpecWorkPoolSize: 5,
 				TransportConfig: &transport.TransportInternalConfig{
 					ConsumerGroupId: "test-hub",
 					TransportType:   string(transport.Kafka),
@@ -94,10 +95,10 @@ func TestCompleteConfig(t *testing.T) {
 			expectConfig: &configs.AgentConfig{
 				LeafHubName:      "123",
 				Standalone:       true,
-				SpecWorkPoolSize: 0,
+				SpecWorkPoolSize: 5,
 				MetricsAddress:   "0.0.0.0:8384",
 				TransportConfig: &transport.TransportInternalConfig{
-					ConsumerGroupId: "",
+					ConsumerGroupId: "123",
 					TransportType:   string(transport.Kafka),
 				},
 			},

--- a/agent/pkg/controllers/init_controller.go
+++ b/agent/pkg/controllers/init_controller.go
@@ -67,6 +67,11 @@ func (c *initController) addACMController(ctx context.Context, request ctrl.Requ
 		return ctrl.Result{}, fmt.Errorf("failed to add the syncer: %w", err)
 	}
 
+	// add spec controllers
+	if err := agentspec.AddToManager(ctx, c.mgr, c.transportClient, c.agentConfig); err != nil {
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, fmt.Errorf("failed to add spec syncer: %w", err)
+	}
+
 	// only enable the status controller in the standalone mode
 	if c.agentConfig.Standalone {
 		return ctrl.Result{}, nil
@@ -80,11 +85,6 @@ func (c *initController) addACMController(ctx context.Context, request ctrl.Requ
 	// Need this controller to update the value of clusterclaim version.open-cluster-management.io
 	if err := AddVersionClusterClaimController(c.mgr); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to add controllers: %w", err)
-	}
-
-	// add spec controllers
-	if err := agentspec.AddToManager(ctx, c.mgr, c.transportClient, c.agentConfig); err != nil {
-		return ctrl.Result{RequeueAfter: 10 * time.Second}, fmt.Errorf("failed to add spec syncer: %w", err)
 	}
 
 	// all the controller started, then add the lease controller

--- a/agent/pkg/spec/spec.go
+++ b/agent/pkg/spec/spec.go
@@ -46,9 +46,9 @@ func AddToManager(context context.Context, mgr ctrl.Manager, transportClient tra
 	}
 
 	dispatcher.RegisterSyncer(constants.CloudEventTypeMigrationFrom,
-		syncers.NewManagedClusterMigrationFromSyncer(mgr.GetClient(), transportClient))
+		syncers.NewManagedClusterMigrationFromSyncer(mgr.GetClient(), transportClient, agentConfig.TransportConfig))
 	dispatcher.RegisterSyncer(constants.CloudEventTypeMigrationTo,
-		syncers.NewManagedClusterMigrationToSyncer(mgr.GetClient(), transportClient))
+		syncers.NewManagedClusterMigrationToSyncer(mgr.GetClient(), transportClient, agentConfig.TransportConfig))
 	dispatcher.RegisterSyncer(constants.ResyncMsgKey, syncers.NewResyncer())
 
 	log.Info("added the spec controllers to manager")

--- a/agent/pkg/spec/syncers/migration_from_syncer_test.go
+++ b/agent/pkg/spec/syncers/migration_from_syncer_test.go
@@ -200,7 +200,8 @@ func TestMigrationSourceHubSyncer(t *testing.T) {
 			transportClient := &controller.TransportClient{}
 			transportClient.SetProducer(&producer)
 
-			managedClusterMigrationSyncer := NewManagedClusterMigrationFromSyncer(fakeClient, transportClient)
+			managedClusterMigrationSyncer := NewManagedClusterMigrationFromSyncer(fakeClient, transportClient, nil)
+			managedClusterMigrationSyncer.sendResources = true
 
 			payload, err := json.Marshal(c.receivedMigrationEventBundle)
 			assert.Nil(t, err)

--- a/agent/pkg/spec/syncers/migration_to_syncer_test.go
+++ b/agent/pkg/spec/syncers/migration_to_syncer_test.go
@@ -553,7 +553,7 @@ func TestMigrationToSyncer(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(c.initObjects...).Build()
-			managedClusterMigrationSyncer := NewManagedClusterMigrationToSyncer(client, nil)
+			managedClusterMigrationSyncer := NewManagedClusterMigrationToSyncer(client, nil, nil)
 
 			err := managedClusterMigrationSyncer.Sync(ctx, testPayload)
 			assert.Nil(t, err)
@@ -724,7 +724,7 @@ func TestMigrationDestinationHubSyncer(t *testing.T) {
 			transportClient := &controller.TransportClient{}
 			transportClient.SetProducer(&producer)
 
-			managedClusterMigrationSyncer := NewManagedClusterMigrationToSyncer(fakeClient, transportClient)
+			managedClusterMigrationSyncer := NewManagedClusterMigrationToSyncer(fakeClient, transportClient, nil)
 
 			payload, err := json.Marshal(c.receivedMigrationEventBundle)
 			assert.Nil(t, err)

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/go-logr/logr v1.4.2
 	github.com/go-logr/zapr v1.3.0
 	github.com/gonvenience/ytbx v1.4.6
+	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/homeport/dyff v1.9.4
 	github.com/lib/pq v1.10.9
@@ -65,13 +66,6 @@ require (
 	sigs.k8s.io/kustomize/api v0.18.0
 	sigs.k8s.io/kustomize/kyaml v0.18.1
 	sigs.k8s.io/yaml v1.4.0
-)
-
-require (
-	github.com/Microsoft/hcsshim v0.12.0-rc.1 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v0.44.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v0.44.0 // indirect
-	go.uber.org/atomic v1.11.0 // indirect
 )
 
 require (
@@ -129,7 +123,6 @@ require (
 	github.com/gonvenience/text v1.0.8 // indirect
 	github.com/google/certificate-transparency-go v1.1.7 // indirect
 	github.com/google/gnostic-models v0.6.9-0.20230804172637-c7be7c783f49 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
@@ -202,6 +195,7 @@ require (
 	github.com/zmap/zlint/v3 v3.5.0 // indirect
 	go.opentelemetry.io/otel v1.32.0 // indirect
 	go.opentelemetry.io/otel/trace v1.32.0 // indirect
+	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/arch v0.8.0 // indirect
 	golang.org/x/crypto v0.35.0 // indirect

--- a/manager/cmd/main.go
+++ b/manager/cmd/main.go
@@ -259,7 +259,9 @@ func transportCallback(mgr ctrl.Manager, managerConfig *configs.ManagerConfig) c
 
 		// start managedclustermigration controller
 		if err := migration.NewMigrationController(mgr.GetClient(), producer,
-			managerConfig.ImportClusterInHosted).SetupWithManager(mgr); err != nil {
+			managerConfig.ImportClusterInHosted,
+			managerConfig.TransportConfig.KafkaCredential.MigrationTopic,
+		).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("failed to add migration controller to manager - %w", err)
 		}
 

--- a/manager/pkg/configs/scheme.go
+++ b/manager/pkg/configs/scheme.go
@@ -4,6 +4,7 @@
 package configs
 
 import (
+	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
 	klusterletv1alpha1 "github.com/stolostron/cluster-lifecycle-api/klusterletconfig/v1alpha1"
 	addonv1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
 	mchv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
@@ -45,5 +46,7 @@ func GetRuntimeScheme() *runtime.Scheme {
 	utilruntime.Must(klusterletv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(addonv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(addonv1.SchemeBuilder.AddToScheme(scheme))
+	// add Kafka scheme
+	utilruntime.Must(kafkav1beta2.AddToScheme(scheme))
 	return scheme
 }

--- a/manager/pkg/migration/migration_controller.go
+++ b/manager/pkg/migration/migration_controller.go
@@ -42,15 +42,17 @@ type ClusterMigrationController struct {
 	transport.Producer
 	BootstrapSecret       *corev1.Secret
 	importClusterInHosted bool
+	migrationTopic        string
 }
 
 func NewMigrationController(client client.Client, producer transport.Producer,
-	importClusterInHosted bool,
+	importClusterInHosted bool, migrationTopic string,
 ) *ClusterMigrationController {
 	return &ClusterMigrationController{
 		Client:                client,
 		Producer:              producer,
 		importClusterInHosted: importClusterInHosted,
+		migrationTopic:        migrationTopic,
 	}
 }
 
@@ -111,6 +113,9 @@ func (m *ClusterMigrationController) SetupWithManager(mgr ctrl.Manager) error {
 
 func (m *ClusterMigrationController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log.Infof("reconcile managed cluster migration %v", req)
+	// TODO: we only allow to have one migration processing at a time.
+	// if there are multiple migrations, we need to wait for the first one to finish.
+	// we need to put the migrations into a queue and provide the message in that CR to tell the user
 	mcm := &migrationv1alpha1.ManagedClusterMigration{}
 	// the migration name is the same as managedserviceaccount and the secret
 	err := m.Get(ctx, types.NamespacedName{Namespace: utils.GetDefaultNamespace(), Name: req.Name}, mcm)

--- a/operator/api/migration/v1alpha1/managedclustermigration_types.go
+++ b/operator/api/migration/v1alpha1/managedclustermigration_types.go
@@ -40,6 +40,7 @@ const (
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:resource:shortName={mcm}
 // +operator-sdk:csv:customresourcedefinitions:resources={{Deployment,v1,multicluster-global-hub-manager}}
 // ManagedClusterMigration is a global hub resource that allows you to migrate managed clusters from one hub to another
 type ManagedClusterMigration struct {

--- a/operator/bundle/manifests/global-hub.open-cluster-management.io_managedclustermigrations.yaml
+++ b/operator/bundle/manifests/global-hub.open-cluster-management.io_managedclustermigrations.yaml
@@ -11,6 +11,8 @@ spec:
     kind: ManagedClusterMigration
     listKind: ManagedClusterMigrationList
     plural: managedclustermigrations
+    shortNames:
+    - mcm
     singular: managedclustermigration
   scope: Namespaced
   versions:

--- a/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -41,7 +41,7 @@ metadata:
     categories: Integration & Delivery,OpenShift Optional
     certified: "false"
     containerImage: quay.io/stolostron/multicluster-global-hub-operator:latest
-    createdAt: "2025-04-17T02:16:02Z"
+    createdAt: "2025-04-16T14:40:30Z"
     description: Manages the installation and upgrade of the Multicluster Global Hub.
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -378,8 +378,9 @@ spec:
           resources:
           - configmaps
           - events
+          - namespaces
+          - pods
           - secrets
-          - serviceaccounts
           - services
           verbs:
           - create
@@ -401,14 +402,33 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - groups
+          - users
+          verbs:
+          - impersonate
+        - apiGroups:
+          - ""
+          resources:
           - jobs
-          - namespaces
           - persistentvolumeclaims
-          - pods
           verbs:
           - create
           - delete
           - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - impersonate
           - list
           - patch
           - update
@@ -474,6 +494,15 @@ spec:
           - update
           - watch
         - apiGroups:
+          - agent.open-cluster-management.io
+          resources:
+          - klusterletaddonconfigs
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+        - apiGroups:
           - apiextensions.k8s.io
           resources:
           - customresourcedefinitions
@@ -489,10 +518,13 @@ spec:
           resources:
           - applications
           verbs:
+          - create
+          - delete
           - get
           - list
           - patch
           - update
+          - watch
         - apiGroups:
           - apps
           resources:
@@ -521,18 +553,13 @@ spec:
           - apps.open-cluster-management.io
           resources:
           - channels
-          - subscriptions
-          verbs:
-          - get
-          - list
-          - patch
-          - update
-        - apiGroups:
-          - apps.open-cluster-management.io
-          resources:
           - placementrules
           - subscriptionreports
+          - subscriptions
+          - subscriptionstatuses
           verbs:
+          - create
+          - delete
           - get
           - list
           - patch
@@ -635,6 +662,7 @@ spec:
           - clusterclaims
           - managedclusters
           - managedclustersetbindings
+          - managedclustersets
           - placements
           verbs:
           - create
@@ -648,7 +676,6 @@ spec:
           - cluster.open-cluster-management.io
           resources:
           - managedclusters/finalizers
-          - managedclustersets
           - placementdecisions
           - placementdecisions/finalizers
           - placements/finalizers
@@ -664,6 +691,14 @@ spec:
           - global
           resources:
           - managedclustersets/bind
+          verbs:
+          - create
+          - delete
+        - apiGroups:
+          - cluster.open-cluster-management.io
+          resources:
+          - managedclustersets/bind
+          - managedclustersets/join
           verbs:
           - create
           - delete
@@ -694,6 +729,7 @@ spec:
           - leases
           verbs:
           - create
+          - delete
           - get
           - list
           - patch
@@ -834,6 +870,14 @@ spec:
           - list
           - watch
         - apiGroups:
+          - platform.stackrox.io
+          resources:
+          - centrals
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - policy.open-cluster-management.io
           resources:
           - placementbindings
@@ -841,6 +885,8 @@ spec:
           - policyautomations
           - policysets
           verbs:
+          - create
+          - delete
           - get
           - list
           - patch
@@ -860,27 +906,23 @@ spec:
           resources:
           - clusterrolebindings
           - clusterroles
+          - rolebindings
+          - roles
           verbs:
           - create
           - delete
           - deletecollection
           - get
           - list
-          - update
-          - watch
-        - apiGroups:
-          - rbac.authorization.k8s.io
-          resources:
-          - rolebindings
-          - roles
-          verbs:
-          - create
-          - delete
-          - get
-          - list
           - patch
           - update
           - watch
+        - apiGroups:
+          - register.open-cluster-management.io
+          resources:
+          - managedclusters/accept
+          verbs:
+          - update
         - apiGroups:
           - route.openshift.io
           resources:

--- a/operator/config/crd/bases/global-hub.open-cluster-management.io_managedclustermigrations.yaml
+++ b/operator/config/crd/bases/global-hub.open-cluster-management.io_managedclustermigrations.yaml
@@ -11,6 +11,8 @@ spec:
     kind: ManagedClusterMigration
     listKind: ManagedClusterMigrationList
     plural: managedclustermigrations
+    shortNames:
+    - mcm
     singular: managedclustermigration
   scope: Namespaced
   versions:

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -9,8 +9,9 @@ rules:
   resources:
   - configmaps
   - events
+  - namespaces
+  - pods
   - secrets
-  - serviceaccounts
   - services
   verbs:
   - create
@@ -32,14 +33,33 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - groups
+  - users
+  verbs:
+  - impersonate
+- apiGroups:
+  - ""
+  resources:
   - jobs
-  - namespaces
   - persistentvolumeclaims
-  - pods
   verbs:
   - create
   - delete
   - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - impersonate
   - list
   - patch
   - update
@@ -105,6 +125,15 @@ rules:
   - update
   - watch
 - apiGroups:
+  - agent.open-cluster-management.io
+  resources:
+  - klusterletaddonconfigs
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
@@ -120,10 +149,13 @@ rules:
   resources:
   - applications
   verbs:
+  - create
+  - delete
   - get
   - list
   - patch
   - update
+  - watch
 - apiGroups:
   - apps
   resources:
@@ -152,18 +184,13 @@ rules:
   - apps.open-cluster-management.io
   resources:
   - channels
-  - subscriptions
-  verbs:
-  - get
-  - list
-  - patch
-  - update
-- apiGroups:
-  - apps.open-cluster-management.io
-  resources:
   - placementrules
   - subscriptionreports
+  - subscriptions
+  - subscriptionstatuses
   verbs:
+  - create
+  - delete
   - get
   - list
   - patch
@@ -266,6 +293,7 @@ rules:
   - clusterclaims
   - managedclusters
   - managedclustersetbindings
+  - managedclustersets
   - placements
   verbs:
   - create
@@ -279,7 +307,6 @@ rules:
   - cluster.open-cluster-management.io
   resources:
   - managedclusters/finalizers
-  - managedclustersets
   - placementdecisions
   - placementdecisions/finalizers
   - placements/finalizers
@@ -295,6 +322,14 @@ rules:
   - global
   resources:
   - managedclustersets/bind
+  verbs:
+  - create
+  - delete
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclustersets/bind
+  - managedclustersets/join
   verbs:
   - create
   - delete
@@ -325,6 +360,7 @@ rules:
   - leases
   verbs:
   - create
+  - delete
   - get
   - list
   - patch
@@ -465,6 +501,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - platform.stackrox.io
+  resources:
+  - centrals
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - policy.open-cluster-management.io
   resources:
   - placementbindings
@@ -472,6 +516,8 @@ rules:
   - policyautomations
   - policysets
   verbs:
+  - create
+  - delete
   - get
   - list
   - patch
@@ -491,27 +537,23 @@ rules:
   resources:
   - clusterrolebindings
   - clusterroles
+  - rolebindings
+  - roles
   verbs:
   - create
   - delete
   - deletecollection
   - get
   - list
-  - update
-  - watch
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - rolebindings
-  - roles
-  verbs:
-  - create
-  - delete
-  - get
-  - list
   - patch
   - update
   - watch
+- apiGroups:
+  - register.open-cluster-management.io
+  resources:
+  - managedclusters/accept
+  verbs:
+  - update
 - apiGroups:
   - route.openshift.io
   resources:

--- a/operator/pkg/controllers/agent/addon/default_agent_controller.go
+++ b/operator/pkg/controllers/agent/addon/default_agent_controller.go
@@ -30,7 +30,7 @@ import (
 )
 
 // +kubebuilder:rbac:groups=operator.open-cluster-management.io,resources=multiclusterglobalhubs,verbs=get;list;watch;
-// +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;watch
+// +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons,verbs=create;update;get;list;watch;delete;deletecollection;patch
 // +kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons/finalizers,verbs=update
 // +kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons/status,verbs=update;patch

--- a/operator/pkg/controllers/agent/addon/manifests/templates/agent/multicluster-global-hub-agent-clusterrole.yaml
+++ b/operator/pkg/controllers/agent/addon/manifests/templates/agent/multicluster-global-hub-agent-clusterrole.yaml
@@ -249,6 +249,8 @@ rules:
   - create
   - update
   - delete
+  - watch
+  - list
 - apiGroups:
   - agent.open-cluster-management.io
   resources:

--- a/operator/pkg/controllers/agent/local_agent_controller.go
+++ b/operator/pkg/controllers/agent/local_agent_controller.go
@@ -79,21 +79,30 @@ func (s *LocalAgentController) IsResourceRemoved() bool {
 	return isResourceRemoved
 }
 
-// +kubebuilder:rbac:groups=operator.open-cluster-management.io,resources=multiclusterglobalhubagents,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=operator.open-cluster-management.io,resources=multiclusterglobalhubagents/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=operator.open-cluster-management.io,resources=multiclusterglobalhubagents/finalizers,verbs=update
-// +kubebuilder:rbac:groups="policy.open-cluster-management.io",resources=policyautomations;policysets;placementbindings;policies,verbs=get;list;watch;patch;update
-// +kubebuilder:rbac:groups="cluster.open-cluster-management.io",resources=placements;managedclustersets;managedclustersetbindings,verbs=get;list;watch;patch;update
-// +kubebuilder:rbac:groups="cluster.open-cluster-management.io",resources=managedclusters;managedclusters/finalizers;placementdecisions;placementdecisions/finalizers;placements;placements/finalizers,verbs=get;list;watch;patch;update
-// +kubebuilder:rbac:groups="cluster.open-cluster-management.io",resources=clusterclaims,verbs=create;get;list;watch;patch;update;delete
-// +kubebuilder:rbac:groups="",resources=namespaces;pods;events,verbs=create;get;list;watch;patch;update;delete
-// +kubebuilder:rbac:groups="apiextensions.k8s.io",resources=customresourcedefinitions,verbs=list;watch
-// +kubebuilder:rbac:groups="route.openshift.io",resources=routes,verbs=get;list;watch
-// +kubebuilder:rbac:groups="internal.open-cluster-management.io",resources=managedclusterinfos,verbs=get;list;watch;update
-// +kubebuilder:rbac:groups="apps.open-cluster-management.io",resources=placementrules;subscriptionreports,verbs=get;list;watch;update;patch
-// +kubebuilder:rbac:groups="coordination.k8s.io",resources=leases,verbs=create;get;list;watch;patch;update
-// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=clusterrolebindings;clusterroles,verbs=get;list;watch;create;update;delete;deletecollection
-// +kubebuilder:rbac:groups="",resources=services;secrets;configmaps;serviceaccounts,verbs=get;list;watch;create;update;delete;deletecollection
+// +kubebuilder:rbac:groups=app.k8s.io,resources=applications,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups=apps.open-cluster-management.io,resources=channels;placementrules;subscriptionreports;subscriptions;subscriptionstatuses,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups=policy.open-cluster-management.io,resources=placementbindings;policies;policyautomations;policysets,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=placements;managedclustersets;managedclustersetbindings,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclustersets/join;managedclustersets/bind,verbs=create;delete
+// +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters;managedclusters/finalizers;placementdecisions;placementdecisions/finalizers;placements;placements/finalizers,verbs=get;list;watch;update
+// +kubebuilder:rbac:groups="",resources=namespaces;pods;configmaps;events;secrets;services;serviceaccounts,verbs=create;delete;get;list;patch;update;watch;deletecollection
+// +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;create;update;delete
+// +kubebuilder:rbac:groups="",resources=users;groups;serviceaccounts,verbs=impersonate
+// +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings;clusterroles;rolebindings;roles,verbs=create;delete;get;list;patch;update;watch;deletecollection
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
+// +kubebuilder:rbac:groups=operator.open-cluster-management.io,resources=multiclusterhubs;clustermanagers,verbs=get;list;watch;patch;update
+// +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=clusterclaims,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=list;watch;get
+// +kubebuilder:rbac:groups=platform.stackrox.io,resources=centrals,verbs=get;list;watch
+// +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get;list;watch
+// +kubebuilder:rbac:groups=internal.open-cluster-management.io,resources=managedclusterinfos,verbs=get;list;watch;update
+// +kubebuilder:rbac:groups=config.open-cluster-management.io,resources=klusterletconfigs,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
+// +kubebuilder:rbac:groups=certificates.k8s.io,resources=certificatesigningrequests,verbs=create;get;list;watch
+// +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;create;update;delete;watch;list
+// +kubebuilder:rbac:groups=agent.open-cluster-management.io,resources=klusterletaddonconfigs,verbs=get;create;watch;list
+// +kubebuilder:rbac:groups=register.open-cluster-management.io,resources=managedclusters/accept,verbs=update
 // +kubebuilder:rbac:groups="apps",resources=deployments,verbs=get;list;watch;create;update;delete;deletecollection
 
 func (s *LocalAgentController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/operator/pkg/controllers/agent/manifests/clusterrole.yaml
+++ b/operator/pkg/controllers/agent/manifests/clusterrole.yaml
@@ -6,6 +6,34 @@ metadata:
     component: multicluster-global-hub-agent
 rules:
 - apiGroups:
+  - "app.k8s.io"
+  resources:
+  - applications
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - "apps.open-cluster-management.io"
+  resources:
+  - channels
+  - placementrules
+  - subscriptionreports
+  - subscriptions
+  - subscriptionstatuses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - "policy.open-cluster-management.io"
   resources:
   - placementbindings
@@ -13,6 +41,8 @@ rules:
   - policyautomations
   - policysets
   verbs:
+  - create
+  - delete
   - get
   - list
   - patch
@@ -25,11 +55,21 @@ rules:
   - managedclustersets
   - managedclustersetbindings
   verbs:
+  - create
+  - delete
   - get
   - list
   - patch
   - update
   - watch
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclustersets/join
+  - managedclustersets/bind
+  verbs:
+  - create
+  - delete
 - apiGroups:
   - cluster.open-cluster-management.io
   resources:
@@ -45,17 +85,11 @@ rules:
   - watch
   - update
 - apiGroups:
-  - cluster.open-cluster-management.io
+  - register.open-cluster-management.io
   resources:
-  - clusterclaims
+  - managedclusters/accept
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
   - update
-  - watch
 - apiGroups:
   - ""
   resources:
@@ -73,11 +107,79 @@ rules:
   - update
   - watch
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - users
+  - groups
+  - serviceaccounts
+  verbs:
+  - impersonate
+- apiGroups:
+  - "coordination.k8s.io"
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
   verbs:
+  - get
   - list
+  - watch
+- apiGroups:
+  - operator.open-cluster-management.io
+  resources:
+  - multiclusterhubs
+  - clustermanagers
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - clusterclaims
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - route.openshift.io
@@ -87,6 +189,14 @@ rules:
   - list
   - watch
   - get
+- apiGroups:
+  - platform.stackrox.io
+  resources:
+  - centrals
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - config.openshift.io
   resources:
@@ -105,24 +215,49 @@ rules:
   - watch
   - update
 - apiGroups:
-  - coordination.k8s.io
+  - config.open-cluster-management.io
   resources:
-  - leases
+  - klusterletconfigs
   verbs:
   - create
+  - delete
   - get
   - list
   - patch
   - update
   - watch
 - apiGroups:
-  - apps.open-cluster-management.io
+  - authorization.k8s.io
   resources:
-  - placementrules
-  - subscriptionreports
+  - subjectaccessreviews
   verbs:
+  - create
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - create
   - get
   - list
-  - patch
-  - update
   - watch
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclusters
+  verbs:
+  - get
+  - create
+  - update
+  - delete
+  - watch
+  - list
+- apiGroups:
+  - agent.open-cluster-management.io
+  resources:
+  - klusterletaddonconfigs
+  verbs:
+  - get
+  - create
+  - watch
+  - list

--- a/operator/pkg/controllers/manager/manager_reconciler.go
+++ b/operator/pkg/controllers/manager/manager_reconciler.go
@@ -68,6 +68,7 @@ import (
 // +kubebuilder:rbac:groups="global-hub.open-cluster-management.io",resources=managedclustermigrations/status,verbs=get;list;watch;update;patch;delete
 // +kubebuilder:rbac:groups=policy.open-cluster-management.io,resources=placementbindings,verbs=get;list;patch;update
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;update
+// +kubebuilder:rbac:groups=kafka.strimzi.io,resources=kafkausers,verbs=get;watch;update
 
 //go:embed manifests
 var fs embed.FS

--- a/operator/pkg/controllers/manager/manifests/clusterrole.yaml
+++ b/operator/pkg/controllers/manager/manifests/clusterrole.yaml
@@ -186,3 +186,12 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - kafka.strimzi.io
+  resources:
+  - kafkausers
+  verbs:
+  - get
+  - update
+  - watch
+  - list

--- a/operator/pkg/controllers/transporter/protocol/strimzi_transporter_test.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_transporter_test.go
@@ -5,6 +5,9 @@ import (
 	"strings"
 	"testing"
 
+	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -300,6 +303,125 @@ func TestNewKafkaCluster(t *testing.T) {
 			s = strings.ReplaceAll(s, "\n", "")
 			if string(clusterBytes) != s {
 				t.Errorf("want %v, but got %v", s, string(clusterBytes))
+			}
+		})
+	}
+}
+
+func TestCombineACLs(t *testing.T) {
+	host1 := "host1"
+	host2 := "host2"
+	resourceName1 := "name1"
+	resourceName2 := "name2"
+	type testCase struct {
+		name           string
+		kafkaUserAcls  []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem
+		desiredAcls    []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem
+		expectedResult []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem
+	}
+
+	// Test cases
+	testCases := []testCase{
+		{
+			name: "Single Acl",
+			kafkaUserAcls: []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
+				{
+					Host: &host1,
+					Resource: kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResource{
+						Type: kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic,
+						Name: &resourceName1,
+					},
+					Operations: []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+						kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+					},
+				},
+			},
+			desiredAcls: []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
+				{
+					Host: &host1,
+					Resource: kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResource{
+						Type: kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic,
+						Name: &resourceName1,
+					},
+					Operations: []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+						kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+					},
+				},
+			},
+			expectedResult: []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
+				{
+					Host: &host1,
+					Resource: kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResource{
+						Type: kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic,
+						Name: &resourceName1,
+					},
+					Operations: []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+						kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+					},
+				},
+			},
+		},
+		{
+			name: "Different Acls",
+			kafkaUserAcls: []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
+				{
+					Host: &host1,
+					Resource: kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResource{
+						Name: &resourceName1,
+						Type: kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic,
+					},
+					Operations: []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+						kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+					},
+				},
+			},
+			desiredAcls: []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
+				{
+					Host: &host2,
+					Resource: kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResource{
+						Name: &resourceName2,
+						Type: kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic,
+					},
+					Operations: []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+						kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite,
+					},
+				},
+			},
+			expectedResult: []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
+				{
+					Host: &host1,
+					Resource: kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResource{
+						Name: &resourceName1,
+						Type: kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic,
+					},
+					Operations: []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+						kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+					},
+				},
+				{
+					Host: &host2,
+					Resource: kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResource{
+						Name: &resourceName2,
+						Type: kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic,
+					},
+					Operations: []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+						kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := combineACLs(tc.kafkaUserAcls, tc.desiredAcls)
+
+			if diff := cmp.Diff(tc.expectedResult, result, cmpopts.SortSlices(func(x, y kafkav1beta2.KafkaUserSpecAuthorizationAclsElem) bool {
+				return *x.Host < *y.Host &&
+					*x.Resource.Name < *y.Resource.Name &&
+					x.Operations[0] < y.Operations[0]
+			})); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/bundle/migration/managedcluster_migration.go
+++ b/pkg/bundle/migration/managedcluster_migration.go
@@ -3,8 +3,10 @@ package migration
 import (
 	addonv1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
 	corev1 "k8s.io/api/core/v1"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
 )
 
+// ManagedClusterMigrationFromEvent defines the resources from migration controller to the source cluster
 type ManagedClusterMigrationFromEvent struct {
 	Stage           string         `json:"stage"`
 	ToHub           string         `json:"toHub"`
@@ -12,6 +14,7 @@ type ManagedClusterMigrationFromEvent struct {
 	BootstrapSecret *corev1.Secret `json:"bootstrapSecret,omitempty"`
 }
 
+// ManagedClusterMigrationToEvent defines the resources from migration controllers to the target cluster
 type ManagedClusterMigrationToEvent struct {
 	Stage                                 string                         `json:"stage"`
 	ManagedServiceAccountName             string                         `json:"managedServiceAccountName"`
@@ -24,4 +27,10 @@ type ManagedClusterMigrationBundle struct {
 	Stage                 string                         `json:"stage"`
 	KlusterletAddonConfig *addonv1.KlusterletAddonConfig `json:"klusterletAddonConfig,omitempty"`
 	ManagedClusters       []string                       `json:"managedClusters,omitempty"`
+}
+
+type SourceClusterMigrationResources struct {
+	ManagedClusters       []clusterv1.ManagedCluster      `json:"managedClusters,omitempty"`
+	KlusterletAddonConfig []addonv1.KlusterletAddonConfig `json:"klusterletAddonConfigs"`
+	// TODO: other resources
 }

--- a/pkg/enum/event_type.go
+++ b/pkg/enum/event_type.go
@@ -12,6 +12,8 @@ const (
 	ManagedClusterInfoType      EventType = EventTypePrefix + "managedclusterinfo"
 	SubscriptionReportType      EventType = EventTypePrefix + "subscription.report"
 	SubscriptionStatusType      EventType = EventTypePrefix + "subscription.status"
+	KlusterletAddonConfigType   EventType = EventTypePrefix + "managedcluster.klusterletaddonconfig"
+	MigrationResourcesType      EventType = EventTypePrefix + "migration.resources"
 
 	// used by the local resources
 	LocalComplianceType         EventType = EventTypePrefix + "policy.localcompliance"

--- a/pkg/transport/config/confluent_config.go
+++ b/pkg/transport/config/confluent_config.go
@@ -223,3 +223,8 @@ func ParseCredentailConn(namespace string, c client.Client, conn transport.Trans
 	}
 	return nil
 }
+
+// GetKafkaUserName gives a kafkaUser name based on the cluster name, it's also the CN of the certificate
+func GetKafkaUserName(clusterName string) string {
+	return fmt.Sprintf("%s-kafka-user", clusterName)
+}

--- a/test/integration/manager/migration/suite_test.go
+++ b/test/integration/manager/migration/suite_test.go
@@ -103,7 +103,7 @@ var _ = BeforeSuite(func() {
 		transportConfig.KafkaCredential.SpecTopic,
 	)
 	Expect(err).NotTo(HaveOccurred())
-	migrationReconciler = migration.NewMigrationController(mgr.GetClient(), genericProducer, false)
+	migrationReconciler = migration.NewMigrationController(mgr.GetClient(), genericProducer, false, "gh-migration")
 	Expect(migrationReconciler.SetupWithManager(mgr)).To(Succeed())
 
 	go func() {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
include `gh-migration` to migrate the resource from the source clusters to the target cluster. we cannot use the existing topics, because the permission is not proper set. In this case, we want to send the resources from the source clusters and receive from the target cluster directly. Keep in mind, try to relieve the dependence of db.

## Related issue(s)

Fixes # [ACM-19539](https://issues.redhat.com/browse/ACM-19539)

## Tests
* [x] Unit/function tests have been added and incorporated into `make unit-tests`.
* [x] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [x] List other manual tests you have done.
1. create a managed cluster with foo=bar label and foo=bar annotation in local-cluster
2. migrate this managed cluster from local-cluster to new-hub cluster.
3. check the foo=bar label and annotation are there in new-hub cluster