### PR TITLE
ACM-32677: refactor Hub HA active syncer trigger workflow

### DIFF
--- a/agent/pkg/spec/hubha/hubha_config_syncer.go
+++ b/agent/pkg/spec/hubha/hubha_config_syncer.go
@@ -19,8 +19,11 @@ import (
 
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/configs"
 	haconfigbundle "github.com/stolostron/multicluster-global-hub/pkg/bundle/haconfig"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
+
+var log = logger.DefaultZapLogger()
 
 const (
 	klusterletConfigAnnotation = "agent.open-cluster-management.io/klusterlet-config"
@@ -67,6 +70,8 @@ func (s *HAConfigSyncer) Sync(ctx context.Context, evt *cloudevents.Event) error
 	if err := s.annotateAllManagedClusters(ctx, klusterletConfigName); err != nil {
 		return fmt.Errorf("failed to annotate managed clusters: %w", err)
 	}
+
+	configs.GetAgentConfig().SetStandbyHub(standbyHub)
 
 	log.Infof("HA config applied: klusterletConfig=%s", klusterletConfigName)
 	return nil

--- a/agent/pkg/status/generic/periodic_syncer.go
+++ b/agent/pkg/status/generic/periodic_syncer.go
@@ -45,8 +45,18 @@ func AddPeriodicSyncer(mgr ctrl.Manager) (*PeriodicSyncer, error) {
 }
 
 // Register adds an emitter to the periodic syncer.
+func (p *PeriodicSyncer) Unregister(eventType string) {
+	for i, state := range p.syncStates {
+		if state.Registration.Emitter.EventType() == eventType {
+			p.syncStates = append(p.syncStates[:i], p.syncStates[i+1:]...)
+			log.Infof("unregistered emitter for event type: %s", eventType)
+			return
+		}
+	}
+}
+
 func (p *PeriodicSyncer) Register(e *EmitterRegistration) {
-	if e.ListFunc == nil || e.Emitter == nil {
+	if e.Emitter == nil {
 		log.Warnf("Emitter registration for event type %v is invalid, skipping", e)
 		return
 	}
@@ -79,6 +89,16 @@ func (p *PeriodicSyncer) Resync(ctx context.Context, eventType string) error {
 			continue
 		}
 
+		if state.Registration.ListFunc == nil {
+			if err := state.Registration.Emitter.Resync(nil); err != nil {
+				return fmt.Errorf("failed to resync objects for event type %s: %w", registeredType, err)
+			}
+			resynced = true
+			state.NextResyncAt = time.Now().Add(configmap.GetResyncInterval(enum.EventType(registeredType)))
+			log.Infof("resynced objects for event type: %s", enum.ShortenEventType(registeredType))
+			continue
+		}
+
 		objects, err := state.Registration.ListFunc()
 		if err != nil {
 			return fmt.Errorf("failed to list objects for event type %s in Resync: %w", registeredType, err)
@@ -93,7 +113,6 @@ func (p *PeriodicSyncer) Resync(ctx context.Context, eventType string) error {
 			return fmt.Errorf("failed to resync objects for event type %s: %w", registeredType, err)
 		}
 		resynced = true
-		// Update the next resync time for this emitter
 		state.NextResyncAt = time.Now().Add(configmap.GetResyncInterval(enum.EventType(registeredType)))
 		log.Infof("resynced %d objects for event type: %s", len(objects), enum.ShortenEventType(registeredType))
 	}

--- a/agent/pkg/status/status.go
+++ b/agent/pkg/status/status.go
@@ -12,11 +12,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/configs"
-	"github.com/stolostron/multicluster-global-hub/agent/pkg/spec/hubha"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/filter"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/generic"
-	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/syncers/configmap"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/syncers/events"
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/syncers/hubha"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/syncers/managedcluster"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/syncers/managedhub"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/syncers/policies"
@@ -44,28 +43,21 @@ func AddToManager(ctx context.Context, mgr ctrl.Manager, transportClient transpo
 func addKafkaSyncer(ctx context.Context, mgr ctrl.Manager, producer transport.Producer,
 	agentConfig *configs.AgentConfig,
 ) error {
-	// Initialize Hub HA syncer manager for dynamic syncer lifecycle management
-	// This allows the configmap controller to start/stop the Hub HA syncer when hubRole changes
-	// Pass the manager-level context for long-lived syncer goroutines
-	configmap.SetHubHASyncerManager(ctx, mgr, producer, hubha.StartHubHAActiveSyncer)
-
-	// Start Hub HA syncer on first boot if agent is in active role
-	// The configmap controller will handle dynamic role changes after this
-	configmap.StartHubHASyncerIfActive()
-
 	// start periodic syncer
 	periodicSyncer, err := generic.AddPeriodicSyncer(mgr)
 	if err != nil {
 		return fmt.Errorf("failed to start the periodic syncer: %w", err)
 	}
+
+	// Hub HA controller watches KlusterletConfig to trigger active syncer
+	if err := hubha.AddHubHAController(ctx, mgr, producer, periodicSyncer); err != nil {
+		return fmt.Errorf("failed to add hub HA controller: %w", err)
+	}
+
 	// managed cluster
 	if err := managedcluster.AddManagedClusterSyncer(ctx, mgr, producer, periodicSyncer); err != nil {
 		return fmt.Errorf("failed to launch managedcluster syncer: %w", err)
 	}
-
-	// Hub HA active syncer lifecycle is now fully managed by the configmap controller
-	// It will start/stop the syncer based on hub role changes in the configmap
-	// No boot-time direct call to avoid creating untracked syncer instances
 
 	// event syncer
 	err = events.AddEventSyncer(ctx, mgr, producer, periodicSyncer)

--- a/agent/pkg/status/syncers/configmap/config_controller.go
+++ b/agent/pkg/status/syncers/configmap/config_controller.go
@@ -3,7 +3,6 @@ package configmap
 import (
 	"context"
 	"fmt"
-	"sync"
 	"time"
 
 	"go.uber.org/zap"
@@ -17,86 +16,15 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/enum"
 	"github.com/stolostron/multicluster-global-hub/pkg/logger"
-	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 )
 
 const (
 	RequeuePeriod = 5 * time.Second
 )
 
-var (
-	// Hub HA syncer management
-	hubHASyncerManager *HubHASyncerManager
-	hubHASyncerOnce    sync.Once
-)
-
-// HubHASyncerStartFunc is a function type to start the Hub HA active syncer
-type HubHASyncerStartFunc func(context.Context, ctrl.Manager, transport.Producer) error
-
-// HubHASyncerManager manages the Hub HA active syncer lifecycle
-type HubHASyncerManager struct {
-	ctx       context.Context // Long-lived manager context for syncer goroutines
-	mgr       ctrl.Manager
-	producer  transport.Producer
-	startFunc HubHASyncerStartFunc
-	cancel    context.CancelFunc
-	mu        sync.Mutex
-}
-
 type hubOfHubsConfigController struct {
 	client client.Client
 	log    *zap.SugaredLogger
-}
-
-// SetHubHASyncerManager initializes the Hub HA syncer manager for dynamic syncer lifecycle management
-// The ctx parameter should be a long-lived manager-level context, not a request-scoped reconcile context
-func SetHubHASyncerManager(ctx context.Context, mgr ctrl.Manager, producer transport.Producer, startFunc HubHASyncerStartFunc) {
-	hubHASyncerOnce.Do(func() {
-		hubHASyncerManager = &HubHASyncerManager{
-			ctx:       ctx,
-			mgr:       mgr,
-			producer:  producer,
-			startFunc: startFunc,
-		}
-	})
-}
-
-// StartHubHASyncerIfActive starts the Hub HA syncer if the agent is in active role
-// This should be called after SetHubHASyncerManager to handle first boot
-func StartHubHASyncerIfActive() {
-	if hubHASyncerManager == nil {
-		return
-	}
-
-	agentConfig := configs.GetAgentConfig()
-	if agentConfig == nil {
-		return
-	}
-
-	hubRole, _ := agentConfig.GetHubRoleAndStandbyHub()
-	if hubRole != constants.GHHubRoleActive {
-		return
-	}
-
-	// Use the manager's lock to avoid race conditions
-	hubHASyncerManager.mu.Lock()
-	defer hubHASyncerManager.mu.Unlock()
-
-	// Only start if not already running
-	if hubHASyncerManager.cancel != nil {
-		return
-	}
-
-	syncerCtx, cancel := context.WithCancel(hubHASyncerManager.ctx)
-	hubHASyncerManager.cancel = cancel
-
-	go func() {
-		if err := hubHASyncerManager.startFunc(syncerCtx, hubHASyncerManager.mgr, hubHASyncerManager.producer); err != nil {
-			logger.DefaultZapLogger().Errorw("Failed to start Hub HA active syncer", "error", err)
-		}
-	}()
-
-	logger.DefaultZapLogger().Info("Started Hub HA active syncer on first boot")
 }
 
 // AddConfigMapController creates a new instance of config controller and adds it to the manager.
@@ -161,7 +89,6 @@ func (c *hubOfHubsConfigController) Reconcile(ctx context.Context, request ctrl.
 	// Update AgentConfig with hubRole and standbyHub
 	agentConfig := configs.GetAgentConfig()
 	if agentConfig != nil {
-		// Determine new values from configmap
 		var newHubRole, newStandbyHub string
 		if hubRole, found := agentConfigMap.Data[AgentHubRoleKey]; found && hubRole != "" {
 			newHubRole = hubRole
@@ -172,77 +99,14 @@ func (c *hubOfHubsConfigController) Reconcile(ctx context.Context, request ctrl.
 			reqLogger.Infof("Updated agent standby hub to: %s", standbyHub)
 		}
 
-		// Atomically update both fields and get previous values
-		previousHubRole, previousStandbyHub := agentConfig.UpdateHubRoleAndStandbyHub(newHubRole, newStandbyHub)
-
-		// Dynamic Hub HA syncer management: restart syncer when:
-		// 1. Hub role changes to/from active
-		// 2. Hub is active and standby hub target changes
-		roleChanged := previousHubRole != newHubRole
-		standbyChanged := previousStandbyHub != newStandbyHub
-		isActiveRole := newHubRole == constants.GHHubRoleActive || previousHubRole == constants.GHHubRoleActive
-
-		if (roleChanged || standbyChanged) && isActiveRole {
-			reqLogger.Infow("Hub HA configuration changed, restarting syncer",
-				"previousRole", previousHubRole,
-				"newRole", newHubRole,
-				"previousStandbyHub", previousStandbyHub,
-				"newStandbyHub", newStandbyHub)
-
-			// Try to restart syncer; if manager not initialized yet, requeue to retry later
-			if !c.restartHubHASyncer(reqLogger) {
-				reqLogger.Info("Hub HA syncer manager not ready, will retry in 5 seconds")
-				return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
-			}
-		}
+		agentConfig.UpdateHubRoleAndStandbyHub(newHubRole, newStandbyHub)
 	}
+
+	c.setSyncInterval(agentConfigMap, GetResyncKey(enum.EventType(constants.HubHAResourcesMsgKey)))
+	c.setSyncInterval(agentConfigMap, GetSyncKey(enum.EventType(constants.HubHAResourcesMsgKey)))
 
 	reqLogger.Debug("Reconciliation complete.")
 	return ctrl.Result{}, nil
-}
-
-// restartHubHASyncer stops any existing Hub HA syncer and starts a new one if role is active
-// Returns true if successful (or manager not needed), false if manager not initialized yet (caller should requeue)
-func (c *hubOfHubsConfigController) restartHubHASyncer(log *zap.SugaredLogger) bool {
-	if hubHASyncerManager == nil {
-		log.Warn("Hub HA syncer manager not initialized, cannot restart syncer")
-		return false
-	}
-
-	hubHASyncerManager.mu.Lock()
-	defer hubHASyncerManager.mu.Unlock()
-
-	// Stop existing syncer if running
-	if hubHASyncerManager.cancel != nil {
-		log.Info("Stopping existing Hub HA syncer")
-		hubHASyncerManager.cancel()
-		hubHASyncerManager.cancel = nil
-	}
-
-	// Start new syncer if role is active
-	agentConfig := configs.GetAgentConfig()
-	if agentConfig != nil {
-		hubRole, standbyHub := agentConfig.GetHubRoleAndStandbyHub()
-		if hubRole == constants.GHHubRoleActive {
-			log.Infow("Starting Hub HA active syncer",
-				"hubRole", hubRole,
-				"standbyHub", standbyHub)
-
-			// Create cancellable context for the syncer from the manager-level context
-			// Do NOT use the reconcile ctx parameter as it is request-scoped and will be
-			// cancelled when reconciliation completes, terminating the long-lived syncer
-			syncerCtx, cancel := context.WithCancel(hubHASyncerManager.ctx)
-			hubHASyncerManager.cancel = cancel
-
-			// Start the syncer using the provided start function
-			go func() {
-				if err := hubHASyncerManager.startFunc(syncerCtx, hubHASyncerManager.mgr, hubHASyncerManager.producer); err != nil {
-					log.Errorw("Failed to start Hub HA active syncer", "error", err)
-				}
-			}()
-		}
-	}
-	return true
 }
 
 func (c *hubOfHubsConfigController) setSyncInterval(configMap *corev1.ConfigMap, key string) {

--- a/agent/pkg/status/syncers/hubha/hubha_active_syncer.go
+++ b/agent/pkg/status/syncers/hubha/hubha_active_syncer.go
@@ -7,9 +7,9 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"time"
 
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -17,19 +17,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 
-	"github.com/stolostron/multicluster-global-hub/agent/pkg/configs"
-	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/logger"
-	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 )
 
 var log = logger.DefaultZapLogger()
 
 const (
-	// Full resync every 30 minutes as a safety net for consistency
-	// This handles edge cases like missed events during network issues or agent restarts
-	hubhaResyncInterval = 30 * time.Minute
-	// API Groups - constants to avoid string literal duplication
 	groupAddonOCM                 = "addon.open-cluster-management.io"
 	groupAgentOCM                 = "agent.open-cluster-management.io"
 	groupAppsOCM                  = "apps.open-cluster-management.io"
@@ -55,107 +48,48 @@ const (
 	groupCAPIProviderAgentInstall = "capi-provider.agent-install.openshift.io"
 )
 
-// hubHAController implements reconciliation for all Hub HA resources using list-watch pattern
-type hubHAController struct {
+type hubHAResourceSyncer struct {
 	client  client.Client
 	emitter *HubHAEmitter
+	enabled atomic.Bool
 }
 
-// StartHubHAActiveSyncer starts the active hub syncer using controller-based list-watch pattern
-func StartHubHAActiveSyncer(ctx context.Context, mgr ctrl.Manager, producer transport.Producer) error {
-	// Only start if this is an active hub with a configured standby
-	agentConfig := configs.GetAgentConfig()
-	if agentConfig == nil {
-		log.Info("Hub HA active syncer not started - agent config is nil")
-		return nil
-	}
-
-	// Get hub role and standby hub atomically
-	hubRole, standbyHub := agentConfig.GetHubRoleAndStandbyHub()
-	if hubRole != constants.GHHubRoleActive {
-		log.Info("Hub HA active syncer not started - this is not an active hub")
-		return nil
-	}
-
-	if standbyHub == "" {
-		log.Warn("Hub HA active syncer not started - no standby hub configured")
-		return nil
-	}
-
-	log.Infof("starting Hub HA active syncer with list-watch pattern: %s (active) -> %s (standby)",
-		agentConfig.LeafHubName, standbyHub)
-
-	// Create shared emitter for all Hub HA resources
-	emitter := NewHubHAEmitter(
-		producer,
-		agentConfig.TransportConfig,
-		agentConfig.LeafHubName,
-		standbyHub,
-	)
-
-	// Start a single controller that watches all resource types
-	allResources := getHubHAResourcesToSync()
-	activeResources, err := startHubHAController(mgr, allResources, emitter)
-	if err != nil {
-		return err
-	}
-
-	log.Infof("Hub HA active syncer started watching %d/%d resource types", len(activeResources), len(allResources))
-
-	// Start periodic resync as a safety net for consistency (handles edge cases like missed events)
-	// Only resync resources that have active controllers
-	go periodicResync(ctx, mgr.GetClient(), emitter, activeResources, hubhaResyncInterval)
-
-	return nil
-}
-
-// startHubHAController starts a single controller that watches all Hub HA resource types
-func startHubHAController(mgr ctrl.Manager, allGVKs []schema.GroupVersionKind,
+func StartHubHAResourceSyncer(mgr ctrl.Manager, allGVKs []schema.GroupVersionKind,
 	emitter *HubHAEmitter,
-) ([]schema.GroupVersionKind, error) {
-	// Create controller that handles all GVKs
-	controller := &hubHAController{
+) (*hubHAResourceSyncer, error) {
+	syncer := &hubHAResourceSyncer{
 		client:  mgr.GetClient(),
 		emitter: emitter,
 	}
+	syncer.enabled.Store(true)
 
-	// Start with empty controller builder
 	builder := ctrl.NewControllerManagedBy(mgr).
 		Named("hubha").
 		WithEventFilter(emitter.Predicate())
 
-	// Track which GVKs were successfully added
 	var activeGVKs []schema.GroupVersionKind
 
-	// Add watches for each GVK using WatchesMetadata with custom handler
 	for _, gvk := range allGVKs {
-		// Check if CRD exists
 		_, err := mgr.GetRESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version)
 		if err != nil {
 			log.Debugf("skipped watch for %s: CRD not installed", gvk.String())
 			continue
 		}
 
-		// Create instance for this GVK
 		instance := &unstructured.Unstructured{}
 		instance.SetGroupVersionKind(gvk)
 
-		// Use WatchesMetadata with custom handler that encodes GVK into the Name field
-		// This allows us to reconstruct the GVK in the Reconcile function
 		builder = builder.WatchesMetadata(instance, handler.EnqueueRequestsFromMapFunc(
 			func(ctx context.Context, obj client.Object) []ctrl.Request {
-				// Get GVK from the object
 				objGVK := obj.GetObjectKind().GroupVersionKind()
 
-				// Encode GVK into Name field using "||" delimiter
-				// Format: Group||Version||Kind||RealName
 				encodedName := fmt.Sprintf("%s||%s||%s||%s",
 					objGVK.Group, objGVK.Version, objGVK.Kind, obj.GetName())
 
 				return []ctrl.Request{{
 					NamespacedName: types.NamespacedName{
-						Namespace: obj.GetNamespace(), // Real namespace
-						Name:      encodedName,        // Encoded: GVK||RealName
+						Namespace: obj.GetNamespace(),
+						Name:      encodedName,
 					},
 				}}
 			},
@@ -165,19 +99,20 @@ func startHubHAController(mgr ctrl.Manager, allGVKs []schema.GroupVersionKind,
 		log.Debugf("added Hub HA watch for %s", gvk.String())
 	}
 
-	// Complete the controller
-	if err := builder.Complete(controller); err != nil {
+	if err := builder.Complete(syncer); err != nil {
 		return nil, fmt.Errorf("failed to build Hub HA controller: %w", err)
 	}
 
-	return activeGVKs, nil
+	emitter.SetActiveResources(activeGVKs)
+
+	return syncer, nil
 }
 
-// Reconcile handles changes to Hub HA resources
-// This reconciler handles all GVKs watched by the controller
-func (c *hubHAController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	// Decode GVK from the encoded Name field
-	// Format: Group||Version||Kind||RealName
+func (c *hubHAResourceSyncer) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	if !c.enabled.Load() {
+		return ctrl.Result{}, nil
+	}
+
 	parts := strings.Split(req.Name, "||")
 	if len(parts) != 4 {
 		log.Errorf("invalid encoded name format: %s", req.Name)
@@ -192,7 +127,6 @@ func (c *hubHAController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	realName := parts[3]
 	realNamespace := req.Namespace
 
-	// Try to get the object as unstructured with the decoded GVK
 	obj := &unstructured.Unstructured{}
 	obj.SetGroupVersionKind(gvk)
 
@@ -202,7 +136,6 @@ func (c *hubHAController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	}, obj)
 	if err != nil {
 		if client.IgnoreNotFound(err) == nil {
-			// Object was deleted
 			obj.SetNamespace(realNamespace)
 			obj.SetName(realName)
 			obj.SetGroupVersionKind(gvk)
@@ -217,7 +150,6 @@ func (c *hubHAController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, err
 	}
 
-	// Object exists but being deleted (has DeletionTimestamp)
 	if !obj.GetDeletionTimestamp().IsZero() {
 		if err := c.emitter.Delete(obj); err != nil {
 			log.Errorf("failed to handle delete for %s/%s (%s): %v",
@@ -227,7 +159,6 @@ func (c *hubHAController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return ctrl.Result{}, nil
 	}
 
-	// Update
 	if err := c.emitter.Update(obj); err != nil {
 		log.Errorf("failed to handle update for %s/%s (%s): %v",
 			realNamespace, realName, gvk.Kind, err)
@@ -237,78 +168,15 @@ func (c *hubHAController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	return ctrl.Result{}, nil
 }
 
-// periodicResync performs full resyncs at regular intervals for consistency
-func periodicResync(ctx context.Context, c client.Client, emitter *HubHAEmitter,
-	resourcesToSync []schema.GroupVersionKind, interval time.Duration,
-) {
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			log.Info("Hub HA periodic resync stopped")
-			return
-		case <-ticker.C:
-			log.Info("starting Hub HA full resync")
-			if err := performFullResync(ctx, c, emitter, resourcesToSync); err != nil {
-				log.Errorf("failed to perform Hub HA full resync: %v", err)
-			}
-		}
-	}
-}
-
-// performFullResync lists all resources and triggers a resync
-func performFullResync(ctx context.Context, c client.Client, emitter *HubHAEmitter,
-	resourcesToSync []schema.GroupVersionKind,
-) error {
-	allObjects := []client.Object{}
-
-	for _, gvk := range resourcesToSync {
-		list := &unstructured.UnstructuredList{}
-		list.SetGroupVersionKind(schema.GroupVersionKind{
-			Group:   gvk.Group,
-			Version: gvk.Version,
-			Kind:    gvk.Kind + "List",
-		})
-
-		if err := c.List(ctx, list); err != nil {
-			// If CRD doesn't exist, skip it
-			if meta.IsNoMatchError(err) {
-				log.Debugf("CRD not installed for %s, skipping resync", gvk.String())
-				continue
-			}
-			log.Warnf("failed to list resources for %s during resync: %v", gvk.String(), err)
-			continue
-		}
-
-		for i := range list.Items {
-			obj := &list.Items[i]
-			allObjects = append(allObjects, obj)
-		}
-	}
-
-	log.Infof("performing Hub HA full resync with %d total objects", len(allObjects))
-	if err := emitter.Resync(allObjects); err != nil {
-		return err
-	}
-	// Send the resync bundle immediately
-	return emitter.Send()
-}
-
-// getHubHAResourcesToSync returns the list of resources to sync for Hub HA
-func getHubHAResourcesToSync() []schema.GroupVersionKind {
+func GetHubHAResourcesToSync() []schema.GroupVersionKind {
 	return []schema.GroupVersionKind{
-		// ACM/OCM Addon resources
 		{Group: groupAddonOCM, Version: "v1beta1", Kind: "AddOnDeploymentConfig"},
 		{Group: groupAddonOCM, Version: "v1alpha1", Kind: "AddOnTemplate"},
 		{Group: groupAddonOCM, Version: "v1beta1", Kind: "ClusterManagementAddOn"},
 		{Group: groupAddonOCM, Version: "v1beta1", Kind: "ManagedClusterAddOn"},
 
-		// ACM/OCM Agent resources
 		{Group: groupAgentOCM, Version: "v1", Kind: "KlusterletAddonConfig"},
 
-		// ACM/OCM Application resources
 		{Group: groupAppsOCM, Version: "v1", Kind: "Channel"},
 		{Group: groupAppsOCM, Version: "v1", Kind: "Deployable"},
 		{Group: groupAppsOCM, Version: "v1beta1", Kind: "GitOpsCluster"},
@@ -319,10 +187,8 @@ func getHubHAResourcesToSync() []schema.GroupVersionKind {
 		{Group: groupAppsOCM, Version: "v1", Kind: "Subscription"},
 		{Group: groupAppsOCM, Version: "v1alpha1", Kind: "SubscriptionStatus"},
 
-		// ACM/OCM Authentication resources
 		{Group: groupAuthenticationOCM, Version: "v1beta1", Kind: "ManagedServiceAccount"},
 
-		// ACM/OCM Cluster resources
 		{Group: groupClusterOCM, Version: "v1alpha1", Kind: "AddOnPlacementScore"},
 		{Group: groupClusterOCM, Version: "v1beta1", Kind: "BackupSchedule"},
 		{Group: groupClusterOCM, Version: "v1alpha1", Kind: "ClusterClaim"},
@@ -334,27 +200,20 @@ func getHubHAResourcesToSync() []schema.GroupVersionKind {
 		{Group: groupClusterOCM, Version: "v1beta1", Kind: "Placement"},
 		{Group: groupClusterOCM, Version: "v1beta1", Kind: "Restore"},
 
-		// ACM/OCM Config resources
 		{Group: groupConfigOCM, Version: "v1alpha1", Kind: "KlusterletConfig"},
 
-		// ACM/OCM Console resources
 		{Group: groupConsoleOCM, Version: "v1", Kind: "UserPreference"},
 
-		// ACM/OCM Discovery resources
 		{Group: groupDiscoveryOCM, Version: "v1", Kind: "DiscoveredCluster"},
 		{Group: groupDiscoveryOCM, Version: "v1", Kind: "DiscoveryConfig"},
 
-		// Global Hub resources
 		{Group: groupGlobalHubOCM, Version: "v1alpha1", Kind: "ManagedClusterMigration"},
 
-		// ACM/OCM Image Registry resources
 		{Group: groupImageRegistryOCM, Version: "v1alpha1", Kind: "ManagedClusterImageRegistry"},
 
-		// ACM/OCM Observability resources
 		{Group: groupObservabilityOCM, Version: "v1beta2", Kind: "MultiClusterObservability"},
 		{Group: groupObservabilityOCM, Version: "v1beta1", Kind: "ObservabilityAddon"},
 
-		// ACM/OCM Policy resources
 		{Group: groupPolicyOCM, Version: "v1", Kind: "CertificatePolicy"},
 		{Group: groupPolicyOCM, Version: "v1", Kind: "ConfigurationPolicy"},
 		{Group: groupPolicyOCM, Version: "v1beta1", Kind: "OperatorPolicy"},
@@ -363,22 +222,17 @@ func getHubHAResourcesToSync() []schema.GroupVersionKind {
 		{Group: groupPolicyOCM, Version: "v1beta1", Kind: "PolicyAutomation"},
 		{Group: groupPolicyOCM, Version: "v1beta1", Kind: "PolicySet"},
 
-		// ACM/OCM RBAC resources
 		{Group: groupRBACOCM, Version: "v1alpha1", Kind: "ClusterPermission"},
 		{Group: groupRBACOCM, Version: "v1beta1", Kind: "MulticlusterRoleAssignment"},
 
-		// ACM/OCM Site Config resources
 		{Group: groupSiteConfigOCM, Version: "v1alpha1", Kind: "ClusterInstance"},
 
-		// ACM/OCM Submariner resources
 		{Group: groupSubmarinerAddonOCM, Version: "v1alpha1", Kind: "SubmarinerConfig"},
 		{Group: groupSubmarinerAddonOCM, Version: "v1alpha1", Kind: "SubmarinerDiagnoseConfig"},
 
-		// Hive extension resources
 		{Group: groupHiveExtensions, Version: "v1beta1", Kind: "AgentClusterInstall"},
 		{Group: groupHiveExtensions, Version: "v1alpha1", Kind: "ImageClusterInstall"},
 
-		// Hive resources
 		{Group: groupHive, Version: "v1", Kind: "Checkpoint"},
 		{Group: groupHive, Version: "v1", Kind: "ClusterClaim"},
 		{Group: groupHive, Version: "v1", Kind: "ClusterDeploymentCustomization"},
@@ -398,41 +252,33 @@ func getHubHAResourcesToSync() []schema.GroupVersionKind {
 		{Group: groupHive, Version: "v1", Kind: "SyncIdentityProvider"},
 		{Group: groupHive, Version: "v1", Kind: "SyncSet"},
 
-		// Hive internal resources
 		{Group: groupHiveInternal, Version: "v1alpha1", Kind: "ClusterSyncLease"},
 		{Group: groupHiveInternal, Version: "v1alpha1", Kind: "ClusterSync"},
 		{Group: groupHiveInternal, Version: "v1alpha1", Kind: "FakeClusterInstall"},
 
-		// ArgoCD Application resources
 		{Group: groupArgoProj, Version: "v1alpha1", Kind: "Application"},
 		{Group: groupArgoProj, Version: "v1alpha1", Kind: "ApplicationSet"},
 		{Group: groupArgoProj, Version: "v1alpha1", Kind: "AppProject"},
 		{Group: groupArgoProj, Version: "v1alpha1", Kind: "ArgoCD"},
 
-		// ArgoCD Workflow resources
 		{Group: groupArgoProj, Version: "v1alpha1", Kind: "Workflow"},
 		{Group: groupArgoProj, Version: "v1alpha1", Kind: "WorkflowTemplate"},
 		{Group: groupArgoProj, Version: "v1alpha1", Kind: "ClusterWorkflowTemplate"},
 		{Group: groupArgoProj, Version: "v1alpha1", Kind: "CronWorkflow"},
 
-		// ArgoCD Events resources
 		{Group: groupArgoProj, Version: "v1alpha1", Kind: "EventSource"},
 		{Group: groupArgoProj, Version: "v1alpha1", Kind: "Sensor"},
 		{Group: groupArgoProj, Version: "v1alpha1", Kind: "EventBus"},
 
-		// ArgoCD Rollouts resources
 		{Group: groupArgoProj, Version: "v1alpha1", Kind: "Rollout"},
 		{Group: groupArgoProj, Version: "v1alpha1", Kind: "Experiment"},
 		{Group: groupArgoProj, Version: "v1alpha1", Kind: "AnalysisTemplate"},
 		{Group: groupArgoProj, Version: "v1alpha1", Kind: "ClusterAnalysisTemplate"},
 
-		// Application resources
 		{Group: groupAppK8s, Version: "v1beta1", Kind: "Application"},
 
-		// Observatorium resources
 		{Group: groupObservatorium, Version: "v1alpha1", Kind: "Observatorium"},
 
-		// Agent install resources (ZTP)
 		{Group: groupAgentInstall, Version: "v1beta1", Kind: "AgentClassification"},
 		{Group: groupAgentInstall, Version: "v1beta1", Kind: "Agent"},
 		{Group: groupAgentInstall, Version: "v1beta1", Kind: "AgentServiceConfig"},
@@ -440,12 +286,10 @@ func getHubHAResourcesToSync() []schema.GroupVersionKind {
 		{Group: groupAgentInstall, Version: "v1beta1", Kind: "InfraEnv"},
 		{Group: groupAgentInstall, Version: "v1beta1", Kind: "NMStateConfig"},
 
-		// CAPI Provider resources
 		{Group: groupCAPIProviderAgentInstall, Version: "v1beta1", Kind: "AgentCluster"},
 		{Group: groupCAPIProviderAgentInstall, Version: "v1beta1", Kind: "AgentMachine"},
 		{Group: groupCAPIProviderAgentInstall, Version: "v1beta1", Kind: "AgentMachineTemplate"},
 
-		// Secrets and ConfigMaps (will be filtered by labels)
 		{Group: "", Version: "v1", Kind: "Secret"},
 		{Group: "", Version: "v1", Kind: "ConfigMap"},
 	}

--- a/agent/pkg/status/syncers/hubha/hubha_active_syncer_test.go
+++ b/agent/pkg/status/syncers/hubha/hubha_active_syncer_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
-	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	corev1 "k8s.io/api/core/v1"
@@ -23,14 +22,12 @@ import (
 )
 
 func TestGetHubHAResourcesToSync(t *testing.T) {
-	resources := getHubHAResourcesToSync()
+	resources := GetHubHAResourcesToSync()
 
-	// Verify we have resources to sync
 	if len(resources) == 0 {
-		t.Error("getHubHAResourcesToSync() returned empty list")
+		t.Error("GetHubHAResourcesToSync() returned empty list")
 	}
 
-	// Verify some key resource types are included
 	expectedResources := []schema.GroupVersionKind{
 		{Group: "policy.open-cluster-management.io", Version: "v1", Kind: "Policy"},
 		{Group: "cluster.open-cluster-management.io", Version: "v1beta1", Kind: "Placement"},
@@ -55,26 +52,23 @@ func TestGetHubHAResourcesToSync(t *testing.T) {
 }
 
 func TestHubHAController_Reconcile_Update(t *testing.T) {
-	// Create fake client
 	scheme := newTestScheme()
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	// Create mock producer and emitter
 	producer := &mockProducer{events: []cloudevents.Event{}}
 	transportConfig := &transport.TransportInternalConfig{
 		KafkaCredential: &transport.KafkaConfig{
 			SpecTopic: "spec-topic",
 		},
 	}
-	emitter := NewHubHAEmitter(producer, transportConfig, "hub1", "hub2")
+	emitter := NewHubHAEmitter(producer, transportConfig, "hub1", "hub2", nil)
 
-	// Create controller
-	controller := &hubHAController{
+	controller := &hubHAResourceSyncer{
 		client:  fakeClient,
 		emitter: emitter,
 	}
+	controller.enabled.Store(true)
 
-	// Create a Secret with required label
 	secret := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "v1",
@@ -87,19 +81,17 @@ func TestHubHAController_Reconcile_Update(t *testing.T) {
 				},
 			},
 			"data": map[string]interface{}{
-				"kubeconfig": "dGVzdA==", // base64 "test"
+				"kubeconfig": "dGVzdA==",
 			},
 		},
 	}
 
-	// Create the secret in fake client
 	err := fakeClient.Create(context.Background(), secret)
 	if err != nil {
 		t.Fatalf("Failed to create secret: %v", err)
 	}
 
-	// Reconcile with encoded name (GVK encoding format)
-	encodedName := "||v1||Secret||test-secret" // Empty group for core/v1 resources
+	encodedName := "||v1||Secret||test-secret"
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{
 			Namespace: "default",
@@ -116,34 +108,30 @@ func TestHubHAController_Reconcile_Update(t *testing.T) {
 		t.Error("Expected no requeue")
 	}
 
-	// Verify event was sent immediately
 	if len(producer.events) != 1 {
 		t.Errorf("Expected 1 event to be sent, got %d", len(producer.events))
 	}
 }
 
 func TestHubHAController_Reconcile_Delete(t *testing.T) {
-	// Create fake client
 	scheme := newTestScheme()
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	// Create mock producer and emitter
 	producer := &mockProducer{events: []cloudevents.Event{}}
 	transportConfig := &transport.TransportInternalConfig{
 		KafkaCredential: &transport.KafkaConfig{
 			SpecTopic: "spec-topic",
 		},
 	}
-	emitter := NewHubHAEmitter(producer, transportConfig, "hub1", "hub2")
+	emitter := NewHubHAEmitter(producer, transportConfig, "hub1", "hub2", nil)
 
-	// Create controller
-	controller := &hubHAController{
+	controller := &hubHAResourceSyncer{
 		client:  fakeClient,
 		emitter: emitter,
 	}
+	controller.enabled.Store(true)
 
-	// Reconcile for non-existent object (deleted) with encoded name
-	encodedName := "||v1||Secret||deleted-secret" // Empty group for core/v1 resources
+	encodedName := "||v1||Secret||deleted-secret"
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{
 			Namespace: "default",
@@ -159,34 +147,26 @@ func TestHubHAController_Reconcile_Delete(t *testing.T) {
 	if result.Requeue {
 		t.Error("Expected no requeue for deleted object")
 	}
-
-	// Note: Delete for non-existent object without required label won't send event
-	// because the filter will reject it
 }
 
 func TestHubHAController_Reconcile_FilteredResource(t *testing.T) {
-	// Create fake client
 	scheme := newTestScheme()
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	// Create mock producer and emitter
 	producer := &mockProducer{events: []cloudevents.Event{}}
 	transportConfig := &transport.TransportInternalConfig{
 		KafkaCredential: &transport.KafkaConfig{
 			SpecTopic: "spec-topic",
 		},
 	}
-	emitter := NewHubHAEmitter(producer, transportConfig, "hub1", "hub2")
+	emitter := NewHubHAEmitter(producer, transportConfig, "hub1", "hub2", nil)
 
-	// Create controller
-	controller := &hubHAController{
+	controller := &hubHAResourceSyncer{
 		client:  fakeClient,
 		emitter: emitter,
 	}
+	controller.enabled.Store(true)
 
-	// Create a Secret WITHOUT required label
-	// Note: In production, the predicate would filter this before Reconcile is called.
-	// This test directly calls Reconcile (bypassing predicate), so it will send the event.
 	secret := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "v1",
@@ -194,19 +174,16 @@ func TestHubHAController_Reconcile_FilteredResource(t *testing.T) {
 			"metadata": map[string]interface{}{
 				"name":      "filtered-secret",
 				"namespace": "default",
-				// No required labels - predicate would filter this in production
 			},
 		},
 	}
 
-	// Create the secret in fake client
 	err := fakeClient.Create(context.Background(), secret)
 	if err != nil {
 		t.Fatalf("Failed to create secret: %v", err)
 	}
 
-	// Reconcile with encoded name
-	encodedName := "||v1||Secret||filtered-secret" // Empty group for core/v1 resources
+	encodedName := "||v1||Secret||filtered-secret"
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{
 			Namespace: "default",
@@ -223,18 +200,14 @@ func TestHubHAController_Reconcile_FilteredResource(t *testing.T) {
 		t.Error("Expected no requeue")
 	}
 
-	// When Reconcile is called directly (bypassing predicate), it will send the event
-	// In production, predicate filters before Reconcile is called
 	if len(producer.events) != 1 {
 		t.Errorf("Expected 1 event when calling Reconcile directly, got %d", len(producer.events))
 	}
 }
 
 func TestPerformFullResync(t *testing.T) {
-	// Create fake client
 	scheme := newTestScheme()
 
-	// Create test secrets
 	secret1 := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "v1",
@@ -268,99 +241,42 @@ func TestPerformFullResync(t *testing.T) {
 		WithObjects(secret1, secret2).
 		Build()
 
-	// Create mock producer and emitter
 	producer := &mockProducer{events: []cloudevents.Event{}}
 	transportConfig := &transport.TransportInternalConfig{
 		KafkaCredential: &transport.KafkaConfig{
 			SpecTopic: "spec-topic",
 		},
 	}
-	emitter := NewHubHAEmitter(producer, transportConfig, "hub1", "hub2")
-
-	// Perform resync
-	resourcesToSync := []schema.GroupVersionKind{
+	emitter := NewHubHAEmitter(producer, transportConfig, "hub1", "hub2", fakeClient)
+	emitter.SetActiveResources([]schema.GroupVersionKind{
 		{Group: "", Version: "v1", Kind: "Secret"},
-	}
+	})
 
-	err := performFullResync(context.Background(), fakeClient, emitter, resourcesToSync)
+	err := emitter.Resync(nil)
 	if err != nil {
-		t.Errorf("performFullResync() error = %v", err)
+		t.Errorf("Resync() error = %v", err)
 	}
 
-	// Verify event was sent
+	err = emitter.Send()
+	if err != nil {
+		t.Errorf("Send() error = %v", err)
+	}
+
 	if len(producer.events) != 1 {
 		t.Errorf("Expected 1 event to be sent after resync, got %d", len(producer.events))
 	}
 
-	// Parse bundle
 	var bundle generic.GenericBundle[*unstructured.Unstructured]
 	err = json.Unmarshal(producer.events[0].Data(), &bundle)
 	if err != nil {
 		t.Errorf("Failed to unmarshal bundle: %v", err)
 	}
 
-	// Should have 2 secrets in resync
 	if len(bundle.Resync) != 2 {
 		t.Errorf("Expected 2 secrets in resync bundle, got %d", len(bundle.Resync))
 	}
 }
 
-func TestPeriodicResync(t *testing.T) {
-	// Create fake client
-	scheme := newTestScheme()
-	secret := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "v1",
-			"kind":       "Secret",
-			"metadata": map[string]interface{}{
-				"name":      "test-secret",
-				"namespace": "default",
-				"labels": map[string]interface{}{
-					"hive.openshift.io/secret-type": "kubeconfig",
-				},
-			},
-		},
-	}
-
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(secret).
-		Build()
-
-	// Create mock producer and emitter
-	producer := &mockProducer{events: []cloudevents.Event{}}
-	transportConfig := &transport.TransportInternalConfig{
-		KafkaCredential: &transport.KafkaConfig{
-			SpecTopic: "spec-topic",
-		},
-	}
-	emitter := NewHubHAEmitter(producer, transportConfig, "hub1", "hub2")
-
-	resourcesToSync := []schema.GroupVersionKind{
-		{Group: "", Version: "v1", Kind: "Secret"},
-	}
-
-	// Start periodic resync with very short interval for testing
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	// Use very short interval for testing
-	interval := 100 * time.Millisecond
-	go periodicResync(ctx, fakeClient, emitter, resourcesToSync, interval)
-
-	// Wait for at least one resync cycle
-	time.Sleep(200 * time.Millisecond)
-
-	// Cancel to stop goroutine
-	cancel()
-
-	// Verify at least one resync event was sent
-	if len(producer.events) < 1 {
-		t.Errorf("Expected at least 1 resync event, got %d", len(producer.events))
-	}
-}
-
-// Helper function to create a test scheme
 func newTestScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)

--- a/agent/pkg/status/syncers/hubha/hubha_controller.go
+++ b/agent/pkg/status/syncers/hubha/hubha_controller.go
@@ -1,0 +1,113 @@
+package hubha
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	klusterletv1alpha1 "github.com/stolostron/cluster-lifecycle-api/klusterletconfig/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/configs"
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/generic"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport"
+)
+
+const klusterletConfigPrefix = "ha-standby-"
+
+type hubHAController struct {
+	ctx            context.Context
+	mgr            ctrl.Manager
+	producer       transport.Producer
+	periodicSyncer *generic.PeriodicSyncer
+	resourceSyncer *hubHAResourceSyncer
+}
+
+func AddHubHAController(ctx context.Context, mgr ctrl.Manager, producer transport.Producer,
+	periodicSyncer *generic.PeriodicSyncer,
+) error {
+	c := &hubHAController{
+		ctx:            ctx,
+		mgr:            mgr,
+		producer:       producer,
+		periodicSyncer: periodicSyncer,
+	}
+
+	pred := predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		standbyHub := configs.GetAgentConfig().GetStandbyHub()
+		if standbyHub == "" {
+			return false
+		}
+		return obj.GetName() == klusterletConfigPrefix+standbyHub
+	})
+
+	if err := ctrl.NewControllerManagedBy(mgr).
+		For(&klusterletv1alpha1.KlusterletConfig{}).
+		WithEventFilter(pred).
+		Complete(c); err != nil {
+		return fmt.Errorf("failed to add hub HA controller: %w", err)
+	}
+	return nil
+}
+
+func (c *hubHAController) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
+	klusterletConfig := &klusterletv1alpha1.KlusterletConfig{}
+	err := c.mgr.GetClient().Get(ctx, request.NamespacedName, klusterletConfig)
+	if apierrors.IsNotFound(err) || (err == nil && !klusterletConfig.DeletionTimestamp.IsZero()) {
+		if c.resourceSyncer != nil {
+			c.resourceSyncer.enabled.Store(false)
+			c.periodicSyncer.Unregister(constants.HubHAResourcesMsgKey)
+			log.Info("Hub HA active syncer disabled: KlusterletConfig deleted")
+		}
+		return ctrl.Result{}, nil
+	}
+	if err != nil {
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, err
+	}
+
+	agentConfig := configs.GetAgentConfig()
+	standbyHub := agentConfig.GetStandbyHub()
+
+	if c.resourceSyncer != nil {
+		c.resourceSyncer.emitter.SetStandbyHub(standbyHub)
+		if !c.resourceSyncer.enabled.Load() {
+			c.resourceSyncer.emitter.SetActiveResources(GetHubHAResourcesToSync())
+			c.periodicSyncer.Register(&generic.EmitterRegistration{
+				Emitter: c.resourceSyncer.emitter,
+			})
+			c.resourceSyncer.enabled.Store(true)
+			log.Info("Hub HA active syncer re-enabled")
+		}
+		return ctrl.Result{}, nil
+	}
+
+	log.Infof("starting Hub HA active syncer: %s (active) -> %s (standby)",
+		agentConfig.LeafHubName, standbyHub)
+
+	emitter := NewHubHAEmitter(
+		c.producer,
+		agentConfig.TransportConfig,
+		agentConfig.LeafHubName,
+		standbyHub,
+		c.mgr.GetClient(),
+	)
+
+	allResources := GetHubHAResourcesToSync()
+	syncer, err := StartHubHAResourceSyncer(c.mgr, allResources, emitter)
+	if err != nil {
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, err
+	}
+
+	log.Infof("Hub HA active syncer watching %d/%d resource types",
+		len(emitter.activeResources), len(allResources))
+
+	c.periodicSyncer.Register(&generic.EmitterRegistration{Emitter: emitter})
+
+	c.resourceSyncer = syncer
+	log.Info("Hub HA active syncer started via KlusterletConfig controller")
+	return ctrl.Result{}, nil
+}

--- a/agent/pkg/status/syncers/hubha/hubha_emitter.go
+++ b/agent/pkg/status/syncers/hubha/hubha_emitter.go
@@ -10,7 +10,9 @@ import (
 	"sync"
 
 	cecontext "github.com/cloudevents/sdk-go/v2/context"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
@@ -20,45 +22,54 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
-// HubHAEmitter implements the Emitter interface for Hub HA resource synchronization.
-// It tracks changes to resources across all GVKs and bundles them for transmission to the standby hub.
 type HubHAEmitter struct {
 	producer        transport.Producer
 	transportConfig *transport.TransportInternalConfig
 	activeHubName   string
 	standbyHubName  string
+	client          client.Client
+	activeResources []schema.GroupVersionKind
 	resourceFilter  *utils.HubHAResourceFilter
 	bundle          *generic.GenericBundle[*unstructured.Unstructured]
 	mu              sync.Mutex
 }
 
-// NewHubHAEmitter creates a new Hub HA emitter that handles all Hub HA resources.
 func NewHubHAEmitter(
 	producer transport.Producer,
 	transportConfig *transport.TransportInternalConfig,
 	activeHubName string,
 	standbyHubName string,
+	c client.Client,
 ) *HubHAEmitter {
 	return &HubHAEmitter{
 		producer:        producer,
 		transportConfig: transportConfig,
 		activeHubName:   activeHubName,
 		standbyHubName:  standbyHubName,
+		client:          c,
 		resourceFilter:  utils.NewHubHAResourceFilter(),
 		bundle:          generic.NewGenericBundle[*unstructured.Unstructured](),
 	}
 }
 
-// EventType returns the event type for Hub HA resources.
+func (e *HubHAEmitter) SetActiveResources(resources []schema.GroupVersionKind) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.activeResources = resources
+}
+
+func (e *HubHAEmitter) SetStandbyHub(standbyHub string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.standbyHubName = standbyHub
+}
+
 func (e *HubHAEmitter) EventType() string {
 	return constants.HubHAResourcesMsgKey
 }
 
-// Predicate returns the predicate for filtering events.
-// Filters resources based on labels and namespace rules.
 func (e *HubHAEmitter) Predicate() predicate.Predicate {
 	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
-		// Convert to unstructured to get GVK
 		uObj, err := toUnstructured(obj)
 		if err != nil {
 			log.Errorf("failed to convert object to unstructured in predicate: %v", err)
@@ -69,46 +80,36 @@ func (e *HubHAEmitter) Predicate() predicate.Predicate {
 	})
 }
 
-// Update handles object creation/update events and sends immediately.
 func (e *HubHAEmitter) Update(obj client.Object) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	// Convert to unstructured to get GVK
 	uObj, err := toUnstructured(obj)
 	if err != nil {
 		return fmt.Errorf("failed to convert object to unstructured: %w", err)
 	}
 
-	// Get GVK from object
 	gvk := uObj.GroupVersionKind()
 
-	// Clean metadata
 	cleanUnstructuredMetadata(uObj)
 
-	// Add to bundle.Update and send immediately
 	e.bundle.Update = append(e.bundle.Update, uObj)
 	log.Debugf("syncing update for %s/%s (%s)", uObj.GetNamespace(), uObj.GetName(), gvk.Kind)
 
-	// Send immediately for fast failover
 	return e.sendBundleUnlocked()
 }
 
-// Delete handles object deletion events and sends immediately.
 func (e *HubHAEmitter) Delete(obj client.Object) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	// Convert to unstructured to get GVK
 	uObj, err := toUnstructured(obj)
 	if err != nil {
 		return fmt.Errorf("failed to convert object to unstructured: %w", err)
 	}
 
-	// Get GVK from object
 	gvk := uObj.GroupVersionKind()
 
-	// Remove from update list if present
 	for i, existingObj := range e.bundle.Update {
 		if existingObj.GetNamespace() == obj.GetNamespace() && existingObj.GetName() == obj.GetName() {
 			e.bundle.Update = append(e.bundle.Update[:i], e.bundle.Update[i+1:]...)
@@ -116,7 +117,6 @@ func (e *HubHAEmitter) Delete(obj client.Object) error {
 		}
 	}
 
-	// Add to bundle.Delete and send immediately
 	objMeta := generic.ObjectMetadata{
 		Namespace: obj.GetNamespace(),
 		Name:      obj.GetName(),
@@ -128,67 +128,66 @@ func (e *HubHAEmitter) Delete(obj client.Object) error {
 	e.bundle.Delete = append(e.bundle.Delete, objMeta)
 	log.Debugf("syncing delete for %s/%s (%s)", obj.GetNamespace(), obj.GetName(), gvk.Kind)
 
-	// Send immediately for fast failover
 	return e.sendBundleUnlocked()
 }
 
-// Resync performs a full resync of all objects.
-func (e *HubHAEmitter) Resync(objects []client.Object) error {
+func (e *HubHAEmitter) Resync(_ []client.Object) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	// Clear existing bundle
 	e.bundle.Clean()
 
-	for _, obj := range objects {
-		// Convert to unstructured to get GVK
-		uObj, err := toUnstructured(obj)
-		if err != nil {
-			log.Warnf("failed to convert object to unstructured during resync: %v", err)
+	ctx := context.TODO()
+	for _, gvk := range e.activeResources {
+		list := &unstructured.UnstructuredList{}
+		list.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   gvk.Group,
+			Version: gvk.Version,
+			Kind:    gvk.Kind + "List",
+		})
+
+		if err := e.client.List(ctx, list); err != nil {
+			if meta.IsNoMatchError(err) {
+				log.Debugf("CRD not installed for %s, skipping resync", gvk.String())
+				continue
+			}
+			log.Warnf("failed to list resources for %s during resync: %v", gvk.String(), err)
 			continue
 		}
 
-		// Get GVK from object
-		gvk := uObj.GroupVersionKind()
-
-		// Filter using resource filter
-		if !e.resourceFilter.ShouldSyncResource(obj, gvk) {
-			continue
+		for i := range list.Items {
+			obj := &list.Items[i]
+			objGVK := obj.GroupVersionKind()
+			if !e.resourceFilter.ShouldSyncResource(obj, objGVK) {
+				continue
+			}
+			cleanUnstructuredMetadata(obj)
+			e.bundle.Resync = append(e.bundle.Resync, obj)
 		}
-
-		// Clean metadata
-		cleanUnstructuredMetadata(uObj)
-
-		// Add to bundle.Resync
-		e.bundle.Resync = append(e.bundle.Resync, uObj)
 	}
 
 	log.Infof("resynced %d Hub HA objects", len(e.bundle.Resync))
 	return nil
 }
 
-// Send sends the current bundle to the standby hub.
 func (e *HubHAEmitter) Send() error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	return e.sendBundleUnlocked()
 }
 
-// sendBundleUnlocked sends the bundle without acquiring the lock (caller must hold lock).
 func (e *HubHAEmitter) sendBundleUnlocked() error {
 	if len(e.bundle.Update) == 0 && len(e.bundle.Delete) == 0 && len(e.bundle.Resync) == 0 {
 		return nil
 	}
 
-	// Create CloudEvent
 	evt := utils.ToCloudEvent(
 		constants.HubHAResourcesMsgKey,
-		e.activeHubName,  // source = active hub
-		e.standbyHubName, // clustername extension = standby hub
+		e.activeHubName,
+		e.standbyHubName,
 		e.bundle,
 	)
 
-	// Send to spec topic
 	ctx := context.TODO()
 	topicCtx := cecontext.WithTopic(ctx, e.transportConfig.KafkaCredential.SpecTopic)
 	if err := e.producer.SendEvent(topicCtx, evt); err != nil {
@@ -199,18 +198,15 @@ func (e *HubHAEmitter) sendBundleUnlocked() error {
 	log.Infof("sent Hub HA bundle: updates=%d, deletes=%d, resync=%d",
 		len(e.bundle.Update), len(e.bundle.Delete), len(e.bundle.Resync))
 
-	// Clear bundle after successful send
 	e.bundle.Clean()
 	return nil
 }
 
-// toUnstructured converts a client.Object to *unstructured.Unstructured.
 func toUnstructured(obj client.Object) (*unstructured.Unstructured, error) {
 	if uObj, ok := obj.(*unstructured.Unstructured); ok {
 		return uObj.DeepCopy(), nil
 	}
 
-	// Convert via JSON marshaling (works for all types)
 	data, err := json.Marshal(obj)
 	if err != nil {
 		return nil, err
@@ -224,7 +220,6 @@ func toUnstructured(obj client.Object) (*unstructured.Unstructured, error) {
 	return uObj, nil
 }
 
-// cleanUnstructuredMetadata removes metadata that should not be synced.
 func cleanUnstructuredMetadata(obj *unstructured.Unstructured) {
 	obj.SetManagedFields(nil)
 	obj.SetResourceVersion("")

--- a/agent/pkg/status/syncers/hubha/hubha_emitter_test.go
+++ b/agent/pkg/status/syncers/hubha/hubha_emitter_test.go
@@ -9,15 +9,18 @@ import (
 	"testing"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/stolostron/multicluster-global-hub/pkg/bundle/generic"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 )
 
-// mockProducer implements transport.Producer for testing
 type mockProducer struct {
 	events []cloudevents.Event
 }
@@ -41,7 +44,7 @@ func TestHubHAEmitter_EventType(t *testing.T) {
 		},
 	}
 
-	emitter := NewHubHAEmitter(producer, transportConfig, "hub1", "hub2")
+	emitter := NewHubHAEmitter(producer, transportConfig, "hub1", "hub2", nil)
 
 	if emitter.EventType() != constants.HubHAResourcesMsgKey {
 		t.Errorf("Expected EventType %s, got %s", constants.HubHAResourcesMsgKey, emitter.EventType())
@@ -56,9 +59,8 @@ func TestHubHAEmitter_Update_SendsImmediately(t *testing.T) {
 		},
 	}
 
-	emitter := NewHubHAEmitter(producer, transportConfig, "hub1", "hub2")
+	emitter := NewHubHAEmitter(producer, transportConfig, "hub1", "hub2", nil)
 
-	// Create an unstructured Secret with required label
 	secret := &unstructured.Unstructured{
 		Object: map[string]any{
 			"apiVersion": "v1",
@@ -76,24 +78,20 @@ func TestHubHAEmitter_Update_SendsImmediately(t *testing.T) {
 		},
 	}
 
-	// Update should send immediately
 	err := emitter.Update(secret)
 	if err != nil {
 		t.Errorf("Update() error = %v", err)
 	}
 
-	// Verify event was sent
 	if len(producer.events) != 1 {
 		t.Errorf("Expected 1 event to be sent immediately, got %d", len(producer.events))
 	}
 
-	// Verify event content
 	event := producer.events[0]
 	if event.Type() != constants.HubHAResourcesMsgKey {
 		t.Errorf("Expected event type %s, got %s", constants.HubHAResourcesMsgKey, event.Type())
 	}
 
-	// Parse bundle from event data
 	var bundle generic.GenericBundle[*unstructured.Unstructured]
 	err = json.Unmarshal(event.Data(), &bundle)
 	if err != nil {
@@ -108,7 +106,6 @@ func TestHubHAEmitter_Update_SendsImmediately(t *testing.T) {
 		t.Errorf("Expected secret name 'test-secret', got %s", bundle.Update[0].GetName())
 	}
 
-	// Bundle should be cleared after send
 	if len(emitter.bundle.Update) != 0 {
 		t.Errorf("Expected bundle to be cleared after send, got %d updates", len(emitter.bundle.Update))
 	}
@@ -122,9 +119,8 @@ func TestHubHAEmitter_Delete_SendsImmediately(t *testing.T) {
 		},
 	}
 
-	emitter := NewHubHAEmitter(producer, transportConfig, "hub1", "hub2")
+	emitter := NewHubHAEmitter(producer, transportConfig, "hub1", "hub2", nil)
 
-	// Create an unstructured Secret with required label
 	secret := &unstructured.Unstructured{
 		Object: map[string]any{
 			"apiVersion": "v1",
@@ -139,18 +135,15 @@ func TestHubHAEmitter_Delete_SendsImmediately(t *testing.T) {
 		},
 	}
 
-	// Delete should send immediately
 	err := emitter.Delete(secret)
 	if err != nil {
 		t.Errorf("Delete() error = %v", err)
 	}
 
-	// Verify event was sent
 	if len(producer.events) != 1 {
 		t.Errorf("Expected 1 event to be sent immediately, got %d", len(producer.events))
 	}
 
-	// Parse bundle from event data
 	var bundle generic.GenericBundle[*unstructured.Unstructured]
 	err = json.Unmarshal(producer.events[0].Data(), &bundle)
 	if err != nil {
@@ -174,11 +167,8 @@ func TestHubHAEmitter_Update_FilteredResource(t *testing.T) {
 		},
 	}
 
-	emitter := NewHubHAEmitter(producer, transportConfig, "hub1", "hub2")
+	emitter := NewHubHAEmitter(producer, transportConfig, "hub1", "hub2", nil)
 
-	// Create a Secret WITHOUT required label
-	// Note: Filtering is done by the predicate, not by Update() method
-	// This test verifies that Update() sends whatever it receives
 	secret := &unstructured.Unstructured{
 		Object: map[string]any{
 			"apiVersion": "v1",
@@ -190,13 +180,11 @@ func TestHubHAEmitter_Update_FilteredResource(t *testing.T) {
 		},
 	}
 
-	// Update() will send it (filtering is predicate's responsibility)
 	err := emitter.Update(secret)
 	if err != nil {
 		t.Errorf("Update() error = %v", err)
 	}
 
-	// Verify event was sent (predicate would have filtered it before calling Update)
 	if len(producer.events) != 1 {
 		t.Errorf("Expected 1 event to be sent, got %d", len(producer.events))
 	}
@@ -210,10 +198,8 @@ func TestHubHAEmitter_Delete_WithoutLabels(t *testing.T) {
 		},
 	}
 
-	emitter := NewHubHAEmitter(producer, transportConfig, "hub1", "hub2")
+	emitter := NewHubHAEmitter(producer, transportConfig, "hub1", "hub2", nil)
 
-	// Create a Secret WITH required label - simulating a deleted object that was synced
-	// The delete event contains the object's last known state with labels
 	secret := &unstructured.Unstructured{
 		Object: map[string]any{
 			"apiVersion": "v1",
@@ -228,19 +214,15 @@ func TestHubHAEmitter_Delete_WithoutLabels(t *testing.T) {
 		},
 	}
 
-	// Delete should send because object has required labels (was synced)
-	// This tests direct Delete() call (predicate is bypassed in unit tests)
 	err := emitter.Delete(secret)
 	if err != nil {
 		t.Errorf("Delete() error = %v", err)
 	}
 
-	// Verify event was sent
 	if len(producer.events) != 1 {
 		t.Errorf("Expected 1 event to be sent for deletion, got %d", len(producer.events))
 	}
 
-	// Parse bundle from event data
 	var bundle generic.GenericBundle[*unstructured.Unstructured]
 	err = json.Unmarshal(producer.events[0].Data(), &bundle)
 	if err != nil {
@@ -264,60 +246,56 @@ func TestHubHAEmitter_Resync(t *testing.T) {
 		},
 	}
 
-	emitter := NewHubHAEmitter(producer, transportConfig, "hub1", "hub2")
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
 
-	// Create test secrets
-	secret1 := &unstructured.Unstructured{
-		Object: map[string]any{
-			"apiVersion": "v1",
-			"kind":       "Secret",
-			"metadata": map[string]any{
-				"name":      "secret1",
-				"namespace": "default",
-				"labels": map[string]any{
-					"hive.openshift.io/secret-type": "kubeconfig",
-				},
+	secret1 := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "secret1",
+			Namespace: "default",
+			Labels: map[string]string{
+				"hive.openshift.io/secret-type": "kubeconfig",
+			},
+		},
+	}
+	secret2 := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "secret2",
+			Namespace: "default",
+			Labels: map[string]string{
+				"cluster.open-cluster-management.io/type": "managed",
 			},
 		},
 	}
 
-	secret2 := &unstructured.Unstructured{
-		Object: map[string]any{
-			"apiVersion": "v1",
-			"kind":       "Secret",
-			"metadata": map[string]any{
-				"name":      "secret2",
-				"namespace": "default",
-				"labels": map[string]any{
-					"cluster.open-cluster-management.io/type": "managed",
-				},
-			},
-		},
-	}
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(secret1, secret2).
+		Build()
 
-	// Resync should NOT send immediately
-	err := emitter.Resync([]client.Object{secret1, secret2})
+	emitter := NewHubHAEmitter(producer, transportConfig, "hub1", "hub2", fakeClient)
+	emitter.SetActiveResources([]schema.GroupVersionKind{
+		{Group: "", Version: "v1", Kind: "Secret"},
+	})
+
+	err := emitter.Resync(nil)
 	if err != nil {
 		t.Errorf("Resync() error = %v", err)
 	}
 
-	// No events should be sent yet
 	if len(producer.events) != 0 {
 		t.Errorf("Expected 0 events after Resync, got %d", len(producer.events))
 	}
 
-	// Now send the bundle
 	err = emitter.Send()
 	if err != nil {
 		t.Errorf("Send() error = %v", err)
 	}
 
-	// Verify event was sent
 	if len(producer.events) != 1 {
 		t.Errorf("Expected 1 event after Send, got %d", len(producer.events))
 	}
 
-	// Parse bundle
 	var bundle generic.GenericBundle[*unstructured.Unstructured]
 	err = json.Unmarshal(producer.events[0].Data(), &bundle)
 	if err != nil {
@@ -365,7 +343,6 @@ func TestCleanUnstructuredMetadata(t *testing.T) {
 		t.Errorf("Expected managedFields to be nil, got %v", uObj.GetManagedFields())
 	}
 
-	// Name and namespace should remain
 	if uObj.GetName() != "test" {
 		t.Errorf("Expected name to remain, got %s", uObj.GetName())
 	}

--- a/manager/pkg/processes/hubmanagement/hub_management.go
+++ b/manager/pkg/processes/hubmanagement/hub_management.go
@@ -46,6 +46,7 @@ type HubManagement struct {
 	producer      transport.Producer
 	probeDuration time.Duration
 	activeTimeout time.Duration
+	db            *gorm.DB // cached db connection for hub management operations
 }
 
 func NewHubManagement(c client.Client, producer transport.Producer, probeDuration,
@@ -105,9 +106,8 @@ func (h *HubManagement) Start(ctx context.Context) error {
 
 func (h *HubManagement) update(ctx context.Context) error {
 	thresholdTime := time.Now().Add(-h.activeTimeout)
-	db := database.GetGorm()
 	var expiredHubs []models.LeafHubHeartbeat
-	if err := db.Where("last_timestamp < ? AND status = ?", thresholdTime, constants.HubStatusActive).
+	if err := h.db.Where("last_timestamp < ? AND status = ?", thresholdTime, constants.HubStatusActive).
 		Find(&expiredHubs).Error; err != nil {
 		return err
 	}
@@ -116,7 +116,7 @@ func (h *HubManagement) update(ctx context.Context) error {
 	}
 
 	var reactiveHubs []models.LeafHubHeartbeat
-	if err := db.Where("last_timestamp > ? AND status = ?", thresholdTime, constants.HubStatusInactive).
+	if err := h.db.Where("last_timestamp > ? AND status = ?", thresholdTime, constants.HubStatusInactive).
 		Find(&reactiveHubs).Error; err != nil {
 		return err
 	}

--- a/test/integration/agent/hubha/hubha_syncer_test.go
+++ b/test/integration/agent/hubha/hubha_syncer_test.go
@@ -18,6 +18,7 @@ import (
 
 	agentconfigs "github.com/stolostron/multicluster-global-hub/agent/pkg/configs"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/spec/hubha"
+	statushubha "github.com/stolostron/multicluster-global-hub/agent/pkg/status/syncers/hubha"
 	"github.com/stolostron/multicluster-global-hub/pkg/bundle/generic"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
@@ -84,8 +85,9 @@ var _ = Describe("Hub HA Active Syncer Integration", Ordered, func() {
 		agentconfigs.SetAgentConfig(agentConfig)
 
 		// Start the syncer once for all tests
-		syncCtx := context.Background()
-		syncErr := hubha.StartHubHAActiveSyncer(syncCtx, mgr, producer)
+		emitter := statushubha.NewHubHAEmitter(producer, transportConfig, "hub1", "hub2", mgr.GetClient())
+		allResources := statushubha.GetHubHAResourcesToSync()
+		_, syncErr := statushubha.StartHubHAResourceSyncer(mgr, allResources, emitter)
 		Expect(syncErr).NotTo(HaveOccurred())
 	})
 

--- a/test/integration/agent/hubha/suite_test.go
+++ b/test/integration/agent/hubha/suite_test.go
@@ -22,7 +22,6 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/configs"
-	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/syncers/configmap"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 )
@@ -40,7 +39,6 @@ var (
 	k8sClient       client.Client
 	mgr             ctrl.Manager
 	transportConfig *transport.TransportInternalConfig
-	suiteProducer   *mockProducer
 )
 
 var _ = BeforeSuite(func() {
@@ -113,28 +111,6 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	By("Adding configmap controller")
-	// Initialize agent config for the controller
-	agentConfig := &configs.AgentConfig{
-		LeafHubName:  "hub1",
-		PodNamespace: constants.GHAgentNamespace,
-	}
-	configs.SetAgentConfig(agentConfig)
-
-	// Add the configmap controller that watches for hub role changes
-	err = configmap.AddConfigMapController(mgr, agentConfig)
-	Expect(err).NotTo(HaveOccurred())
-
-	By("Setting up Hub HA syncer manager")
-	// Create suite-level mock producer for all lifecycle tests
-	suiteProducer = newMockProducer()
-	// Initialize Hub HA syncer manager once for all tests
-	// Use suite-level context for long-lived syncer goroutines
-	configmap.SetHubHASyncerManager(ctx, mgr, suiteProducer, func(ctx context.Context, m ctrl.Manager, prod transport.Producer) error {
-		// Mock start function for testing - doesn't actually start syncers
-		return nil
-	})
-
 	go func() {
 		defer GinkgoRecover()
 		err := mgr.Start(ctx)
@@ -147,10 +123,6 @@ var _ = BeforeSuite(func() {
 
 var _ = AfterSuite(func() {
 	By("Tearing down the test environment")
-	// Stop suite-level producer
-	if suiteProducer != nil {
-		suiteProducer.Stop()
-	}
 	if cancel != nil {
 		cancel()
 	}


### PR DESCRIPTION
## Summary

Optimize the Hub HA active syncer trigger workflow by replacing the configmap-based HubHASyncerManager lifecycle management with a KlusterletConfig controller.

## Changes

1. **Package reorganization**: move Hub HA active syncer from agent/pkg/spec/hubha to agent/pkg/status/syncers/hubha (spec = inbound, status = outbound)

2. **HAConfigSyncer**: writes standby hub info into AgentConfig when processing HA config events

3. **KlusterletConfig controller** (hubha_controller.go): watches ha-standby-hub KlusterletConfig to enable/disable the active syncer, replacing HubHASyncerManager and dynamic restart logic

4. **Leverage PeriodicSyncer**: HubHAEmitter integrates with existing periodic syncer infrastructure (Register/Unregister, sync/resync intervals). PeriodicSyncer now supports ListFunc=nil for emitters that handle their own resync listing internally.

## Testing

- go build ./...
- go test ./agent/pkg/status/syncers/hubha/...
- go test ./agent/pkg/status/generic/...
- go test ./agent/pkg/spec/hubha/...

Ref: [ACM-32677](https://redhat.atlassian.net/browse/ACM-32677)

[ACM-32677]: https://redhat.atlassian.net/browse/ACM-32677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced Hub HA synchronization with dynamic resource management and lifecycle-aware controllers
  * Added ability to dynamically enable/disable HA resource synchronization based on cluster configuration

* **Improvements**
  * Restructured Hub HA initialization for improved reliability and management
  * Optimized configuration handling for hub role and standby hub updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->