### PR TITLE
fix: enable CGO for e2e tests to support confluent-kafka package

### DIFF
--- a/test/script/e2e_run_qe.sh
+++ b/test/script/e2e_run_qe.sh
@@ -23,4 +23,5 @@ docker pull quay.io/hchenxa/acmqe-hoh-e2e:$imageTag
 docker run --name qe-test -d quay.io/hchenxa/acmqe-hoh-e2e:$imageTag  tail -f /dev/null
 docker cp qe-test:/e2e.test ./
 
-SERVICE_TYPE=NODE_PORT KUBECONFIG=$GH_KUBECONFIG SPOKE_KUBECONFIG=$MH1_KUBECONFIG ./e2e.test --ginkgo.fail-fast --ginkgo.vv --ginkgo.label-filter='e2e && !migration'
+# CGO_ENABLED=1: Go programs typically use dynamic linking for C libraries: confluent-kafka package is used in e2e test
+CGO_ENABLED=1 SERVICE_TYPE=NODE_PORT KUBECONFIG=$GH_KUBECONFIG SPOKE_KUBECONFIG=$MH1_KUBECONFIG ./e2e.test --ginkgo.fail-fast --ginkgo.vv --ginkgo.label-filter='e2e && !migration'


### PR DESCRIPTION
## Summary
Enable CGO support for e2e tests to fix failures related to the confluent-kafka package which requires dynamic linking with C libraries.

## Changes
- Add CGO_ENABLED=1 flag to e2e test execution in test/script/e2e_run_qe.sh
- Include explanatory comment about CGO requirement for confluent-kafka package

## Test plan
- [ ] E2e tests run successfully with CGO enabled
- [ ] No regression in test execution
- [ ] Confluent-kafka package works correctly

## Checklist
- [x] Code follows project conventions
- [x] Commit message follows conventional format
- [x] Change is minimal and focused
- [x] Explanatory comment added

🤖 Generated with [Claude Code](https://claude.ai/code)