### PR TITLE
fix cluster update conflict.

### DIFF
--- a/agent/pkg/spec/hubstatus/hub_status_syncer.go
+++ b/agent/pkg/spec/hubstatus/hub_status_syncer.go
@@ -91,23 +91,32 @@ func (s *HubStatusSyncer) Sync(ctx context.Context, evt *cloudevents.Event) erro
 func (s *HubStatusSyncer) updateManagedClusterHubAcceptsClient(ctx context.Context, clusterName string,
 	hubAcceptsClient bool,
 ) error {
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		// Get the ManagedCluster
-		managedCluster := &clusterv1.ManagedCluster{}
-		if err := s.client.Get(ctx, client.ObjectKey{Name: clusterName}, managedCluster); err != nil {
-			if errors.IsNotFound(err) {
-				log.Debugw("ManagedCluster not found, skipping update", "cluster", clusterName)
-				return nil
-			}
-			return fmt.Errorf("failed to get ManagedCluster: %w", err)
+	// First, try to get the cluster without retry to check if it exists
+	managedCluster := &clusterv1.ManagedCluster{}
+	if err := s.client.Get(ctx, client.ObjectKey{Name: clusterName}, managedCluster); err != nil {
+		if errors.IsNotFound(err) {
+			// Return NotFound error - this will cause Sync() to return error
+			// triggering message-level retry with proper backoff, giving cache time to sync
+			log.Debugw("ManagedCluster not found, will retry message later",
+				"cluster", clusterName)
+			return fmt.Errorf("ManagedCluster not found (may be cache sync delay): %s", clusterName)
 		}
+		return fmt.Errorf("failed to get ManagedCluster: %w", err)
+	}
 
-		// Check if update is needed
-		if managedCluster.Spec.HubAcceptsClient == hubAcceptsClient {
-			log.Debugw("ManagedCluster hubAcceptsClient already set to desired value",
-				"cluster", clusterName,
-				"hubAcceptsClient", hubAcceptsClient)
-			return nil
+	// Check if update is needed
+	if managedCluster.Spec.HubAcceptsClient == hubAcceptsClient {
+		log.Debugw("ManagedCluster hubAcceptsClient already set to desired value",
+			"cluster", clusterName,
+			"hubAcceptsClient", hubAcceptsClient)
+		return nil
+	}
+
+	// Use retry for update conflicts only
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		// Re-get the latest version before update
+		if err := s.client.Get(ctx, client.ObjectKey{Name: clusterName}, managedCluster); err != nil {
+			return fmt.Errorf("failed to get ManagedCluster: %w", err)
 		}
 
 		// Set hubAcceptsClient
@@ -118,12 +127,15 @@ func (s *HubStatusSyncer) updateManagedClusterHubAcceptsClient(ctx context.Conte
 			return fmt.Errorf("failed to update ManagedCluster: %w", err)
 		}
 
-		log.Infow("updated ManagedCluster hubAcceptsClient",
-			"cluster", clusterName,
-			"hubAcceptsClient", hubAcceptsClient)
-
 		return nil
 	})
+	if err != nil {
+		return err
+	}
 
-	return err
+	log.Infow("updated ManagedCluster hubAcceptsClient",
+		"cluster", clusterName,
+		"hubAcceptsClient", hubAcceptsClient)
+
+	return nil
 }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes # https://github.com/stolostron/multicluster-global-hub/issues/2378

## Tests
* [ ] Unit/function tests have been added and incorporated into `make unit-tests`.
* [ ] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [ ] List other manual tests you have done.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error detection and reporting for managed cluster updates when a cluster no longer exists, preventing silent operation failures.

* **Improvements**
  * Optimized cluster status synchronization to avoid redundant updates when desired configuration already matches the current state.
  * Enhanced retry and conflict resolution logic for more reliable cluster management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->