### PR TITLE
adding auto pr review trigger

### DIFF
--- a/.github/scripts/auto_review.py
+++ b/.github/scripts/auto_review.py
@@ -1,0 +1,64 @@
+import os
+import sys
+import json
+from github import Github
+from openai import OpenAI
+
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--pr", type=int, help="PR number to review")
+args = parser.parse_args()
+
+# if args.pr:
+#     pr_number = args.pr
+# else:
+
+pr_number = args.pr
+
+# ─── Load webhook/event payload ───────────────────────────────────────────────
+event_path = os.environ.get("GITHUB_EVENT_PATH")
+if not event_path or not os.path.exists(event_path):
+    print("ERROR: GITHUB_EVENT_PATH not set or invalid", file=sys.stderr)
+    sys.exit(1)
+
+with open(event_path, 'r') as fp:
+    data = json.load(fp)
+    print(data)
+
+
+# sanity check
+if pr_number is None:
+    print("ERROR: Unable to determine PR number", file=sys.stderr)
+    sys.exit(1)
+
+# ─── Initialize GitHub & OpenAI clients ───────────────────────────────────────
+gh = Github(os.environ["GITHUB_TOKEN"])
+repo = gh.get_repo(os.environ["GITHUB_REPOSITORY"])
+pr = repo.get_pull(pr_number)
+
+openai_key = os.environ.get("OPENAI_API_KEY")
+if not openai_key:
+    print("ERROR: OPENAI_API_KEY not set", file=sys.stderr)
+    sys.exit(1)
+client = OpenAI(api_key=openai_key)
+
+# ─── Gather diffs and post comments ────────────────────────────────────────────
+for f in pr.get_files():
+    # only review Python files
+    if not f.filename.endswith(".py") or not f.patch:
+        continue
+
+    diff = f.patch
+    response = client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[
+            {"role": "system", "content": "You are a code review assistant."},
+            {"role": "user", "content": f"Please review this patch and suggest improvements:\n\n```diff\n{diff}\n```"},
+        ]
+    )
+
+    review_text = response.choices[0].message.content.strip()
+    pr.create_review(body=review_text, event="COMMENT")
+
+print(f"✅ Posted review comments on PR #{pr_number}")

--- a/.github/workflows/auto_code_review.yml
+++ b/.github/workflows/auto_code_review.yml
@@ -1,0 +1,41 @@
+# .github/workflows/ai-code-review.yml
+name: AI Code Review
+on:
+  # Automatically trigger on PR events
+  pull_request:
+    types: [opened, synchronize, reopened]
+  # Keep manual trigger option
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'The PR number to review'
+        required: true
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine PR number
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "PR_NUMBER=${{ github.event.number }}" >> $GITHUB_ENV
+          else
+            echo "PR_NUMBER=${{ github.event.inputs.pr_number }}" >> $GITHUB_ENV
+          fi
+      - name: Checkout PR merge ref
+        uses: actions/checkout@v4
+        with:
+          # For pull_request events, checkout the merge commit
+          # For manual dispatch, use the specified PR number
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || format('refs/pull/{0}/merge', env.PR_NUMBER) }}
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install deps
+        run: pip install PyGithub openai
+      - name: Run AI Review
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          python .github/scripts/auto_review.py --pr $PR_NUMBER


### PR DESCRIPTION
## Summary

Adding a worflow to trigger automatic code review. This requires adding a secret called OPENAI_API_KEY. I can add mine if I am allowed the permission.
Henceforth, whenever a PR is `opened, synchronize, reopened` this bot will be called in and code review will be run. This can also be run manually anytime under Actions tab.

In addition to this we should also add code review by sourcery by clicking from here - https://github.com/sourcery-ai/sourcery?tab=readme-ov-file#getting-started. (This also uses openai under the covers).

We should check out both and see which works better. And we can make our code reviewer much smarter - if needed - then what it is now.

## Related issue(s)

Fixes #

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
