### PR TITLE
refactor: enhance migration error handling and cluster status tracking

### DIFF
--- a/agent/pkg/spec/migration/migration_to_syncer.go
+++ b/agent/pkg/spec/migration/migration_to_syncer.go
@@ -218,7 +218,6 @@ func (s *MigrationTargetSyncer) registering(ctx context.Context,
 			if len(clusterErrors) > 0 {
 				return false, nil
 			}
-			// if all the clusters are ready, set the clusterErrorMap to empty
 			clusterErrors = map[string]string{}
 			return true, nil
 		},

--- a/agent/pkg/spec/migration/migration_to_syncer_test.go
+++ b/agent/pkg/spec/migration/migration_to_syncer_test.go
@@ -1190,7 +1190,7 @@ func TestRegistering(t *testing.T) {
 			migrationEvent: &migration.MigrationTargetBundle{
 				ManagedClusters: []string{"cluster1", "cluster2"},
 			},
-			expectedError: "failed to wait for all managed clusters to be ready",
+			expectedError: "failed to wait for the managed clusters to be ready",
 		},
 	}
 

--- a/manager/pkg/status/handlers/clustermigartion/managedclustermigration_handler.go
+++ b/manager/pkg/status/handlers/clustermigartion/managedclustermigration_handler.go
@@ -86,8 +86,10 @@ func (k *managedClusterMigrationHandler) handle(ctx context.Context, evt *cloude
 
 	if bundle.ErrMessage != "" {
 		migration.SetErrorMessage(bundle.MigrationId, hubClusterName, bundle.Stage, bundle.ErrMessage)
+		migration.SetClusterErrorMessage(bundle.MigrationId, hubClusterName, bundle.Stage, bundle.ClusterErrors)
 	} else {
 		migration.SetFinished(bundle.MigrationId, hubClusterName, bundle.Stage)
 	}
+
 	return nil
 }

--- a/pkg/bundle/migration/managedcluster_migration.go
+++ b/pkg/bundle/migration/managedcluster_migration.go
@@ -39,11 +39,12 @@ type MigrationTargetBundle struct {
 
 // The bundle sent from the managed hubs to the global hub
 type MigrationStatusBundle struct {
-	MigrationId     string   `json:"migrationId"`
-	Stage           string   `json:"stage"`
-	ErrMessage      string   `json:"errMessage,omitempty"`
-	Resync          bool     `json:"resync,omitempty"`
-	ManagedClusters []string `json:"managedClusters,omitempty"`
+	MigrationId     string            `json:"migrationId"`
+	Stage           string            `json:"stage"`
+	ErrMessage      string            `json:"errMessage,omitempty"`
+	Resync          bool              `json:"resync,omitempty"`
+	ManagedClusters []string          `json:"managedClusters,omitempty"`
+	ClusterErrors   map[string]string `json:"clusterErrors,omitempty"`
 }
 
 type MigrationResourceBundle struct {


### PR DESCRIPTION
Improved migration workflow with better error reporting and cluster management:

- Added cluster-specific error mapping in migration syncer for detailed error reporting
- Enhanced migration status bundle to include cluster-level error information
- Improved registering stage timeout handling with per-cluster error tracking
- Updated rollback logic to handle only failed clusters during registering phase
- Added cluster error state management in migration event status handling
- Enhanced migration status reporting with granular cluster error details

## Related Jira Issue
[ACM-22959](https://issues.redhat.com/browse/ACM-22959)

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.