### PR TITLE
:bug: Use transporter to cleanup the kafka resources when disable local agent

### DIFF
--- a/operator/pkg/controllers/agent/local_agent_controller.go
+++ b/operator/pkg/controllers/agent/local_agent_controller.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"reflect"
 
-	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -173,26 +172,14 @@ func pruneAgentResources(ctx context.Context, c client.Client, namespace string)
 		return err
 	}
 
-	err = c.Delete(ctx, &kafkav1beta2.KafkaUser{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      config.GetKafkaUserName(constants.LocalClusterName),
-			Namespace: namespace,
-		},
-	})
-	if err != nil && !errors.IsNotFound(err) {
+	trans := config.GetTransporter()
+	if trans == nil {
+		return fmt.Errorf("failed to get the transporter")
+	}
+	err = trans.Prune(constants.LocalClusterName)
+	if err != nil {
 		return err
 	}
-
-	err = c.Delete(ctx, &kafkav1beta2.KafkaTopic{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      config.GetStatusTopic(constants.LocalClusterName),
-			Namespace: namespace,
-		},
-	})
-	if err != nil && !errors.IsNotFound(err) {
-		return err
-	}
-
 	return nil
 }
 

--- a/operator/pkg/controllers/agent/local_agent_controller_test.go
+++ b/operator/pkg/controllers/agent/local_agent_controller_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 
 	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
-	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
-	"github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/transporter/protocol"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -16,6 +14,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/transporter/protocol"
 )
 
 func TestPruneAgentResources(t *testing.T) {

--- a/operator/pkg/controllers/agent/local_agent_controller_test.go
+++ b/operator/pkg/controllers/agent/local_agent_controller_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/transporter/protocol"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -19,6 +21,7 @@ import (
 func TestPruneAgentResources(t *testing.T) {
 	// Define test namespace and transport secret name
 	namespace := "test-namespace"
+	config.SetTransporter(&protocol.BYOTransporter{})
 
 	// Create a fake client with initial objects
 	scheme := runtime.NewScheme()

--- a/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
@@ -498,6 +498,8 @@ func (k *strimziTransporter) Prune(clusterName string) error {
 	}
 
 	// only delete the topic when removing the CR, otherwise the manager throws error like "Unknown topic or partition"
+	// If a topic is deleted, its offset should also be removed from database.
+	// Otherwise, if the topic is recreated, old offsets in db may block message consumption
 	// if k.sharedTopics || !strings.Contains(config.GetRawStatusTopic(), "*") {
 	// 	return nil
 	// }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

When detaching the cluster or disabling the local agent:
The topic shouldn't be deleted. If you have to delete the topic, its offset should also be removed from the database. Otherwise, old offsets may block message consumption if the topic is recreated.

## Related issue(s)

Fixes # https://issues.redhat.com/browse/ACM-20179

## Tests
* [x] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
