### PR TITLE
auto review non-py files as well

### DIFF
--- a/.github/scripts/auto_review.py
+++ b/.github/scripts/auto_review.py
@@ -50,8 +50,8 @@ for f in pr.get_files():
         print(f"⏭️  Skipping workflow file: {f.filename}")
         continue
     
-    # Only review Python files with changes
-    if not f.filename.endswith(".py") or not f.patch:
+    # Review all files with changes
+    if not f.patch:
         continue
 
     diff = f.patch


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
The Auto review PR was only looking for python files. Removing that filter.

## Related issue(s)
You can see that it ran successfully being able to read all secrets - https://github.com/stolostron/multicluster-global-hub/actions/runs/15337707328
But did not report anything as it did not review any files because it was looking for python files only.
Fixes #

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
