### PR TITLE
:bug: skip cleanup when the migration is not initialized

### DIFF
--- a/manager/pkg/migration/migration_cleaning.go
+++ b/manager/pkg/migration/migration_cleaning.go
@@ -38,6 +38,12 @@ func (m *ClusterMigrationController) completed(ctx context.Context,
 		return false, nil
 	}
 
+	sourceHubClusters := GetSourceClusters(string(mcm.GetUID()))
+	if sourceHubClusters == nil {
+		log.Infof("skipping cleanup: migration %q not initialized", mcm.Name)
+		return false, nil
+	}
+
 	log.Infof("migration start cleaning: %s - %s", mcm.Name, mcm.Status.Phase)
 
 	var err error
@@ -77,13 +83,6 @@ func (m *ClusterMigrationController) completed(ctx context.Context,
 	if err := m.deleteManagedServiceAccount(ctx, mcm); err != nil {
 		log.Errorf("failed to delete the managedServiceAccount: %s/%s", mcm.Spec.To, mcm.Name)
 		return false, err
-	}
-
-	sourceHubClusters := GetSourceClusters(string(mcm.GetUID()))
-	if sourceHubClusters == nil {
-		condMsg = "Skipping cleanup: the migration has not been initialized."
-		succeed = true
-		return false, nil
 	}
 
 	// cleanup the source hub: cleaning or failed state

--- a/manager/pkg/migration/migration_cleaning.go
+++ b/manager/pkg/migration/migration_cleaning.go
@@ -38,12 +38,6 @@ func (m *ClusterMigrationController) completed(ctx context.Context,
 		return false, nil
 	}
 
-	sourceHubClusters := GetSourceClusters(string(mcm.GetUID()))
-	if sourceHubClusters == nil {
-		log.Infof("skipping cleanup: migration %q not initialized", mcm.Name)
-		return false, nil
-	}
-
 	log.Infof("migration start cleaning: %s - %s", mcm.Name, mcm.Status.Phase)
 
 	var err error
@@ -77,6 +71,13 @@ func (m *ClusterMigrationController) completed(ctx context.Context,
 			log.Errorf("failed to update the condition %v", err)
 		}
 	}()
+
+	sourceHubClusters := GetSourceClusters(string(mcm.GetUID()))
+	if sourceHubClusters == nil {
+		log.Infof("skipping cleanup: migration %q not initialized", mcm.Name)
+		succeed = true
+		return false, nil
+	}
 
 	// Deleting the ManagedServiceAccount will revoke the bootstrap kubeconfig secret of the migrated cluster.
 	// Be cautious — this action may carry potential risks.


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)
https://issues.redhat.com/browse/ACM-21114
Fixes #

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
