### PR TITLE
feat: change migration timeout from cumulative to per-stage

### DIFF
--- a/manager/pkg/migration/migration_controller.go
+++ b/manager/pkg/migration/migration_controller.go
@@ -368,3 +368,13 @@ func getTimeout(stage string) time.Duration {
 		return migratingTimeout
 	}
 }
+
+func getLastTransitionTime(mcm *migrationv1alpha1.ManagedClusterMigration) time.Time {
+	lastTransitionTime := time.Time{}
+	for _, cond := range mcm.Status.Conditions {
+		if lastTransitionTime.Before(cond.LastTransitionTime.Time) {
+			lastTransitionTime = cond.LastTransitionTime.Time
+		}
+	}
+	return lastTransitionTime
+}

--- a/manager/pkg/migration/migration_controller.go
+++ b/manager/pkg/migration/migration_controller.go
@@ -43,10 +43,10 @@ const (
 
 var (
 	// the following timeouts are accumulated from the start of the migration
-	migratingTimeout   time.Duration
-	cleaningTimeout    time.Duration
-	rollbackingTimeout time.Duration
-	registeringTimeout time.Duration
+	migratingTimeout   time.Duration = 5 * time.Minute
+	cleaningTimeout    time.Duration = 5 * time.Minute
+	rollbackingTimeout time.Duration = 5 * time.Minute
+	registeringTimeout time.Duration = 12 * time.Minute
 )
 
 var log = logger.DefaultZapLogger()
@@ -349,10 +349,9 @@ func (m *ClusterMigrationController) SetupMigrationStageTimeout(mcm *migrationv1
 	} else {
 		migratingTimeout = 5 * time.Minute
 		rollbackingTimeout = migratingTimeout
+		cleaningTimeout = migratingTimeout
 		registeringTimeout = 12 * time.Minute
-		cleaningTimeout = registeringTimeout
 	}
-
 	return nil
 }
 
@@ -371,10 +370,15 @@ func getTimeout(stage string) time.Duration {
 
 func getLastTransitionTime(mcm *migrationv1alpha1.ManagedClusterMigration) time.Time {
 	lastTransitionTime := time.Time{}
+	updated := false
 	for _, cond := range mcm.Status.Conditions {
 		if lastTransitionTime.Before(cond.LastTransitionTime.Time) {
 			lastTransitionTime = cond.LastTransitionTime.Time
+			updated = true
 		}
+	}
+	if !updated {
+		lastTransitionTime = time.Now()
 	}
 	return lastTransitionTime
 }

--- a/manager/pkg/migration/migration_controller_test.go
+++ b/manager/pkg/migration/migration_controller_test.go
@@ -595,3 +595,145 @@ func TestSetupTimeoutsFromConfig(t *testing.T) {
 		registeringTimeout = originalRegisteringTimeout
 	})
 }
