### PR TITLE
fix the resync is not trigger some time

### DIFF
--- a/agent/pkg/status/syncers/managedcluster/managed_cluster_syncer.go
+++ b/agent/pkg/status/syncers/managedcluster/managed_cluster_syncer.go
@@ -35,8 +35,8 @@ func AddManagedClusterSyncer(ctx context.Context, mgr ctrl.Manager, p transport.
 		p,
 		emitters.WithPredicateFunc(predicate.NewPredicateFuncs(validCluster)),
 		emitters.WithFilterFunc(validCluster),
-		emitters.WithTweakFunc(clusterTweakFunc),     // clean unnecessary fields, like managedFields
-		emitters.WithMetadataFunc(clusterMedataFunc), // extract metadata from object, use clusterClaim id as the object id
+		emitters.WithTweakFunc(clusterTweakFunc),       // clean unnecessary fields, like managedFields
+		emitters.WithMetadataFunc(clusterMetadataFunc), // extract metadata from object, use clusterClaim id as the object id
 	)
 
 	// 2. add the emitter to controller
@@ -61,6 +61,7 @@ func AddManagedClusterSyncer(ctx context.Context, mgr ctrl.Manager, p transport.
 			for i := range clusters.Items {
 				obj := &clusters.Items[i]
 				if validCluster(obj) {
+					log.Infof("valid cluster: %s", obj.GetName())
 					filtered = append(filtered, obj)
 				}
 			}
@@ -90,7 +91,7 @@ func clusterTweakFunc(object client.Object) {
 	object.SetManagedFields(nil)
 }
 
-func clusterMedataFunc(object client.Object) *genericbundle.ObjectMetadata {
+func clusterMetadataFunc(object client.Object) *genericbundle.ObjectMetadata {
 	return &genericbundle.ObjectMetadata{
 		ID:        getClusterClaimID(object),
 		Namespace: object.GetNamespace(),


### PR DESCRIPTION
## Related Jira Issue
https://issues.redhat.com/browse/ACM-24613

## Root Cause
The issue is caused by improper timing of `configs.GlobalResyncQueue` addition, which can result in an empty resync queue during startup.

## Summary

This PR improves code quality and logging consistency across multiple components in the Global Hub project.

## Changes

### Code Quality Improvements
- **Variable Naming**: Renamed `metas` to `metadataList` in `object_emitter.go` for better clarity
- **Function Naming**: Fixed typo `clusterMedataFunc` → `clusterMetadataFunc` in managed cluster syncer
- **Import Cleanup**: Removed unused imports in sample receiver

### Logging Enhancements
- **Consistency**: Standardized log message capitalization (lowercase for consistency)
- **Debug Info**: Added logging for valid cluster processing to aid debugging
- **Initial Sync**: Added logging for initial resync operations

### Sample Code Updates
- **Error Handling**: Improved error handling in confluent receiver sample
- **Debug Support**: Enhanced debugging capabilities with additional logging
- **Code Cleanup**: Removed commented-out code and unused imports

## Files Changed

- `agent/pkg/status/emitters/object_emitter.go`
- `agent/pkg/status/generic/periodic_syncer.go` 
- `agent/pkg/status/syncers/managedcluster/managed_cluster_syncer.go`
- `samples/cloudevent/confluent-receiver/main.go`

## Test Plan

- [ ] Code follows Go naming conventions
- [ ] Logging messages are consistent and helpful
- [ ] No functional changes that affect behavior
- [ ] Sample code improvements don't break functionality

## Benefits

- Better code readability and maintainability
- Consistent logging helps with debugging and monitoring
- Follows Go best practices for naming conventions
- Enhanced debugging capabilities for troubleshooting

🤖 Generated with [Claude Code](https://claude.ai/code)