### PR TITLE
:bug: Don't install the global hub agent in brownfield mode

### DIFF
--- a/agent/pkg/spec/syncers/migration_from_syncer.go
+++ b/agent/pkg/spec/syncers/migration_from_syncer.go
@@ -401,15 +401,6 @@ func (s *migrationSourceSyncer) SendMigrationResources(ctx context.Context,
 		cluster.Spec.ManagedClusterClientConfigs = nil
 		cluster.Status = clusterv1.ManagedClusterStatus{}
 
-		// Do not deploy globalhub agent in the cluster
-		// hanlde the target cluster is globalhub cluster
-		labels := cluster.GetLabels()
-		if labels == nil {
-			labels = make(map[string]string)
-		}
-		labels[constants.GHAgentDeployModeLabelKey] = constants.GHAgentDeployModeNone
-		cluster.Labels = labels
-
 		// remove migrating and klusterletconfig annotations from managedcluster
 		annotations := cluster.GetAnnotations()
 		if annotations != nil {

--- a/operator/pkg/controllers/agent/addon/default_agent_controller.go
+++ b/operator/pkg/controllers/agent/addon/default_agent_controller.go
@@ -256,13 +256,13 @@ func (r *DefaultAgentController) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, nil
 	}
 
-	// Don't install the global hub agent in the following case:
+	// Don't install the global hub agent in the following cases:
 	//   1. Detaching cluster
-	//   2. Install global hub in brownfield mode, and deploy model label doesn't exists
-	//   3. The cluster have the 'agent-deploy-mode' = None
+	//   2. Install global hub in brownfield mode, and cluster deploy mode label doesn't exists
+	//   3. The cluster have the label 'agent-deploy-mode' = None
 	deployMode, ok := cluster.GetLabels()[constants.GHAgentDeployModeLabelKey]
 	if !cluster.DeletionTimestamp.IsZero() ||
-		(!ok && mgh.Spec.InstallAgentOnLocal) ||
+		(mgh.Spec.InstallAgentOnLocal && !ok) ||
 		deployMode == constants.GHAgentDeployModeNone {
 		log.Infow("deleting resources and addon", "cluster", cluster.Name, "deployMode", deployMode)
 		if err := r.removeResourcesAndAddon(ctx, cluster); err != nil {

--- a/test/e2e/local_agent_test.go
+++ b/test/e2e/local_agent_test.go
@@ -46,19 +46,6 @@ var _ = Describe("Local Agent", Label("e2e-test-local-agent"), Ordered, func() {
 		}, 5*time.Minute, 1*time.Second).Should(Succeed())
 	})
 
-	It("validate the clusters on database", func() {
-		Eventually(func() (err error) {
-			curManagedCluster, err := getManagedCluster(httpClient)
-			if err != nil {
-				return err
-			}
-			if len(curManagedCluster) != (ExpectedMH*ExpectedMC + 2) {
-				return fmt.Errorf("managed cluster number: want %d, got %d", (ExpectedMH*ExpectedMC + 2), len(curManagedCluster))
-			}
-			return nil
-		}, 6*time.Minute, 10*time.Second).ShouldNot(HaveOccurred())
-	})
-
 	It("disable local agent in globalhub", func() {
 		// Wait for the leafhub heartbeat and leafhub info to update
 		Eventually(func() error {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

https://github.com/open-cluster-management-io/ocm/issues/1017

Fixes # https://issues.redhat.com/browse/ACM-21092

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
