### PR TITLE
Wait for 5 seconds to ensure topic is authorized

### DIFF
--- a/agent/pkg/spec/syncers/migration_from_syncer.go
+++ b/agent/pkg/spec/syncers/migration_from_syncer.go
@@ -398,6 +398,8 @@ func (s *managedClusterMigrationFromSyncer) SendSourceClusterMigrationResources(
 	e.SetID(migrationId)
 	e.SetExtension(eventversion.ExtVersion, s.bundleVersion.String())
 	log.Info("send the migration resources to the migration topic from the source cluster")
+	// TODO: sleep 5 seconds to ensure topic authorization finished
+	time.Sleep(5 * time.Second)
 	if err := s.migrationProducer.SendEvent(ctx, e); err != nil {
 		return fmt.Errorf("failed to send event(%s) from %s to %s: %v",
 			string(enum.MigrationResourcesType), fromHub, toHub, err)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This is a temporary solution to wait for 5 seconds to ensure the topic is authorized. this is an experienced value.
We will enhance it by using `gh-spec` and give the write permission to all the managed hub cluster at the beginning.

why do we need to enhance it?
that is because `KafkaProducer().Produce(event, nil)` is an asynchronous call, we cannot capture the error to retry.
here is one case I observed
```
2025-04-30T12:07:21.217Z	INFO	syncers/migration_from_syncer.go:398	send the migration resources to the migration topic from the source cluster
2025-04-30T12:07:21.242Z	DEBUG	syncers/migration_from_syncer.go:332	resend the migration resources due to topicPartition error
2025-04-30T12:07:26.243Z	WARN	kafka-producer	producer/generic_producer.go:202	delivery failed	{"error": "Broker: Topic authorization failed"}
github.com/stolostron/multicluster-global-hub/pkg/transport/producer.handleProducerEvents.func1
	/workspace/pkg/transport/producer/generic_producer.go:202
```

## Related issue(s)

Fixes #

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
