### PR TITLE
set timeout for each migration cr

### DIFF
--- a/manager/pkg/migration/migration_controller.go
+++ b/manager/pkg/migration/migration_controller.go
@@ -40,9 +40,9 @@ const (
 )
 
 var (
-	cleaningTimeout       = 10 * time.Minute // Separate timeout for cleaning phase
-	migrationStageTimeout = 5 * time.Minute  // Default timeout for most migration stages
-	registeringTimeout    = 12 * time.Minute // Extended timeout for registering phase
+	cleaningTimeout       time.Duration
+	migrationStageTimeout time.Duration
+	registeringTimeout    time.Duration
 )
 
 var log = logger.DefaultZapLogger()
@@ -279,16 +279,19 @@ func (m *ClusterMigrationController) sendEventToTargetHub(ctx context.Context,
 
 // setupTimeoutsFromConfig reads the SupportedConfigs field and sets custom timeouts
 func (m *ClusterMigrationController) setupTimeoutsFromConfig(mcm *migrationv1alpha1.ManagedClusterMigration) error {
+	cleaningTimeout = 10 * time.Minute      // Separate timeout for cleaning phase
+	migrationStageTimeout = 5 * time.Minute // Default timeout for most migration stages
+	registeringTimeout = 12 * time.Minute   // Extended timeout for registering phase
+
 	// Check if StageTimeout is specified in SupportedConfigs
 	if mcm.Spec.SupportedConfigs != nil && mcm.Spec.SupportedConfigs.StageTimeout != nil {
 		timeout := mcm.Spec.SupportedConfigs.StageTimeout.Duration
-
 		// Set the timeout value to all three timeout variables
 		cleaningTimeout = timeout
 		registeringTimeout = timeout
 		migrationStageTimeout = timeout
 
-		log.Infof("set all migration timeouts to %v", timeout)
+		log.Infof("set migration: %v timeouts to %v", mcm.Name, timeout)
 	}
 
 	return nil

--- a/manager/pkg/migration/migration_controller_test.go
+++ b/manager/pkg/migration/migration_controller_test.go
@@ -406,9 +406,9 @@ func TestSetupTimeoutsFromConfig(t *testing.T) {
 	_ = migrationv1alpha1.AddToScheme(scheme)
 
 	// Store original timeout values to restore after tests
-	originalCleaningTimeout := cleaningTimeout
-	originalMigrationStageTimeout := migrationStageTimeout
-	originalRegisteringTimeout := registeringTimeout
+	originalCleaningTimeout := 10 * time.Minute
+	originalMigrationStageTimeout := 5 * time.Minute
+	originalRegisteringTimeout := 12 * time.Minute
 
 	tests := []struct {
 		name                       string


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
The config set in migration cr, so it should only take effect for this migraiton, instead of all migraiton
## Related issue(s)

Fixes #

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.
