### PR TITLE
:bug:  Fix no CSR to approve for cluster issue

### DIFF
--- a/test/script/ocm.sh
+++ b/test/script/ocm.sh
@@ -24,7 +24,7 @@ kind_cluster "$spoken"
 install_crds "$hub"  # router, mch(not needed for the managed clusters)
 install_crds "$spoken" 
 
-retry "(join_cluster $hub $spoken) && kubectl get mcl $spoken --context $hub" 10
+retry "(join_cluster $hub $spoken) && kubectl get mcl $spoken --context $hub" 5
 
 # async
 init_app "$hub" "$spoken" 

--- a/test/script/util.sh
+++ b/test/script/util.sh
@@ -199,7 +199,7 @@ join_cluster() {
     else
       sed -e "s;<cluster_name>;$cluster --context $cluster --wait;" "$join_file" | bash
     fi
-    timeout 5m clusteradm accept --clusters "$2" --context "${hub}" --wait
+    timeout 1m clusteradm accept --clusters "$2" --context "${hub}" --wait
   fi
 }
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

sometimes, we found that the cluster is not ready due to `no CSR to approve for cluster hub2` in e2e. that is because the join command is not executed successfully. we already have the logic to retry, but the `clusteradm accept` wait too long time (5m) so that the kafka and postgres can be ready and the test starts to run.

## Related issue(s)

Fixes #

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
