### PR TITLE
:bug: use the reconnect to establish consumer session

### DIFF
--- a/pkg/transport/consumer/generic_consumer.go
+++ b/pkg/transport/consumer/generic_consumer.go
@@ -132,11 +132,13 @@ func (c *GenericConsumer) Reconnect(ctx context.Context,
 		c.consumerCancel()
 	}
 	c.consumerCtx, c.consumerCancel = context.WithCancel(ctx)
-
+	consumerGroupId := tranConfig.KafkaCredential.ConsumerGroupID
 	go func() {
+		log.Infof("reconnect consumer: %s", consumerGroupId)
 		if err := c.Start(c.consumerCtx); err != nil {
-			log.Errorf("failed to reconnect(start) the consumer: %v", err)
+			log.Warnf("stop the consumer(%s): %v", consumerGroupId, err)
 		}
+		log.Infof("consumer stopped: %s", consumerGroupId)
 	}()
 	return nil
 }
@@ -174,9 +176,8 @@ func (c *GenericConsumer) Start(ctx context.Context) error {
 		return ceprotocol.ResultACK
 	})
 	if err != nil {
-		return fmt.Errorf("failed to start Receiver: %w", err)
+		return fmt.Errorf("consumer receiver stopped with error: %w", err)
 	}
-	log.Info("receiver stopped\n")
 	return nil
 }
 

--- a/pkg/transport/type.go
+++ b/pkg/transport/type.go
@@ -36,7 +36,7 @@ type TransportInternalConfig struct {
 	CommitterInterval time.Duration
 	// EnableDatabaseOffset affects only the manager, deciding if consumption starts from a database-stored offset
 	EnableDatabaseOffset bool
-	// set the kafka credentail in the transport controller
+	// set the kafka credential in the transport controller
 	KafkaCredential   *KafkaConfig
 	RestfulCredential *RestfulConfig
 	Extends           map[string]interface{}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

The reason why the agent stopped resuming messages is that the the dispatcher chan only receive message from the channel of the first consumer. So we can not start a new consumer instance to receive messages

## Related issue(s)

Fixes # https://issues.redhat.com/browse/ACM-23741

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [x] List other manual tests you have done.
```bash
2025-09-03T07:24:04.066Z        INFO    controller/controller.go:109    reconcile transport(producer/consumer): multicluster-global-hub/transport-config-local-cluster
2025-09-03T07:24:04.067Z        INFO    controller/controller.go:326    update transport config secret
2025-09-03T07:24:04.077Z        INFO    consumer/generic_consumer.go:83 transport consumer with cloudevents-kafka receiver
2025-09-03T07:24:04.079Z        INFO    consumer/generic_consumer.go:137        reconnect consumer: org39_local_cluster
2025-09-03T07:24:04.079Z        INFO    cloudevents     v2@v2.0.0-20250811193955-d8449ff1e35a/protocol.go:166   Subscribing to topics: [gh-spec]
2025-09-03T07:24:04.103Z        INFO    cmd/main.go:247 add the init controller to manager
2025-09-03T07:24:04.166Z        INFO    cloudevents     v2@v2.0.0-20250811193955-d8449ff1e35a/protocol.go:179   Closing consumer [gh-spec]
2025-09-03T07:24:04.174Z        WARN    consumer/generic_consumer.go:139        stop the consumer(org38_local_cluster): consumer receiver stopped with error: error while opening the inbound connection: context canceled
github.com/stolostron/multicluster-global-hub/pkg/transport/consumer.(*GenericConsumer).Reconnect.func1
        /workspace/pkg/transport/consumer/generic_consumer.go:139
2025-09-03T07:24:04.174Z        INFO    consumer/generic_consumer.go:141        consumer stopped: org38_local_cluster

```
