### PR TITLE
validate configmap 

### DIFF
--- a/manager/pkg/migration/migration_validating.go
+++ b/manager/pkg/migration/migration_validating.go
@@ -30,8 +30,8 @@ var AllowedKinds = map[string]bool{
 	"secret":    true,
 }
 
-// Kubernetes DNS-1123 label regex for name and namespace
-var dns1123LabelRegex = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
+// DNS Subdomain (RFC 1123) — for ConfigMap, Secret, Namespace, etc.
+var dns1123SubdomainRegex = regexp.MustCompile(`^[a-z0-9]([-a-z0-9\.]*[a-z0-9])?$`)
 
 // Validation:
 // 1. Verify if the migrating clusters exist in the current hubs
@@ -180,10 +180,10 @@ func IsValidResource(resource string) error {
 	if !AllowedKinds[kind] {
 		return fmt.Errorf("unsupported kind: %s", kind)
 	}
-	if !dns1123LabelRegex.MatchString(ns) {
+	if !dns1123SubdomainRegex.MatchString(ns) {
 		return fmt.Errorf("invalid namespace: %s", ns)
 	}
-	if !dns1123LabelRegex.MatchString(name) {
+	if !dns1123SubdomainRegex.MatchString(name) {
 		return fmt.Errorf("invalid name: %s", name)
 	}
 	return nil

--- a/manager/pkg/migration/migration_validating_test.go
+++ b/manager/pkg/migration/migration_validating_test.go
@@ -3,40 +3,37 @@ package migration
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-// go test -run ^TestIsValidResource$ github.com/stolostron/multicluster-global-hub/manager/pkg/migration -v
+// go test -run ^TestIsValidResource$ ./manager/pkg/migration -v
 func TestIsValidResource(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
-		wantErr  bool
 		errorMsg string
 	}{
-		{"valid configmap", "configmap/default/my-config", false, ""},
-		{"valid secret with wildcard", "secret/ns1/*", true, "invalid name"},
-		{"invalid format", "configmap/default", true, "invalid format"},
-		{"unsupported kind", "pod/ns1/name1", true, "unsupported kind"},
-		{"invalid namespace", "configmap/Inv@lid/ns", true, "invalid namespace"},
-		{"invalid name", "secret/default/Invalid*", true, "invalid name"},
-		{"invalid wildcard placement", "secret/ns1/na*me", true, "invalid name"},
-		{"empty name with wildcard char", "secret/ns1/*x", true, "invalid name"},
+		{"valid configmap within dot", "configmap/default/kube-root-ca.crt", ""},
+		{"invalid configmap prefix dot", "configmap/default/.kube-root-ca.crt ", "invalid name: .kube-root-ca.crt"},
+		{"valid configmap", "configmap/default/my-config", ""},
+		{"valid secret with wildcard", "secret/ns1/*", "invalid name: *"},
+		{"invalid format", "configmap/default", "invalid format (must be kind/namespace/name): configmap/default"},
+		{"unsupported kind", "pod/ns1/name1", "unsupported kind: pod"},
+		{"invalid namespace", "configmap/Inv@lid/ns", "invalid namespace: Inv@lid"},
+		{"invalid name", "secret/default/Invalid*", "invalid name: Invalid*"},
+		{"invalid wildcard placement", "secret/ns1/na*me", "invalid name: na*me"},
+		{"empty name with wildcard char", "secret/ns1/*x", "invalid name: *x"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := IsValidResource(tt.input)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("expected error=%v, got error=%v", tt.wantErr, err)
+			actualErrMessage := ""
+			if err != nil {
+				actualErrMessage = err.Error()
 			}
-			if tt.wantErr && err != nil && !contains(err.Error(), tt.errorMsg) {
-				t.Errorf("expected error message to contain '%s', got '%s'", tt.errorMsg, err.Error())
-			}
+			require.Equal(t, strings.TrimSpace(tt.errorMsg), strings.TrimSpace(actualErrMessage), tt.name)
 		})
 	}
-}
-
-// helper for substring match
-func contains(s, substr string) bool {
-	return strings.Contains(s, substr)
 }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

1. use the DNS Subdomain (RFC 1123) to validate the configmap, secret and namespace name

## Related issue(s)

Fixes #

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
