### PR TITLE
:bug: Detach the migrated clusters from source hub

### DIFF
--- a/agent/pkg/spec/spec.go
+++ b/agent/pkg/spec/spec.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/configs"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/spec/syncers"
@@ -46,15 +45,11 @@ func AddToManager(context context.Context, mgr ctrl.Manager, transportClient tra
 			syncers.NewManagedClusterLabelSyncer(workers))
 	}
 
-	// create a non-cached client for the migration, cause the manager client will only get the cached objects
-	c, err := client.New(mgr.GetConfig(), client.Options{Scheme: configs.GetRuntimeScheme()})
-	if err != nil {
-		return fmt.Errorf("failed to create a non-cached client: %w", err)
-	}
+	mgr.GetConfig()
 	dispatcher.RegisterSyncer(constants.MigrationSourceMsgKey,
-		syncers.NewMigrationSourceSyncer(c, transportClient, agentConfig.TransportConfig))
+		syncers.NewMigrationSourceSyncer(mgr.GetClient(), mgr.GetConfig(), transportClient, agentConfig.TransportConfig))
 	dispatcher.RegisterSyncer(constants.MigrationTargetMsgKey,
-		syncers.NewMigrationTargetSyncer(c, transportClient, agentConfig.TransportConfig))
+		syncers.NewMigrationTargetSyncer(mgr.GetClient(), transportClient, agentConfig.TransportConfig))
 
 	dispatcher.RegisterSyncer(constants.ResyncMsgKey, syncers.NewResyncer())
 

--- a/agent/pkg/spec/syncers/migration_from_syncer.go
+++ b/agent/pkg/spec/syncers/migration_from_syncer.go
@@ -73,6 +73,8 @@ func (s *migrationSourceSyncer) Sync(ctx context.Context, evt *cloudevents.Event
 
 	if migrationSourceHubEvent.Stage == migrationv1alpha1.PhaseInitializing {
 		s.currentMigrationId = migrationSourceHubEvent.MigrationId
+		// reset the bundle version for the new migration
+		s.bundleVersion.Reset()
 		if err := s.initializing(ctx, migrationSourceHubEvent); err != nil {
 			return err
 		}

--- a/agent/pkg/spec/syncers/migration_from_syncer.go
+++ b/agent/pkg/spec/syncers/migration_from_syncer.go
@@ -270,6 +270,7 @@ func (m *migrationSourceSyncer) initializing(
 	if err != nil {
 		return err
 	}
+	log.Info("initializing migration is finished")
 	return nil
 }
 

--- a/agent/pkg/spec/syncers/migration_from_syncer_test.go
+++ b/agent/pkg/spec/syncers/migration_from_syncer_test.go
@@ -114,8 +114,9 @@ func TestMigrationSourceHubSyncer(t *testing.T) {
 				},
 			},
 			receivedMigrationEventBundle: migration.ManagedClusterMigrationFromEvent{
-				ToHub: "hub2",
-				Stage: migrationv1alpha1.PhaseInitializing,
+				MigrationId: "020340324302432049234023040320",
+				ToHub:       "hub2",
+				Stage:       migrationv1alpha1.PhaseInitializing,
 				BootstrapSecret: &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{Name: bootstrapSecretNamePrefix + "hub2", Namespace: "multicluster-engine"},
 				},
@@ -156,6 +157,7 @@ func TestMigrationSourceHubSyncer(t *testing.T) {
 				},
 			},
 			receivedMigrationEventBundle: migration.ManagedClusterMigrationFromEvent{
+				MigrationId:     "020340324302432049234023040320",
 				ToHub:           "hub2",
 				Stage:           migrationv1alpha1.PhaseRegistering,
 				ManagedClusters: []string{"cluster1"},
@@ -196,8 +198,9 @@ func TestMigrationSourceHubSyncer(t *testing.T) {
 				},
 			},
 			receivedMigrationEventBundle: migration.ManagedClusterMigrationFromEvent{
-				ToHub: "hub2",
-				Stage: migrationv1alpha1.PhaseCleaning,
+				MigrationId: "020340324302432049234023040320",
+				ToHub:       "hub2",
+				Stage:       migrationv1alpha1.PhaseCleaning,
 				BootstrapSecret: &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      bootstrapSecretNamePrefix + "hub2",

--- a/agent/pkg/spec/syncers/migration_from_syncer_test.go
+++ b/agent/pkg/spec/syncers/migration_from_syncer_test.go
@@ -245,7 +245,7 @@ func TestMigrationSourceHubSyncer(t *testing.T) {
 				},
 			}
 
