### PR TITLE
:sparkles: Add the resync queue for the streaming-based bundle 

### DIFF
--- a/agent/pkg/configs/resync_config.go
+++ b/agent/pkg/configs/resync_config.go
@@ -1,0 +1,30 @@
+package configs
+
+import "sync"
+
+type ResyncTypeQueue struct {
+	mu    sync.Mutex
+	queue []string
+}
+
+// GlobalResyncQueue is a ready-to-use, globally accessible queue.
+var GlobalResyncQueue = &ResyncTypeQueue{}
+
+// Add appends a type to the end of the queue
+func (q *ResyncTypeQueue) Add(t string) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.queue = append(q.queue, t)
+}
+
+// Pop removes and returns the first element in the queue. Returns empty string if empty.
+func (q *ResyncTypeQueue) Pop() string {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if len(q.queue) == 0 {
+		return ""
+	}
+	t := q.queue[0]
+	q.queue = q.queue[1:]
+	return t
+}

--- a/agent/pkg/configs/resync_config_test.go
+++ b/agent/pkg/configs/resync_config_test.go
@@ -1,0 +1,39 @@
+package configs
+
+import (
+	"testing"
+)
+
+func TestResyncTypeQueue_Basic(t *testing.T) {
+	queue := &ResyncTypeQueue{}
+
+	// Test empty queue
+	if queue.Pop() != "" {
+		t.Error("Empty queue should return empty string")
+	}
+
+	// Test add and pop
+	queue.Add("test1")
+	queue.Add("test2")
+
+	if queue.Pop() != "test1" {
+		t.Error("Should return first item")
+	}
+	if queue.Pop() != "test2" {
+		t.Error("Should return second item")
+	}
+	if queue.Pop() != "" {
+		t.Error("Empty queue should return empty string")
+	}
+}
+
+func TestGlobalResyncQueue(t *testing.T) {
+	if GlobalResyncQueue == nil {
+		t.Error("GlobalResyncQueue should not be nil")
+	}
+
+	GlobalResyncQueue.Add("test")
+	if GlobalResyncQueue.Pop() != "test" {
+		t.Error("Global queue should work")
+	}
+}

--- a/agent/pkg/spec/syncers/resync_syncer.go
+++ b/agent/pkg/spec/syncers/resync_syncer.go
@@ -7,7 +7,9 @@ import (
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"go.uber.org/zap"
 
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/configs"
 	"github.com/stolostron/multicluster-global-hub/pkg/bundle/version"
+	"github.com/stolostron/multicluster-global-hub/pkg/enum"
 	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 )
 
@@ -38,11 +40,13 @@ func (s *resyncer) Sync(ctx context.Context, evt *cloudevents.Event) error {
 	}
 
 	for _, eventType := range eventTypes {
-		s.log.Info("resync event", "type", eventType)
+		s.log.Infow("resyncing event type", "eventType", enum.ShortenEventType(eventType))
+		configs.GlobalResyncQueue.Add(eventType)
+		// deprecated
 		resyncVersion, ok := registeredResyncTypes[eventType]
 		if !ok {
-			s.log.Warn("not support to resync the current resource type", "event key", eventType)
-			return nil
+			s.log.Infof("event type %s is not registered for resync", eventType)
+			continue
 		}
 		resyncVersion.Incr()
 	}

--- a/pkg/enum/event_type.go
+++ b/pkg/enum/event_type.go
@@ -1,5 +1,7 @@
 package enum
 
+import "strings"
+
 const EventTypePrefix = "io.open-cluster-management.operator.multiclusterglobalhubs."
 
 type EventType string
@@ -40,3 +42,7 @@ const (
 	// Used to send security alerts:
 	SecurityAlertCountsType EventType = EventTypePrefix + "security.alertcounts"
 )
+
+func ShortenEventType(eventType string) string {
+	return strings.Replace(eventType, EventTypePrefix, "", -1)
+}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary


Previously, the agent held the entire bundle in memory and triggered resyncs by updating the bundle version.

With the streaming-based approach, resyncing involves listing resources, converting them into bundles, and sending them. A `ResyncQueue` object tracks resync progress, and a periodic syncer uses the resync queue to drive both sync and resync operations.

## Related issue(s)

Fixes #

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
