### PR TITLE
:sparkles:  Wait for managed clusters are available

### DIFF
--- a/agent/pkg/spec/syncers/migration_from_syncer.go
+++ b/agent/pkg/spec/syncers/migration_from_syncer.go
@@ -356,7 +356,7 @@ func (s *managedClusterMigrationFromSyncer) SendSourceClusterMigrationResources(
 	for _, managedCluster := range managedClusters {
 		// add cluster
 		cluster := &clusterv1.ManagedCluster{}
-		err := s.client.Get(ctx, types.NamespacedName{Name: managedCluster, Namespace: managedCluster}, cluster)
+		err := s.client.Get(ctx, types.NamespacedName{Name: managedCluster}, cluster)
 		if err != nil {
 			return err
 		}

--- a/agent/pkg/spec/syncers/migration_from_syncer.go
+++ b/agent/pkg/spec/syncers/migration_from_syncer.go
@@ -49,7 +49,6 @@ type managedClusterMigrationFromSyncer struct {
 	transportConfig   *transport.TransportInternalConfig
 	migrationProducer *producer.GenericProducer
 	bundleVersion     *eventversion.Version
-	sendResources     bool
 }
 
 func NewManagedClusterMigrationFromSyncer(client client.Client,
@@ -61,7 +60,6 @@ func NewManagedClusterMigrationFromSyncer(client client.Client,
 		transportClient: transportClient,
 		transportConfig: transportConfig,
 		bundleVersion:   eventversion.NewVersion(),
-		sendResources:   false,
 	}
 }
 
@@ -138,7 +136,7 @@ func (m *managedClusterMigrationFromSyncer) cleanup(
 		}
 	}
 
-	// dleete klusterletconfig
+	// delete klusterletconfig
 	klusterletConfig := &klusterletv1alpha1.KlusterletConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: klusterletConfigNamePrefix + migratingEvt.ToHub,
@@ -167,7 +165,6 @@ func (m *managedClusterMigrationFromSyncer) cleanup(
 			m.log.Errorf("failed to close producer: %v", err)
 		}
 		m.migrationProducer = nil
-		m.sendResources = false
 	}
 	return nil
 }
