### PR TITLE
:bug: trigger cleaning up process if previous stage failed with timeout

### DIFF
--- a/manager/pkg/migration/migration_cleaning.go
+++ b/manager/pkg/migration/migration_cleaning.go
@@ -53,7 +53,7 @@ func (m *ClusterMigrationController) completed(ctx context.Context,
 			condStatus = metav1.ConditionTrue
 			condReason = conditionReasonResourceCleaned
 			condMsg = "Resources have been successfully cleaned up from the hub clusters"
-		} else if time.Since(mcm.CreationTimestamp.Time) > migrationStageTimeout {
+		} else if time.Since(mcm.CreationTimestamp.Time) > migrationStageTimeout+migrationStageTimeout {
 			// If clean timeout, update the condition
 			errMessage := "cleanup timeout. "
 			if err != nil {

--- a/manager/pkg/migration/migration_controller.go
+++ b/manager/pkg/migration/migration_controller.go
@@ -221,6 +221,10 @@ func (m *ClusterMigrationController) getCurrentMigration(ctx context.Context,
 		// skip the migration which is failed and cleaned
 		if migration.Status.Phase == migrationv1alpha1.PhaseFailed &&
 			meta.FindStatusCondition(migration.Status.Conditions, migrationv1alpha1.ConditionTypeCleaned) != nil {
+			// Deprecated: if not started, means the clean condition is added for the placeholder, like validating failed
+			if !GetStarted(string(migration.GetUID()), migration.Spec.To, migrationv1alpha1.PhaseCleaning) {
+				continue
+			}
 			// Need to wait until the cleanup is done, otherwise we may meet the message is dropped
 			// due to the version is not newer than the previous one.
 			isCleanCompleted := true

--- a/manager/pkg/migration/migration_controller_test.go
+++ b/manager/pkg/migration/migration_controller_test.go
@@ -47,27 +47,6 @@ func TestGetCurrentMigration(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "Should not skip the failed migration since it is not completed",
-			migrations: []migrationv1alpha1.ManagedClusterMigration{
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "migration2"},
-					Status: migrationv1alpha1.ManagedClusterMigrationStatus{
-						Phase: migrationv1alpha1.PhaseFailed,
-						Conditions: []metav1.Condition{
-							{
-								Type:    migrationv1alpha1.ConditionTypeCleaned,
-								Status:  metav1.ConditionTrue,
-								Reason:  "ResourceCleaned",
-								Message: "Resources have been cleaned from the hub clusters",
-							},
-						},
-					},
-				},
-			},
-			expectedName:  "migration2",
-			expectedError: false,
-		},
-		{
 			name: "Should skip the failed migration since it was completed",
 			migrations: []migrationv1alpha1.ManagedClusterMigration{
 				{


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

1. trigger cleanup process if previous stage failed with timeout 
2. fix the issue that migration cr always pending even if the cleaning stage don't start(validating error)

## Related issue(s)

Fixes # https://issues.redhat.com/browse/ACM-21572

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
