### PR TITLE
fix: update Containerfile.bundle labels in bundle release script

### DIFF
--- a/.claude/skills/new-release/scripts/03-bundle.sh
+++ b/.claude/skills/new-release/scripts/03-bundle.sh
@@ -476,6 +476,33 @@ else
   echo "   ⚠️  File not found: $KONFLUX_SCRIPT" >&2
 fi
 
+# Step 5.5: Update Containerfile.bundle labels
+echo ""
+echo "📍 Step 5.5: Updating Containerfile.bundle labels..."
+
+CONTAINERFILE="Containerfile.bundle"
+if [[ -f "$CONTAINERFILE" ]]; then
+  if [[ -n "$PREV_BUNDLE_VERSION" ]]; then
+    echo "   Updating version labels in $CONTAINERFILE"
+    echo "   Changing: ${PREV_BUNDLE_VERSION} → ${BUNDLE_VERSION}"
+
+    # Update bundle channels
+    sed "${SED_INPLACE[@]}" "s|operators.operatorframework.io.bundle.channels.v1=release-${PREV_BUNDLE_VERSION}|operators.operatorframework.io.bundle.channels.v1=release-${BUNDLE_VERSION}|g" "$CONTAINERFILE"
+    # Update default channel
+    sed "${SED_INPLACE[@]}" "s|operators.operatorframework.io.bundle.channel.default.v1=release-${PREV_BUNDLE_VERSION}|operators.operatorframework.io.bundle.channel.default.v1=release-${BUNDLE_VERSION}|g" "$CONTAINERFILE"
+    # Update CPE label
+    sed "${SED_INPLACE[@]}" "s|cpe:/a:redhat:multicluster_globalhub:${PREV_BUNDLE_VERSION}|cpe:/a:redhat:multicluster_globalhub:${BUNDLE_VERSION}|g" "$CONTAINERFILE"
+    # Update version label
+    sed "${SED_INPLACE[@]}" "s|version=\"release-${PREV_BUNDLE_VERSION}\"|version=\"release-${BUNDLE_VERSION}\"|g" "$CONTAINERFILE"
+
+    echo "   ✅ Updated Containerfile.bundle labels to ${BUNDLE_VERSION}"
+  else
+    echo "   ⚠️  No previous bundle version found, skipping Containerfile.bundle update" >&2
+  fi
+else
+  echo "   ⚠️  File not found: $CONTAINERFILE" >&2
+fi
+
 # Step 6: Check if there are actual changes before committing
 echo ""
 echo "📍 Step 6: Checking for changes on $BUNDLE_BRANCH..."
@@ -501,11 +528,9 @@ elif git diff --quiet && git diff --cached --quiet; then
   CHANGES_COMMITTED=false
 else
   # Check if the only changes are createdAt timestamps (should be ignored)
-  DIFF_OUTPUT=$(git diff "origin/$BUNDLE_BRANCH" 2>/dev/null || echo "")
-
   # Filter out createdAt changes and check if there are any other changes
-  # Remove lines with createdAt changes and diff markers (---, +++)
-  NON_CREATEDAT_CHANGES=$(echo "$DIFF_OUTPUT" | grep -E '^[-+]' | grep -v 'createdAt:' | grep -v '^---' | grep -v '^\+\+\+' || echo "")
+  # Use git diff directly with grep to avoid issues with large diffs or special characters
+  NON_CREATEDAT_CHANGES=$(git diff "origin/$BUNDLE_BRANCH" 2>/dev/null | grep -E '^[-+]' | grep -vF -- '---' | grep -vF -- '+++' | grep -v 'createdAt:' || echo "")
 
   if [[ -z "$NON_CREATEDAT_CHANGES" ]]; then
     echo "   ℹ️  Only createdAt timestamp changes detected - ignoring"
@@ -523,6 +548,7 @@ else
 - Update CSV skipRange to '>=${PREV_BUNDLE_VERSION}.0 <${BUNDLE_VERSION}.0'
 - Update konflux-patch.sh image references to ${BUNDLE_TAG}
 - Update konflux-patch.sh version replacement to ${BUNDLE_VERSION}.0
+- Update Containerfile.bundle labels to ${BUNDLE_VERSION}
 
 Corresponds to ACM ${RELEASE_BRANCH} / Global Hub ${GH_VERSION}
 Bundle source: ${BUNDLE_SOURCE_DESCRIPTION}"