-			managedClusterMigrationSyncer := NewMigrationSourceSyncer(fakeClient, transportClient,
+			managedClusterMigrationSyncer := NewMigrationSourceSyncer(fakeClient, nil, transportClient,
 				transportConfig)
 
 			payload, err := json.Marshal(c.receivedMigrationEventBundle)

--- a/agent/pkg/spec/syncers/migration_to_syncer.go
+++ b/agent/pkg/spec/syncers/migration_to_syncer.go
@@ -73,6 +73,8 @@ func (s *migrationTargetSyncer) Sync(ctx context.Context, evt *cloudevents.Event
 
 		if managedClusterMigrationToEvent.Stage == migrationv1alpha1.PhaseInitializing {
 			s.currentMigrationId = managedClusterMigrationToEvent.MigrationId
+			// reset the bundle version for each new migration
+			s.bundleVersion.Reset()
 			if err := s.initializing(ctx, managedClusterMigrationToEvent); err != nil {
 				log.Errorf("failed to initialize the migration resources %v", err)
 				return err

--- a/agent/pkg/spec/syncers/migration_to_syncer_test.go
+++ b/agent/pkg/spec/syncers/migration_to_syncer_test.go
@@ -45,7 +45,7 @@ func TestMigrationToSyncer(t *testing.T) {
 		{
 			name: "Initializing: migration with cluster manager having no registration configuration",
 			migrationEvent: &migration.ManagedClusterMigrationToEvent{
-				MigrationId:                           "migration-id",
+				MigrationId:                           "020340324302432049234023040320",
 				Stage:                                 migrationv1alpha1.PhaseInitializing,
 				ManagedServiceAccountName:             "test", // the migration cr name
 				ManagedServiceAccountInstallNamespace: "test",
@@ -129,7 +129,7 @@ func TestMigrationToSyncer(t *testing.T) {
 		{
 			name: "migration with cluster manager having empty registration configuration",
 			migrationEvent: &migration.ManagedClusterMigrationToEvent{
-				MigrationId:                           "migration-id",
+				MigrationId:                           "020340324302432049234023040320",
 				Stage:                                 migrationv1alpha1.PhaseInitializing,
 				ManagedServiceAccountName:             "test", // the migration cr name
 				ManagedServiceAccountInstallNamespace: "test",
@@ -171,7 +171,7 @@ func TestMigrationToSyncer(t *testing.T) {
 		{
 			name: "migration with cluster manager having registration configuration with other feature gates and auto approve users",
 			migrationEvent: &migration.ManagedClusterMigrationToEvent{
-				MigrationId:                           "migration-id",
+				MigrationId:                           "020340324302432049234023040320",
 				Stage:                                 migrationv1alpha1.PhaseInitializing,
 				ManagedServiceAccountName:             "test", // the migration cr name
 				ManagedServiceAccountInstallNamespace: "test",
@@ -222,7 +222,7 @@ func TestMigrationToSyncer(t *testing.T) {
 		{
 			name: "migration with cluster manager having registration configuration with feature gate disabled",
 			migrationEvent: &migration.ManagedClusterMigrationToEvent{
-				MigrationId:                           "migration-id",
+				MigrationId:                           "020340324302432049234023040320",
 				Stage:                                 migrationv1alpha1.PhaseInitializing,
 				ManagedServiceAccountName:             "test", // the migration cr name
 				ManagedServiceAccountInstallNamespace: "test",
@@ -268,6 +268,12 @@ func TestMigrationToSyncer(t *testing.T) {
 		},
 		{
 			name: "migration with cluster manager having registration configuration with feature gate auto approve user",
+			migrationEvent: &migration.ManagedClusterMigrationToEvent{
+				MigrationId:                           "020340324302432049234023040320",
+				Stage:                                 migrationv1alpha1.PhaseInitializing,
+				ManagedServiceAccountName:             "test", // the migration cr name
+				ManagedServiceAccountInstallNamespace: "test",
+			},
 			initObjects: []client.Object{
 				&operatorv1.ClusterManager{
 					ObjectMeta: metav1.ObjectMeta{
@@ -310,7 +316,7 @@ func TestMigrationToSyncer(t *testing.T) {
 		{
 			name: "migration with existing clusterrole and clusterrolebinding",
 			migrationEvent: &migration.ManagedClusterMigrationToEvent{
-				MigrationId:                           "migration-id",
+				MigrationId:                           "020340324302432049234023040320",
 				Stage:                                 migrationv1alpha1.PhaseInitializing,
 				ManagedServiceAccountName:             "test", // the migration cr name
 				ManagedServiceAccountInstallNamespace: "test",
@@ -440,7 +446,7 @@ func TestMigrationToSyncer(t *testing.T) {
 		{
 			name: "migration with changed clusterrole and clusterrolebinding",
 			migrationEvent: &migration.ManagedClusterMigrationToEvent{
-				MigrationId:                           "migration-id",
+				MigrationId:                           "020340324302432049234023040320",
 				Stage:                                 migrationv1alpha1.PhaseInitializing,
 				ManagedServiceAccountName:             "test", // the migration cr name
 				ManagedServiceAccountInstallNamespace: "test",
@@ -643,6 +649,7 @@ func TestMigrationDestinationHubSyncer(t *testing.T) {
 		{
 			name: "Deploying resources: migrate cluster from hub1 to hub2",
 			receivedMigrationEventBundle: migration.ManagedClusterMigrationToEvent{
+				MigrationId:                           "020340324302432049234023040320",
 				Stage:                                 migrationv1alpha1.ConditionTypeDeployed,
 				ManagedServiceAccountName:             "test", // the migration cr name
 				ManagedServiceAccountInstallNamespace: "test",
@@ -663,6 +670,7 @@ func TestMigrationDestinationHubSyncer(t *testing.T) {
 		{
 			name: "Cleaning up resources: migrate cluster from hub1 to hub2",
 			receivedMigrationEventBundle: migration.ManagedClusterMigrationToEvent{
+				MigrationId:                           "020340324302432049234023040320",
 				Stage:                                 migrationv1alpha1.PhaseCleaning,
 				ManagedServiceAccountName:             "test", // the migration cr name
 				ManagedServiceAccountInstallNamespace: "test",

--- a/manager/pkg/migration/migration_cleaning.go
+++ b/manager/pkg/migration/migration_cleaning.go
@@ -25,6 +25,7 @@ func (m *ClusterMigrationController) completed(ctx context.Context,
 	mcm *migrationv1alpha1.ManagedClusterMigration,
 ) (bool, error) {
 	if !mcm.DeletionTimestamp.IsZero() {
+		RemoveMigrationStatus(string(mcm.GetUID()))
 		return false, nil
 	}
 
@@ -61,9 +62,9 @@ func (m *ClusterMigrationController) completed(ctx context.Context,
 		return false, err
 	}
 
-	sourceHubClusters, err := getSourceClusters(mcm)
-	if err != nil {
-		return false, err
+	sourceHubClusters := GetSourceClusters(string(mcm.GetUID()))
+	if sourceHubClusters == nil {
+		return false, fmt.Errorf("Not initialized the source clusters for migrationId: %s", string(mcm.GetUID()))
 	}
 
 	// cleanup the source hub: cleaning or failed state

--- a/manager/pkg/migration/migration_eventstatus.go
+++ b/manager/pkg/migration/migration_eventstatus.go
@@ -74,7 +74,7 @@ func getMigrationStatus(migrationId string) *MigrationStatus {
 	return status
 }
 
-func ensureProgress(migrationId, hub, phase string) *MigrationProgress {
+func getProgress(migrationId, hub, phase string) *MigrationProgress {
 	status := getMigrationStatus(migrationId)
 	if status == nil {
 		return nil
@@ -90,7 +90,7 @@ func ensureProgress(migrationId, hub, phase string) *MigrationProgress {
 func SetStarted(migrationId, hub, phase string) {
 	mu.RLock()
 	defer mu.RUnlock()
-	if p := ensureProgress(migrationId, hub, phase); p != nil {
+	if p := getProgress(migrationId, hub, phase); p != nil {
 		p.started = true
 	}
 }
@@ -99,7 +99,7 @@ func SetStarted(migrationId, hub, phase string) {
 func SetFinished(migrationId, hub, phase string) {
 	mu.RLock()
 	defer mu.RUnlock()
-	if p := ensureProgress(migrationId, hub, phase); p != nil {
+	if p := getProgress(migrationId, hub, phase); p != nil {
 		p.finished = true
 	}
 }
@@ -107,7 +107,7 @@ func SetFinished(migrationId, hub, phase string) {
 func SetErrorMessage(migrationId, hub, phase, errMessage string) {
 	mu.RLock()
 	defer mu.RUnlock()
-	if p := ensureProgress(migrationId, hub, phase); p != nil {
+	if p := getProgress(migrationId, hub, phase); p != nil {
 		p.error = errMessage
 	}
 }
@@ -116,7 +116,7 @@ func SetErrorMessage(migrationId, hub, phase, errMessage string) {
 func GetStarted(migrationId, hub, phase string) bool {
 	mu.RLock()
 	defer mu.RUnlock()
-	p := ensureProgress(migrationId, hub, phase)
+	p := getProgress(migrationId, hub, phase)
 	return p.started
 }
 
@@ -124,14 +124,14 @@ func GetStarted(migrationId, hub, phase string) bool {
 func GetFinished(migrationId, hub, phase string) bool {
 	mu.RLock()
 	defer mu.RUnlock()
-	p := ensureProgress(migrationId, hub, phase)
+	p := getProgress(migrationId, hub, phase)
 	return p.finished
 }
 
 func GetErrorMessage(migrationId, hub, phase string) string {
 	mu.RLock()
 	defer mu.RUnlock()
-	p := ensureProgress(migrationId, hub, phase)
+	p := getProgress(migrationId, hub, phase)
 
 	return p.error
 }

--- a/manager/pkg/migration/migration_eventstatus.go
+++ b/manager/pkg/migration/migration_eventstatus.go
@@ -86,19 +86,6 @@ func ensureProgress(migrationId, hub, phase string) *MigrationProgress {
 	return status.Progress[key]
 }
 
-func getProgress(migrationId, hub, phase string) *MigrationProgress {
-	status := getMigrationStatus(migrationId)
-	if status == nil {
-		return nil
-	}
-	key := hubPhaseKey(hub, phase)
-	progress, ok := status.Progress[key]
-	if !ok {
-		log.Warnf("MigrationStatus %s: %s - %s hasn't been initialized", migrationId, hub, phase)
-	}
-	return progress
-}
-
 // SetStarted sets the status of the given stage to started for the hub cluster
 func SetStarted(migrationId, hub, phase string) {
 	mu.RLock()
@@ -129,27 +116,22 @@ func SetErrorMessage(migrationId, hub, phase, errMessage string) {
 func GetStarted(migrationId, hub, phase string) bool {
 	mu.RLock()
 	defer mu.RUnlock()
-	if p := getProgress(migrationId, hub, phase); p != nil {
-		return p.started
-	}
-	return false
+	p := ensureProgress(migrationId, hub, phase)
+	return p.started
 }
 
 // GetFinished returns true if the status of the given stage is finished for the hub cluster
 func GetFinished(migrationId, hub, phase string) bool {
 	mu.RLock()
 	defer mu.RUnlock()
-	if p := getProgress(migrationId, hub, phase); p != nil {
-		return p.finished
-	}
-	return false
+	p := ensureProgress(migrationId, hub, phase)
+	return p.finished
 }
 
 func GetErrorMessage(migrationId, hub, phase string) string {
 	mu.RLock()
 	defer mu.RUnlock()
-	if p := getProgress(migrationId, hub, phase); p != nil {
-		return p.error
-	}
-	return ""
+	p := ensureProgress(migrationId, hub, phase)
+
+	return p.error
 }

--- a/manager/pkg/migration/migration_eventstatus.go
+++ b/manager/pkg/migration/migration_eventstatus.go
@@ -1,122 +1,144 @@
 package migration
 
 import (
-	"reflect"
+	"fmt"
+	"sync"
 )
 
-type MigrationPhaseStatus struct {
+var (
+	migrationStatuses = make(map[string]*MigrationStatus)
+	mu                sync.RWMutex // optional: for concurrent access
+)
+
+type MigrationStatus struct {
+	Progress map[string]*MigrationProgress // key: hub-phase
+	Clusters map[string][]string           // key: source hub -> clusters
+}
+
+type MigrationProgress struct {
 	started  bool
 	finished bool
 	error    string
 }
 
-type MigrationPhases struct {
-	Validating, Initializing, Deploying, Registering, Cleaning MigrationPhaseStatus
+// AddMigrationStatus init the migration status for the migrationId
+func AddMigrationStatus(migrationId string) {
+	mu.Lock()
+	defer mu.Unlock()
+	migrationStatuses[migrationId] = &MigrationStatus{
+		Progress: make(map[string]*MigrationProgress),
+	}
+	log.Infof("initialize migration status for migrationId: %s", migrationId)
 }
 
-type MigrationEventProgress map[string]*MigrationPhases
+// AddMigrationStatus clean the migration status for the migrationId
+func RemoveMigrationStatus(migrationId string) {
+	mu.Lock()
+	defer mu.Unlock()
+	delete(migrationStatuses, migrationId)
+	log.Infof("clean up migration status for migrationId: %s", migrationId)
+}
 
-// Initialize the global variable
-var MigrationEventProgressMap = make(map[string]*MigrationEventProgress)
+func AddSourceClusters(migrationId string, clusters map[string][]string) {
+	mu.RLock()
+	defer mu.RUnlock()
 
-// updatePhaseStatus updates the status (started/finished) in the source or target cluster
-func updatePhaseStatus(migrationId, hubCluster, phase string,
-	updateFunc func(*MigrationPhaseStatus),
-) {
-	mep := MigrationEventProgressMap[migrationId]
-	if mep == nil {
-		log.Warnf("MigrationEventProgress is nil for migrationId: %s", migrationId)
+	status, ok := migrationStatuses[migrationId]
+	if !ok {
+		log.Warnf("MigrationStatus is nil for migrationId: %s", migrationId)
 		return
 	}
-	mp := (*mep)[hubCluster]
-	if mp == nil {
-		mp = &MigrationPhases{}
-		(*mep)[hubCluster] = mp
-	}
+	status.Clusters = clusters
+}
 
-	v := reflect.ValueOf(mp).Elem()
-	field := v.FieldByName(phase)
-	if field.IsValid() && field.CanSet() {
-		status, ok := field.Interface().(MigrationPhaseStatus)
-		if ok {
-			updateFunc(&status)
-			field.Set(reflect.ValueOf(status))
-		}
+func GetSourceClusters(migrationId string) map[string][]string {
+	mu.RLock()
+	defer mu.RUnlock()
+
+	status, ok := migrationStatuses[migrationId]
+	if !ok {
+		log.Warnf("MigrationStatus is nil for migrationId: %s", migrationId)
+		return nil
 	}
+	return status.Clusters
+}
+
+func hubPhaseKey(hub, phase string) string {
+	return fmt.Sprintf("%s-%s", hub, phase)
+}
+
+func ensureProgress(migrationId, hub, phase string) *MigrationProgress {
+	mu.Lock()
+	defer mu.Unlock()
+
+	status, ok := migrationStatuses[migrationId]
+	if !ok {
+		log.Warnf("MigrationStatus is nil for migrationId: %s", migrationId)
+		return nil
+	}
+	key := hubPhaseKey(hub, phase)
+	if _, exists := status.Progress[key]; !exists {
+		status.Progress[key] = &MigrationProgress{}
+	}
+	return status.Progress[key]
+}
+
+func getProgress(migrationId, hub, phase string) *MigrationProgress {
+	mu.RLock()
+	defer mu.RUnlock()
+
+	status, ok := migrationStatuses[migrationId]
+	if !ok {
+		log.Warnf("MigrationStatus is nil for migrationId: %s", migrationId)
+		return nil
+	}
+	key := hubPhaseKey(hub, phase)
+	progress, ok := status.Progress[key]
+	if !ok {
+		log.Warnf("MigrationStatus %s: %s - %s hasn't been initialized", migrationId, hub, phase)
+	}
+	return progress
 }
 
 // SetStarted sets the status of the given stage to started for the hub cluster
-func SetStarted(migrationId, hubCluster, phase string) {
-	updatePhaseStatus(migrationId, hubCluster, phase, func(status *MigrationPhaseStatus) {
-		status.started = true
-	})
+func SetStarted(migrationId, hub, phase string) {
+	if p := ensureProgress(migrationId, hub, phase); p != nil {
+		p.started = true
+	}
 }
 
 // SetFinished sets the status of the given stage to finished for the hub cluster
-func SetFinished(migrationId, cluster, phase string) {
-	updatePhaseStatus(migrationId, cluster, phase, func(status *MigrationPhaseStatus) {
-		status.finished = true
-	})
+func SetFinished(migrationId, hub, phase string) {
+	if p := ensureProgress(migrationId, hub, phase); p != nil {
+		p.finished = true
+	}
 }
 
-func SetErrorMessage(migrationId, hubCluster, phase, errMessage string) {
-	updatePhaseStatus(migrationId, hubCluster, phase, func(status *MigrationPhaseStatus) {
-		status.error = errMessage
-	})
-}
-
-// getPhaseStatus extracts the MigrationPhaseStatus for a given phase
-func getPhaseStatus(mp *MigrationPhases, phase string) (MigrationPhaseStatus, bool) {
-	if mp == nil {
-		return MigrationPhaseStatus{}, false
+func SetErrorMessage(migrationId, hub, phase, errMessage string) {
+	if p := ensureProgress(migrationId, hub, phase); p != nil {
+		p.error = errMessage
 	}
-
-	v := reflect.ValueOf(mp).Elem()
-	field := v.FieldByName(phase)
-	if !field.IsValid() {
-		return MigrationPhaseStatus{}, false
-	}
-
-	status, ok := field.Interface().(MigrationPhaseStatus)
-	if !ok {
-		return MigrationPhaseStatus{}, false
-	}
-
-	return status, true
 }
 
 // GetStarted returns true if the status of the given stage is started for the hub cluster
-func GetStarted(migrationId, hubCluster, phase string) bool {
-	mep := MigrationEventProgressMap[migrationId]
-	if mep == nil {
-		log.Warnf("MigrationEventProgress is nil for migrationId: %s", migrationId)
-		return false
+func GetStarted(migrationId, hub, phase string) bool {
+	if p := getProgress(migrationId, hub, phase); p != nil {
+		return p.started
 	}
-	mp := (*mep)[hubCluster]
-	status, ok := getPhaseStatus(mp, phase)
-	if !ok {
-		return false
-	}
-	return status.started
+	return false
 }
 
 // GetFinished returns true if the status of the given stage is finished for the hub cluster
-func GetFinished(migrationId, hubCluster, phase string) bool {
-	mep := MigrationEventProgressMap[migrationId]
-	mp := (*mep)[hubCluster]
-	status, ok := getPhaseStatus(mp, phase)
-	if !ok {
-		return false
+func GetFinished(migrationId, hub, phase string) bool {
+	if p := getProgress(migrationId, hub, phase); p != nil {
+		return p.finished
 	}
-	return status.finished
+	return false
 }
 
-func GetErrorMessage(migrationId, hubCluster, phase string) string {
-	mep := MigrationEventProgressMap[migrationId]
-	mp := (*mep)[hubCluster]
-	status, ok := getPhaseStatus(mp, phase)
-	if !ok {
-		return ""
+func GetErrorMessage(migrationId, hub, phase string) string {
+	if p := getProgress(migrationId, hub, phase); p != nil {
+		return p.error
 	}
-	return status.error
+	return ""
 }

--- a/manager/pkg/migration/migration_eventstatus_test.go
+++ b/manager/pkg/migration/migration_eventstatus_test.go
@@ -10,15 +10,7 @@ import (
 
 func TestMigrationEventProgress(t *testing.T) {
 	migrateId := "migration"
-	MigrationEventProgressMap[migrateId] = &MigrationEventProgress{
-		"source-cluster": &MigrationPhases{
-			Validating: MigrationPhaseStatus{
-				started:  false,
-				finished: false,
-				error:    "",
-			},
-		},
-	}
+	AddMigrationStatus(migrateId)
 
 	assert.False(t, GetStarted(migrateId, "source-cluster", migrationv1alpha1.PhaseInitializing))
 	SetStarted(migrateId, "source-cluster", migrationv1alpha1.PhaseInitializing)

--- a/manager/pkg/migration/migration_initializing.go
+++ b/manager/pkg/migration/migration_initializing.go
@@ -76,6 +76,7 @@ func (m *ClusterMigrationController) initializing(ctx context.Context,
 	if err != nil {
 		return false, err
 	}
+	AddSourceClusters(string(mcm.GetUID()), sourceHubToClusters)
 
 	// 1. Create the managedserviceaccount -> generate bootstrap secret
 	if err := m.ensureManagedServiceAccount(ctx, mcm); err != nil {

--- a/manager/pkg/migration/migration_initializing.go
+++ b/manager/pkg/migration/migration_initializing.go
@@ -111,7 +111,7 @@ func (m *ClusterMigrationController) initializing(ctx context.Context,
 		if err := m.sendEventToDestinationHub(ctx, mcm, migrationv1alpha1.PhaseInitializing, nil); err != nil {
 			return false, err
 		}
-		log.Info("sent initializing event to target hub")
+		log.Infof("sent initializing event to target hub %s", mcm.Spec.To)
 		SetStarted(string(mcm.GetUID()), mcm.Spec.To, migrationv1alpha1.PhaseInitializing)
 	}
 
@@ -123,7 +123,7 @@ func (m *ClusterMigrationController) initializing(ctx context.Context,
 			if err != nil {
 				return false, err
 			}
-			log.Info("sent initialing events to source hubs: %s", fromHubName)
+			log.Infof("sent initialing events to source hubs: %s", fromHubName)
 			SetStarted(string(mcm.GetUID()), fromHubName, migrationv1alpha1.PhaseInitializing)
 		}
 	}
@@ -257,6 +257,7 @@ func (m *ClusterMigrationController) sendEventToSourceHub(ctx context.Context, f
 		ToHub:           migration.Spec.To,
 		ManagedClusters: managedClusters,
 		BootstrapSecret: bootstrapSecret,
+		Resources:       resources,
 	}
 
 	payloadBytes, err := json.Marshal(managedClusterMigrationFromEvent)

--- a/manager/pkg/migration/migration_registering.go
+++ b/manager/pkg/migration/migration_registering.go
@@ -56,9 +56,9 @@ func (m *ClusterMigrationController) registering(ctx context.Context,
 		}
 	}()
 
-	sourceHubToClusters, err := getSourceClusters(mcm)
-	if err != nil {
-		return false, err
+	sourceHubToClusters := GetSourceClusters(string(mcm.GetUID()))
+	if sourceHubToClusters == nil {
+		return false, fmt.Errorf("Not initialized the source clusters for migrationId: %s", string(mcm.GetUID()))
 	}
 
 	for fromHub := range sourceHubToClusters {

--- a/manager/pkg/migration/migration_validating.go
+++ b/manager/pkg/migration/migration_validating.go
@@ -50,8 +50,8 @@ func (m *ClusterMigrationController) validating(ctx context.Context,
 		if err := m.Client.Status().Update(ctx, mcm); err != nil {
 			return err
 		}
-		// initializing the migration event progress
-		MigrationEventProgressMap[string(mcm.GetUID())] = &MigrationEventProgress{}
+		// initializing the migration status for the instance
+		AddMigrationStatus(string(mcm.GetUID()))
 	}
 
 	// Skip validation if the ResourceValidated is true,

--- a/manager/pkg/status/handlers/clustermigartion/managedclustermigration_handler.go
+++ b/manager/pkg/status/handlers/clustermigartion/managedclustermigration_handler.go
@@ -33,7 +33,7 @@ type managedClusterMigrationHandler struct {
 func RegisterManagedClusterMigrationHandler(mgr ctrl.Manager, conflationManager *conflator.ConflationManager) {
 	k := &managedClusterMigrationHandler{
 		eventType:     string(enum.ManagedClusterMigrationType),
-		eventSyncMode: enum.CompleteStateMode,
+		eventSyncMode: enum.DeltaStateMode, // the migration event is not full bundle, it's an delta event handle one by one
 		eventPriority: conflator.ManagedClusterMigrationPriority,
 		client:        mgr.GetClient(),
 	}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

After migration, the cluster is managed by the target hub. To detach it from the source hub upon successful migration, we need to cache its original location under the source hub.

## Related issue(s)

Fixes # https://issues.redhat.com/browse/ACM-20710

## Tests
* [x] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