+
+func TestGetLastTransitionTime(t *testing.T) {
+	baseTime := time.Now()
+	older := baseTime.Add(-2 * time.Hour)
+	recent := baseTime.Add(-1 * time.Hour)
+	newest := baseTime
+
+	tests := []struct {
+		name                string
+		migration           *migrationv1alpha1.ManagedClusterMigration
+		expectedTimeCloseTo time.Time
+		expectCurrentTime   bool
+	}{
+		{
+			name: "Should return latest transition time from multiple conditions",
+			migration: &migrationv1alpha1.ManagedClusterMigration{
+				Status: migrationv1alpha1.ManagedClusterMigrationStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               migrationv1alpha1.ConditionTypeStarted,
+							Status:             metav1.ConditionTrue,
+							LastTransitionTime: metav1.Time{Time: older},
+						},
+						{
+							Type:               migrationv1alpha1.ConditionTypeValidated,
+							Status:             metav1.ConditionTrue,
+							LastTransitionTime: metav1.Time{Time: newest},
+						},
+						{
+							Type:               migrationv1alpha1.ConditionTypeInitialized,
+							Status:             metav1.ConditionTrue,
+							LastTransitionTime: metav1.Time{Time: recent},
+						},
+					},
+				},
+			},
+			expectedTimeCloseTo: newest,
+			expectCurrentTime:   false,
+		},
+		{
+			name: "Should return single condition transition time",
+			migration: &migrationv1alpha1.ManagedClusterMigration{
+				Status: migrationv1alpha1.ManagedClusterMigrationStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               migrationv1alpha1.ConditionTypeStarted,
+							Status:             metav1.ConditionTrue,
+							LastTransitionTime: metav1.Time{Time: recent},
+						},
+					},
+				},
+			},
+			expectedTimeCloseTo: recent,
+			expectCurrentTime:   false,
+		},
+		{
+			name: "Should return current time when no conditions exist",
+			migration: &migrationv1alpha1.ManagedClusterMigration{
+				Status: migrationv1alpha1.ManagedClusterMigrationStatus{
+					Conditions: []metav1.Condition{},
+				},
+			},
+			expectCurrentTime: true,
+		},
+		{
+			name: "Should return current time when conditions is nil",
+			migration: &migrationv1alpha1.ManagedClusterMigration{
+				Status: migrationv1alpha1.ManagedClusterMigrationStatus{
+					Conditions: nil,
+				},
+			},
+			expectCurrentTime: true,
+		},
+		{
+			name: "Should handle multiple conditions with same timestamp",
+			migration: &migrationv1alpha1.ManagedClusterMigration{
+				Status: migrationv1alpha1.ManagedClusterMigrationStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               migrationv1alpha1.ConditionTypeStarted,
+							Status:             metav1.ConditionTrue,
+							LastTransitionTime: metav1.Time{Time: recent},
+						},
+						{
+							Type:               migrationv1alpha1.ConditionTypeValidated,
+							Status:             metav1.ConditionTrue,
+							LastTransitionTime: metav1.Time{Time: recent},
+						},
+					},
+				},
+			},
+			expectedTimeCloseTo: recent,
+			expectCurrentTime:   false,
+		},
+		{
+			name: "Should correctly handle conditions in random order",
+			migration: &migrationv1alpha1.ManagedClusterMigration{
+				Status: migrationv1alpha1.ManagedClusterMigrationStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               migrationv1alpha1.ConditionTypeValidated,
+							Status:             metav1.ConditionTrue,
+							LastTransitionTime: metav1.Time{Time: recent},
+						},
+						{
+							Type:               migrationv1alpha1.ConditionTypeStarted,
+							Status:             metav1.ConditionTrue,
+							LastTransitionTime: metav1.Time{Time: newest},
+						},
+						{
+							Type:               migrationv1alpha1.ConditionTypeInitialized,
+							Status:             metav1.ConditionTrue,
+							LastTransitionTime: metav1.Time{Time: older},
+						},
+					},
+				},
+			},
+			expectedTimeCloseTo: newest,
+			expectCurrentTime:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			beforeCall := time.Now()
+			result := getLastTransitionTime(tt.migration)
+			afterCall := time.Now()
+
+			if tt.expectCurrentTime {
+				// For cases where function should return time.Now(), verify it's between before and after call
+				assert.True(t, result.After(beforeCall) || result.Equal(beforeCall),
+					"Result should be after or equal to time before function call")
+				assert.True(t, result.Before(afterCall) || result.Equal(afterCall),
+					"Result should be before or equal to time after function call")
+			} else {
+				// For cases where function should return specific transition time
+				assert.True(t, result.Equal(tt.expectedTimeCloseTo),
+					"Expected time %v, got %v", tt.expectedTimeCloseTo, result)
+			}
+		})
+	}
+}