@@ -350,10 +347,6 @@ func (s *managedClusterMigrationFromSyncer) resendMigrationResources(event *kafk
 func (s *managedClusterMigrationFromSyncer) SendSourceClusterMigrationResources(ctx context.Context,
 	migrationId string, managedClusters []string, fromHub, toHub string,
 ) error {
-	// aovid duplicate sending
-	if s.sendResources {
-		return nil
-	}
 	// send the managed cluster and klusterletAddonConfig to the target cluster
 	migrationResources := &migration.SourceClusterMigrationResources{
 		ManagedClusters:       []clusterv1.ManagedCluster{},
@@ -408,8 +401,6 @@ func (s *managedClusterMigrationFromSyncer) SendSourceClusterMigrationResources(
 			string(enum.MigrationResourcesType), fromHub, toHub, err)
 	}
 	s.bundleVersion.Next()
-	// set the sendResources to true to avoid duplicate sending
-	s.sendResources = true
 	return nil
 }
 

--- a/agent/pkg/spec/syncers/migration_from_syncer_test.go
+++ b/agent/pkg/spec/syncers/migration_from_syncer_test.go
@@ -195,7 +195,6 @@ func TestMigrationSourceHubSyncer(t *testing.T) {
 
 			managedClusterMigrationSyncer := NewManagedClusterMigrationFromSyncer(fakeClient, transportClient,
 				transportConfig)
-			managedClusterMigrationSyncer.sendResources = true
 
 			payload, err := json.Marshal(c.receivedMigrationEventBundle)
 			assert.Nil(t, err)

--- a/agent/pkg/spec/syncers/migration_to_syncer.go
+++ b/agent/pkg/spec/syncers/migration_to_syncer.go
@@ -81,7 +81,6 @@ func (s *managedClusterMigrationToSyncer) Sync(ctx context.Context, payload []by
 			s.log.Errorf("failed to start migration consumer: %v", err)
 			return err
 		}
-		s.log.Info("finished the deploying")
 	}
 
 	// expected registered
@@ -395,7 +394,8 @@ func (s *managedClusterMigrationToSyncer) syncMigrationResources(ctx context.Con
 		return err
 	}
 
-	s.log.Info("finish sync migration resources")
+	s.log.Info("finished sync migration resources")
+	s.log.Info("finished the deploying")
 	// stop the migration consumer
 	s.migrationConsumerCtxCancel()
 	s.migrationConsumer = nil

--- a/agent/pkg/spec/syncers/migration_to_syncer.go
+++ b/agent/pkg/spec/syncers/migration_to_syncer.go
@@ -88,7 +88,7 @@ func (s *managedClusterMigrationToSyncer) Sync(ctx context.Context, payload []by
 		go func() {
 			s.log.Infof("registering managed cluster migration")
 			notAvailableManagedClusters := []string{}
-			if err := wait.PollUntilContextTimeout(ctx, 1*time.Minute, 10*time.Minute, false, func(context.Context) (done bool, err error) {
+			if err := wait.PollUntilContextTimeout(ctx, 10*time.Second, 10*time.Minute, false, func(context.Context) (done bool, err error) {
 				if err := s.registering(ctx, managedClusterMigrationToEvent, notAvailableManagedClusters); err != nil {
 					return false, err
 				}

--- a/agent/pkg/spec/syncers/migration_to_syncer.go
+++ b/agent/pkg/spec/syncers/migration_to_syncer.go
@@ -76,13 +76,13 @@ func (s *managedClusterMigrationToSyncer) Sync(ctx context.Context, payload []by
 			return err
 		}
 		s.log.Info("finished the initializing")
-	}
 
-	if err := s.deploying(ctx, managedClusterMigrationToEvent); err != nil {
-		s.log.Errorf("failed to start migration consumer: %v", err)
-		return err
+		if err := s.deploying(ctx, managedClusterMigrationToEvent); err != nil {
+			s.log.Errorf("failed to start migration consumer: %v", err)
+			return err
+		}
+		s.log.Info("finished the deploying")
 	}
-	s.log.Info("finished the deploying")
 
 	// expected registered
 	if managedClusterMigrationToEvent.Stage == migrationv1alpha1.PhaseRegistering {

--- a/manager/pkg/migration/migration_deploying.go
+++ b/manager/pkg/migration/migration_deploying.go
@@ -29,7 +29,7 @@ func (m *ClusterMigrationController) deploying(ctx context.Context,
 	}
 
 	if meta.IsStatusConditionTrue(mcm.Status.Conditions, migrationv1alpha1.ConditionTypeDeployed) ||
-		mcm.Status.Phase != migrationv1alpha1.PhaseMigrating {
+		mcm.Status.Phase != migrationv1alpha1.PhaseDeploying {
 		return false, nil
 	}
 	log.Info("migration deploying")

--- a/manager/pkg/migration/migration_initializing.go
+++ b/manager/pkg/migration/migration_initializing.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
-	addonv1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -256,48 +255,6 @@ func (m *ClusterMigrationController) UpdateConditionWithRetry(ctx context.Contex
 		}
 		return nil
 	})
-}
-
-// sendEventToDestinationHub:
-// 1. only send the msa info to allow auto approve if KlusterletAddonConfig is nil -> registering
-// 2. if KlusterletAddonConfig is not nil -> deploying
-func (m *ClusterMigrationController) sendEventToDestinationHub(ctx context.Context,
-	migration *migrationv1alpha1.ManagedClusterMigration, stage string, addonConfig *addonv1.KlusterletAddonConfig,
-) error {
-	// default managedserviceaccount addon namespace
-	msaNamespace := "open-cluster-management-agent-addon"
-	if m.importClusterInHosted {
-		// hosted mode, the  managedserviceaccount addon namespace
-		msaNamespace = "open-cluster-management-global-hub-agent-addon"
-	}
-	msaInstallNamespaceAnnotation := "global-hub.open-cluster-management.io/managed-serviceaccount-install-namespace"
-	// if user specifies the managedserviceaccount addon namespace, then use it
-	if val, ok := migration.Annotations[msaInstallNamespaceAnnotation]; ok {
-		msaNamespace = val
-	}
-	managedClusterMigrationToEvent := &migrationbundle.ManagedClusterMigrationToEvent{
-		MigrationId:                           string(migration.GetUID()),
-		Stage:                                 stage,
-		ManagedServiceAccountName:             migration.Name,
-		ManagedServiceAccountInstallNamespace: msaNamespace,
-	}
-	if addonConfig != nil {
-		managedClusterMigrationToEvent.KlusterletAddonConfig = addonConfig
-	}
-
-	payloadToBytes, err := json.Marshal(managedClusterMigrationToEvent)
-	if err != nil {
-		return fmt.Errorf("failed to marshal managed cluster migration to event(%v) - %w",
-			managedClusterMigrationToEvent, err)
-	}
-
-	eventType := constants.CloudEventTypeMigrationTo
-	evt := utils.ToCloudEvent(eventType, constants.CloudEventGlobalHubClusterName, migration.Spec.To, payloadToBytes)
-	if err := m.Producer.SendEvent(ctx, evt); err != nil {
-		return fmt.Errorf("failed to sync managedclustermigration event(%s) from source(%s) to destination(%s) - %w",
-			eventType, constants.CloudEventGlobalHubClusterName, migration.Spec.To, err)
-	}
-	return nil
 }
 
 func (m *ClusterMigrationController) UpdateCondition(

--- a/manager/pkg/migration/migration_initializing.go
+++ b/manager/pkg/migration/migration_initializing.go
@@ -286,12 +286,16 @@ func (m *ClusterMigrationController) UpdateCondition(
 			if mcm.Status.Phase != migrationv1alpha1.PhaseCompleted {
 				mcm.Status.Phase = migrationv1alpha1.PhaseInitializing
 			}
-		case migrationv1alpha1.ConditionTypeInitialized, migrationv1alpha1.ConditionTypeRegistered:
-			if mcm.Status.Phase != migrationv1alpha1.PhaseMigrating {
-				mcm.Status.Phase = migrationv1alpha1.PhaseMigrating
+		case migrationv1alpha1.ConditionTypeInitialized:
+			if mcm.Status.Phase != migrationv1alpha1.PhaseCompleted {
+				mcm.Status.Phase = migrationv1alpha1.PhaseDeploying
 			}
 		case migrationv1alpha1.ConditionTypeDeployed:
-			if mcm.Status.Phase != migrationv1alpha1.PhaseCleaning {
+			if mcm.Status.Phase != migrationv1alpha1.PhaseCompleted {
+				mcm.Status.Phase = migrationv1alpha1.PhaseRegistering
+			}
+		case migrationv1alpha1.ConditionTypeRegistered:
+			if mcm.Status.Phase != migrationv1alpha1.PhaseCompleted {
 				mcm.Status.Phase = migrationv1alpha1.PhaseCleaning
 			}
 		case migrationv1alpha1.ConditionTypeCleaned:

--- a/manager/pkg/migration/migration_initializing.go
+++ b/manager/pkg/migration/migration_initializing.go
@@ -127,7 +127,7 @@ func (m *ClusterMigrationController) initializing(ctx context.Context,
 	// 4. Send event to Source Hub
 	for fromHubName, clusters := range sourceHubToClusters {
 		if !GetStarted(string(mcm.GetUID()), fromHubName, migrationv1alpha1.PhaseInitializing) {
-			err := m.sendEventToSourceHub(ctx, fromHubName, mcm, migrationv1alpha1.ConditionTypeInitialized, clusters,
+			err := m.sendEventToSourceHub(ctx, fromHubName, mcm, migrationv1alpha1.PhaseInitializing, clusters,
 				bootstrapSecret)
 			if err != nil {
 				return false, err

--- a/manager/pkg/migration/migration_registering.go
+++ b/manager/pkg/migration/migration_registering.go
@@ -2,6 +2,7 @@ package migration
 
 import (
 	"context"
+	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,8 +21,8 @@ const (
 // Migrating - registering:
 //  1. Source Hub: set the bootstrap secret for the migrating clusters, change hubAccpetClient to trigger registering
 //     Related Issue: https://issues.redhat.com/browse/ACM-15758
-//  2. Destination Hub: don't need to do anything
-//  3. Global Hub: update the staging in database from MigrationResourceInitialized -> MigrationClusterRegistered
+//  2. Destination Hub: report the status of migrated managed cluster
+//  3. Global Hub: update the CR status
 func (m *ClusterMigrationController) registering(ctx context.Context,
 	mcm *migrationv1alpha1.ManagedClusterMigration,
 ) (bool, error) {
@@ -39,17 +40,17 @@ func (m *ClusterMigrationController) registering(ctx context.Context,
 	condType := migrationv1alpha1.ConditionTypeRegistered
 	condStatus := metav1.ConditionTrue
 	condReason := conditionReasonClusterRegistered
-	condMsg := "All migrated clusters registered"
+	condMessage := "All migrated clusters are registered"
 	var err error
 
 	defer func() {
 		if err != nil {
-			condMsg = err.Error()
+			condMessage = err.Error()
 			condStatus = metav1.ConditionFalse
 			condReason = conditionReasonClusterNotRegistered
 		}
-		log.Infof("registering condition %s(%s): %s", condType, condReason, condMsg)
-		err = m.UpdateConditionWithRetry(ctx, mcm, condType, condStatus, condReason, condMsg)
+		log.Infof("registering condition %s(%s): %s", condType, condReason, condMessage)
+		err = m.UpdateConditionWithRetry(ctx, mcm, condType, condStatus, condReason, condMessage)
 		if err != nil {
 			log.Errorf("failed to update the %s condition: %v", condType, err)
 		}
@@ -85,6 +86,20 @@ func (m *ClusterMigrationController) registering(ctx context.Context,
 			return false, err
 		}
 		SetStarted(string(mcm.GetUID()), mcm.Spec.To, migrationv1alpha1.PhaseRegistering)
+	}
+
+	errMessage := GetErrorMessage(string(mcm.GetUID()), mcm.Spec.To, migrationv1alpha1.PhaseRegistering)
+	if errMessage != "" {
+		err = fmt.Errorf("register to hub %s with error: %s", mcm.Spec.To, errMessage)
+		return false, nil
+	}
+
+	// waiting the resources deployed confirmation
+	if !GetFinished(string(mcm.GetUID()), mcm.Spec.To, migrationv1alpha1.PhaseRegistering) {
+		condMessage = fmt.Sprintf("the migrated clusters are registering to the target hub %s", mcm.Spec.To)
+		condStatus = metav1.ConditionFalse
+		condReason = conditionReasonClusterRegistered
+		return true, nil
 	}
 
 	return true, nil

--- a/manager/pkg/migration/migration_registering.go
+++ b/manager/pkg/migration/migration_registering.go
@@ -30,7 +30,7 @@ func (m *ClusterMigrationController) registering(ctx context.Context,
 	}
 
 	if meta.IsStatusConditionTrue(mcm.Status.Conditions, migrationv1alpha1.ConditionTypeRegistered) ||
-		mcm.Status.Phase != migrationv1alpha1.PhaseMigrating {
+		mcm.Status.Phase != migrationv1alpha1.PhaseRegistering {
 		return false, nil
 	}
 

--- a/manager/pkg/migration/migration_registering.go
+++ b/manager/pkg/migration/migration_registering.go
@@ -75,8 +75,12 @@ func (m *ClusterMigrationController) registering(ctx context.Context,
 
 	if !GetStarted(string(mcm.GetUID()), mcm.Spec.To, migrationv1alpha1.PhaseRegistering) {
 		log.Infof("migration registering: %s", mcm.Spec.To)
+		allClusters := []string{}
+		for _, clusters := range sourceHubToClusters {
+			allClusters = append(allClusters, clusters...)
+		}
 		// notify the target hub to start registering
-		err = m.sendEventToDestinationHub(ctx, mcm, migrationv1alpha1.PhaseRegistering, nil)
+		err = m.sendEventToDestinationHub(ctx, mcm, migrationv1alpha1.PhaseRegistering, allClusters)
 		if err != nil {
 			return false, err
 		}

--- a/manager/pkg/status/handlers/clustermigartion/managedclustermigration_handler.go
+++ b/manager/pkg/status/handlers/clustermigartion/managedclustermigration_handler.go
@@ -77,5 +77,15 @@ func (k *managedClusterMigrationHandler) handle(ctx context.Context, evt *cloude
 	if bundle.Stage == migrationv1alpha1.ConditionTypeDeployed {
 		migration.SetFinished(bundle.MigrationId, hubClusterName, migrationv1alpha1.PhaseDeploying)
 	}
+
+	if bundle.Stage == migrationv1alpha1.ConditionTypeRegistered {
+		migration.SetFinished(bundle.MigrationId, hubClusterName, migrationv1alpha1.PhaseRegistering)
+		migration.SetErrorMessage(bundle.MigrationId, hubClusterName,
+			migrationv1alpha1.PhaseRegistering, bundle.ErrMessage)
+	}
+
+	if bundle.Stage == migrationv1alpha1.ConditionTypeCleaned {
+		migration.SetFinished(bundle.MigrationId, hubClusterName, migrationv1alpha1.PhaseCleaning)
+	}
 	return nil
 }

--- a/operator/api/migration/v1alpha1/managedclustermigration_types.go
+++ b/operator/api/migration/v1alpha1/managedclustermigration_types.go
@@ -24,7 +24,6 @@ import (
 const (
 	PhaseValidating   = "Validating"
 	PhaseInitializing = "Initializing"
-	PhaseMigrating    = "Migrating" // deprecated
 	PhaseDeploying    = "Deploying"
 	PhaseRegistering  = "Registering"
 	PhaseCleaning     = "Cleaning"
@@ -36,8 +35,8 @@ const (
 const (
 	ConditionTypeValidated   = "ResourceValidated"
 	ConditionTypeInitialized = "ResourceInitialized"
-	ConditionTypeRegistered  = "ClusterRegistered" // -> Phase: Migrating
-	ConditionTypeDeployed    = "ResourceDeployed"  // -> Phase: Migrating
+	ConditionTypeRegistered  = "ClusterRegistered"
+	ConditionTypeDeployed    = "ResourceDeployed"
 	ConditionTypeCleaned     = "ResourceCleaned"
 )
 
@@ -76,7 +75,7 @@ type ManagedClusterMigrationSpec struct {
 // ManagedClusterMigrationStatus defines the observed state of managedclustermigration
 type ManagedClusterMigrationStatus struct {
 	// Phase represents the current phase of the migration
-	// +kubebuilder:validation:Enum=Validating;Initializing;Deploying;Registering;Cleaning;Completed;Failed;Migrating
+	// +kubebuilder:validation:Enum=Validating;Initializing;Deploying;Registering;Cleaning;Completed;Failed
 	// +operator-sdk:csv:customresourcedefinitions:type=status
 	Phase string `json:"phase,omitempty"`
 

--- a/operator/bundle/manifests/global-hub.open-cluster-management.io_managedclustermigrations.yaml
+++ b/operator/bundle/manifests/global-hub.open-cluster-management.io_managedclustermigrations.yaml
@@ -136,7 +136,6 @@ spec:
                 - Cleaning
                 - Completed
                 - Failed
-                - Migrating
                 type: string
             type: object
         type: object

--- a/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -41,7 +41,7 @@ metadata:
     categories: Integration & Delivery,OpenShift Optional
     certified: "false"
     containerImage: quay.io/stolostron/multicluster-global-hub-operator:latest
-    createdAt: "2025-04-28T04:00:52Z"
+    createdAt: "2025-04-29T05:49:53Z"
     description: Manages the installation and upgrade of the Multicluster Global Hub.
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"

--- a/operator/config/crd/bases/global-hub.open-cluster-management.io_managedclustermigrations.yaml
+++ b/operator/config/crd/bases/global-hub.open-cluster-management.io_managedclustermigrations.yaml
@@ -136,7 +136,6 @@ spec:
                 - Cleaning
                 - Completed
                 - Failed
-                - Migrating
                 type: string
             type: object
         type: object

--- a/pkg/bundle/migration/managedcluster_migration.go
+++ b/pkg/bundle/migration/managedcluster_migration.go
@@ -31,6 +31,7 @@ type ManagedClusterMigrationToEvent struct {
 	ManagedServiceAccountName             string                         `json:"managedServiceAccountName"`
 	ManagedServiceAccountInstallNamespace string                         `json:"installNamespace,omitempty"`
 	KlusterletAddonConfig                 *addonv1.KlusterletAddonConfig `json:"klusterletAddonConfig,omitempty"`
+	ManagedClusters                       []string                       `json:"managedClusters,omitempty"`
 }
 
 // The bundle sent from the managed hubs to the global hub

--- a/test/integration/manager/migration/migration_test.go
+++ b/test/integration/manager/migration/migration_test.go
@@ -433,17 +433,17 @@ var _ = Describe("migration", Ordered, func() {
 				return err
 			}
 
-			if migrationInstance.Status.Phase != migrationv1alpha1.PhaseMigrating &&
+			if migrationInstance.Status.Phase != migrationv1alpha1.PhaseInitializing &&
 				migrationInstance.Status.Phase != migrationv1alpha1.PhaseCompleted {
 				utils.PrettyPrint(migrationInstance.Status)
 				return fmt.Errorf("wait for the migration Migrating to be ready: %s", migrationInstance.Status.Phase)
 			}
 
-			registeredCond := meta.FindStatusCondition(migrationInstance.Status.Conditions,
-				migrationv1alpha1.ConditionTypeRegistered)
-			if registeredCond == nil {
+			initCond := meta.FindStatusCondition(migrationInstance.Status.Conditions,
+				migrationv1alpha1.ConditionTypeInitialized)
+			if initCond == nil {
 				utils.PrettyPrint(migrationInstance.Status)
-				return fmt.Errorf("the registering condition should appears in the migration CR")
+				return fmt.Errorf("the initializing condition should appears in the migration CR")
 			}
 			return nil
 		}, 30*time.Second, 100*time.Millisecond).Should(Succeed())


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
https://issues.redhat.com/browse/ACM-20319
## Related issue(s)

Fixes #

## Tests
* [x] Unit/function tests have been added and incorporated into `make unit-tests`.
* [x] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [x] List other manual tests you have done.
- run e2e tests
```
  conditions:
  - lastTransitionTime: "2025-04-29T06:46:09Z"
    message: Migration resources have been validated
    reason: ResourceValidated
    status: "True"
    type: ResourceValidated
  - lastTransitionTime: "2025-04-29T06:46:14Z"
    message: All source and target hubs have been successfully initialized
    reason: ResourceInitialized
    status: "True"
    type: ResourceInitialized
  - lastTransitionTime: "2025-04-29T06:46:19Z"
    message: Resources have been deployed to the target hub cluster
    reason: ResourcesDeployed
    status: "True"
    type: ResourceDeployed
  - lastTransitionTime: "2025-04-29T06:50:00Z"
    message: All migrated clusters are registered
    reason: ClusterRegistered
    status: "True"
    type: ClusterRegistered
  - lastTransitionTime: "2025-04-29T06:50:00Z"
    message: Resources have been cleaned from the hub clusters
    reason: ResourceCleaned
    status: "True"
    type: ResourceCleaned
  phase: Completed
```