### PR TITLE
fix issue: can not enable local-cluster when globalhub installed

### DIFF
--- a/operator/pkg/webhook/admission_handler.go
+++ b/operator/pkg/webhook/admission_handler.go
@@ -10,10 +10,10 @@ import (
 	"net/http"
 
 	addonv1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -162,14 +162,25 @@ func getLocalClusterName(ctx context.Context, client client.Client) (string, err
 // isInHostedCluster check if the cluster has hosted annotations
 func (a *admissionHandler) isInHostedCluster(ctx context.Context, client client.Client, mcName string) (bool, error) {
 	mc := &clusterv1.ManagedCluster{}
-	err := client.Get(ctx, types.NamespacedName{Name: mcName}, mc)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return false, nil
+
+	// Retry to get the managed cluster, since it may not be created yet
+	err := retry.OnError(retry.DefaultBackoff, func(err error) bool {
+		if err != nil {
+			log.Warnf("failed to get managedcluster, err:%v", err)
+			return true
 		}
-		errMsg := fmt.Errorf("failed to get managedcluster, err:%v", err)
-		log.Errorf(errMsg.Error())
-		return false, errMsg
+		return false
+	},
+		func() error {
+			err := client.Get(ctx, types.NamespacedName{Name: mcName}, mc)
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		return false, fmt.Errorf("failed to get managedcluster %s, err: %v", mcName, err)
 	}
 
 	if (mc.Annotations[constants.AnnotationClusterDeployMode] == constants.ClusterDeployModeHosted) &&

--- a/operator/pkg/webhook/admission_handler.go
+++ b/operator/pkg/webhook/admission_handler.go
@@ -52,10 +52,6 @@ func (a *admissionHandler) Handle(ctx context.Context, req admission.Request) ad
 			return admission.Errored(http.StatusBadRequest, err)
 		}
 
-		if klusterletaddonconfig.Spec.ClusterLabels[constants.LocalClusterName] == "true" {
-			return admission.Allowed("")
-		}
-
 		// only handle hosted clusters
 		isHosted, err := a.isInHostedCluster(ctx, a.client, klusterletaddonconfig.Namespace)
 		if err != nil {
@@ -169,7 +165,7 @@ func (a *admissionHandler) isInHostedCluster(ctx context.Context, client client.
 	err := client.Get(ctx, types.NamespacedName{Name: mcName}, mc)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			return true, nil
+			return false, nil
 		}
 		errMsg := fmt.Errorf("failed to get managedcluster, err:%v", err)
 		log.Errorf(errMsg.Error())

--- a/operator/pkg/webhook/admission_handler_test.go
+++ b/operator/pkg/webhook/admission_handler_test.go
@@ -178,7 +178,7 @@ func Test_isInHostedCluster(t *testing.T) {
 					Name: "test-not",
 				},
 			},
-			want: true,
+			want: false,
 		},
 		{
 			name: "has annotation, but not hosted",

--- a/test/integration/operator/webhook/admission_handler_test.go
+++ b/test/integration/operator/webhook/admission_handler_test.go
@@ -9,30 +9,47 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	addonv1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
-	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
+
+var testmanagedcluster = &clusterv1.ManagedCluster{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "mc1",
+		Labels: map[string]string{
+			// global hub featuregate for klusterlet hosted, this label for addon hosted
+			constants.GHDeployModeLabelKey: constants.GHDeployModeHosted,
+		},
+		Annotations: map[string]string{},
+	},
+}
+
+var klusterletConfig = &addonv1.KlusterletAddonConfig{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "mc1",
+		Namespace: "mc1",
+	},
+	Spec: addonv1.KlusterletAddonConfigSpec{
+		ApplicationManagerConfig: addonv1.KlusterletAddonAgentConfigSpec{
+			Enabled: true,
+		},
+		PolicyController: addonv1.KlusterletAddonAgentConfigSpec{
+			Enabled: true,
+		},
+		CertPolicyControllerConfig: addonv1.KlusterletAddonAgentConfigSpec{
+			Enabled: true,
+		},
+	},
+}
 
 var _ = Describe("Multicluster hub webhook", func() {
 	Context("Test managedclusters are handled by the global hub manager webhook", Ordered, func() {
 		It("managedcluster should be added the hosted annotations", func() {
-			testmanagedcluster := &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "test-mc-",
-					Namespace:    utils.GetDefaultNamespace(),
-					Labels: map[string]string{
-						// global hub featuregate for klusterlet hosted, this label for addon hosted
-						constants.GHDeployModeLabelKey: constants.GHDeployModeHosted,
-					},
-					Annotations: map[string]string{},
-				},
-			}
-
 			Eventually(func() bool {
 				if err := c.Create(ctx, testmanagedcluster, &client.CreateOptions{}); err != nil {
 					return false
@@ -54,23 +71,11 @@ var _ = Describe("Multicluster hub webhook", func() {
 
 	Context("Test klusterletaddonconfig are handled by the global hub manager webhook", Ordered, func() {
 		It("klusterletaddonconfig should be added the hosted annotations", func() {
-			klusterletConfig := &addonv1.KlusterletAddonConfig{
+			Expect(c.Create(ctx, &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "default",
+					Name: "mc1",
 				},
-				Spec: addonv1.KlusterletAddonConfigSpec{
-					ApplicationManagerConfig: addonv1.KlusterletAddonAgentConfigSpec{
-						Enabled: true,
-					},
-					PolicyController: addonv1.KlusterletAddonAgentConfigSpec{
-						Enabled: true,
-					},
-					CertPolicyControllerConfig: addonv1.KlusterletAddonAgentConfigSpec{
-						Enabled: true,
-					},
-				},
-			}
+			})).To(Succeed())
 
 			Eventually(func() bool {
 				if err := c.Create(ctx, klusterletConfig, &client.CreateOptions{}); err != nil {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
when MCE enable local-cluster, the klusterletaddonconfig created before the managedcluster cr created, so we should allow the request if the managedcluster is not found.
## Related issue(s)
https://issues.redhat.com/browse/ACM-21723
Fixes #

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