--- a/manager/pkg/migration/migration_controller_test.go
+++ b/manager/pkg/migration/migration_controller_test.go
@@ -406,7 +406,7 @@ func TestSetupTimeoutsFromConfig(t *testing.T) {
 	_ = migrationv1alpha1.AddToScheme(scheme)
 
 	// Store original timeout values to restore after tests
-	originalCleaningTimeout := 12 * time.Minute
+	originalCleaningTimeout := 5 * time.Minute
 	originalMigrationStageTimeout := 5 * time.Minute
 	originalRegisteringTimeout := 12 * time.Minute
 

--- a/manager/pkg/migration/migration_initializing.go
+++ b/manager/pkg/migration/migration_initializing.go
@@ -157,9 +157,7 @@ func (m *ClusterMigrationController) handleStatusWithRollback(ctx context.Contex
 		return
 	}
 
-	startedCond := meta.FindStatusCondition(mcm.Status.Conditions, migrationv1alpha1.ConditionTypeStarted)
-	if condition.Reason == ConditionReasonWaiting && startedCond != nil &&
-		time.Since(startedCond.LastTransitionTime.Time) > stageTimeout {
+	if condition.Reason == ConditionReasonWaiting && time.Since(getLastTransitionTime(mcm)) > stageTimeout {
 		condition.Reason = ConditionReasonTimeout
 		condition.Message = fmt.Sprintf("Timeout: %s", condition.Message)
 		*nextPhase = migrationv1alpha1.PhaseRollbacking

--- a/manager/pkg/migration/migration_initializing.go
+++ b/manager/pkg/migration/migration_initializing.go
@@ -157,9 +157,7 @@ func (m *ClusterMigrationController) handleStatusWithRollback(ctx context.Contex
 		return
 	}
 
-	if condition.Reason == ConditionReasonWaiting && time.Since(getLastTransitionTime(mcm)) > stageTimeout {
-		condition.Reason = ConditionReasonTimeout
-		condition.Message = fmt.Sprintf("Timeout: %s", condition.Message)
+	if updateConditionWithTimeout(ctx, mcm, condition, stageTimeout, "") {
 		*nextPhase = migrationv1alpha1.PhaseRollbacking
 	}
 

--- a/manager/pkg/migration/migration_rollbacking.go
+++ b/manager/pkg/migration/migration_rollbacking.go
@@ -3,7 +3,6 @@ package migration
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -162,11 +161,8 @@ func (m *ClusterMigrationController) handleRollbackStatus(ctx context.Context,
 	waitingHub *string,
 	failedStage string,
 ) {
-	if condition.Reason == ConditionReasonWaiting &&
-		time.Since(getLastTransitionTime(mcm)) > getTimeout(migrationv1alpha1.PhaseRollbacking) {
-		condition.Reason = ConditionReasonTimeout
-		condition.Message = m.manuallyRollbackMsg(failedStage, *waitingHub, "Timeout")
-	}
+	_ = updateConditionWithTimeout(ctx, mcm, condition, getTimeout(migrationv1alpha1.PhaseRollbacking),
+		m.manuallyRollbackMsg(failedStage, *waitingHub, "Timeout"))
 
 	if condition.Reason != ConditionReasonWaiting {
 		*nextPhase = migrationv1alpha1.PhaseFailed

--- a/manager/pkg/migration/migration_rollbacking.go
+++ b/manager/pkg/migration/migration_rollbacking.go
@@ -162,11 +162,8 @@ func (m *ClusterMigrationController) handleRollbackStatus(ctx context.Context,
 	waitingHub *string,
 	failedStage string,
 ) {
-	startedCond := meta.FindStatusCondition(mcm.Status.Conditions, migrationv1alpha1.ConditionTypeStarted)
-	// Handle timeout - still transition to Failed but with timeout message
-	timeout := getTimeout(failedStage) + getTimeout(migrationv1alpha1.PhaseRollbacking)
-	if condition.Reason == ConditionReasonWaiting && startedCond != nil &&
-		time.Since(startedCond.LastTransitionTime.Time) > timeout {
+	if condition.Reason == ConditionReasonWaiting &&
+		time.Since(getLastTransitionTime(mcm)) > getTimeout(migrationv1alpha1.PhaseRollbacking) {
 		condition.Reason = ConditionReasonTimeout
 		condition.Message = m.manuallyRollbackMsg(failedStage, *waitingHub, "Timeout")
 	}

--- a/manager/pkg/migration/migration_validating.go
+++ b/manager/pkg/migration/migration_validating.go
@@ -322,7 +322,9 @@ func isHubCluster(ctx context.Context, c client.Client, mc *clusterv1.ManagedClu
 	return false
 }
 
-func updateConditionWithTimeout(ctx context.Context, mcm *migrationv1alpha1.ManagedClusterMigration, condition *metav1.Condition, stageTimeout time.Duration, timeoutMessage string) bool {
+func updateConditionWithTimeout(ctx context.Context, mcm *migrationv1alpha1.ManagedClusterMigration,
+	condition *metav1.Condition, stageTimeout time.Duration, timeoutMessage string,
+) bool {
 	if condition.Reason == ConditionReasonWaiting && time.Since(getLastTransitionTime(mcm)) > stageTimeout {
 		condition.Reason = ConditionReasonTimeout
 		if timeoutMessage != "" {


### PR DESCRIPTION
## Summary
Changes migration timeout calculation from cumulative time (from migration start) to individual stage timeouts (from last transition time) for more accurate timeout handling across different migration phases.

## Background
The migration process consists of multiple phases as documented in [`ai-doc/migration-sequence-diagram.md`](../blob/main/ai-doc/migration-sequence-diagram.md):
- **Validating** → **Initializing** → **Deploying** → **Registering** → **Cleaning**

Each phase has configurable timeout values (default 5-12 minutes per phase) to ensure migration operations don't hang indefinitely.

## Problem
Previously, migration timeout was calculated as cumulative time from the initial migration start time. This approach had several issues:
- If one stage took longer, it would reduce the available time for subsequent stages
- Stages could timeout prematurely even if they were within their allocated time window
- Debugging timeout issues was difficult due to cumulative time calculations

## Solution
Implemented per-stage timeout calculation using the most recent condition transition time as the baseline:

### Changes Made
- **Added `getLastTransitionTime()` helper** (`migration_controller.go:372`): Finds the most recent condition transition time across all migration status conditions
- **Updated initializing phase** (`migration_initializing.go:160`): Uses stage-specific timeout from last transition instead of cumulative time from migration start
- **Updated rollbacking phase** (`migration_rollbacking.go:165`): Uses rollback-specific timeout instead of combined cumulative timeout  
- **Enhanced validating phase** (`migration_validating.go:92`): Added proper timeout handling with stage-specific timeout calculation

### Technical Implementation
```go
// Before: Cumulative timeout from migration start
startedCond := meta.FindStatusCondition(mcm.Status.Conditions, migrationv1alpha1.ConditionTypeStarted)
if condition.Reason == ConditionReasonWaiting && startedCond != nil &&
    time.Since(startedCond.LastTransitionTime.Time) > stageTimeout {

// After: Per-stage timeout from last transition
if condition.Reason == ConditionReasonWaiting && 
    time.Since(getLastTransitionTime(mcm)) > getTimeout(migrationv1alpha1.PhaseValidating) {
```

## Benefits
- **Predictable timeout behavior**: Each migration stage gets its full allocated time window
- **Better stage isolation**: Previous stage duration doesn't affect subsequent stage timeouts
- **Improved debugging**: Timeout calculations are more intuitive and stage-specific
- **Enhanced reliability**: Reduces false timeout failures during normal migration operations

## Testing Considerations
Based on the migration sequence documentation, timeout scenarios should be tested for:
- Long-running validating phase (cluster validation delays)
- Slow initializing phase (bootstrap secret creation delays) 
- Extended deploying phase (resource deployment delays)
- Delayed registering phase (cluster re-registration delays)
- Rollback timeout scenarios for each phase

## Documentation References
- Migration flow details: [`ai-doc/migration-sequence-diagram.md`](../blob/main/ai-doc/migration-sequence-diagram.md)
- Timeout configuration: Migration Controller at `manager/pkg/migration/migration_controller.go:108`

## Related Jira Issue
[ACM-24677](https://issues.redhat.com/browse/ACM-24677) - The stageTimeout has problems

🤖 Generated with [Claude Code](https://claude.ai/code)