### PR TITLE
:seedling: Correct the registering error message

### DIFF
--- a/agent/pkg/spec/syncers/migration_to_syncer.go
+++ b/agent/pkg/spec/syncers/migration_to_syncer.go
@@ -111,7 +111,7 @@ func (s *migrationTargetSyncer) Sync(ctx context.Context, evt *cloudevents.Event
 				// the reportErrMessage record the detailed information why the registering failed,
 				// if registered successfully, remove the record error message during the registering
 				if err != nil {
-					reportErrMessage = fmt.Sprintf("failed to register clusters %s: %s", err.Error(), reportErrMessage)
+					reportErrMessage = fmt.Sprintf("registering %s - %s", err.Error(), reportErrMessage)
 				}
 
 				err = ReportMigrationStatus(
@@ -235,7 +235,7 @@ func (s *migrationTargetSyncer) registering(ctx context.Context,
 	}
 
 	if len(notAvailableManagedClusters) > 0 {
-		return fmt.Errorf("manifestwork(cluster-klusterlet) are not applied: %v", notAvailableManagedClusters)
+		return fmt.Errorf("manifestwork(*-klusterlet) are not applied in these clusters: %v", notAvailableManagedClusters)
 	}
 	return nil
 }

--- a/agent/pkg/spec/syncers/migration_to_syncer_test.go
+++ b/agent/pkg/spec/syncers/migration_to_syncer_test.go
@@ -850,6 +850,7 @@ func TestDeploying(t *testing.T) {
 	assert.Equal(t, "secret", secret.StringData["test"])
 }
 
+// go test -timeout 30s -run ^TestRegistering$ github.com/stolostron/multicluster-global-hub/agent/pkg/spec/syncers -v
 func TestRegistering(t *testing.T) {
 	ctx := context.Background()
 	scheme := configs.GetRuntimeScheme()
@@ -969,7 +970,7 @@ func TestRegistering(t *testing.T) {
 			migrationEvent: &migration.ManagedClusterMigrationToEvent{
 				ManagedClusters: []string{"cluster1", "cluster2"},
 			},
-			expectedError: "manifestworks.work.open-cluster-management.io \"cluster2-klusterlet\" not found",
+			expectedError: "manifestwork(*-klusterlet) are not applied in these clusters: [cluster2]",
 		},
 	}
 

--- a/agent/pkg/spec/syncers/migration_to_syncer_test.go
+++ b/agent/pkg/spec/syncers/migration_to_syncer_test.go
@@ -981,8 +981,7 @@ func TestRegistering(t *testing.T) {
 
 			managedClusterMigrationSyncer := NewMigrationTargetSyncer(fakeClient, nil, nil)
 
-			notAvailableManagedClusters := []string{}
-			err := managedClusterMigrationSyncer.registering(ctx, c.migrationEvent, notAvailableManagedClusters)
+			err := managedClusterMigrationSyncer.registering(ctx, c.migrationEvent)
 			if c.expectedError == "" {
 				assert.Nil(t, err)
 			} else {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This pr fix the error message in registering condition like
```yaml
  - lastTransitionTime: "2025-06-03T09:38:48Z"
    message: 'register to hub local-cluster with error: failed to register these clusters
      []: works aren''t applied: [clc-iks-969-qnprf-iks]'
    reason: Timeout
    status: "False"
    type: ClusterRegistered
```
the correct registering error message:
```yaml
  - lastTransitionTime: "2025-06-03T09:38:48Z"
    message: 'register to hub local-cluster with error: registering "timeout" - manifestwork(*-klusterlet) are not applied in these clusters: [clc-iks-969-qnprf-iks]'
    reason: Timeout
    status: "False"
    type: ClusterRegistered
```

But the root reason for the error is the manifestwork not ready after 10 minutes, the agent log from the target hub

```bash
2025-06-03T09:38:48.426Z	INFO	syncers/migration_to_syncer.go:98	registering managed cluster migration
2025-06-03T09:38:48.528Z	INFO	syncers/migration_to_syncer.go:230	work clc-iks-969-qnprf-iks-klusterlet is not applied
2025-06-03T09:38:48.528Z	INFO	syncers/migration_to_syncer.go:104	waiting the migrating clusters are available: works aren't applied: [clc-iks-969-qnprf-iks]
...
2025-06-03T09:48:38.427Z	INFO	syncers/migration_to_syncer.go:104	waiting the migrating clusters are available: works aren't applied: [clc-iks-969-qnprf-iks]
2025-06-03T09:48:48.427Z	INFO	syncers/migration_to_syncer.go:230	work clc-iks-969-qnprf-iks-klusterlet is not applied
2025-06-03T09:48:48.427Z	INFO	syncers/migration_to_syncer.go:104	waiting the migrating clusters are available: works aren't applied: [clc-iks-969-qnprf-iks]
2025-06-03T09:48:48.427Z	INFO	syncers/migration_to_syncer.go:130	finished registering clusters
```

The klustelet manifestwork for the migrating cluster:

```yaml
apiVersion: work.open-cluster-management.io/v1
kind: ManifestWork
metadata:
  creationTimestamp: "2025-06-03T09:38:44Z"
  finalizers:
  - cluster.open-cluster-management.io/manifest-work-cleanup
  generation: 2
  labels:
    import.open-cluster-management.io/klusterlet-works: "true"
  name: clc-iks-969-qnprf-iks-klusterlet
  namespace: clc-iks-969-qnprf-iks
  ownerReferences:
  - apiVersion: cluster.open-cluster-management.io/v1
    blockOwnerDeletion: true
    controller: true
    kind: ManagedCluster
    name: clc-iks-969-qnprf-iks
    uid: 665d9c5c-f6ef-4f83-a120-f16d84f1e64d
  resourceVersion: "1116172"
  uid: a5ea1f72-bdb9-47b2-af6a-44dac1ce2aa3
spec:
  deleteOption:
    propagationPolicy: Orphan
  workload:
    manifests:
    ...
status:
  conditions:
  - lastTransitionTime: "2025-06-03T10:02:23Z"
    message: Apply manifest work complete
    observedGeneration: 2
    reason: AppliedManifestWorkComplete
    status: "True"
    type: Applied
  - lastTransitionTime: "2025-06-03T09:39:37Z"
    message: All resources are available
    observedGeneration: 2
    reason: ResourcesAvailable
    status: "True"
    type: Available
```

## Related issue(s)

Fixes # https://issues.redhat.com/browse/ACM-21232

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
