### PR TITLE
:sparkles: Event status

### DIFF
--- a/manager/pkg/migration/migration_controller.go
+++ b/manager/pkg/migration/migration_controller.go
@@ -40,10 +40,11 @@ var log = logger.DefaultZapLogger()
 type ClusterMigrationController struct {
 	client.Client
 	transport.Producer
-	BootstrapSecret        *corev1.Secret
-	importClusterInHosted  bool
-	migrationTopic         string
-	migrationEventProgress []MigrationEventProgress
+	BootstrapSecret       *corev1.Secret
+	importClusterInHosted bool
+	migrationTopic        string
+	// string is MCM ID
+	migrationEventProgress map[string]*MigrationEventProgress
 }
 
 func NewMigrationController(client client.Client, producer transport.Producer,

--- a/manager/pkg/migration/migration_controller.go
+++ b/manager/pkg/migration/migration_controller.go
@@ -44,17 +44,18 @@ type ClusterMigrationController struct {
 	importClusterInHosted bool
 	migrationTopic        string
 	// string is MCM ID
-	migrationEventProgress map[string]*MigrationEventProgress
+	migrationEventProgressMap map[string]*MigrationEventProgress
 }
 
 func NewMigrationController(client client.Client, producer transport.Producer,
 	importClusterInHosted bool, migrationTopic string,
 ) *ClusterMigrationController {
 	return &ClusterMigrationController{
-		Client:                client,
-		Producer:              producer,
-		importClusterInHosted: importClusterInHosted,
-		migrationTopic:        migrationTopic,
+		Client:                    client,
+		Producer:                  producer,
+		importClusterInHosted:     importClusterInHosted,
+		migrationTopic:            migrationTopic,
+		migrationEventProgressMap: make(map[string]*MigrationEventProgress),
 	}
 }
 
@@ -131,6 +132,9 @@ func (m *ClusterMigrationController) Reconcile(ctx context.Context, req ctrl.Req
 		log.Errorf("failed to get managedclustermigration %v", err)
 		return ctrl.Result{}, err
 	}
+
+	// initializing the migration event progress
+	m.migrationEventProgressMap[string(mcm.GetUID())] = &MigrationEventProgress{}
 
 	// add finalizer if resources is not being deleted
 	if !controllerutil.ContainsFinalizer(mcm, constants.ManagedClusterMigrationFinalizer) {

--- a/manager/pkg/migration/migration_controller.go
+++ b/manager/pkg/migration/migration_controller.go
@@ -43,19 +43,16 @@ type ClusterMigrationController struct {
 	BootstrapSecret       *corev1.Secret
 	importClusterInHosted bool
 	migrationTopic        string
-	// string is MCM ID
-	migrationEventProgressMap map[string]*MigrationEventProgress
 }
 
 func NewMigrationController(client client.Client, producer transport.Producer,
 	importClusterInHosted bool, migrationTopic string,
 ) *ClusterMigrationController {
 	return &ClusterMigrationController{
-		Client:                    client,
-		Producer:                  producer,
-		importClusterInHosted:     importClusterInHosted,
-		migrationTopic:            migrationTopic,
-		migrationEventProgressMap: make(map[string]*MigrationEventProgress),
+		Client:                client,
+		Producer:              producer,
+		importClusterInHosted: importClusterInHosted,
+		migrationTopic:        migrationTopic,
 	}
 }
 
@@ -132,9 +129,6 @@ func (m *ClusterMigrationController) Reconcile(ctx context.Context, req ctrl.Req
 		log.Errorf("failed to get managedclustermigration %v", err)
 		return ctrl.Result{}, err
 	}
-
-	// initializing the migration event progress
-	m.migrationEventProgressMap[string(mcm.GetUID())] = &MigrationEventProgress{}
 
 	// add finalizer if resources is not being deleted
 	if !controllerutil.ContainsFinalizer(mcm, constants.ManagedClusterMigrationFinalizer) {

--- a/manager/pkg/migration/migration_controller.go
+++ b/manager/pkg/migration/migration_controller.go
@@ -40,9 +40,10 @@ var log = logger.DefaultZapLogger()
 type ClusterMigrationController struct {
 	client.Client
 	transport.Producer
-	BootstrapSecret       *corev1.Secret
-	importClusterInHosted bool
-	migrationTopic        string
+	BootstrapSecret        *corev1.Secret
+	importClusterInHosted  bool
+	migrationTopic         string
+	migrationEventProgress []MigrationEventProgress
 }
 
 func NewMigrationController(client client.Client, producer transport.Producer,

--- a/manager/pkg/migration/migration_eventstatus.go
+++ b/manager/pkg/migration/migration_eventstatus.go
@@ -1,0 +1,17 @@
+package migration
+
+import migrationv1alpha1 "github.com/stolostron/multicluster-global-hub/operator/api/migration/v1alpha1"
+
+type MigrationEventStatus struct {
+	Stage  migrationv1alpha1.StageStatus `json:"stage"`
+	IsSent bool                          `json:"isSent"`
+	Error  string                        `json:"error,omitempty"` // not used
+}
+
+type MigrationEventProgress struct {
+	ID              string                 `json:"id"` // Migration CR UID
+	Source_Statuses []MigrationEventStatus `json:"source_statuses"`
+	Target_Statuses []MigrationEventStatus `json:"target_statuses"`
+	Completed       bool                   `json:"completed"`            // not used
+	FinalError      string                 `json:"finalError,omitempty"` // not used
+}

--- a/manager/pkg/migration/migration_eventstatus.go
+++ b/manager/pkg/migration/migration_eventstatus.go
@@ -1,49 +1,129 @@
 package migration
 
-import migrationv1alpha1 "github.com/stolostron/multicluster-global-hub/operator/api/migration/v1alpha1"
+import (
+	"reflect"
+)
 
-type MigrationEventStatus struct {
-	Stage      migrationv1alpha1.StageStatus `json:"stage"`
-	IsSent     bool                          `json:"isSent"`
-	IsReceived bool                          `json:"isReceived"`
-	Error      string                        `json:"error,omitempty"` // not used
+type MigrationPhaseStatus struct {
+	started  bool
+	finished bool
+	error    string
+}
+
+type MigrationPhase struct {
+	Validating, Initializing, Deploying, Registering, Cleaning MigrationPhaseStatus
 }
 
 type MigrationEventProgress struct {
-	Source_Statuses map[migrationv1alpha1.StageStatus]*MigrationEventStatus `json:"source_statuses"`
-	Target_Statuses map[migrationv1alpha1.StageStatus]*MigrationEventStatus `json:"target_statuses"`
-	Completed       bool                                                    `json:"completed"`            // not used
-	FinalError      string                                                  `json:"finalError,omitempty"` // not used
+	sourceStatuses map[string]*MigrationPhase
+	targetStatuses map[string]*MigrationPhase
 }
 
-// ReportSentStatus returns true if the status of the given stage is sent
-func ReportSentStatus(mep MigrationEventProgress, Stage migrationv1alpha1.StageStatus) bool {
-	if mep.Source_Statuses[Stage] == nil {
+// getPhaseStatus extracts the MigrationPhaseStatus for a given phase
+func getPhaseStatus(mp *MigrationPhase, phase string) (MigrationPhaseStatus, bool) {
+	if mp == nil {
+		return MigrationPhaseStatus{}, false
+	}
+
+	v := reflect.ValueOf(mp).Elem()
+	field := v.FieldByName(phase)
+	if !field.IsValid() {
+		return MigrationPhaseStatus{}, false
+	}
+
+	status, ok := field.Interface().(MigrationPhaseStatus)
+	if !ok {
+		return MigrationPhaseStatus{}, false
+	}
+
+	return status, true
+}
+
+// IsSourceStarted returns true if the status of the given stage is started in the source cluster
+func IsSourceStarted(mep *MigrationEventProgress, phase, cluster string) bool {
+	mp := mep.sourceStatuses[cluster]
+	status, ok := getPhaseStatus(mp, phase)
+	if !ok {
 		return false
 	}
-	return mep.Source_Statuses[Stage].IsSent
+	return status.started
 }
 
-// ReportReceivedStatus returns true if the status of the given stage is received
-func ReportReceivedStatus(mep MigrationEventProgress, Stage migrationv1alpha1.StageStatus) bool {
-	if mep.Target_Statuses[Stage] == nil {
+// IsSourceFinished returns true if the status of the given stage is finished in the source cluster
+func IsSourceFinished(mep *MigrationEventProgress, phase, cluster string) bool {
+	mp := mep.sourceStatuses[cluster]
+	status, ok := getPhaseStatus(mp, phase)
+	if !ok {
 		return false
 	}
-	return mep.Target_Statuses[Stage].IsReceived
+	return status.finished
 }
 
-// SetSentStatus sets the sent status of the given stage
-func SetSentStatus(mep MigrationEventProgress, Stage migrationv1alpha1.StageStatus, isSent bool) {
-	if mep.Source_Statuses[Stage] == nil {
-		mep.Source_Statuses[Stage] = &MigrationEventStatus{}
+// IsTargetStarted returns true if the status of the given stage is started in the target cluster
+func IsTargetStarted(mep *MigrationEventProgress, phase, cluster string) bool {
+	mp := mep.targetStatuses[cluster]
+	status, ok := getPhaseStatus(mp, phase)
+	if !ok {
+		return false
 	}
-	mep.Source_Statuses[Stage].IsSent = isSent
+	return status.started
 }
 
-// SetReceivedStatus sets the received status of the given stage
-func SetReceivedStatus(mep MigrationEventProgress, Stage migrationv1alpha1.StageStatus, isReceived bool) {
-	if mep.Target_Statuses[Stage] == nil {
-		mep.Target_Statuses[Stage] = &MigrationEventStatus{}
+// IsTargetFinished returns true if the status of the given stage is finished in the target cluster
+func IsTargetFinished(mep *MigrationEventProgress, phase, cluster string) bool {
+	mp := mep.targetStatuses[cluster]
+	status, ok := getPhaseStatus(mp, phase)
+	if !ok {
+		return false
 	}
-	mep.Target_Statuses[Stage].IsReceived = isReceived
+	return status.finished
+}
+
+// updatePhaseStatus updates the status (started/finished) in the source or target cluster
+func updatePhaseStatus(phases map[string]*MigrationPhase, cluster, phase string,
+	updateFunc func(*MigrationPhaseStatus),
+) {
+	mp := phases[cluster]
+	if mp == nil {
+		mp = &MigrationPhase{}
+		phases[cluster] = mp
+	}
+
+	v := reflect.ValueOf(mp).Elem()
+	field := v.FieldByName(phase)
+	if field.IsValid() && field.CanSet() {
+		status, ok := field.Interface().(MigrationPhaseStatus)
+		if ok {
+			updateFunc(&status)
+			field.Set(reflect.ValueOf(status))
+		}
+	}
+}
+
+// SetSourceStarted sets the status of the given stage to started in the source cluster
+func SetSourceStarted(mep *MigrationEventProgress, phase, cluster string) {
+	updatePhaseStatus(mep.sourceStatuses, cluster, phase, func(status *MigrationPhaseStatus) {
+		status.started = true
+	})
+}
+
+// SetSourceFinished sets the status of the given stage to finished in the source cluster
+func SetSourceFinished(mep *MigrationEventProgress, phase, cluster string) {
+	updatePhaseStatus(mep.sourceStatuses, cluster, phase, func(status *MigrationPhaseStatus) {
+		status.finished = true
+	})
+}
+
+// SetTargetStarted sets the status of the given stage to started in the target cluster
+func SetTargetStarted(mep *MigrationEventProgress, phase, cluster string) {
+	updatePhaseStatus(mep.targetStatuses, cluster, phase, func(status *MigrationPhaseStatus) {
+		status.started = true
+	})
+}
+
+// SetTargetFinished sets the status of the given stage to finished in the target cluster
+func SetTargetFinished(mep *MigrationEventProgress, phase, cluster string) {
+	updatePhaseStatus(mep.targetStatuses, cluster, phase, func(status *MigrationPhaseStatus) {
+		status.finished = true
+	})
 }

--- a/manager/pkg/migration/migration_eventstatus.go
+++ b/manager/pkg/migration/migration_eventstatus.go
@@ -3,15 +3,47 @@ package migration
 import migrationv1alpha1 "github.com/stolostron/multicluster-global-hub/operator/api/migration/v1alpha1"
 
 type MigrationEventStatus struct {
-	Stage  migrationv1alpha1.StageStatus `json:"stage"`
-	IsSent bool                          `json:"isSent"`
-	Error  string                        `json:"error,omitempty"` // not used
+	Stage      migrationv1alpha1.StageStatus `json:"stage"`
+	IsSent     bool                          `json:"isSent"`
+	IsReceived bool                          `json:"isReceived"`
+	Error      string                        `json:"error,omitempty"` // not used
 }
 
 type MigrationEventProgress struct {
-	ID              string                 `json:"id"` // Migration CR UID
-	Source_Statuses []MigrationEventStatus `json:"source_statuses"`
-	Target_Statuses []MigrationEventStatus `json:"target_statuses"`
-	Completed       bool                   `json:"completed"`            // not used
-	FinalError      string                 `json:"finalError,omitempty"` // not used
+	Source_Statuses map[migrationv1alpha1.StageStatus]*MigrationEventStatus `json:"source_statuses"`
+	Target_Statuses map[migrationv1alpha1.StageStatus]*MigrationEventStatus `json:"target_statuses"`
+	Completed       bool                                                    `json:"completed"`            // not used
+	FinalError      string                                                  `json:"finalError,omitempty"` // not used
+}
+
+// ReportSentStatus returns true if the status of the given stage is sent
+func ReportSentStatus(mep MigrationEventProgress, Stage migrationv1alpha1.StageStatus) bool {
+	if mep.Source_Statuses[Stage] == nil {
+		return false
+	}
+	return mep.Source_Statuses[Stage].IsSent
+}
+
+// ReportReceivedStatus returns true if the status of the given stage is received
+func ReportReceivedStatus(mep MigrationEventProgress, Stage migrationv1alpha1.StageStatus) bool {
+	if mep.Target_Statuses[Stage] == nil {
+		return false
+	}
+	return mep.Target_Statuses[Stage].IsReceived
+}
+
+// SetSentStatus sets the sent status of the given stage
+func SetSentStatus(mep MigrationEventProgress, Stage migrationv1alpha1.StageStatus, isSent bool) {
+	if mep.Source_Statuses[Stage] == nil {
+		mep.Source_Statuses[Stage] = &MigrationEventStatus{}
+	}
+	mep.Source_Statuses[Stage].IsSent = isSent
+}
+
+// SetReceivedStatus sets the received status of the given stage
+func SetReceivedStatus(mep MigrationEventProgress, Stage migrationv1alpha1.StageStatus, isReceived bool) {
+	if mep.Target_Statuses[Stage] == nil {
+		mep.Target_Statuses[Stage] = &MigrationEventStatus{}
+	}
+	mep.Target_Statuses[Stage].IsReceived = isReceived
 }

--- a/manager/pkg/migration/migration_eventstatus_test.go
+++ b/manager/pkg/migration/migration_eventstatus_test.go
@@ -1,0 +1,177 @@
+package migration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	migrationv1alpha1 "github.com/stolostron/multicluster-global-hub/operator/api/migration/v1alpha1"
+)
+
+func TestSetReceivedStatus(t *testing.T) {
+	tests := []struct {
+		name          string
+		initialStatus map[migrationv1alpha1.StageStatus]*MigrationEventStatus
+		stage         migrationv1alpha1.StageStatus
+		isReceived    bool
+		expected      bool
+	}{
+		{
+			name:          "Set received status for a new stage",
+			initialStatus: map[migrationv1alpha1.StageStatus]*MigrationEventStatus{},
+			stage:         migrationv1alpha1.StageStatus("Stage1"),
+			isReceived:    true,
+			expected:      true,
+		},
+		{
+			name: "Update received status for an existing stage",
+			initialStatus: map[migrationv1alpha1.StageStatus]*MigrationEventStatus{
+				migrationv1alpha1.StageStatus("Stage1"): {IsReceived: false},
+			},
+			stage:      migrationv1alpha1.StageStatus("Stage1"),
+			isReceived: true,
+			expected:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mep := MigrationEventProgress{
+				Target_Statuses: tt.initialStatus,
+			}
+
+			SetReceivedStatus(mep, tt.stage, tt.isReceived)
+
+			assert.NotNil(t, mep.Target_Statuses[tt.stage])
+			assert.Equal(t, tt.expected, mep.Target_Statuses[tt.stage].IsReceived)
+		})
+	}
+}
+
+func TestSetSentStatus(t *testing.T) {
+	tests := []struct {
+		name          string
+		initialStatus map[migrationv1alpha1.StageStatus]*MigrationEventStatus
+		stage         migrationv1alpha1.StageStatus
+		isSent        bool
+		expected      bool
+	}{
+		{
+			name:          "Set sent status for a new stage",
+			initialStatus: map[migrationv1alpha1.StageStatus]*MigrationEventStatus{},
+			stage:         migrationv1alpha1.StageStatus("Stage1"),
+			isSent:        true,
+			expected:      true,
+		},
+		{
+			name: "Update sent status for an existing stage",
+			initialStatus: map[migrationv1alpha1.StageStatus]*MigrationEventStatus{
+				migrationv1alpha1.StageStatus("Stage1"): {IsSent: false},
+			},
+			stage:    migrationv1alpha1.StageStatus("Stage1"),
+			isSent:   true,
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mep := MigrationEventProgress{
+				Source_Statuses: tt.initialStatus,
+			}
+
+			SetSentStatus(mep, tt.stage, tt.isSent)
+
+			assert.NotNil(t, mep.Source_Statuses[tt.stage])
+			assert.Equal(t, tt.expected, mep.Source_Statuses[tt.stage].IsSent)
+		})
+	}
+}
+
+func TestReportReceivedStatus(t *testing.T) {
+	tests := []struct {
+		name          string
+		initialStatus map[migrationv1alpha1.StageStatus]*MigrationEventStatus
+		stage         migrationv1alpha1.StageStatus
+		expected      bool
+	}{
+		{
+			name:          "Report received status for a non-existent stage",
+			initialStatus: map[migrationv1alpha1.StageStatus]*MigrationEventStatus{},
+			stage:         migrationv1alpha1.StageStatus("Stage1"),
+			expected:      false,
+		},
+		{
+			name: "Report received status for an existing stage with IsReceived set to true",
+			initialStatus: map[migrationv1alpha1.StageStatus]*MigrationEventStatus{
+				migrationv1alpha1.StageStatus("Stage1"): {IsReceived: true},
+			},
+			stage:    migrationv1alpha1.StageStatus("Stage1"),
+			expected: true,
+		},
+		{
+			name: "Report received status for an existing stage with IsReceived set to false",
+			initialStatus: map[migrationv1alpha1.StageStatus]*MigrationEventStatus{
+				migrationv1alpha1.StageStatus("Stage1"): {IsReceived: false},
+			},
+			stage:    migrationv1alpha1.StageStatus("Stage1"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mep := MigrationEventProgress{
+				Target_Statuses: tt.initialStatus,
+			}
+
+			result := ReportReceivedStatus(mep, tt.stage)
+
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestReportSentStatus(t *testing.T) {
+	tests := []struct {
+		name          string
+		initialStatus map[migrationv1alpha1.StageStatus]*MigrationEventStatus
+		stage         migrationv1alpha1.StageStatus
+		expected      bool
+	}{
+		{
+			name:          "Report sent status for a non-existent stage",
+			initialStatus: map[migrationv1alpha1.StageStatus]*MigrationEventStatus{},
+			stage:         migrationv1alpha1.StageStatus("Stage1"),
+			expected:      false,
+		},
+		{
+			name: "Report sent status for an existing stage with IsSent set to true",
+			initialStatus: map[migrationv1alpha1.StageStatus]*MigrationEventStatus{
+				migrationv1alpha1.StageStatus("Stage1"): {IsSent: true},
+			},
+			stage:    migrationv1alpha1.StageStatus("Stage1"),
+			expected: true,
+		},
+		{
+			name: "Report sent status for an existing stage with IsSent set to false",
+			initialStatus: map[migrationv1alpha1.StageStatus]*MigrationEventStatus{
+				migrationv1alpha1.StageStatus("Stage1"): {IsSent: false},
+			},
+			stage:    migrationv1alpha1.StageStatus("Stage1"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mep := MigrationEventProgress{
+				Source_Statuses: tt.initialStatus,
+			}
+
+			result := ReportSentStatus(mep, tt.stage)
+
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/manager/pkg/migration/migration_eventstatus_test.go
+++ b/manager/pkg/migration/migration_eventstatus_test.go
@@ -8,170 +8,49 @@ import (
 	migrationv1alpha1 "github.com/stolostron/multicluster-global-hub/operator/api/migration/v1alpha1"
 )
 
-func TestSetReceivedStatus(t *testing.T) {
-	tests := []struct {
-		name          string
-		initialStatus map[migrationv1alpha1.StageStatus]*MigrationEventStatus
-		stage         migrationv1alpha1.StageStatus
-		isReceived    bool
-		expected      bool
-	}{
-		{
-			name:          "Set received status for a new stage",
-			initialStatus: map[migrationv1alpha1.StageStatus]*MigrationEventStatus{},
-			stage:         migrationv1alpha1.StageStatus("Stage1"),
-			isReceived:    true,
-			expected:      true,
-		},
-		{
-			name: "Update received status for an existing stage",
-			initialStatus: map[migrationv1alpha1.StageStatus]*MigrationEventStatus{
-				migrationv1alpha1.StageStatus("Stage1"): {IsReceived: false},
+func TestMigrationEventProgress(t *testing.T) {
+	mep := &MigrationEventProgress{
+		sourceStatuses: map[string]*MigrationPhase{
+			"source-cluster": {
+				Validating: MigrationPhaseStatus{
+					started:  false,
+					finished: false,
+					error:    "",
+				},
 			},
-			stage:      migrationv1alpha1.StageStatus("Stage1"),
-			isReceived: true,
-			expected:   true,
 		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mep := MigrationEventProgress{
-				Target_Statuses: tt.initialStatus,
-			}
-
-			SetReceivedStatus(mep, tt.stage, tt.isReceived)
-
-			assert.NotNil(t, mep.Target_Statuses[tt.stage])
-			assert.Equal(t, tt.expected, mep.Target_Statuses[tt.stage].IsReceived)
-		})
-	}
-}
-
-func TestSetSentStatus(t *testing.T) {
-	tests := []struct {
-		name          string
-		initialStatus map[migrationv1alpha1.StageStatus]*MigrationEventStatus
-		stage         migrationv1alpha1.StageStatus
-		isSent        bool
-		expected      bool
-	}{
-		{
-			name:          "Set sent status for a new stage",
-			initialStatus: map[migrationv1alpha1.StageStatus]*MigrationEventStatus{},
-			stage:         migrationv1alpha1.StageStatus("Stage1"),
-			isSent:        true,
-			expected:      true,
-		},
-		{
-			name: "Update sent status for an existing stage",
-			initialStatus: map[migrationv1alpha1.StageStatus]*MigrationEventStatus{
-				migrationv1alpha1.StageStatus("Stage1"): {IsSent: false},
+		targetStatuses: map[string]*MigrationPhase{
+			"target-cluster": {
+				Validating: MigrationPhaseStatus{
+					started:  false,
+					finished: false,
+					error:    "",
+				},
 			},
-			stage:    migrationv1alpha1.StageStatus("Stage1"),
-			isSent:   true,
-			expected: true,
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mep := MigrationEventProgress{
-				Source_Statuses: tt.initialStatus,
-			}
+	assert.False(t, IsSourceStarted(mep, migrationv1alpha1.PhaseInitializing, "source-cluster"))
+	SetSourceStarted(mep, migrationv1alpha1.PhaseInitializing, "source-cluster")
+	assert.True(t, IsSourceStarted(mep, migrationv1alpha1.PhaseInitializing, "source-cluster"))
 
-			SetSentStatus(mep, tt.stage, tt.isSent)
+	// Test IsSourceStarted
+	assert.False(t, IsSourceStarted(mep, migrationv1alpha1.PhaseValidating, "source-cluster"))
+	SetSourceStarted(mep, migrationv1alpha1.PhaseValidating, "source-cluster")
+	assert.True(t, IsSourceStarted(mep, migrationv1alpha1.PhaseValidating, "source-cluster"))
 
-			assert.NotNil(t, mep.Source_Statuses[tt.stage])
-			assert.Equal(t, tt.expected, mep.Source_Statuses[tt.stage].IsSent)
-		})
-	}
-}
+	// Test IsSourceFinished
+	assert.False(t, IsSourceFinished(mep, migrationv1alpha1.PhaseValidating, "source-cluster"))
+	SetSourceFinished(mep, migrationv1alpha1.PhaseValidating, "source-cluster")
+	assert.True(t, IsSourceFinished(mep, migrationv1alpha1.PhaseValidating, "source-cluster"))
 
-func TestReportReceivedStatus(t *testing.T) {
-	tests := []struct {
-		name          string
-		initialStatus map[migrationv1alpha1.StageStatus]*MigrationEventStatus
-		stage         migrationv1alpha1.StageStatus
-		expected      bool
-	}{
-		{
-			name:          "Report received status for a non-existent stage",
-			initialStatus: map[migrationv1alpha1.StageStatus]*MigrationEventStatus{},
-			stage:         migrationv1alpha1.StageStatus("Stage1"),
-			expected:      false,
-		},
-		{
-			name: "Report received status for an existing stage with IsReceived set to true",
-			initialStatus: map[migrationv1alpha1.StageStatus]*MigrationEventStatus{
-				migrationv1alpha1.StageStatus("Stage1"): {IsReceived: true},
-			},
-			stage:    migrationv1alpha1.StageStatus("Stage1"),
-			expected: true,
-		},
-		{
-			name: "Report received status for an existing stage with IsReceived set to false",
-			initialStatus: map[migrationv1alpha1.StageStatus]*MigrationEventStatus{
-				migrationv1alpha1.StageStatus("Stage1"): {IsReceived: false},
-			},
-			stage:    migrationv1alpha1.StageStatus("Stage1"),
-			expected: false,
-		},
-	}
+	// Test IsTargetStarted
+	assert.False(t, IsTargetStarted(mep, migrationv1alpha1.PhaseValidating, "target-cluster"))
+	SetTargetStarted(mep, migrationv1alpha1.PhaseValidating, "target-cluster")
+	assert.True(t, IsTargetStarted(mep, migrationv1alpha1.PhaseValidating, "target-cluster"))
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mep := MigrationEventProgress{
-				Target_Statuses: tt.initialStatus,
-			}
-
-			result := ReportReceivedStatus(mep, tt.stage)
-
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestReportSentStatus(t *testing.T) {
-	tests := []struct {
-		name          string
-		initialStatus map[migrationv1alpha1.StageStatus]*MigrationEventStatus
-		stage         migrationv1alpha1.StageStatus
-		expected      bool
-	}{
-		{
-			name:          "Report sent status for a non-existent stage",
-			initialStatus: map[migrationv1alpha1.StageStatus]*MigrationEventStatus{},
-			stage:         migrationv1alpha1.StageStatus("Stage1"),
-			expected:      false,
-		},
-		{
-			name: "Report sent status for an existing stage with IsSent set to true",
-			initialStatus: map[migrationv1alpha1.StageStatus]*MigrationEventStatus{
-				migrationv1alpha1.StageStatus("Stage1"): {IsSent: true},
-			},
-			stage:    migrationv1alpha1.StageStatus("Stage1"),
-			expected: true,
-		},
-		{
-			name: "Report sent status for an existing stage with IsSent set to false",
-			initialStatus: map[migrationv1alpha1.StageStatus]*MigrationEventStatus{
-				migrationv1alpha1.StageStatus("Stage1"): {IsSent: false},
-			},
-			stage:    migrationv1alpha1.StageStatus("Stage1"),
-			expected: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mep := MigrationEventProgress{
-				Source_Statuses: tt.initialStatus,
-			}
-
-			result := ReportSentStatus(mep, tt.stage)
-
-			assert.Equal(t, tt.expected, result)
-		})
-	}
+	// Test IsTargetFinished
+	assert.False(t, IsTargetFinished(mep, migrationv1alpha1.PhaseValidating, "target-cluster"))
+	SetTargetFinished(mep, migrationv1alpha1.PhaseValidating, "target-cluster")
+	assert.True(t, IsTargetFinished(mep, migrationv1alpha1.PhaseValidating, "target-cluster"))
 }

--- a/manager/pkg/migration/migration_eventstatus_test.go
+++ b/manager/pkg/migration/migration_eventstatus_test.go
@@ -9,48 +9,43 @@ import (
 )
 
 func TestMigrationEventProgress(t *testing.T) {
-	mep := &MigrationEventProgress{
-		sourceStatuses: map[string]*MigrationPhase{
-			"source-cluster": {
-				Validating: MigrationPhaseStatus{
-					started:  false,
-					finished: false,
-					error:    "",
-				},
-			},
-		},
-		targetStatuses: map[string]*MigrationPhase{
-			"target-cluster": {
-				Validating: MigrationPhaseStatus{
-					started:  false,
-					finished: false,
-					error:    "",
-				},
+	migrateId := "migration"
+	MigrationEventProgressMap[migrateId] = &MigrationEventProgress{
+		"source-cluster": &MigrationPhases{
+			Validating: MigrationPhaseStatus{
+				started:  false,
+				finished: false,
+				error:    "",
 			},
 		},
 	}
 
-	assert.False(t, IsSourceStarted(mep, migrationv1alpha1.PhaseInitializing, "source-cluster"))
-	SetSourceStarted(mep, migrationv1alpha1.PhaseInitializing, "source-cluster")
-	assert.True(t, IsSourceStarted(mep, migrationv1alpha1.PhaseInitializing, "source-cluster"))
+	assert.False(t, GetStarted(migrateId, "source-cluster", migrationv1alpha1.PhaseInitializing))
+	SetStarted(migrateId, "source-cluster", migrationv1alpha1.PhaseInitializing)
+	assert.True(t, GetStarted(migrateId, "source-cluster", migrationv1alpha1.PhaseInitializing))
 
-	// Test IsSourceStarted
-	assert.False(t, IsSourceStarted(mep, migrationv1alpha1.PhaseValidating, "source-cluster"))
-	SetSourceStarted(mep, migrationv1alpha1.PhaseValidating, "source-cluster")
-	assert.True(t, IsSourceStarted(mep, migrationv1alpha1.PhaseValidating, "source-cluster"))
+	// Test GetStarted
+	assert.False(t, GetStarted(migrateId, "source-cluster", migrationv1alpha1.PhaseValidating))
+	SetStarted(migrateId, "source-cluster", migrationv1alpha1.PhaseValidating)
+	assert.True(t, GetStarted(migrateId, "source-cluster", migrationv1alpha1.PhaseValidating))
 
-	// Test IsSourceFinished
-	assert.False(t, IsSourceFinished(mep, migrationv1alpha1.PhaseValidating, "source-cluster"))
-	SetSourceFinished(mep, migrationv1alpha1.PhaseValidating, "source-cluster")
-	assert.True(t, IsSourceFinished(mep, migrationv1alpha1.PhaseValidating, "source-cluster"))
+	// Test GetFinished
+	assert.False(t, GetFinished(migrateId, "source-cluster", migrationv1alpha1.PhaseValidating))
+	SetFinished(migrateId, "source-cluster", migrationv1alpha1.PhaseValidating)
+	assert.True(t, GetFinished(migrateId, "source-cluster", migrationv1alpha1.PhaseValidating))
 
-	// Test IsTargetStarted
-	assert.False(t, IsTargetStarted(mep, migrationv1alpha1.PhaseValidating, "target-cluster"))
-	SetTargetStarted(mep, migrationv1alpha1.PhaseValidating, "target-cluster")
-	assert.True(t, IsTargetStarted(mep, migrationv1alpha1.PhaseValidating, "target-cluster"))
+	// Test GetStarted
+	assert.False(t, GetStarted(migrateId, "target-cluster", migrationv1alpha1.PhaseValidating))
+	SetStarted(migrateId, "target-cluster", migrationv1alpha1.PhaseValidating)
+	assert.True(t, GetStarted(migrateId, "target-cluster", migrationv1alpha1.PhaseValidating))
 
-	// Test IsTargetFinished
-	assert.False(t, IsTargetFinished(mep, migrationv1alpha1.PhaseValidating, "target-cluster"))
-	SetTargetFinished(mep, migrationv1alpha1.PhaseValidating, "target-cluster")
-	assert.True(t, IsTargetFinished(mep, migrationv1alpha1.PhaseValidating, "target-cluster"))
+	// Test GetFinished
+	assert.False(t, GetFinished(migrateId, "target-cluster", migrationv1alpha1.PhaseValidating))
+	SetFinished(migrateId, "target-cluster", migrationv1alpha1.PhaseValidating)
+	assert.True(t, GetFinished(migrateId, "target-cluster", migrationv1alpha1.PhaseValidating))
+
+	// Test Get/Set Error
+	assert.Empty(t, GetErrorMessage(migrateId, "target-cluster", migrationv1alpha1.PhaseValidating))
+	SetErrorMessage(migrateId, "target-cluster", migrationv1alpha1.PhaseValidating, "failed to validate")
+	assert.NotEmpty(t, GetErrorMessage(migrateId, "target-cluster", migrationv1alpha1.PhaseValidating))
 }

--- a/manager/pkg/migration/migration_validating.go
+++ b/manager/pkg/migration/migration_validating.go
@@ -38,6 +38,8 @@ func (m *ClusterMigrationController) validating(ctx context.Context,
 		if err := m.Client.Status().Update(ctx, mcm); err != nil {
 			return false, err
 		}
+		// initializing the migration event progress
+		MigrationEventProgressMap[string(mcm.GetUID())] = &MigrationEventProgress{}
 	}
 
 	// Skip validation if the ResourceValidated is true,

--- a/operator/api/migration/v1alpha1/managedclustermigration_types.go
+++ b/operator/api/migration/v1alpha1/managedclustermigration_types.go
@@ -76,7 +76,7 @@ type ManagedClusterMigrationSpec struct {
 // ManagedClusterMigrationStatus defines the observed state of managedclustermigration
 type ManagedClusterMigrationStatus struct {
 	// Phase represents the current phase of the migration
-	// +kubebuilder:validation:Enum=Validating;Initializing;Deploying;Registering;Cleaning;Completed;Failed
+	// +kubebuilder:validation:Enum=Validating;Initializing;Deploying;Registering;Cleaning;Completed;Failed;Migrating
 	// +operator-sdk:csv:customresourcedefinitions:type=status
 	Phase string `json:"phase,omitempty"`
 

--- a/operator/api/migration/v1alpha1/managedclustermigration_types.go
+++ b/operator/api/migration/v1alpha1/managedclustermigration_types.go
@@ -24,7 +24,9 @@ import (
 const (
 	PhaseValidating   = "Validating"
 	PhaseInitializing = "Initializing"
-	PhaseMigrating    = "Migrating"
+	PhaseMigrating    = "Migrating" // deprecated
+	PhaseDeploying    = "Deploying"
+	PhaseRegistering  = "Registering"
 	PhaseCleaning     = "Cleaning"
 	PhaseCompleted    = "Completed"
 	PhaseFailed       = "Failed"
@@ -37,17 +39,6 @@ const (
 	ConditionTypeRegistered  = "ClusterRegistered" // -> Phase: Migrating
 	ConditionTypeDeployed    = "ResourceDeployed"  // -> Phase: Migrating
 	ConditionTypeCleaned     = "ResourceCleaned"
-)
-
-// Migration stages used internally
-type StageStatus string
-
-const (
-	StageValidating   StageStatus = "Validating"
-	StageInitializing StageStatus = "Initializing"
-	StageDeploying    StageStatus = "Deploying"
-	StageRegistering  StageStatus = "Registering"
-	StageCleaning     StageStatus = "Cleaning"
 )
 
 // +kubebuilder:object:root=true
@@ -85,7 +76,7 @@ type ManagedClusterMigrationSpec struct {
 // ManagedClusterMigrationStatus defines the observed state of managedclustermigration
 type ManagedClusterMigrationStatus struct {
 	// Phase represents the current phase of the migration
-	// +kubebuilder:validation:Enum=Initializing;Validating;Migrating;Cleaning;Completed;Failed
+	// +kubebuilder:validation:Enum=Validating;Initializing;Deploying;Registering;Cleaning;Completed;Failed
 	// +operator-sdk:csv:customresourcedefinitions:type=status
 	Phase string `json:"phase,omitempty"`
 

--- a/operator/api/migration/v1alpha1/managedclustermigration_types.go
+++ b/operator/api/migration/v1alpha1/managedclustermigration_types.go
@@ -39,6 +39,17 @@ const (
 	ConditionTypeCleaned     = "ResourceCleaned"
 )
 
+// Migration stages used internally
+type StageStatus string
+
+const (
+	StageValidating   StageStatus = "Validating"
+	StageInitializing StageStatus = "Initializing"
+	StageDeploying    StageStatus = "Deploying"
+	StageRegistering  StageStatus = "Registering"
+	StageCleaning     StageStatus = "Cleaning"
+)
+
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName={mcm}

--- a/operator/bundle/manifests/global-hub.open-cluster-management.io_managedclustermigrations.yaml
+++ b/operator/bundle/manifests/global-hub.open-cluster-management.io_managedclustermigrations.yaml
@@ -129,9 +129,10 @@ spec:
               phase:
                 description: Phase represents the current phase of the migration
                 enum:
-                - Initializing
                 - Validating
-                - Migrating
+                - Initializing
+                - Deploying
+                - Registering
                 - Cleaning
                 - Completed
                 - Failed

--- a/operator/bundle/manifests/global-hub.open-cluster-management.io_managedclustermigrations.yaml
+++ b/operator/bundle/manifests/global-hub.open-cluster-management.io_managedclustermigrations.yaml
@@ -136,6 +136,7 @@ spec:
                 - Cleaning
                 - Completed
                 - Failed
+                - Migrating
                 type: string
             type: object
         type: object

--- a/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -41,7 +41,7 @@ metadata:
     categories: Integration & Delivery,OpenShift Optional
     certified: "false"
     containerImage: quay.io/stolostron/multicluster-global-hub-operator:latest
-    createdAt: "2025-04-27T14:09:03Z"
+    createdAt: "2025-04-28T04:00:52Z"
     description: Manages the installation and upgrade of the Multicluster Global Hub.
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"

--- a/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -41,7 +41,7 @@ metadata:
     categories: Integration & Delivery,OpenShift Optional
     certified: "false"
     containerImage: quay.io/stolostron/multicluster-global-hub-operator:latest
-    createdAt: "2025-04-24T13:35:04Z"
+    createdAt: "2025-04-27T14:09:03Z"
     description: Manages the installation and upgrade of the Multicluster Global Hub.
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"

--- a/operator/config/crd/bases/global-hub.open-cluster-management.io_managedclustermigrations.yaml
+++ b/operator/config/crd/bases/global-hub.open-cluster-management.io_managedclustermigrations.yaml
@@ -129,9 +129,10 @@ spec:
               phase:
                 description: Phase represents the current phase of the migration
                 enum:
-                - Initializing
                 - Validating
-                - Migrating
+                - Initializing
+                - Deploying
+                - Registering
                 - Cleaning
                 - Completed
                 - Failed

--- a/operator/config/crd/bases/global-hub.open-cluster-management.io_managedclustermigrations.yaml
+++ b/operator/config/crd/bases/global-hub.open-cluster-management.io_managedclustermigrations.yaml
@@ -136,6 +136,7 @@ spec:
                 - Cleaning
                 - Completed
                 - Failed
+                - Migrating
                 type: string
             type: object
         type: object


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Define the event status struct to be used by migration in different stages.

## Related issue(s)

Fixes #

## Tests
* [x] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
