### PR TITLE
:bug:  Fix integration issue

### DIFF
--- a/operator/pkg/controllers/agent/standalone_agent_controller.go
+++ b/operator/pkg/controllers/agent/standalone_agent_controller.go
@@ -137,7 +137,7 @@ func (s *StandaloneAgentController) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 	}
 
-	if config.IsAgentPaused(mgha) || mgha.DeletionTimestamp != nil {
+	if mgha == nil || config.IsAgentPaused(mgha) || mgha.DeletionTimestamp != nil {
 		return ctrl.Result{}, nil
 	}
 

--- a/test/integration/operator/controllers/agent/standalone_agent/suite_test.go
+++ b/test/integration/operator/controllers/agent/standalone_agent/suite_test.go
@@ -91,15 +91,15 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sManager).ToNot(BeNil())
 
-	By("start the standalone agent controller to manager")
-	Expect(agent.StartStandaloneAgentController(ctx, k8sManager)).ToNot(HaveOccurred())
-
 	go func() {
 		defer GinkgoRecover()
 		err = k8sManager.Start(ctx)
 		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
 	}()
 	Expect(k8sManager.GetCache().WaitForCacheSync(ctx)).To(BeTrue())
+
+	By("start the standalone agent controller to manager")
+	Expect(agent.StartStandaloneAgentController(ctx, k8sManager)).ToNot(HaveOccurred())
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
fix this issue
```
 2025-04-22T14:05:03.482Z	ERROR	agent/standalone_agent_controller.go:110	the cache is not started, can not read objects
github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/agent.StartStandaloneAgentController
	/go/src/github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/agent/standalone_agent_controller.go:110
github.com/stolostron/multicluster-global-hub/test/integration/operator/controllers/agent/standalone_agent.init.func2
	/go/src/github.com/stolostron/multicluster-global-hub/test/integration/operator/controllers/agent/standalone_agent/suite_test.go:95
github.com/onsi/ginkgo/v2/internal.extractBodyFunction.func3
	/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.22.2/internal/node.go:475
github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func3
	/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.22.2/internal/suite.go:894 

 • [FAILED] [24.538 seconds]
standalone agent [It] Should create standalone agent in the default namespace
/go/src/github.com/stolostron/multicluster-global-hub/test/integration/operator/controllers/agent/standalone_agent/standalone_agent_test.go:20
  Timeline >>
  STEP: Creating multiclusterglobalhubagent CR @ 04/22/25 14:05:03.583
  STEP: Creating OpenShift Infrastructure CR @ 04/22/25 14:05:07.409
  STEP: By checking the GH agent is created in default namespace @ 04/22/25 14:05:18.012
  [FAILED] in [It] - /go/src/github.com/stolostron/multicluster-global-hub/test/integration/operator/controllers/agent/standalone_agent/standalone_agent_test.go:49 @ 04/22/25 14:05:28.121
  << Timeline
  [FAILED] Timed out after 10.001s.
  Unexpected error:
      <*errors.StatusError | 0xc001376aa0>: 
      deployments.apps "multicluster-global-hub-agent" not found
      {
          ErrStatus: {
              TypeMeta: {Kind: "", APIVersion: ""},
              ListMeta: {
                  SelfLink: "",
                  ResourceVersion: "",
                  Continue: "",
                  RemainingItemCount: nil,
              },
              Status: "Failure",
              Message: "deployments.apps \"multicluster-global-hub-agent\" not found",
              Reason: "NotFound",
              Details: {
                  Name: "multicluster-global-hub-agent",
                  Group: "apps",
                  Kind: "deployments",
                  UID: "",
                  Causes: nil,
                  RetryAfterSeconds: 0,
              },
              Code: 404,
          },
      }
  occurred
  In [It] at: /go/src/github.com/stolostron/multicluster-global-hub/test/integration/operator/controllers/agent/standalone_agent/standalone_agent_test.go:49 @ 04/22/25 14:05:28.121
------------------------------
2025-04-22T14:05:28.170Z	INFO	manager/internal.go:538	Stopping and waiting for non leader election runnables
2025-04-22T14:05:28.170Z	INFO	manager/internal.go:542	Stopping and waiting for leader election runnables
2025-04-22T14:05:28.170Z	INFO	controller/controller.go:237	Shutdown signal received, waiting for all workers to finish	{"controller": "standalone-agent-reconciler"}
2025-04-22T14:05:28.177Z	INFO	controller/controller.go:239	All workers finished	{"controller": "standalone-agent-reconciler"}
2025-04-22T14:05:28.177Z	INFO	manager/internal.go:550	Stopping and waiting for caches
W0422 14:05:28.177602   26213 reflector.go:492] pkg/mod/k8s.io/client-go@v0.32.3/tools/cache/reflector.go:251: watch of *v1.Infrastructure ended with: an error on the server ("unable to decode an event from the watch stream: context canceled") has prevented the request from succeeding
2025-04-22T14:05:28.177Z	INFO	manager/internal.go:554	Stopping and waiting for webhooks
2025-04-22T14:05:28.177Z	INFO	manager/internal.go:557	Stopping and waiting for HTTP servers
2025-04-22T14:05:28.177Z	INFO	manager/internal.go:561	Wait completed, proceeding to shutdown the manager
Summarizing 1 Failure:
  [FAIL] standalone agent [It] Should create standalone agent in the default namespace
  /go/src/github.com/stolostron/multicluster-global-hub/test/integration/operator/controllers/agent/standalone_agent/standalone_agent_test.go:49
Ran 1 of 1 Specs in 34.222 seconds
FAIL! -- 0 Passed | 1 Failed | 0 Pending | 0 Skipped
--- FAIL: TestControllers (34.23s) 
```

## Related issue(s)

Fixes #

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
