### PR TITLE
:sparkles: Add cluster validation before starting migration process

### DIFF
--- a/manager/pkg/migration/migration_cleaning.go
+++ b/manager/pkg/migration/migration_cleaning.go
@@ -23,7 +23,8 @@ func (m *ClusterMigrationController) completed(ctx context.Context,
 		return false, nil
 	}
 
-	if meta.IsStatusConditionTrue(mcm.Status.Conditions, migrationv1alpha1.ConditionTypeCleaned) {
+	if meta.IsStatusConditionTrue(mcm.Status.Conditions, migrationv1alpha1.ConditionTypeCleaned) ||
+		mcm.Status.Phase != migrationv1alpha1.PhaseCleaning {
 		return false, nil
 	}
 

--- a/manager/pkg/migration/migration_controller.go
+++ b/manager/pkg/migration/migration_controller.go
@@ -138,8 +138,17 @@ func (m *ClusterMigrationController) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, err
 	}
 
+	// validating
+	requeue, err := m.validating(ctx, mcm)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if requeue {
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	}
+
 	// initializing
-	requeue, err := m.initializing(ctx, mcm)
+	requeue, err = m.initializing(ctx, mcm)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/manager/pkg/migration/migration_deploying.go
+++ b/manager/pkg/migration/migration_deploying.go
@@ -25,7 +25,8 @@ func (m *ClusterMigrationController) deploying(ctx context.Context,
 		return false, nil
 	}
 
-	if meta.IsStatusConditionTrue(mcm.Status.Conditions, migrationv1alpha1.ConditionTypeDeployed) {
+	if meta.IsStatusConditionTrue(mcm.Status.Conditions, migrationv1alpha1.ConditionTypeDeployed) ||
+		mcm.Status.Phase != migrationv1alpha1.PhaseMigrating {
 		return false, nil
 	}
 

--- a/manager/pkg/migration/migration_registering.go
+++ b/manager/pkg/migration/migration_registering.go
@@ -41,7 +41,8 @@ func (m *ClusterMigrationController) registering(ctx context.Context,
 		return false, nil
 	}
 
-	if meta.IsStatusConditionTrue(mcm.Status.Conditions, migrationv1alpha1.ConditionTypeRegistered) {
+	if meta.IsStatusConditionTrue(mcm.Status.Conditions, migrationv1alpha1.ConditionTypeRegistered) ||
+		mcm.Status.Phase != migrationv1alpha1.PhaseMigrating {
 		return false, nil
 	}
 

--- a/manager/pkg/migration/migration_validating.go
+++ b/manager/pkg/migration/migration_validating.go
@@ -1,0 +1,119 @@
+package migration
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	migrationv1alpha1 "github.com/stolostron/multicluster-global-hub/operator/api/migration/v1alpha1"
+	"github.com/stolostron/multicluster-global-hub/pkg/database"
+)
+
+const (
+	ConditionReasonClusterNotFound   = "ClusterNotFound"
+	ConditionReasonResourceValidated = "ResourceValidated"
+)
+
+// Validation:
+// 1. Verify if the migrating clusters exist in the current hubs
+//   - If the clusters do not exist in both the from and to hubs, report a validating error and mark status as failed
+//   - If the clusters exist in the destination hub, mark the status as completed.
+//   - If the clusters exist in the source hub, mark the status as validated and change the phase to initializing.
+func (m *ClusterMigrationController) validating(ctx context.Context,
+	mcm *migrationv1alpha1.ManagedClusterMigration,
+) (bool, error) {
+	if !mcm.DeletionTimestamp.IsZero() {
+		return false, nil
+	}
+
+	if mcm.Status.Phase == "" {
+		mcm.Status.Phase = migrationv1alpha1.PhaseValidating
+		if err := m.Client.Status().Update(ctx, mcm); err != nil {
+			return false, err
+		}
+	}
+
+	if meta.IsStatusConditionTrue(mcm.Status.Conditions, migrationv1alpha1.ConditionTypeValidated) ||
+		mcm.Status.Phase != migrationv1alpha1.PhaseValidating {
+		return false, nil
+	}
+	log.Info("migration validating")
+
+	condType := migrationv1alpha1.ConditionTypeValidated
+	condStatus := metav1.ConditionTrue
+	condReason := ConditionReasonResourceValidated
+	condMessage := "Migration resources have been validated"
+	var err error
+
+	defer func() {
+		if err != nil {
+			condMessage = err.Error()
+			condStatus = metav1.ConditionFalse
+		}
+		log.Infof("validating condition %s(%s): %s", condType, condReason, condMessage)
+		e := m.UpdateConditionWithRetry(ctx, mcm, condType, condStatus, condReason, condMessage)
+		if e != nil {
+			log.Errorf("failed to update the %s condition: %v", condType, e)
+		}
+	}()
+
+	// cluster: hub in database
+	clusterWithHub, err := getClusterWithHub(mcm)
+
+	notFoundClusters := []string{}
+	movedClusters := []string{}
+	for _, cluster := range mcm.Spec.IncludedManagedClusters {
+		hub := clusterWithHub[cluster]
+		if hub == mcm.Spec.To {
+			movedClusters = append(movedClusters, cluster)
+		} else if mcm.Spec.From != "" && hub != mcm.Spec.From {
+			notFoundClusters = append(notFoundClusters, cluster)
+		}
+	}
+
+	// cluster has been migrated
+	if len(movedClusters) == len(mcm.Spec.IncludedManagedClusters) {
+		mcm.Status.Phase = migrationv1alpha1.PhaseCompleted
+		condMessage = fmt.Sprintf("The clusters has been migrated into the hub %s", mcm.Spec.To)
+		return false, nil
+	}
+
+	// not found validated clusters
+	if len(notFoundClusters) > 0 {
+		mcm.Status.Phase = migrationv1alpha1.PhaseFailed
+		condStatus = metav1.ConditionFalse
+		condReason = ConditionReasonClusterNotFound
+		clusters := notFoundClusters
+		if len(notFoundClusters) > 3 {
+			clusters = append(clusters[:3], "...")
+		}
+		condMessage = fmt.Sprintf("The validated clusters %v are not found in the source hub %s", clusters,
+			mcm.Spec.From)
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func getClusterWithHub(mcm *migrationv1alpha1.ManagedClusterMigration) (map[string]string, error) {
+	db := database.GetGorm()
+	managedClusterMap := make(map[string]string)
+
+	rows, err := db.Raw(`SELECT leaf_hub_name, cluster_name FROM status.managed_clusters
+			WHERE cluster_name IN (?)`,
+		mcm.Spec.IncludedManagedClusters).Rows()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get migrating clusters - %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var leafHubName, managedClusterName string
+		if err := rows.Scan(&leafHubName, &managedClusterName); err != nil {
+			return nil, fmt.Errorf("failed to scan hub and managed cluster name - %w", err)
+		}
+		managedClusterMap[managedClusterName] = leafHubName
+	}
+	return managedClusterMap, nil
+}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes # https://issues.redhat.com/browse/ACM-19782

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [x] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
