### PR TITLE
:bug:  Fix app is not ready

### DIFF
--- a/test/script/util.sh
+++ b/test/script/util.sh
@@ -220,7 +220,7 @@ init_app() {
   fi
 
   # enable the addon on the managed clusters
-  clusteradm addon enable --names application-manager --clusters "$cluster" --context "$hub"
+  retry "clusteradm addon enable --names application-manager --clusters $cluster --context $hub" 10
 }
 
 init_policy() {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

fix the app cannot be ready.
```
 🙊 Waiting 562 seconds: kubectl get deploy/application-manager -n open-cluster-management-agent-addon --context hub2Error from server (NotFound): deployments.apps "application-manager" not found
```
the problem is that when enable app addon, the cluster namespace is not there.

## Related issue(s)

Fixes #

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
