### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for multicluster-global-hub-manager-globalhub-1-5

### DIFF
--- a/manager/Containerfile.manager
+++ b/manager/Containerfile.manager
@@ -22,12 +22,13 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 # Red Hat annotations.
 LABEL com.redhat.component="multicluster-global-hub-manager"
+LABEL cpe="cpe:/a:redhat:multicluster_globalhub:1.5::el9"
 LABEL org.label-schema.vendor="Red Hat"
 LABEL org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA"
 LABEL org.label-schema.schema-version="1.0"
 
 # Bundle metadata
-LABEL name="multicluster-global-hub/multicluster-global-hub-manager"
+LABEL name="multicluster-globalhub/multicluster-globalhub-manager-rhel9"
 LABEL version="release-1.5"
 LABEL summary="multicluster global hub manager"
 LABEL io.openshift.expose-services=""


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
