### PR TITLE
trigger cleanup when the deploying failed with timeout

### DIFF
--- a/manager/pkg/migration/migration_eventstatus.go
+++ b/manager/pkg/migration/migration_eventstatus.go
@@ -11,8 +11,36 @@ var (
 )
 
 type MigrationStatus struct {
-	Progress map[string]*MigrationProgress // key: hub-phase
-	Clusters map[string][]string           // key: source hub -> clusters
+	Progress       map[string]*MigrationProgress // key: hub-phase
+	Clusters       map[string][]string           // key: source hub -> clusters
+	RequireCleanup bool
+}
+
+// ToCleanup indicates whether the cleanup stage should be started.
+func ToCleanup(migrationId string) bool {
+	status := getMigrationStatus(migrationId)
+	if status == nil {
+		return false
+	}
+	return status.RequireCleanup
+}
+
+// SetCleanup determines whether the cleanup stage should be triggered.
+//
+//	true:
+//	  1. Registering is complete.
+//	  2. Initialing, deploying, or registering has failed due to a timeout.
+//
+//	false:
+//	  1. Cleaning condition with timed out.
+//	  2. Cleaning has completed successfully.
+func SetCleanup(migrationId string, required bool) {
+	status := getMigrationStatus(migrationId)
+	if status == nil {
+		log.Warnf("not get the status for the migration cleanup: %s", migrationId)
+		return
+	}
+	status.RequireCleanup = required
 }
 
 type MigrationProgress struct {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
```bash
  status:
    conditions:
    - lastTransitionTime: "2025-06-18T06:53:54Z"
      message: Migration resources have been validated
      reason: ResourceValidated
      status: "True"
      type: ResourceValidated
    - lastTransitionTime: "2025-06-18T06:53:59Z"
      message: All source and target hubs have been successfully initialized
      reason: ResourceInitialized
      status: "True"
      type: ResourceInitialized
    - lastTransitionTime: "2025-06-18T06:53:59Z"
      message: 'deploying source hub hub2 error: failed to get configmap default/foo:
        configmaps "foo" not found'
      reason: Timeout
      status: "False"
      type: ResourceDeployed
    - lastTransitionTime: "2025-06-18T06:59:36Z"
      message: Resources have been successfully cleaned up from the hub clusters
      reason: ResourceCleaned
      status: "True"
      type: ResourceCleaned
    phase: Failed
```

## Related issue(s)

Fixes # https://issues.redhat.com/browse/ACM-21572

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
