### PR TITLE
:bug: use pull_request_target instead

### DIFF
--- a/.github/workflows/auto_code_review.yml
+++ b/.github/workflows/auto_code_review.yml
@@ -2,8 +2,9 @@
 name: AI Code Review
 on:
   # Automatically trigger on PR events
-  pull_request:
-    types: [opened, synchronize, reopened]
+    pull_request_target:
+    branches:
+      - main
     paths-ignore:
       - '.github/workflows/**'
       - '.github/scripts/**'


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

ref: https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#using-secrets-in-a-workflow

> With the exception of GITHUB_TOKEN, secrets are not passed to the runner when a workflow is triggered from a forked repository.

try to use pull_request_target with manual approval.

## Related issue(s)

Fixes #

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
