### PR TITLE
:sparkles: Ensure the managed cluster is available when registering failed

### DIFF
--- a/agent/pkg/spec/syncers/migration_from_syncer.go
+++ b/agent/pkg/spec/syncers/migration_from_syncer.go
@@ -604,7 +604,7 @@ func (s *MigrationSourceSyncer) rollbackRegistering(ctx context.Context, spec *m
 			if mc.Spec.HubAcceptsClient {
 				return nil
 			}
-			mc.Spec.HubAcceptsClient = false
+			mc.Spec.HubAcceptsClient = true
 			return s.client.Update(ctx, mc)
 		})
 		if err != nil {

--- a/agent/pkg/spec/syncers/migration_to_syncer.go
+++ b/agent/pkg/spec/syncers/migration_to_syncer.go
@@ -702,9 +702,6 @@ func (s *MigrationTargetSyncer) rollbackDeploying(ctx context.Context, spec *mig
 // rollbackRegistering handles rollback of registering phase on target hub
 func (s *MigrationTargetSyncer) rollbackRegistering(ctx context.Context, spec *migration.MigrationTargetBundle) error {
 	log.Infof("rollback registering stage for clusters: %v", spec.ManagedClusters)
-
-	// For registering rollback, we need to do similar cleanup as deploying
-	// since clusters might have been partially registered
 	return s.rollbackDeploying(ctx, spec)
 }
 

--- a/manager/pkg/migration/migration_validating_test.go
+++ b/manager/pkg/migration/migration_validating_test.go
@@ -403,7 +403,7 @@ func TestValidatingEdgeCases(t *testing.T) {
 
 func TestGetAndValidateHubCluster(t *testing.T) {
 	scheme := runtime.NewScheme()
-	appsv1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
 	require.NoError(t, clusterv1.AddToScheme(scheme))
 
 	type fields struct {

--- a/manager/pkg/status/conflator/element_delta.go
+++ b/manager/pkg/status/conflator/element_delta.go
@@ -51,7 +51,11 @@ func (e *deltaElement) Predicate(eventVersion *version.Version) bool {
 			"version", eventVersion)
 	}
 	if !eventVersion.NewerThan(e.lastProcessedVersion) {
-		log.Debugw("drop delta bundle: get version %s, current hold version%s", eventVersion, e.metadata.Version())
+		if e.metadata != nil {
+			log.Debugw("drop delta bundle: get version %s, current hold metadata %s", eventVersion, e.metadata.Version())
+		} else {
+			log.Debugw("drop delta bundle: get version %s, current hold metadata nil", eventVersion)
+		}
 		return false
 	}
 	log.Debugw("inserting event", "version", eventVersion)

--- a/samples/cloudevent/migration/agent/main.go
+++ b/samples/cloudevent/migration/agent/main.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	kafka_confluent "github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/bundle/migration"
+	eventversion "github.com/stolostron/multicluster-global-hub/pkg/bundle/version"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/enum"
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
+	"github.com/stolostron/multicluster-global-hub/samples/config"
+)
+
+// go run ./samples/cloudevent/migration/agent/main.go "hub1" "Registering" "1234567890"
+func main() {
+	if len(os.Args) < 3 {
+		fmt.Println("Please provide at least one topic command-line argument.")
+		os.Exit(1)
+	}
+	hubName := os.Args[1]
+	stage := os.Args[2]
+	migrationId := os.Args[3]
+
+	ctx, cancel := context.WithCancel(context.Background())
+	configMap, err := config.GetConfluentConfigMapByTransportConfig("multicluster-global-hub-agent", "")
+	if err != nil {
+		log.Fatalf("failed to create protocol: %s", err.Error())
+	}
+	// exactly once - producer
+	configMap.SetKey("enable.idempotence", "true")
+	configMap.SetKey("acks", "all")
+	configMap.SetKey("retries", "3")
+	configMap.SetKey("max.in.flight.requests.per.connection", "5")
+	// Sends messages immediately, without waiting to batch them. This reduces latency but can reduce throughput.
+	configMap.SetKey("linger.ms", "0")
+
+	sender, err := kafka_confluent.New(kafka_confluent.WithConfigMap(configMap),
+		kafka_confluent.WithSenderTopic(fmt.Sprintf("gh-status.%s", hubName)))
+	if err != nil {
+		log.Fatalf("failed to create protocol, %v", err)
+	}
+	defer sender.Close(ctx)
+	eventChan, _ := sender.Events()
+	handleProducerEvents(eventChan)
+
+	c, err := cloudevents.NewClient(sender, cloudevents.WithTimeNow(), cloudevents.WithUUIDs())
+	if err != nil {
+		log.Fatalf("failed to create client, %v", err)
+	}
+
+	bundle := &migration.MigrationStatusBundle{
+		MigrationId: migrationId,
+		Stage:       stage,
+		ErrMessage:  "mock the error message in hub",
+	}
+	payloadBytes, err := json.Marshal(bundle)
+	if err != nil {
+		log.Fatalf("failed to create client, %v", err)
+	}
+
+	version := eventversion.NewVersion()
+
+	version.Incr()
+
+	clusterName := constants.CloudEventGlobalHubClusterName
+	e := utils.ToCloudEvent(string(enum.ManagedClusterMigrationType), hubName, clusterName, payloadBytes)
+	e.SetExtension(eventversion.ExtVersion, version.String())
+
+	if result := c.Send(
+		kafka_confluent.WithMessageKey(context.Background(), "test1"),
+		e,
+	); cloudevents.IsUndelivered(result) {
+		log.Printf("failed to send: %v", result)
+	} else {
+		log.Printf("sent accepted: %t", cloudevents.IsACK(result))
+	}
+	cancel()
+}
+
+func handleProducerEvents(eventChan chan kafka.Event) {
+	go func() {
+		for e := range eventChan {
+			switch ev := e.(type) {
+			case *kafka.Message:
+				// The message delivery report, indicating success or
+				// permanent failure after retries have been exhausted.
+				// Application level retries won't help since the client
+				// is already configured to do that.
+				m := ev
+				if m.TopicPartition.Error != nil {
+					log.Printf("Delivery failed: %v\n", m.TopicPartition.Error)
+				} else {
+					log.Printf("Delivered message %v\n", string(m.Value))
+					// log.Printf("Delivered message to topic %s [%d] at offset %v\n",
+					// 	*m.TopicPartition.Topic, m.TopicPartition.Partition, m.TopicPartition.Offset)
+				}
+			case kafka.Error:
+				// Generic client instance-level errors, such as
+				// broker connection failures, authentication issues, etc.
+				//
+				// These errors should generally be considered informational
+				// as the underlying client will automatically try to
+				// recover from any errors encountered, the application
+				// does not need to take action on them.
+				log.Printf("Error: %v\n", ev)
+			default:
+				log.Printf("Ignored event: %v\n", ev)
+			}
+		}
+	}()
+}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes # https://issues.redhat.com/browse/ACM-19540

## Tests
* [x] Unit/function tests have been added and incorporated into `make unit-tests`.
* [x] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [x] List other manual tests you have done.
1. create a migration resources

```yaml
apiVersion: global-hub.open-cluster-management.io/v1alpha1
kind: ManagedClusterMigration
metadata:
  ...
  finalizers:
  - global-hub.open-cluster-management.io/migration-cleanup
  generation: 1
  name: migration-sample
  namespace: multicluster-global-hub
spec:
  from: local-cluster
  includedManagedClusters:
  - cluster1
  to: hub1
```
2. mock sending a registring error message to the global hub manager

```bash
apiVersion: global-hub.open-cluster-management.io/v1alpha1
kind: ManagedClusterMigration
metadata:
  ...
  uid: 86d3a764-f736-441f-8910-33a3ac765b44
spec:
  from: local-cluster
  includedManagedClusters:
  - cluster1
  to: hub1
status:
  conditions:
  - lastTransitionTime: "2025-08-11T13:21:13Z"
    message: Migration instance is started
    reason: InstanceStarted
    status: "True"
    type: MigrationStarted
  - lastTransitionTime: "2025-08-11T13:21:13Z"
    message: Migration resources have been validated
    reason: ResourceValidated
    status: "True"
    type: ResourceValidated
  - lastTransitionTime: "2025-08-11T13:21:18Z"
    message: All source and target hubs have been successfully initialized
    reason: ResourceInitialized
    status: "True"
    type: ResourceInitialized
  - lastTransitionTime: "2025-08-11T13:21:23Z"
    message: Resources have been successfully deployed to the target hub cluster
    reason: ResourcesDeployed
    status: "True"
    type: ResourceDeployed
  - lastTransitionTime: "2025-08-11T13:21:23Z"
    message: 'registering to hub hub1 error: mock the error message in hub'
    reason: Error
    status: "False"
    type: ClusterRegistered
  - lastTransitionTime: "2025-08-11T13:21:38Z"
    message: 'Registering rollback completed successfully'
    reason: ResourceRolledBack
    status: "True"
    type: ResourceRolledBack
  phase: Failed
```
3. the cluster1 back to the local-cluster
```bash
NAME            HUB ACCEPTED   MANAGED CLUSTER URLS                                                            JOINED   AVAILABLE   AGE
cluster1        true           https://api.obs-hub-of-hubs-aws-418-sno-tsphv.scale.red-chesterfield.com:6443   True     True        28m
hub1            true           https://api.obs-hub-of-hubs-aws-418-sno-hs7sd.scale.red-chesterfield.com:6443   True     True        40d
local-cluster   true           https://api.obs-hub-of-hubs-aws-418-sno-c82l2.scale.red-chesterfield.com:6443   True     True        17d
```