### PR TITLE
do not change local-cluster addon ns in hosted mode

### DIFF
--- a/operator/pkg/controllers/agent/addon/hosted_agent_controller.go
+++ b/operator/pkg/controllers/agent/addon/hosted_agent_controller.go
@@ -172,6 +172,12 @@ func (r *HostedAgentController) Reconcile(ctx context.Context, req ctrl.Request)
 		log.Errorf("Failed to get managed cluster %s, err:%v", req.NamespacedName.Namespace, err)
 		return ctrl.Result{}, err
 	}
+
+	// If the cluster is local cluster, skip the reconcile
+	if mc.Labels[constants.LocalClusterName] == "true" {
+		return ctrl.Result{}, nil
+	}
+
 	isHosted := false
 	needUpdate := false
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

this case is add `deploy-mode` label to local-cluster so that the namespace is updated.

## Related issue(s)
https://issues.redhat.com/browse/ACM-21516
Fixes #

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
