### PR TITLE
Update VolSync backup configuration to Direct copy method

### DIFF
--- a/doc/simulation/backup_restore/backup/volsync-config.yaml
+++ b/doc/simulation/backup_restore/backup/volsync-config.yaml
@@ -7,7 +7,7 @@ metadata:
    cluster.open-cluster-management.io/backup: cluster-activation
 data:
  cacheCapacity: 1Gi
- copyMethod: Snapshot
+ copyMethod: Direct
  pruneIntervalDays: '2'
  repository: restic-secret
  retain_daily: '2'


### PR DESCRIPTION
## Summary

- Update VolSync backup configuration copyMethod from Snapshot to Direct
- Aligns with recommended disaster recovery backup practices

## Changes

### Documentation (doc/simulation/backup_restore/backup/)
- Change `copyMethod: Snapshot` to `copyMethod: Direct` in volsync-config.yaml

## Test plan

- [ ] Verify backup/restore simulation documentation is accurate
- [ ] Test disaster recovery scenarios with Direct copy method
- [ ] Ensure configuration aligns with VolSync best practices

## Related Issues

Related to: https://github.com/open-cluster-management-io/policy-collection/pull/544

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Signed-off-by: daliu@redhat.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backup configuration settings to change the copy mechanism used for backup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->