@@ -614,6 +640,7 @@ fi
 - Update CSV skipRange to \`>=${PREV_BUNDLE_VERSION}.0 <${BUNDLE_VERSION}.0\`
 - Update konflux-patch.sh image references to \`${BUNDLE_TAG}\`
 - Update konflux-patch.sh version replacement to \`${BUNDLE_VERSION}.0\`
+- Update Containerfile.bundle labels to \`${BUNDLE_VERSION}\`
 
 ## Version Mapping
 
@@ -667,6 +694,7 @@ if [[ -n "$PREV_BUNDLE_TAG" ]]; then
   echo "  ✓ Updated bundle image labels to ${BUNDLE_VERSION}"
   echo "  ✓ Updated CSV skipRange to '>=${PREV_BUNDLE_VERSION} <${BUNDLE_VERSION}'"
   echo "  ✓ Updated konflux-patch.sh image refs and version replacement"
+  echo "  ✓ Updated Containerfile.bundle labels to ${BUNDLE_VERSION}"
 fi
 if [[ "$PUSHED_TO_ORIGIN" = true ]]; then
   echo "  ✓ Pushed to origin: ${BUNDLE_REPO}/${BUNDLE_BRANCH}"

--- a/.claude/skills/new-release/scripts/04-catalog.sh
+++ b/.claude/skills/new-release/scripts/04-catalog.sh
@@ -506,20 +506,22 @@ if [[ -n "$PREV_CATALOG_TAG" ]]; then
     fi
   done
 
-  # Remove old OCP version pipelines (only if OCP range changed)
-  if [[ "$PREV_OCP_MAX" != "$OCP_MAX" ]]; then
-    OLD_OCP_PR=".tekton/multicluster-global-hub-operator-catalog-v4${OLD_OCP_VER}-${PREV_CATALOG_TAG}-pull-request.yaml"
-    OLD_OCP_PUSH=".tekton/multicluster-global-hub-operator-catalog-v4${OLD_OCP_VER}-${PREV_CATALOG_TAG}-push.yaml"
-
-    if [[ -f "$OLD_OCP_PR" ]]; then
-      git rm "$OLD_OCP_PR" 2>/dev/null || rm "$OLD_OCP_PR"
-      echo "   ✅ Removed old OCP 4.${OLD_OCP_VER} pull-request pipeline"
+  # Remove all tekton pipelines for OCP versions below OCP_MIN
+  echo ""
+  echo "   Cleaning up outdated OCP tekton pipelines (below 4.$((OCP_MIN%100)))..."
+  CLEANED_PIPELINES=false
+  for old_pipeline in .tekton/multicluster-global-hub-operator-catalog-v4*; do
+    [[ -f "$old_pipeline" ]] || continue
+    # Extract OCP version number from filename (e.g., v416 -> 16, v417 -> 17)
+    pipeline_ocp_ver=$(echo "$old_pipeline" | grep -oE 'v4[0-9]+' | head -1 | sed 's/v4//')
+    if [[ -n "$pipeline_ocp_ver" ]] && (( pipeline_ocp_ver < (OCP_MIN%100) )); then
+      git rm "$old_pipeline" 2>/dev/null || rm "$old_pipeline"
+      echo "   ✅ Removed outdated pipeline: $(basename "$old_pipeline")"
+      CLEANED_PIPELINES=true
     fi
-
-    if [[ -f "$OLD_OCP_PUSH" ]]; then
-      git rm "$OLD_OCP_PUSH" 2>/dev/null || rm "$OLD_OCP_PUSH"
-      echo "   ✅ Removed old OCP 4.${OLD_OCP_VER} push pipeline"
-    fi
+  done
+  if [[ "$CLEANED_PIPELINES" = false ]]; then
+    echo "   ✓ No outdated tekton pipelines found"
   fi
 
   # Update Containerfile.catalog for OCP versions (only if OCP range changed)
@@ -527,12 +529,16 @@ if [[ -n "$PREV_CATALOG_TAG" ]]; then
     echo ""
     echo "   Updating Containerfile.catalog files..."
 
-    # Remove old OCP version directory
-    OLD_OCP_DIR="v4.${OLD_OCP_VER}"
-    if [[ -d "$OLD_OCP_DIR" ]]; then
-      git rm -r "$OLD_OCP_DIR" 2>/dev/null || rm -rf "$OLD_OCP_DIR"
-      echo "   ✅ Removed old OCP directory: $OLD_OCP_DIR"
-    fi
+    # Remove all OCP version directories below OCP_MIN
+    for old_dir in v4.*/; do
+      [[ -d "$old_dir" ]] || continue
+      old_ver="${old_dir#v4.}"
+      old_ver="${old_ver%/}"
+      if [[ "$old_ver" =~ ^[0-9]+$ ]] && (( old_ver < (OCP_MIN%100) )); then
+        git rm -r "$old_dir" 2>/dev/null || rm -rf "$old_dir"
+        echo "   ✅ Removed old OCP directory: ${old_dir%/}"
+      fi
+    done
 
     # Create new OCP version directory and Containerfile.catalog
     NEW_OCP_DIR="v4.${NEW_OCP_VER}"
@@ -652,6 +658,22 @@ elif [[ ! -f "$FILTER_CATALOG_FILE" ]]; then
   echo "   ⚠️  File not found: $FILTER_CATALOG_FILE" >&2
 fi
 
+# Step 2.7: Update README.md
+echo ""
+echo "📍 Step 2.7: Updating README.md..."
+
+README_FILE="README.md"
+if [[ -f "$README_FILE" && -n "$PREV_CATALOG_TAG" ]]; then
+  echo "   Updating image references in $README_FILE"
+  echo "   Changing: ${PREV_CATALOG_TAG} → ${CATALOG_TAG}"
+
+  sed "${SED_INPLACE[@]}" "s/${PREV_CATALOG_TAG}/${CATALOG_TAG}/g" "$README_FILE"
+
+  echo "   ✅ Updated $README_FILE"
+elif [[ ! -f "$README_FILE" ]]; then
+  echo "   ⚠️  File not found: $README_FILE" >&2
+fi
+
 # Step 3: Commit changes
 echo ""
 echo "📍 Step 3: Committing changes on $CATALOG_BRANCH..."
@@ -672,6 +694,7 @@ else
 - Remove OCP 4.${OLD_OCP_VER} pipelines and directory
 - Update existing OCP 4.$((OCP_MIN%100))-4.$((OCP_MAX-1%100)) pipelines
 - Update all Containerfile.catalog files with new bundle reference (${PREV_CATALOG_TAG} -> ${CATALOG_TAG})
+- Update README.md image references to ${CATALOG_TAG}
 
 Supports OCP 4.$((OCP_MIN%100)) - 4.$((OCP_MAX%100))
 Corresponds to ACM ${RELEASE_BRANCH} / Global Hub ${GH_VERSION}"

--- a/.claude/skills/new-release/scripts/05-grafana.sh
+++ b/.claude/skills/new-release/scripts/05-grafana.sh
@@ -187,6 +187,29 @@ else
   echo "   ⚠️  No previous grafana tag found, skipping pipeline update" >&2
 fi
 
+# Step 1.5: Update Containerfile.konflux labels
+echo ""
+echo "📍 Step 1.5: Updating Containerfile.konflux labels..."
+
+CONTAINERFILE="Containerfile.konflux"
+if [[ -f "$CONTAINERFILE" ]]; then
+  PREV_GH_VERSION_SHORT="1.${PREV_GH_MINOR}"
+
+  if [[ "$PREV_GH_VERSION_SHORT" != "$GH_VERSION_SHORT" ]]; then
+    echo "   Updating cpe: ${PREV_GH_VERSION_SHORT} → ${GH_VERSION_SHORT}"
+    sed "${SED_INPLACE[@]}" "s|cpe:/a:redhat:multicluster_globalhub:${PREV_GH_VERSION_SHORT}|cpe:/a:redhat:multicluster_globalhub:${GH_VERSION_SHORT}|g" "$CONTAINERFILE"
+
+    echo "   Updating version: release-${PREV_GH_VERSION_SHORT} → release-${GH_VERSION_SHORT}"
+    sed "${SED_INPLACE[@]}" "s|version=\"release-${PREV_GH_VERSION_SHORT}\"|version=\"release-${GH_VERSION_SHORT}\"|g" "$CONTAINERFILE"
+
+    echo "   ✅ Updated $CONTAINERFILE"
+  else
+    echo "   ℹ️  Version unchanged (${GH_VERSION_SHORT}), skipping"
+  fi
+else
+  echo "   ⚠️  File not found: $CONTAINERFILE" >&2
+fi
+
 # Step 2: Commit changes
 echo ""
 echo "📍 Step 2: Committing changes on $GRAFANA_BRANCH..."
@@ -202,6 +225,7 @@ else
 - Rename and update pull-request pipeline for ${GRAFANA_TAG}
 - Rename and update push pipeline for ${GRAFANA_TAG}
 - Update branch references to ${GRAFANA_BRANCH}
+- Update Containerfile.konflux labels (cpe, version)
 
 Corresponds to ACM ${RELEASE_BRANCH} / Global Hub ${GH_VERSION}"
 
@@ -293,6 +317,7 @@ else
 - Rename and update pull-request pipeline for \`${GRAFANA_TAG}\`
 - Rename and update push pipeline for \`${GRAFANA_TAG}\`
 - Update branch references to \`${GRAFANA_BRANCH}\`
+- Update Containerfile.konflux labels (cpe, version)
 
 ## Version Mapping
 

--- a/.claude/skills/new-release/scripts/06-postgres-exporter.sh
+++ b/.claude/skills/new-release/scripts/06-postgres-exporter.sh
@@ -190,6 +190,31 @@ else
   echo "   ⚠️  No previous postgres tag found, skipping pipeline update" >&2
 fi
 
+# Step 1.5: Update Containerfile.konflux labels
+echo ""
+echo "📍 Step 1.5: Updating Containerfile.konflux labels..."
+
+CONTAINERFILE="Containerfile.konflux"
+if [[ -f "$CONTAINERFILE" ]]; then
+  GH_VERSION_SHORT="${GH_VERSION#v}"        # v1.8.0 -> 1.8.0
+  GH_VERSION_SHORT="${GH_VERSION_SHORT%.*}"  # 1.8.0 -> 1.8
+  PREV_GH_VERSION_SHORT="1.${PREV_GH_MINOR}"
+
+  if [[ "$PREV_GH_VERSION_SHORT" != "$GH_VERSION_SHORT" ]]; then
+    echo "   Updating cpe: ${PREV_GH_VERSION_SHORT} → ${GH_VERSION_SHORT}"
+    sed "${SED_INPLACE[@]}" "s|cpe:/a:redhat:multicluster_globalhub:${PREV_GH_VERSION_SHORT}|cpe:/a:redhat:multicluster_globalhub:${GH_VERSION_SHORT}|g" "$CONTAINERFILE"
+
+    echo "   Updating version: release-${PREV_GH_VERSION_SHORT} → release-${GH_VERSION_SHORT}"
+    sed "${SED_INPLACE[@]}" "s|version=\"release-${PREV_GH_VERSION_SHORT}\"|version=\"release-${GH_VERSION_SHORT}\"|g" "$CONTAINERFILE"
+
+    echo "   ✅ Updated $CONTAINERFILE"
+  else
+    echo "   ℹ️  Version unchanged (${GH_VERSION_SHORT}), skipping"
+  fi
+else
+  echo "   ⚠️  File not found: $CONTAINERFILE" >&2
+fi
+
 # Step 2: Commit changes
 echo ""
 echo "📍 Step 2: Committing changes on $RELEASE_BRANCH..."
@@ -205,6 +230,7 @@ else
 - Rename and update pull-request pipeline for ${POSTGRES_TAG}
 - Rename and update push pipeline for ${POSTGRES_TAG}
 - Update branch references to ${RELEASE_BRANCH}
+- Update Containerfile.konflux labels (cpe, version)
 
 Corresponds to ACM ${RELEASE_BRANCH} / Global Hub ${GH_VERSION}"
 
@@ -296,6 +322,7 @@ else
 - Rename and update pull-request pipeline for \`${POSTGRES_TAG}\`
 - Rename and update push pipeline for \`${POSTGRES_TAG}\`
 - Update branch references to \`${RELEASE_BRANCH}\`
+- Update Containerfile.konflux labels (cpe, version)
 
 ## Version Mapping
 


### PR DESCRIPTION
## Summary

Fix missing version updates in new-release automation scripts. Previously, several Containerfile labels and catalog resources were not being updated during release cuts.

### Changes by script

**`03-bundle.sh`**
- Add Containerfile.bundle label updates (channels, default channel, cpe, version)
- Fix macOS grep compatibility (`grep -vF` with `--` separator)

**`04-catalog.sh`**
- Clean up ALL outdated OCP tekton pipelines and directories below OCP_MIN (not just the previous version)
- Add README.md image reference updates

**`05-grafana.sh`**
- Add Containerfile.konflux label updates (cpe, version)

**`06-postgres-exporter.sh`**
- Add Containerfile.konflux label updates (cpe, version)

### Verification PRs (ACM 2.17 / Global Hub 1.8)

- stolostron/multicluster-global-hub-operator-bundle#904
- stolostron/multicluster-global-hub-operator-catalog#395
- stolostron/postgres_exporter#153

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined release automation scripts for consistent version label management across container images
  * Streamlined cleanup processes for build pipelines and directories

* **Documentation**
  * Automated version reference updates in release documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->