### PR TITLE
:bug: Need to wait until the cleanup is done

### DIFF
--- a/manager/pkg/migration/migration_eventstatus.go
+++ b/manager/pkg/migration/migration_eventstatus.go
@@ -116,22 +116,27 @@ func SetErrorMessage(migrationId, hub, phase, errMessage string) {
 func GetStarted(migrationId, hub, phase string) bool {
 	mu.RLock()
 	defer mu.RUnlock()
-	p := getProgress(migrationId, hub, phase)
-	return p.started
+	if p := getProgress(migrationId, hub, phase); p != nil {
+		return p.started
+	}
+	return false
 }
 
 // GetFinished returns true if the status of the given stage is finished for the hub cluster
 func GetFinished(migrationId, hub, phase string) bool {
 	mu.RLock()
 	defer mu.RUnlock()
-	p := getProgress(migrationId, hub, phase)
-	return p.finished
+	if p := getProgress(migrationId, hub, phase); p != nil {
+		return p.finished
+	}
+	return false
 }
 
 func GetErrorMessage(migrationId, hub, phase string) string {
 	mu.RLock()
 	defer mu.RUnlock()
-	p := getProgress(migrationId, hub, phase)
-
-	return p.error
+	if p := getProgress(migrationId, hub, phase); p != nil {
+		return p.error
+	}
+	return ""
 }

--- a/test/script/kessel_e2e_setup.sh
+++ b/test/script/kessel_e2e_setup.sh
@@ -13,7 +13,7 @@ source "$CURRENT_DIR/util.sh"
 
 cluster_name="global-hub-kessel"
 
-kind_cluster $cluster_name
+kind_cluster $cluster_name "kindest/node:v1.32.2"
 install_crds $cluster_name false
 enable_service_ca $cluster_name "$TEST_DIR/manifest"
 enable_olm $cluster_name

--- a/test/script/util.sh
+++ b/test/script/util.sh
@@ -113,10 +113,11 @@ check_kind() {
 kind_cluster() {
   dir="${CONFIG_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
   local cluster_name="$1"
-  local kind_image="$2"
   local kubeconfig="$dir/$cluster_name"
   local max_retries=5
   local counter=0
+  local kind_image="${2:-}"
+
   while [ $counter -lt $max_retries ] && ! (kind get clusters 2>/dev/null | grep -xq "$cluster_name"); do
     echo "creating cluster $cluster_name"
     ensure_cluster "$cluster_name" "$kubeconfig" "$kind_image"

--- a/test/script/util.sh
+++ b/test/script/util.sh
@@ -113,12 +113,13 @@ check_kind() {
 kind_cluster() {
   dir="${CONFIG_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
   local cluster_name="$1"
+  local kind_image="$2"
   local kubeconfig="$dir/$cluster_name"
   local max_retries=5
   local counter=0
   while [ $counter -lt $max_retries ] && ! (kind get clusters 2>/dev/null | grep -xq "$cluster_name"); do
     echo "creating cluster $cluster_name"
-    ensure_cluster "$cluster_name" "$kubeconfig"
+    ensure_cluster "$cluster_name" "$kubeconfig" "$kind_image"
     counter=$((counter + 1))
   done
   if [ $counter -eq $max_retries ]; then
@@ -131,12 +132,17 @@ kind_cluster() {
 ensure_cluster() {
   local cluster_name="$1"
   local kubeconfig="$2"
+  local kind_image="$3"
 
   if kind get clusters 2>/dev/null | grep -xq "$cluster_name"; then
     kind delete cluster --name="$cluster_name"
   fi
 
-  kind create cluster --name "$cluster_name" --wait 5m
+  if [ -n "$kind_image" ]; then
+    kind create cluster --name "$cluster_name" --image "$kind_image" --wait 5m
+  else
+    kind create cluster --name "$cluster_name" --wait 5m
+  fi
 
   # modify the context = KinD cluster name = kubeconfig name
   kubectl config delete-context "$cluster_name" 2>/dev/null || true


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

the root cause is the message is dropped. refer to this info `conflator/conflation_unit.go:68 the conflationElement predication is false      {"event": "Context Attributes,\n  specversion: 1.0\n  type: io.open-cluster-management.operator.multiclusterglobalhubs.managedclustermigration\n  source: local-cluster\n  id: 2f090ebd-29a1-42f8-bff3-9fc00db9ec6a\n  time: 2025-06-10T06:33:36.025868688Z\n  datacontenttype: application/json\nExtensions,\n  clustername: global-hub\n  extversion: 1.2\n  kafkamessagekey: io.open-cluster-management.operator.multiclusterglobalhubs.managedclustermigration\n  kafkaoffset: 2008\n  kafkapartition: 0\n  kafkatopic: gh-status.local-cluster\nData,\n  {\n    \"migrationId\": \"e49d44d5-4ae3-458f-b84e-74cb38bb8cab\",\n    \"stage\": \"ResourceDeployed\"\n  }\n"}`

that is because the previous migration is not completed so that the `extversion` can be set as a value which is greater than `1.2`. when received this message, the extversion is less than the last one, this message can be dropped.

the solution is to wait until the cleanup is done.

## Related issue(s)

Fixes # https://issues.redhat.com/browse/ACM-21331

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
