### PR TITLE
Add CPE labels to global hub components for release 1.5

### DIFF
--- a/agent/Containerfile.agent
+++ b/agent/Containerfile.agent
@@ -20,13 +20,14 @@ RUN PKG_CONFIG_PATH=/usr/local/lib/pkgconfig CGO_ENABLED=1 GOFLAGS="-p=4" go bui
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 # Red Hat annotations.
-LABEL com.redhat.component="multicluster-global-hub-agent"
+LABEL com.redhat.component="multicluster-globalhub-agent"
+LABEL cpe="cpe:/a:redhat:multicluster_globalhub:1.5::el9"
 LABEL org.label-schema.vendor="Red Hat"
 LABEL org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA"
 LABEL org.label-schema.schema-version="1.0"
 
 # Bundle metadata
-LABEL name="multicluster-global-hub/multicluster-global-hub-agent"
+LABEL name="multicluster-globalhub/multicluster-globalhub-agent"
 LABEL version="release-1.5"
 LABEL summary="multicluster global hub agent"
 LABEL io.openshift.expose-services=""

--- a/manager/Containerfile.manager
+++ b/manager/Containerfile.manager
@@ -21,13 +21,14 @@ RUN PKG_CONFIG_PATH=/usr/local/lib/pkgconfig CGO_ENABLED=1 GOFLAGS="-p=4" go bui
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 # Red Hat annotations.
-LABEL com.redhat.component="multicluster-global-hub-manager"
+LABEL com.redhat.component="multicluster-globalhub-manager"
+LABEL cpe="cpe:/a:redhat:multicluster_globalhub:1.5::el9"
 LABEL org.label-schema.vendor="Red Hat"
 LABEL org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA"
 LABEL org.label-schema.schema-version="1.0"
 
 # Bundle metadata
-LABEL name="multicluster-global-hub/multicluster-global-hub-manager"
+LABEL name="multicluster-globalhub/multicluster-globalhub-manager"
 LABEL version="release-1.5"
 LABEL summary="multicluster global hub manager"
 LABEL io.openshift.expose-services=""

--- a/operator/Containerfile.operator
+++ b/operator/Containerfile.operator
@@ -16,13 +16,14 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 
 # Red Hat annotations.
-LABEL com.redhat.component="multicluster-global-hub-operator-container"
+LABEL com.redhat.component="multicluster-globalhub-operator-container"
+LABEL cpe="cpe:/a:redhat:multicluster_globalhub:1.5::el9"
 LABEL org.label-schema.vendor="Red Hat"
 LABEL org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA"
 LABEL org.label-schema.schema-version="1.0"
 
 # Bundle metadata
-LABEL name="multicluster-global-hub/multicluster-global-hub-operator"
+LABEL name="multicluster-globalhub/multicluster-globalhub-operator"
 LABEL version="release-1.5"
 LABEL summary="multicluster global hub operator"
 LABEL io.openshift.expose-services=""


### PR DESCRIPTION
## Summary
- Add CPE label cpe:/a:redhat:multicluster_globalhub:1.5::el9 to all three global hub components
- Update component names from multicluster-global-hub-* to multicluster-globalhub-* for consistency
- Target release 1.5 (release-2.14 branch)

## Changes Made
- Agent: Added CPE label to agent/Containerfile.agent
- Manager: Added CPE label to manager/Containerfile.manager  
- Operator: Added CPE label to operator/Containerfile.operator

## Test plan
- Verify Containerfiles build successfully with new labels
- Confirm CPE labels are present in built container images
- Validate component name changes don't break existing functionality

🤖 Generated with Claude Code