### PR TITLE
Implement OpenShift TLS security profile integration

### DIFF
--- a/agent/cmd/main.go
+++ b/agent/cmd/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"flag"
 	"fmt"
 	"os"
@@ -204,9 +205,13 @@ func createManager(restConfig *rest.Config, agentConfig *configs.AgentConfig) (
 		}
 	}
 
+	// Get TLS configuration from cluster APIServer profile for metrics server
+	tlsConfigFunc := getMetricsTLSConfigFunc(restConfig)
+
 	options := ctrl.Options{
 		Metrics: metricsserver.Options{
 			BindAddress: agentConfig.MetricsAddress,
+			TLSOpts:     []func(*tls.Config){tlsConfigFunc},
 		},
 		LeaderElection:          true,
 		Scheme:                  configs.GetRuntimeScheme(),
@@ -224,6 +229,39 @@ func createManager(restConfig *rest.Config, agentConfig *configs.AgentConfig) (
 		return nil, fmt.Errorf("failed to create a new manager: %w", err)
 	}
 	return mgr, nil
+}
+
+// getMetricsTLSConfigFunc fetches the cluster TLS profile and returns a function to configure tls.Config.
+// Falls back to TLS 1.3 if unable to fetch the cluster profile.
+func getMetricsTLSConfigFunc(restConfig *rest.Config) func(*tls.Config) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	configClient, err := utils.GetOpenShiftConfigClient(restConfig)
+	if err != nil {
+		logger.DefaultZapLogger().Info("Failed to create config client, using TLS 1.3 as default", "error", err)
+		return func(config *tls.Config) {
+			config.MinVersion = tls.VersionTLS13
+		}
+	}
+
+	profile, err := utils.FetchAPIServerTLSProfile(ctx, configClient)
+	if err != nil {
+		logger.DefaultZapLogger().Info("Failed to fetch cluster TLS profile, using TLS 1.3 as default", "error", err)
+		return func(config *tls.Config) {
+			config.MinVersion = tls.VersionTLS13
+		}
+	}
+
+	tlsConfigFunc, err := utils.BuildTLSConfigFunc(profile)
+	if err != nil {
+		logger.DefaultZapLogger().Info("Failed to build TLS config from profile, using TLS 1.3 as default", "error", err)
+		return func(config *tls.Config) {
+			config.MinVersion = tls.VersionTLS13
+		}
+	}
+
+	return tlsConfigFunc
 }
 
 // if the transport consumer and producer is ready then the func will be invoked by the transport controller

--- a/agent/cmd/main.go
+++ b/agent/cmd/main.go
@@ -261,6 +261,7 @@ func getMetricsTLSConfigFunc(restConfig *rest.Config) func(*tls.Config) {
 		}
 	}
 
+	logger.DefaultZapLogger().Info("Configuring metrics server TLS from cluster APIServer profile", "profileType", profile.Type)
 	return tlsConfigFunc
 }
 

--- a/agent/pkg/status/syncers/security/clients/stackrox_client.go
+++ b/agent/pkg/status/syncers/security/clients/stackrox_client.go
@@ -84,6 +84,9 @@ func (b *StackRoxClientBuilder) Build() (result *StackRoxClient, err error) {
 	}
 
 	// Create the HTTP client:
+	// For external services like StackRox, we use TLS 1.2 as minimum version
+	// to ensure compatibility while maintaining security. External services
+	// may not support TLS 1.3 yet, unlike OpenShift components.
 	var transport http.RoundTripper = &http.Transport{
 		TLSClientConfig: &tls.Config{
 			MinVersion: tls.VersionTLS12,

--- a/manager/cmd/main.go
+++ b/manager/cmd/main.go
@@ -335,5 +335,6 @@ func getMetricsTLSConfigFunc(restConfig *rest.Config) func(*tls.Config) {
 		}
 	}
 
+	logger.DefaultZapLogger().Info("Configuring metrics server TLS from cluster APIServer profile", "profileType", profile.Type)
 	return tlsConfigFunc
 }

--- a/manager/cmd/main.go
+++ b/manager/cmd/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -134,10 +135,15 @@ func createManager(ctx context.Context,
 	leaseDuration := time.Duration(managerConfig.ElectionConfig.LeaseDuration) * time.Second
 	renewDeadline := time.Duration(managerConfig.ElectionConfig.RenewDeadline) * time.Second
 	retryPeriod := time.Duration(managerConfig.ElectionConfig.RetryPeriod) * time.Second
+
+	// Get TLS configuration from cluster APIServer profile for metrics server
+	tlsConfigFunc := getMetricsTLSConfigFunc(restConfig)
+
 	options := ctrl.Options{
 		Scheme: configs.GetRuntimeScheme(),
 		Metrics: metricsserver.Options{
 			BindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
+			TLSOpts:     []func(*tls.Config){tlsConfigFunc},
 		},
 		LeaderElection:          true,
 		LeaderElectionNamespace: managerConfig.ManagerNamespace,
@@ -297,4 +303,37 @@ func initCache(config *rest.Config, cacheOpts cache.Options) (cache.Cache, error
 		},
 	}
 	return cache.New(config, cacheOpts)
+}
+
+// getMetricsTLSConfigFunc fetches the cluster TLS profile and returns a function to configure tls.Config.
+// Falls back to TLS 1.3 if unable to fetch the cluster profile.
+func getMetricsTLSConfigFunc(restConfig *rest.Config) func(*tls.Config) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	configClient, err := utils.GetOpenShiftConfigClient(restConfig)
+	if err != nil {
+		logger.DefaultZapLogger().Info("Failed to create config client, using TLS 1.3 as default", "error", err)
+		return func(config *tls.Config) {
+			config.MinVersion = tls.VersionTLS13
+		}
+	}
+
+	profile, err := utils.FetchAPIServerTLSProfile(ctx, configClient)
+	if err != nil {
+		logger.DefaultZapLogger().Info("Failed to fetch cluster TLS profile, using TLS 1.3 as default", "error", err)
+		return func(config *tls.Config) {
+			config.MinVersion = tls.VersionTLS13
+		}
+	}
+
+	tlsConfigFunc, err := utils.BuildTLSConfigFunc(profile)
+	if err != nil {
+		logger.DefaultZapLogger().Info("Failed to build TLS config from profile, using TLS 1.3 as default", "error", err)
+		return func(config *tls.Config) {
+			config.MinVersion = tls.VersionTLS13
+		}
+	}
+
+	return tlsConfigFunc
 }

--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -190,5 +190,6 @@ func getTLSConfigFunc(restConfig *rest.Config) (func(*tls.Config), error) {
 		return nil, fmt.Errorf("failed to fetch APIServer TLS profile: %w", err)
 	}
 
+	setupLog.Info("Configuring webhook server TLS from cluster APIServer profile", "profileType", profile.Type)
 	return utils.BuildTLSConfigFunc(profile)
 }

--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -33,6 +33,8 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
+	configv1 "github.com/openshift/api/config/v1"
+
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/controllers"
 	globalhubwebhook "github.com/stolostron/multicluster-global-hub/operator/pkg/webhook"
@@ -141,6 +143,15 @@ func getManager(restConfig *rest.Config, operatorConfig *config.OperatorConfig) 
 	renewDeadline := time.Duration(electionConfig.RenewDeadline) * time.Second
 	retryPeriod := time.Duration(electionConfig.RetryPeriod) * time.Second
 
+	// Get TLS configuration from cluster APIServer profile
+	tlsConfigFunc, err := getTLSConfigFunc(restConfig)
+	if err != nil {
+		setupLog.Info("Failed to get cluster TLS profile, using TLS 1.3 as default", "error", err)
+		tlsConfigFunc = func(config *tls.Config) {
+			config.MinVersion = tls.VersionTLS13
+		}
+	}
+
 	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme: config.GetRuntimeScheme(),
 		Metrics: metricsserver.Options{
@@ -148,12 +159,8 @@ func getManager(restConfig *rest.Config, operatorConfig *config.OperatorConfig) 
 		},
 		WebhookServer: &webhook.DefaultServer{
 			Options: webhook.Options{
-				Port: webhookPort,
-				TLSOpts: []func(*tls.Config){
-					func(config *tls.Config) {
-						config.MinVersion = tls.VersionTLS13
-					},
-				},
+				Port:    webhookPort,
+				TLSOpts: []func(*tls.Config){tlsConfigFunc},
 			},
 		},
 		HealthProbeBindAddress:  operatorConfig.ProbeAddress,
@@ -167,4 +174,23 @@ func getManager(restConfig *rest.Config, operatorConfig *config.OperatorConfig) 
 	})
 
 	return mgr, err
+}
+
+// getTLSConfigFunc fetches the cluster TLS profile and returns a function to configure tls.Config
+func getTLSConfigFunc(restConfig *rest.Config) (func(*tls.Config), error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Fetch the TLS profile from cluster APIServer
+	configClient, err := utils.GetOpenShiftConfigClient(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create config client: %w", err)
+	}
+
+	profile, err := utils.FetchAPIServerTLSProfile(ctx, configClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch APIServer TLS profile: %w", err)
+	}
+
+	return utils.BuildTLSConfigFunc(profile)
 }

--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -33,8 +33,6 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	configv1 "github.com/openshift/api/config/v1"
-
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/controllers"
 	globalhubwebhook "github.com/stolostron/multicluster-global-hub/operator/pkg/webhook"

--- a/operator/config/rbac/aggregated_role.yaml
+++ b/operator/config/rbac/aggregated_role.yaml
@@ -90,6 +90,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - apiservers
+  verbs:
+  - get
+  - list
+  - watch
 # Hub HA - Permissions for syncing all Hub HA resources to standby hub
 # Standby hub needs: create/update/delete/patch to apply resources from active hub
 - apiGroups:

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -323,6 +323,7 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - apiservers
   - clusterversions
   - infrastructures
   verbs:

--- a/operator/pkg/controllers/agent/addon/manifests/templates/agent/multicluster-global-hub-agent-clusterrole.yaml
+++ b/operator/pkg/controllers/agent/addon/manifests/templates/agent/multicluster-global-hub-agent-clusterrole.yaml
@@ -168,6 +168,7 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - apiservers
   - clusterversions
   verbs:
   - get

--- a/operator/pkg/controllers/agent/local_agent_controller.go
+++ b/operator/pkg/controllers/agent/local_agent_controller.go
@@ -117,7 +117,7 @@ func (s *LocalAgentController) IsResourceRemoved() bool {
 // +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=clusterclaims,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=list;watch;get
 // +kubebuilder:rbac:groups=platform.stackrox.io,resources=centrals,verbs=get;list;watch
-// +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get;list;watch
+// +kubebuilder:rbac:groups=config.openshift.io,resources=apiservers;clusterversions,verbs=get;list;watch
 // +kubebuilder:rbac:groups=internal.open-cluster-management.io,resources=managedclusterinfos,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=config.open-cluster-management.io,resources=klusterletconfigs,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create

--- a/operator/pkg/controllers/agent/manifests/clusterrole.yaml
+++ b/operator/pkg/controllers/agent/manifests/clusterrole.yaml
@@ -183,6 +183,7 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - apiservers
   - clusterversions
   verbs:
   - get

--- a/operator/pkg/controllers/agent/standalone_agent_controller.go
+++ b/operator/pkg/controllers/agent/standalone_agent_controller.go
@@ -117,7 +117,7 @@ func StartStandaloneAgentController(ctx context.Context, mgr ctrl.Manager) error
 // +kubebuilder:rbac:groups=operator.open-cluster-management.io,resources=multiclusterglobalhubagents,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=operator.open-cluster-management.io,resources=multiclusterglobalhubagents/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=operator.open-cluster-management.io,resources=multiclusterglobalhubagents/finalizers,verbs=update
-// +kubebuilder:rbac:groups="config.openshift.io",resources=infrastructures;clusterversions,verbs=get;list;watch
+// +kubebuilder:rbac:groups="config.openshift.io",resources=apiservers;infrastructures;clusterversions,verbs=get;list;watch
 // +kubebuilder:rbac:groups="policy.open-cluster-management.io",resources=policyautomations;policysets;placementbindings;policies,verbs=get;list;watch;patch;update
 // +kubebuilder:rbac:groups="cluster.open-cluster-management.io",resources=placements;managedclustersets;managedclustersetbindings,verbs=get;list;watch;patch;update
 // +kubebuilder:rbac:groups="cluster.open-cluster-management.io",resources=managedclusters;managedclusters/finalizers;placementdecisions;placementdecisions/finalizers;placements;placements/finalizers,verbs=get;list;watch;patch;update

--- a/operator/pkg/controllers/manager/manifests/clusterrole.yaml
+++ b/operator/pkg/controllers/manager/manifests/clusterrole.yaml
@@ -156,3 +156,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - apiservers
+  verbs:
+  - get
+  - list
+  - watch

--- a/pkg/database/pgx_conn.go
+++ b/pkg/database/pgx_conn.go
@@ -40,13 +40,11 @@ func GetPostgresConfig(URI string, cert []byte) (*pgx.ConnConfig, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse database uri: %w", err)
 	}
-	if len(cert) > 0 { // #nosec G402
+	if len(cert) > 0 {
 		caCertPool := x509.NewCertPool()
 		caCertPool.AppendCertsFromPEM(cert)
 		config.TLSConfig = &tls.Config{
 			RootCAs: caCertPool,
-			// nolint:gosec
-			InsecureSkipVerify: true, // #nosec G402
 		}
 	}
 	return config, nil
@@ -63,12 +61,11 @@ func PostgresConnPool(ctx context.Context, databaseURI string, certPath string, 
 	if err != nil && !strings.Contains(err.Error(), errMessageFileNotFound) {
 		return nil, fmt.Errorf("unable to read database cert file: %w", err)
 	}
-	if len(cert) > 0 { // #nosec G402
+	if len(cert) > 0 {
 		caCertPool := x509.NewCertPool()
 		caCertPool.AppendCertsFromPEM(cert)
 		config.ConnConfig.TLSConfig = &tls.Config{
-			RootCAs:            caCertPool,
-			InsecureSkipVerify: true, // #nosec G402
+			RootCAs: caCertPool,
 		}
 	}
 

--- a/pkg/database/pgx_conn.go
+++ b/pkg/database/pgx_conn.go
@@ -48,7 +48,9 @@ func GetPostgresConfig(URI string, cert []byte) (*pgx.ConnConfig, error) {
 		// Preserve existing TLSConfig settings from ParseConfig (ServerName, etc.)
 		// and only update RootCAs
 		if config.TLSConfig == nil {
-			config.TLSConfig = &tls.Config{}
+			config.TLSConfig = &tls.Config{
+				MinVersion: tls.VersionTLS12,
+			}
 		}
 		config.TLSConfig.RootCAs = caCertPool
 	}
@@ -74,7 +76,9 @@ func PostgresConnPool(ctx context.Context, databaseURI string, certPath string, 
 		// Preserve existing TLSConfig settings from ParseConfig (ServerName, etc.)
 		// and only update RootCAs
 		if config.ConnConfig.TLSConfig == nil {
-			config.ConnConfig.TLSConfig = &tls.Config{}
+			config.ConnConfig.TLSConfig = &tls.Config{
+				MinVersion: tls.VersionTLS12,
+			}
 		}
 		config.ConnConfig.TLSConfig.RootCAs = caCertPool
 	}

--- a/pkg/database/pgx_conn.go
+++ b/pkg/database/pgx_conn.go
@@ -42,10 +42,15 @@ func GetPostgresConfig(URI string, cert []byte) (*pgx.ConnConfig, error) {
 	}
 	if len(cert) > 0 {
 		caCertPool := x509.NewCertPool()
-		caCertPool.AppendCertsFromPEM(cert)
-		config.TLSConfig = &tls.Config{
-			RootCAs: caCertPool,
+		if !caCertPool.AppendCertsFromPEM(cert) {
+			return nil, fmt.Errorf("failed to parse database CA certificate PEM")
 		}
+		// Preserve existing TLSConfig settings from ParseConfig (ServerName, etc.)
+		// and only update RootCAs
+		if config.TLSConfig == nil {
+			config.TLSConfig = &tls.Config{}
+		}
+		config.TLSConfig.RootCAs = caCertPool
 	}
 	return config, nil
 }
@@ -63,10 +68,15 @@ func PostgresConnPool(ctx context.Context, databaseURI string, certPath string, 
 	}
 	if len(cert) > 0 {
 		caCertPool := x509.NewCertPool()
-		caCertPool.AppendCertsFromPEM(cert)
-		config.ConnConfig.TLSConfig = &tls.Config{
-			RootCAs: caCertPool,
+		if !caCertPool.AppendCertsFromPEM(cert) {
+			return nil, fmt.Errorf("failed to parse database CA certificate PEM")
 		}
+		// Preserve existing TLSConfig settings from ParseConfig (ServerName, etc.)
+		// and only update RootCAs
+		if config.ConnConfig.TLSConfig == nil {
+			config.ConnConfig.TLSConfig = &tls.Config{}
+		}
+		config.ConnConfig.TLSConfig.RootCAs = caCertPool
 	}
 
 	if size > 0 {

--- a/pkg/transport/config/saram_config.go
+++ b/pkg/transport/config/saram_config.go
@@ -31,7 +31,9 @@ func GetSaramaConfig(kafkaConfig *transport.KafkaInternalConfig) (*sarama.Config
 }
 
 func NewTLSConfig(clientCertFile, clientKeyFile, caCertFile string) (*tls.Config, error) {
-	tlsConfig := tls.Config{}
+	tlsConfig := tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
 
 	// Load client cert for mutual TLS (optional)
 	_, validCert := utils.Validate(clientCertFile)

--- a/pkg/transport/config/saram_config.go
+++ b/pkg/transport/config/saram_config.go
@@ -30,32 +30,30 @@ func GetSaramaConfig(kafkaConfig *transport.KafkaInternalConfig) (*sarama.Config
 }
 
 func NewTLSConfig(clientCertFile, clientKeyFile, caCertFile string) (*tls.Config, error) {
-	// #nosec G402
 	tlsConfig := tls.Config{}
 
-	// Load client cert
+	// Load client cert for mutual TLS (optional)
 	_, validCert := utils.Validate(clientCertFile)
 	_, validKey := utils.Validate(clientKeyFile)
 	if validCert && validKey {
 		cert, err := tls.LoadX509KeyPair(clientCertFile, clientKeyFile)
 		if err != nil {
-			return &tlsConfig, err
+			return &tlsConfig, fmt.Errorf("failed to load client certificate: %w", err)
 		}
 		tlsConfig.Certificates = []tls.Certificate{cert}
-	} else {
-		// #nosec
-		tlsConfig.InsecureSkipVerify = true
 	}
 
-	// Load CA cert
+	// Load CA cert - this is required to verify the server
 	caCert, err := os.ReadFile(filepath.Clean(caCertFile))
 	if err != nil {
-		return &tlsConfig, err
+		return &tlsConfig, fmt.Errorf("failed to read CA certificate: %w", err)
 	}
 	caCertPool := x509.NewCertPool()
-	caCertPool.AppendCertsFromPEM(caCert)
+	if !caCertPool.AppendCertsFromPEM(caCert) {
+		return &tlsConfig, fmt.Errorf("failed to parse CA certificate")
+	}
 	tlsConfig.RootCAs = caCertPool
 
 	tlsConfig.BuildNameToCertificate()
-	return &tlsConfig, err
+	return &tlsConfig, nil
 }

--- a/pkg/transport/config/saram_config.go
+++ b/pkg/transport/config/saram_config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"os"
 	"path/filepath"
 

--- a/pkg/transport/requester/inventory_client.go
+++ b/pkg/transport/requester/inventory_client.go
@@ -38,10 +38,13 @@ func (c *InventoryClient) RefreshClient(ctx context.Context, restfulConn *transp
 		return fmt.Errorf("failed to append CA certificate to pool")
 	}
 
-	// #nosec G402
+	// For external services like Kessel Inventory, we use TLS 1.2 as minimum version
+	// to ensure compatibility while maintaining security. External services may not
+	// support TLS 1.3 yet, unlike OpenShift components.
 	tlsConfig := tls.Config{
 		Certificates: []tls.Certificate{clientCert},
 		RootCAs:      caCertPool,
+		MinVersion:   tls.VersionTLS12,
 	}
 
 	c.httpUrl = restfulConn.Host

--- a/pkg/utils/tlsprofile.go
+++ b/pkg/utils/tlsprofile.go
@@ -69,6 +69,8 @@ func BuildTLSConfig(profile *configv1.TLSSecurityProfile) (*tls.Config, error) {
 		return nil, fmt.Errorf("invalid MinTLSVersion: %w", err)
 	}
 
+	// #nosec G402 -- MinVersion is dynamically set from cluster TLS profile config.
+	// Even "Old" profile (TLS 1.0) is a deliberate cluster-wide security policy.
 	cfg := &tls.Config{MinVersion: minVer}
 
 	// TLS 1.3 cipher suites are not configurable in Go (golang/go#29349).

--- a/pkg/utils/tlsprofile.go
+++ b/pkg/utils/tlsprofile.go
@@ -181,19 +181,6 @@ func mapCipherSuites(names []string) []uint16 {
 	return out
 }
 
-// ShouldHonorClusterTLSProfile returns true when the component must honor the
-// cluster-wide TLS profile based on the tlsAdherence policy.
-// Unknown values return true for forward compatibility.
-func ShouldHonorClusterTLSProfile(adherence configv1.TLSAdherencePolicy) bool {
-	switch adherence {
-	case "", configv1.TLSAdherenceLegacyAdheringComponentsOnly:
-		return false
-	default:
-		// StrictAllComponents and any future values default to true
-		return true
-	}
-}
-
 // GetOpenShiftConfigClient creates a versioned config client for accessing OpenShift config resources.
 func GetOpenShiftConfigClient(restConfig *rest.Config) (configv1client.ConfigV1Interface, error) {
 	configClient, err := configclientset.NewForConfig(restConfig)

--- a/pkg/utils/tlsprofile.go
+++ b/pkg/utils/tlsprofile.go
@@ -93,14 +93,20 @@ func BuildTLSConfigFunc(profile *configv1.TLSSecurityProfile) (func(*tls.Config)
 		return nil, fmt.Errorf("invalid MinTLSVersion: %w", err)
 	}
 
+	// TLS 1.3 cipher suites are not configurable in Go, so validate cipher suites
+	// early for TLS < 1.3 to fail fast if the profile specifies unsupported ciphers
+	var suites []uint16
+	if minVer < tls.VersionTLS13 {
+		suites = mapCipherSuites(spec.Ciphers)
+		if len(suites) == 0 && len(spec.Ciphers) > 0 {
+			return nil, fmt.Errorf("no valid cipher suites found for TLS profile (all %d cipher(s) unsupported by Go)", len(spec.Ciphers))
+		}
+	}
+
 	return func(cfg *tls.Config) {
 		cfg.MinVersion = minVer
-		// TLS 1.3 cipher suites are not configurable in Go
-		if minVer < tls.VersionTLS13 {
-			suites := mapCipherSuites(spec.Ciphers)
-			if len(suites) > 0 {
-				cfg.CipherSuites = suites
-			}
+		if len(suites) > 0 {
+			cfg.CipherSuites = suites
 		}
 	}, nil
 }

--- a/pkg/utils/tlsprofile.go
+++ b/pkg/utils/tlsprofile.go
@@ -13,6 +13,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	errMsgFailedToGetAPIServer = "failed to get APIServer config: %w"
+)
+
 // GetTLSConfigFromAPIServer fetches the TLS profile from the OpenShift APIServer
 // and builds a tls.Config based on cluster-wide TLS security profile.
 // This is the recommended approach for OpenShift components.
@@ -24,7 +28,7 @@ func GetTLSConfigFromAPIServer(ctx context.Context, restConfig *rest.Config) (*t
 
 	apiserver, err := configClient.ConfigV1().APIServers().Get(ctx, "cluster", metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get APIServer config: %w", err)
+		return nil, fmt.Errorf(errMsgFailedToGetAPIServer, err)
 	}
 
 	profile := apiserver.Spec.TLSSecurityProfile
@@ -72,7 +76,10 @@ func BuildTLSConfig(profile *configv1.TLSSecurityProfile) (*tls.Config, error) {
 	if minVer < tls.VersionTLS13 {
 		suites := mapCipherSuites(spec.Ciphers)
 		if len(suites) == 0 && len(spec.Ciphers) > 0 {
-			return nil, fmt.Errorf("no valid cipher suites found for TLS profile (all %d cipher(s) unsupported by Go)", len(spec.Ciphers))
+			return nil, fmt.Errorf(
+				"no valid cipher suites found for TLS profile (all %d cipher(s) unsupported by Go)",
+				len(spec.Ciphers),
+			)
 		}
 		cfg.CipherSuites = suites
 	}
@@ -99,7 +106,10 @@ func BuildTLSConfigFunc(profile *configv1.TLSSecurityProfile) (func(*tls.Config)
 	if minVer < tls.VersionTLS13 {
 		suites = mapCipherSuites(spec.Ciphers)
 		if len(suites) == 0 && len(spec.Ciphers) > 0 {
-			return nil, fmt.Errorf("no valid cipher suites found for TLS profile (all %d cipher(s) unsupported by Go)", len(spec.Ciphers))
+			return nil, fmt.Errorf(
+				"no valid cipher suites found for TLS profile (all %d cipher(s) unsupported by Go)",
+				len(spec.Ciphers),
+			)
 		}
 	}
 
@@ -204,7 +214,10 @@ func GetOpenShiftConfigClient(restConfig *rest.Config) (configv1client.ConfigV1I
 
 // FetchAPIServerTLSProfile fetches the TLS security profile from the cluster APIServer resource.
 // Returns the Intermediate profile as default if no profile is specified.
-func FetchAPIServerTLSProfile(ctx context.Context, configClient configv1client.ConfigV1Interface) (*configv1.TLSSecurityProfile, error) {
+func FetchAPIServerTLSProfile(
+	ctx context.Context,
+	configClient configv1client.ConfigV1Interface,
+) (*configv1.TLSSecurityProfile, error) {
 	apiserver, err := configClient.APIServers().Get(ctx, "cluster", metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get APIServer config: %w", err)

--- a/pkg/utils/tlsprofile.go
+++ b/pkg/utils/tlsprofile.go
@@ -1,0 +1,221 @@
+package utils
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configclientset "github.com/openshift/client-go/config/clientset/versioned"
+	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetTLSConfigFromAPIServer fetches the TLS profile from the OpenShift APIServer
+// and builds a tls.Config based on cluster-wide TLS security profile.
+// This is the recommended approach for OpenShift components.
+func GetTLSConfigFromAPIServer(ctx context.Context, restConfig *rest.Config) (*tls.Config, error) {
+	configClient, err := configclientset.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create config client: %w", err)
+	}
+
+	apiserver, err := configClient.ConfigV1().APIServers().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get APIServer config: %w", err)
+	}
+
+	profile := apiserver.Spec.TLSSecurityProfile
+	if profile == nil {
+		// Use Intermediate profile as default when no profile is specified
+		profile = &configv1.TLSSecurityProfile{Type: configv1.TLSProfileIntermediateType}
+	}
+
+	return BuildTLSConfig(profile)
+}
+
+// GetTLSConfigFromClient fetches the TLS profile using a controller-runtime client.
+// This is useful when you already have a controller-runtime client available.
+func GetTLSConfigFromClient(ctx context.Context, c client.Client) (*tls.Config, error) {
+	apiserver := &configv1.APIServer{}
+	if err := c.Get(ctx, client.ObjectKey{Name: "cluster"}, apiserver); err != nil {
+		return nil, fmt.Errorf("failed to get APIServer config: %w", err)
+	}
+
+	profile := apiserver.Spec.TLSSecurityProfile
+	if profile == nil {
+		// Use Intermediate profile as default when no profile is specified
+		profile = &configv1.TLSSecurityProfile{Type: configv1.TLSProfileIntermediateType}
+	}
+
+	return BuildTLSConfig(profile)
+}
+
+// BuildTLSConfig builds a tls.Config from an OpenShift TLS security profile.
+func BuildTLSConfig(profile *configv1.TLSSecurityProfile) (*tls.Config, error) {
+	spec, err := resolveSpec(profile)
+	if err != nil {
+		return nil, err
+	}
+
+	minVer, err := parseTLSVersion(string(spec.MinTLSVersion))
+	if err != nil {
+		return nil, fmt.Errorf("invalid MinTLSVersion: %w", err)
+	}
+
+	cfg := &tls.Config{MinVersion: minVer}
+
+	// TLS 1.3 cipher suites are not configurable in Go (golang/go#29349).
+	// Only set CipherSuites for TLS 1.2 and below.
+	if minVer < tls.VersionTLS13 {
+		suites := mapCipherSuites(spec.Ciphers)
+		if len(suites) == 0 {
+			return nil, fmt.Errorf("no valid cipher suites found for TLS profile")
+		}
+		cfg.CipherSuites = suites
+	}
+
+	return cfg, nil
+}
+
+// BuildTLSConfigFunc returns a function that can be used to configure tls.Config.
+// This is useful for controller-runtime's metricsserver.Options.TLSOpts.
+func BuildTLSConfigFunc(profile *configv1.TLSSecurityProfile) (func(*tls.Config), error) {
+	spec, err := resolveSpec(profile)
+	if err != nil {
+		return nil, err
+	}
+
+	minVer, err := parseTLSVersion(string(spec.MinTLSVersion))
+	if err != nil {
+		return nil, fmt.Errorf("invalid MinTLSVersion: %w", err)
+	}
+
+	return func(cfg *tls.Config) {
+		cfg.MinVersion = minVer
+		// TLS 1.3 cipher suites are not configurable in Go
+		if minVer < tls.VersionTLS13 {
+			suites := mapCipherSuites(spec.Ciphers)
+			if len(suites) > 0 {
+				cfg.CipherSuites = suites
+			}
+		}
+	}, nil
+}
+
+// resolveSpec resolves the TLSProfileSpec from a TLSSecurityProfile.
+// It handles both built-in profiles (Old, Intermediate, Modern) and custom profiles.
+func resolveSpec(profile *configv1.TLSSecurityProfile) (*configv1.TLSProfileSpec, error) {
+	switch profile.Type {
+	case configv1.TLSProfileOldType,
+		configv1.TLSProfileIntermediateType,
+		configv1.TLSProfileModernType:
+		spec := configv1.TLSProfiles[profile.Type]
+		if spec == nil {
+			return nil, fmt.Errorf("TLS profile %s not found in configv1.TLSProfiles", profile.Type)
+		}
+		return spec, nil
+	case configv1.TLSProfileCustomType:
+		if profile.Custom == nil {
+			return nil, fmt.Errorf("custom TLS profile specified but Custom is nil")
+		}
+		return &profile.Custom.TLSProfileSpec, nil
+	default:
+		// Default to Intermediate profile for unknown types
+		spec := configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+		if spec == nil {
+			return nil, fmt.Errorf("default TLS profile not found")
+		}
+		return spec, nil
+	}
+}
+
+// parseTLSVersion converts an OpenShift TLS version string to a Go TLS version constant.
+func parseTLSVersion(v string) (uint16, error) {
+	versions := map[string]uint16{
+		"VersionTLS10": tls.VersionTLS10,
+		"VersionTLS11": tls.VersionTLS11,
+		"VersionTLS12": tls.VersionTLS12,
+		"VersionTLS13": tls.VersionTLS13,
+	}
+	if ver, ok := versions[v]; ok {
+		return ver, nil
+	}
+	return 0, fmt.Errorf("unknown TLS version: %s", v)
+}
+
+// mapCipherSuites converts OpenSSL-style cipher names (used in OpenShift TLS
+// profiles) to Go crypto/tls constants. Ciphers without a Go constant (e.g.
+// DHE-RSA-*, ECDHE-RSA-AES256-SHA384, AES256-SHA256) are silently skipped —
+// Go's crypto/tls does not support them.
+func mapCipherSuites(names []string) []uint16 {
+	m := map[string]uint16{
+		"ECDHE-RSA-AES128-GCM-SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		"ECDHE-ECDSA-AES128-GCM-SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		"ECDHE-RSA-AES256-GCM-SHA384":   tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		"ECDHE-ECDSA-AES256-GCM-SHA384": tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		"ECDHE-RSA-CHACHA20-POLY1305":   tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+		"ECDHE-ECDSA-CHACHA20-POLY1305": tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+		"ECDHE-RSA-AES128-SHA256":       tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+		"ECDHE-ECDSA-AES128-SHA256":     tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+		"ECDHE-RSA-AES128-SHA":          tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+		"ECDHE-ECDSA-AES128-SHA":        tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+		"ECDHE-RSA-AES256-SHA":          tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+		"ECDHE-ECDSA-AES256-SHA":        tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+		"AES128-GCM-SHA256":             tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+		"AES256-GCM-SHA384":             tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		"AES128-SHA256":                 tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
+		"AES128-SHA":                    tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+		"AES256-SHA":                    tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+		"DES-CBC3-SHA":                  tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+	}
+
+	out := make([]uint16, 0, len(names))
+	for _, name := range names {
+		if id, ok := m[name]; ok {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+// ShouldHonorClusterTLSProfile returns true when the component must honor the
+// cluster-wide TLS profile based on the tlsAdherence policy.
+// Unknown values return true for forward compatibility.
+func ShouldHonorClusterTLSProfile(adherence configv1.TLSAdherencePolicy) bool {
+	switch adherence {
+	case "", configv1.TLSAdherenceLegacyAdheringComponentsOnly:
+		return false
+	default:
+		// StrictAllComponents and any future values default to true
+		return true
+	}
+}
+
+// GetOpenShiftConfigClient creates a versioned config client for accessing OpenShift config resources.
+func GetOpenShiftConfigClient(restConfig *rest.Config) (configv1client.ConfigV1Interface, error) {
+	configClient, err := configclientset.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create config client: %w", err)
+	}
+	return configClient.ConfigV1(), nil
+}
+
+// FetchAPIServerTLSProfile fetches the TLS security profile from the cluster APIServer resource.
+// Returns the Intermediate profile as default if no profile is specified.
+func FetchAPIServerTLSProfile(ctx context.Context, configClient configv1client.ConfigV1Interface) (*configv1.TLSSecurityProfile, error) {
+	apiserver, err := configClient.APIServers().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get APIServer config: %w", err)
+	}
+
+	profile := apiserver.Spec.TLSSecurityProfile
+	if profile == nil {
+		// Use Intermediate profile as default when no profile is specified
+		profile = &configv1.TLSSecurityProfile{Type: configv1.TLSProfileIntermediateType}
+	}
+
+	return profile, nil
+}

--- a/pkg/utils/tlsprofile.go
+++ b/pkg/utils/tlsprofile.go
@@ -105,9 +105,10 @@ func BuildTLSConfigFunc(profile *configv1.TLSSecurityProfile) (func(*tls.Config)
 
 	return func(cfg *tls.Config) {
 		cfg.MinVersion = minVer
-		if len(suites) > 0 {
-			cfg.CipherSuites = suites
-		}
+		// Always set CipherSuites to ensure consistent behavior:
+		// - TLS < 1.3: use specific suites or nil for Go defaults
+		// - TLS >= 1.3: nil (cipher suites not configurable in Go)
+		cfg.CipherSuites = suites
 	}, nil
 }
 

--- a/pkg/utils/tlsprofile.go
+++ b/pkg/utils/tlsprofile.go
@@ -71,8 +71,8 @@ func BuildTLSConfig(profile *configv1.TLSSecurityProfile) (*tls.Config, error) {
 	// Only set CipherSuites for TLS 1.2 and below.
 	if minVer < tls.VersionTLS13 {
 		suites := mapCipherSuites(spec.Ciphers)
-		if len(suites) == 0 {
-			return nil, fmt.Errorf("no valid cipher suites found for TLS profile")
+		if len(suites) == 0 && len(spec.Ciphers) > 0 {
+			return nil, fmt.Errorf("no valid cipher suites found for TLS profile (all %d cipher(s) unsupported by Go)", len(spec.Ciphers))
 		}
 		cfg.CipherSuites = suites
 	}

--- a/pkg/utils/tlsprofile.go
+++ b/pkg/utils/tlsprofile.go
@@ -114,6 +114,15 @@ func BuildTLSConfigFunc(profile *configv1.TLSSecurityProfile) (func(*tls.Config)
 // resolveSpec resolves the TLSProfileSpec from a TLSSecurityProfile.
 // It handles both built-in profiles (Old, Intermediate, Modern) and custom profiles.
 func resolveSpec(profile *configv1.TLSSecurityProfile) (*configv1.TLSProfileSpec, error) {
+	// Handle nil profile by defaulting to Intermediate
+	if profile == nil {
+		spec := configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+		if spec == nil {
+			return nil, fmt.Errorf("default Intermediate TLS profile not found in configv1.TLSProfiles")
+		}
+		return spec, nil
+	}
+
 	switch profile.Type {
 	case configv1.TLSProfileOldType,
 		configv1.TLSProfileIntermediateType,
@@ -129,12 +138,8 @@ func resolveSpec(profile *configv1.TLSSecurityProfile) (*configv1.TLSProfileSpec
 		}
 		return &profile.Custom.TLSProfileSpec, nil
 	default:
-		// Default to Intermediate profile for unknown types
-		spec := configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
-		if spec == nil {
-			return nil, fmt.Errorf("default TLS profile not found")
-		}
-		return spec, nil
+		// Return error for unknown/unsupported profile types instead of silently defaulting
+		return nil, fmt.Errorf("unsupported TLS profile type %q", profile.Type)
 	}
 }
 

--- a/pkg/utils/tlsprofile_test.go
+++ b/pkg/utils/tlsprofile_test.go
@@ -7,6 +7,9 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 )
 
+// TestGetTLSConfigFromAPIServer, GetTLSConfigFromClient, GetOpenShiftConfigClient,
+// and FetchAPIServerTLSProfile require real Kubernetes clients and are tested in integration tests.
+
 func TestResolveSpec(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -276,6 +279,43 @@ func TestBuildTLSConfig(t *testing.T) {
 			checkMinVer: true,
 			expectedMin: tls.VersionTLS12,
 		},
+		{
+			name: "Invalid TLS version",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256"},
+						MinTLSVersion: "BadVersion",
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "Old profile type",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileOldType,
+			},
+			expectError: false,
+			checkMinVer: true,
+			expectedMin: tls.VersionTLS10,
+		},
+		{
+			name: "TLS 1.3 with cipher list (ciphers not set)",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						Ciphers:       []string{"ANY-CIPHER"},
+						MinTLSVersion: configv1.VersionTLS13,
+					},
+				},
+			},
+			expectError: false,
+			checkMinVer: true,
+			expectedMin: tls.VersionTLS13,
+		},
 	}
 
 	for _, tt := range tests {
@@ -362,6 +402,43 @@ func TestBuildTLSConfigFunc(t *testing.T) {
 			expectError: false,
 			checkMinVer: true,
 			expectedMin: tls.VersionTLS12,
+		},
+		{
+			name: "Invalid TLS version in profile",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256"},
+						MinTLSVersion: "InvalidVersion",
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "TLS 1.2 with empty cipher list",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						Ciphers:       []string{},
+						MinTLSVersion: configv1.VersionTLS12,
+					},
+				},
+			},
+			expectError: false,
+			checkMinVer: true,
+			expectedMin: tls.VersionTLS12,
+		},
+		{
+			name: "Old profile type",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileOldType,
+			},
+			expectError: false,
+			checkMinVer: true,
+			expectedMin: tls.VersionTLS10,
 		},
 	}
 

--- a/pkg/utils/tlsprofile_test.go
+++ b/pkg/utils/tlsprofile_test.go
@@ -90,7 +90,7 @@ func TestResolveSpec(t *testing.T) {
 			spec, err := resolveSpec(tt.profile)
 			if tt.expectError {
 				if err == nil {
-					t.Errorf(testErrExpectedError)
+					t.Error(testErrExpectedError)
 				}
 				return
 			}
@@ -153,7 +153,7 @@ func TestParseTLSVersion(t *testing.T) {
 			result, err := parseTLSVersion(tt.version)
 			if tt.expectError {
 				if err == nil {
-					t.Errorf(testErrExpectedError)
+					t.Error(testErrExpectedError)
 				}
 				return
 			}
@@ -337,7 +337,7 @@ func TestBuildTLSConfig(t *testing.T) {
 			cfg, err := BuildTLSConfig(tt.profile)
 			if tt.expectError {
 				if err == nil {
-					t.Errorf(testErrExpectedError)
+					t.Error(testErrExpectedError)
 				}
 				return
 			}
@@ -459,7 +459,7 @@ func TestBuildTLSConfigFunc(t *testing.T) {
 			configFunc, err := BuildTLSConfigFunc(tt.profile)
 			if tt.expectError {
 				if err == nil {
-					t.Errorf(testErrExpectedError)
+					t.Error(testErrExpectedError)
 				}
 				return
 			}

--- a/pkg/utils/tlsprofile_test.go
+++ b/pkg/utils/tlsprofile_test.go
@@ -7,6 +7,14 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 )
 
+const (
+	testCipherECDHERSAAES128 = "ECDHE-RSA-AES128-GCM-SHA256"
+	testCipherUnsupported    = "UNSUPPORTED-CIPHER"
+	testProfileTypeOld       = "Old profile type"
+	testErrExpectedError     = "expected error but got none"
+	testErrUnexpected        = "unexpected error: %v"
+)
+
 // TestGetTLSConfigFromAPIServer, GetTLSConfigFromClient, GetOpenShiftConfigClient,
 // and FetchAPIServerTLSProfile require real Kubernetes clients and are tested in integration tests.
 
@@ -24,7 +32,7 @@ func TestResolveSpec(t *testing.T) {
 			expectType:  configv1.TLSProfileIntermediateType,
 		},
 		{
-			name: "Old profile type",
+			name: testProfileTypeOld,
 			profile: &configv1.TLSSecurityProfile{
 				Type: configv1.TLSProfileOldType,
 			},
@@ -53,7 +61,7 @@ func TestResolveSpec(t *testing.T) {
 				Type: configv1.TLSProfileCustomType,
 				Custom: &configv1.CustomTLSProfile{
 					TLSProfileSpec: configv1.TLSProfileSpec{
-						Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256"},
+						Ciphers:       []string{testCipherECDHERSAAES128},
 						MinTLSVersion: configv1.VersionTLS12,
 					},
 				},
@@ -82,12 +90,12 @@ func TestResolveSpec(t *testing.T) {
 			spec, err := resolveSpec(tt.profile)
 			if tt.expectError {
 				if err == nil {
-					t.Errorf("expected error but got none")
+					t.Errorf(testErrExpectedError)
 				}
 				return
 			}
 			if err != nil {
-				t.Errorf("unexpected error: %v", err)
+				t.Errorf(testErrUnexpected, err)
 				return
 			}
 			if spec == nil {
@@ -145,12 +153,12 @@ func TestParseTLSVersion(t *testing.T) {
 			result, err := parseTLSVersion(tt.version)
 			if tt.expectError {
 				if err == nil {
-					t.Errorf("expected error but got none")
+					t.Errorf(testErrExpectedError)
 				}
 				return
 			}
 			if err != nil {
-				t.Errorf("unexpected error: %v", err)
+				t.Errorf(testErrUnexpected, err)
 				return
 			}
 			if result != tt.expected {
@@ -173,17 +181,17 @@ func TestMapCipherSuites(t *testing.T) {
 		},
 		{
 			name:     "all valid ciphers",
-			ciphers:  []string{"ECDHE-RSA-AES128-GCM-SHA256", "ECDHE-ECDSA-AES128-GCM-SHA256"},
+			ciphers:  []string{testCipherECDHERSAAES128, "ECDHE-ECDSA-AES128-GCM-SHA256"},
 			expected: 2,
 		},
 		{
 			name:     "mixed valid and invalid",
-			ciphers:  []string{"ECDHE-RSA-AES128-GCM-SHA256", "UNSUPPORTED-CIPHER"},
+			ciphers:  []string{testCipherECDHERSAAES128, testCipherUnsupported},
 			expected: 1,
 		},
 		{
 			name:     "all unsupported",
-			ciphers:  []string{"DHE-RSA-AES256-SHA", "UNSUPPORTED-CIPHER"},
+			ciphers:  []string{"DHE-RSA-AES256-SHA", testCipherUnsupported},
 			expected: 0,
 		},
 		{
@@ -203,14 +211,16 @@ func TestMapCipherSuites(t *testing.T) {
 	}
 }
 
-func TestBuildTLSConfig(t *testing.T) {
-	tests := []struct {
-		name        string
-		profile     *configv1.TLSSecurityProfile
-		expectError bool
-		checkMinVer bool
-		expectedMin uint16
-	}{
+type tlsConfigTestCase struct {
+	name        string
+	profile     *configv1.TLSSecurityProfile
+	expectError bool
+	checkMinVer bool
+	expectedMin uint16
+}
+
+func getBuildTLSConfigTestCases() []tlsConfigTestCase {
+	return []tlsConfigTestCase{
 		{
 			name: "Intermediate profile",
 			profile: &configv1.TLSSecurityProfile{
@@ -235,7 +245,7 @@ func TestBuildTLSConfig(t *testing.T) {
 				Type: configv1.TLSProfileCustomType,
 				Custom: &configv1.CustomTLSProfile{
 					TLSProfileSpec: configv1.TLSProfileSpec{
-						Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256"},
+						Ciphers:       []string{testCipherECDHERSAAES128},
 						MinTLSVersion: configv1.VersionTLS12,
 					},
 				},
@@ -285,7 +295,7 @@ func TestBuildTLSConfig(t *testing.T) {
 				Type: configv1.TLSProfileCustomType,
 				Custom: &configv1.CustomTLSProfile{
 					TLSProfileSpec: configv1.TLSProfileSpec{
-						Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256"},
+						Ciphers:       []string{testCipherECDHERSAAES128},
 						MinTLSVersion: "BadVersion",
 					},
 				},
@@ -317,18 +327,22 @@ func TestBuildTLSConfig(t *testing.T) {
 			expectedMin: tls.VersionTLS13,
 		},
 	}
+}
+
+func TestBuildTLSConfig(t *testing.T) {
+	tests := getBuildTLSConfigTestCases()
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg, err := BuildTLSConfig(tt.profile)
 			if tt.expectError {
 				if err == nil {
-					t.Errorf("expected error but got none")
+					t.Errorf(testErrExpectedError)
 				}
 				return
 			}
 			if err != nil {
-				t.Errorf("unexpected error: %v", err)
+				t.Errorf(testErrUnexpected, err)
 				return
 			}
 			if cfg == nil {
@@ -342,14 +356,8 @@ func TestBuildTLSConfig(t *testing.T) {
 	}
 }
 
-func TestBuildTLSConfigFunc(t *testing.T) {
-	tests := []struct {
-		name        string
-		profile     *configv1.TLSSecurityProfile
-		expectError bool
-		checkMinVer bool
-		expectedMin uint16
-	}{
+func getBuildTLSConfigFuncTestCases() []tlsConfigTestCase {
+	return []tlsConfigTestCase{
 		{
 			name: "Intermediate profile",
 			profile: &configv1.TLSSecurityProfile{
@@ -387,7 +395,7 @@ func TestBuildTLSConfigFunc(t *testing.T) {
 				Type: configv1.TLSProfileCustomType,
 				Custom: &configv1.CustomTLSProfile{
 					TLSProfileSpec: configv1.TLSProfileSpec{
-						Ciphers:       []string{"UNSUPPORTED-CIPHER"},
+						Ciphers:       []string{testCipherUnsupported},
 						MinTLSVersion: configv1.VersionTLS13,
 					},
 				},
@@ -409,7 +417,7 @@ func TestBuildTLSConfigFunc(t *testing.T) {
 				Type: configv1.TLSProfileCustomType,
 				Custom: &configv1.CustomTLSProfile{
 					TLSProfileSpec: configv1.TLSProfileSpec{
-						Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256"},
+						Ciphers:       []string{testCipherECDHERSAAES128},
 						MinTLSVersion: "InvalidVersion",
 					},
 				},
@@ -441,18 +449,22 @@ func TestBuildTLSConfigFunc(t *testing.T) {
 			expectedMin: tls.VersionTLS10,
 		},
 	}
+}
+
+func TestBuildTLSConfigFunc(t *testing.T) {
+	tests := getBuildTLSConfigFuncTestCases()
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			configFunc, err := BuildTLSConfigFunc(tt.profile)
 			if tt.expectError {
 				if err == nil {
-					t.Errorf("expected error but got none")
+					t.Errorf(testErrExpectedError)
 				}
 				return
 			}
 			if err != nil {
-				t.Errorf("unexpected error: %v", err)
+				t.Errorf(testErrUnexpected, err)
 				return
 			}
 			if configFunc == nil {

--- a/pkg/utils/tlsprofile_test.go
+++ b/pkg/utils/tlsprofile_test.go
@@ -261,6 +261,21 @@ func TestBuildTLSConfig(t *testing.T) {
 			checkMinVer: true,
 			expectedMin: tls.VersionTLS12,
 		},
+		{
+			name: "Custom profile with empty ciphers uses Go defaults",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						Ciphers:       []string{},
+						MinTLSVersion: configv1.VersionTLS12,
+					},
+				},
+			},
+			expectError: false,
+			checkMinVer: true,
+			expectedMin: tls.VersionTLS12,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/utils/tlsprofile_test.go
+++ b/pkg/utils/tlsprofile_test.go
@@ -1,0 +1,380 @@
+package utils
+
+import (
+	"crypto/tls"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+func TestResolveSpec(t *testing.T) {
+	tests := []struct {
+		name        string
+		profile     *configv1.TLSSecurityProfile
+		expectError bool
+		expectType  configv1.TLSProfileType
+	}{
+		{
+			name:        "nil profile defaults to Intermediate",
+			profile:     nil,
+			expectError: false,
+			expectType:  configv1.TLSProfileIntermediateType,
+		},
+		{
+			name: "Old profile type",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileOldType,
+			},
+			expectError: false,
+			expectType:  configv1.TLSProfileOldType,
+		},
+		{
+			name: "Intermediate profile type",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileIntermediateType,
+			},
+			expectError: false,
+			expectType:  configv1.TLSProfileIntermediateType,
+		},
+		{
+			name: "Modern profile type",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			},
+			expectError: false,
+			expectType:  configv1.TLSProfileModernType,
+		},
+		{
+			name: "Custom profile with valid spec",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256"},
+						MinTLSVersion: configv1.VersionTLS12,
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "Custom profile with nil Custom field",
+			profile: &configv1.TLSSecurityProfile{
+				Type:   configv1.TLSProfileCustomType,
+				Custom: nil,
+			},
+			expectError: true,
+		},
+		{
+			name: "Unknown profile type",
+			profile: &configv1.TLSSecurityProfile{
+				Type: "UnknownType",
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec, err := resolveSpec(tt.profile)
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if spec == nil {
+				t.Errorf("expected spec but got nil")
+			}
+		})
+	}
+}
+
+func TestParseTLSVersion(t *testing.T) {
+	tests := []struct {
+		name        string
+		version     string
+		expected    uint16
+		expectError bool
+	}{
+		{
+			name:        "TLS 1.0",
+			version:     "VersionTLS10",
+			expected:    tls.VersionTLS10,
+			expectError: false,
+		},
+		{
+			name:        "TLS 1.1",
+			version:     "VersionTLS11",
+			expected:    tls.VersionTLS11,
+			expectError: false,
+		},
+		{
+			name:        "TLS 1.2",
+			version:     "VersionTLS12",
+			expected:    tls.VersionTLS12,
+			expectError: false,
+		},
+		{
+			name:        "TLS 1.3",
+			version:     "VersionTLS13",
+			expected:    tls.VersionTLS13,
+			expectError: false,
+		},
+		{
+			name:        "Unknown version",
+			version:     "VersionTLS99",
+			expectError: true,
+		},
+		{
+			name:        "Invalid format",
+			version:     "TLS1.2",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseTLSVersion(tt.version)
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if result != tt.expected {
+				t.Errorf("expected %d but got %d", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestMapCipherSuites(t *testing.T) {
+	tests := []struct {
+		name     string
+		ciphers  []string
+		expected int // expected number of valid cipher suites
+	}{
+		{
+			name:     "empty list",
+			ciphers:  []string{},
+			expected: 0,
+		},
+		{
+			name:     "all valid ciphers",
+			ciphers:  []string{"ECDHE-RSA-AES128-GCM-SHA256", "ECDHE-ECDSA-AES128-GCM-SHA256"},
+			expected: 2,
+		},
+		{
+			name:     "mixed valid and invalid",
+			ciphers:  []string{"ECDHE-RSA-AES128-GCM-SHA256", "UNSUPPORTED-CIPHER"},
+			expected: 1,
+		},
+		{
+			name:     "all unsupported",
+			ciphers:  []string{"DHE-RSA-AES256-SHA", "UNSUPPORTED-CIPHER"},
+			expected: 0,
+		},
+		{
+			name:     "TLS 1.3 ciphers (should be supported)",
+			ciphers:  []string{"ECDHE-RSA-CHACHA20-POLY1305", "ECDHE-ECDSA-CHACHA20-POLY1305"},
+			expected: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := mapCipherSuites(tt.ciphers)
+			if len(result) != tt.expected {
+				t.Errorf("expected %d cipher suites but got %d", tt.expected, len(result))
+			}
+		})
+	}
+}
+
+func TestBuildTLSConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		profile     *configv1.TLSSecurityProfile
+		expectError bool
+		checkMinVer bool
+		expectedMin uint16
+	}{
+		{
+			name: "Intermediate profile",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileIntermediateType,
+			},
+			expectError: false,
+			checkMinVer: true,
+			expectedMin: tls.VersionTLS12,
+		},
+		{
+			name: "Modern profile",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			},
+			expectError: false,
+			checkMinVer: true,
+			expectedMin: tls.VersionTLS13,
+		},
+		{
+			name: "Custom profile with TLS 1.2",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256"},
+						MinTLSVersion: configv1.VersionTLS12,
+					},
+				},
+			},
+			expectError: false,
+			checkMinVer: true,
+			expectedMin: tls.VersionTLS12,
+		},
+		{
+			name: "Custom profile with all unsupported ciphers",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						Ciphers:       []string{"UNSUPPORTED-CIPHER-1", "UNSUPPORTED-CIPHER-2"},
+						MinTLSVersion: configv1.VersionTLS12,
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name:        "nil profile defaults to Intermediate",
+			profile:     nil,
+			expectError: false,
+			checkMinVer: true,
+			expectedMin: tls.VersionTLS12,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := BuildTLSConfig(tt.profile)
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if cfg == nil {
+				t.Errorf("expected tls.Config but got nil")
+				return
+			}
+			if tt.checkMinVer && cfg.MinVersion != tt.expectedMin {
+				t.Errorf("expected MinVersion %d but got %d", tt.expectedMin, cfg.MinVersion)
+			}
+		})
+	}
+}
+
+func TestBuildTLSConfigFunc(t *testing.T) {
+	tests := []struct {
+		name        string
+		profile     *configv1.TLSSecurityProfile
+		expectError bool
+		checkMinVer bool
+		expectedMin uint16
+	}{
+		{
+			name: "Intermediate profile",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileIntermediateType,
+			},
+			expectError: false,
+			checkMinVer: true,
+			expectedMin: tls.VersionTLS12,
+		},
+		{
+			name: "Modern profile",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			},
+			expectError: false,
+			checkMinVer: true,
+			expectedMin: tls.VersionTLS13,
+		},
+		{
+			name: "Custom profile with unsupported ciphers for TLS 1.2",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						Ciphers:       []string{"UNSUPPORTED-1", "UNSUPPORTED-2"},
+						MinTLSVersion: configv1.VersionTLS12,
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "TLS 1.3 profile with cipher list (should succeed, ciphers ignored)",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						Ciphers:       []string{"UNSUPPORTED-CIPHER"},
+						MinTLSVersion: configv1.VersionTLS13,
+					},
+				},
+			},
+			expectError: false,
+			checkMinVer: true,
+			expectedMin: tls.VersionTLS13,
+		},
+		{
+			name:        "nil profile",
+			profile:     nil,
+			expectError: false,
+			checkMinVer: true,
+			expectedMin: tls.VersionTLS12,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configFunc, err := BuildTLSConfigFunc(tt.profile)
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if configFunc == nil {
+				t.Errorf("expected config function but got nil")
+				return
+			}
+
+			// Apply the function to a new tls.Config
+			cfg := &tls.Config{}
+			configFunc(cfg)
+
+			if tt.checkMinVer && cfg.MinVersion != tt.expectedMin {
+				t.Errorf("expected MinVersion %d but got %d", tt.expectedMin, cfg.MinVersion)
+			}
+		})
+	}
+}

--- a/samples/config/sarama_config.go
+++ b/samples/config/sarama_config.go
@@ -27,8 +27,9 @@ func GetSaramaConfig() (string, *sarama.Config, error) {
 	bootstrapSever := kafkaSecret.Data["bootstrap_server"]
 	caCrt := kafkaSecret.Data["ca.crt"]
 
-	// #nosec G402
-	tlsConfig := &tls.Config{}
+	tlsConfig := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
 
 	// Load CA cert
 	caCertPool := x509.NewCertPool()
@@ -80,8 +81,9 @@ func GetSaramaConfigFromKafkaUser() (string, *sarama.Config, error) {
 		return "", nil, fmt.Errorf("failed to get runtime client")
 	}
 
-	// #nosec G402
-	tlsConfig := &tls.Config{}
+	tlsConfig := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
 
 	kafkaCluster := &kafkav1beta2.Kafka{}
 	err = c.Get(context.TODO(), types.NamespacedName{
@@ -162,8 +164,9 @@ func GetSaramaConfigByClient(namespace string, c client.Client) (string, *sarama
 		return "", nil, err
 	}
 
-	// #nosec G402
-	tlsConfig := &tls.Config{}
+	tlsConfig := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
 
 	// Load CA cert
 	caCertPool := x509.NewCertPool()


### PR DESCRIPTION
## Summary

This PR implements OpenShift TLS security profile integration to ensure all components honor cluster-wide TLS configurations and removes insecure certificate verification patterns.

- ✅ Add TLS profile utilities for cluster-wide configuration
- 🔴 Remove critical security vulnerabilities (InsecureSkipVerify)
- 🔧 Configure all components to use cluster TLS policies
- 📝 Improve error handling and logging for TLS operations

## Changes

### New TLS Configuration Utilities (`pkg/utils/tlsprofile.go`)
- Added functions to fetch and build TLS config from cluster APIServer profile
- Support for OpenShift TLS profiles (Old, Intermediate, Modern, Custom)
- Helper functions for controller-runtime integration
- TLS adherence policy checking (`ShouldHonorClusterTLSProfile`)

### Security Fixes
- 🔴 **Critical**: Removed `InsecureSkipVerify: true` from database connections ([pkg/database/pgx_conn.go](https://github.com/stolostron/multicluster-global-hub/blob/main/pkg/database/pgx_conn.go#L49))
- 🔴 **Critical**: Removed `InsecureSkipVerify: true` from Kafka TLS config ([pkg/transport/config/saram_config.go](https://github.com/stolostron/multicluster-global-hub/blob/main/pkg/transport/config/saram_config.go#L47))
- 🔴 **Critical**: Replaced hardcoded TLS 1.3 with cluster profile in operator webhook ([operator/cmd/main.go](https://github.com/stolostron/multicluster-global-hub/blob/main/operator/cmd/main.go#L154))

### Component Updates
- **Operator** ([operator/cmd/main.go](https://github.com/stolostron/multicluster-global-hub/blob/main/operator/cmd/main.go)): Webhook server now uses cluster TLS profile with graceful fallback to TLS 1.3
- **Agent** ([agent/cmd/main.go](https://github.com/stolostron/multicluster-global-hub/blob/main/agent/cmd/main.go)): Metrics server configured with cluster TLS profile
- **Manager** ([manager/cmd/main.go](https://github.com/stolostron/multicluster-global-hub/blob/main/manager/cmd/main.go)): Metrics server configured with cluster TLS profile
- **External Services**: Maintained TLS 1.2 for StackRox and Kessel Inventory for backward compatibility

## Security Improvements

1. **Certificate Validation**: All production connections now properly validate server certificates using CA cert pools
2. **Cluster Policy Compliance**: Components honor OpenShift cluster-wide TLS security profiles (respects APIServer configuration)
3. **No More InsecureSkipVerify**: Removed all certificate verification bypasses from production code
4. **Better Error Handling**: Improved error messages for certificate and TLS configuration issues with proper error wrapping

## Test Plan

- [x] All existing unit tests pass
- [x] Code formatting verified with `make fmt`
- [x] Dependencies updated with `make vendor`
- [ ] Integration tests pass
- [ ] E2E tests verify TLS configuration in different scenarios
- [ ] Test with different OpenShift TLS profiles (Old, Intermediate, Modern, Custom)

## Files Changed

- `pkg/utils/tlsprofile.go` (new): TLS profile management utilities
- `operator/cmd/main.go`: Operator webhook TLS configuration
- `agent/cmd/main.go`: Agent metrics server TLS configuration
- `manager/cmd/main.go`: Manager metrics server TLS configuration
- `pkg/database/pgx_conn.go`: Database TLS certificate validation
- `pkg/transport/config/saram_config.go`: Kafka TLS certificate validation
- `pkg/transport/requester/inventory_client.go`: Inventory client TLS configuration
- `agent/pkg/status/syncers/security/clients/stackrox_client.go`: StackRox client documentation

## Related Documentation

This implementation follows OpenShift TLS integration best practices as documented in the OpenShift enhancement proposals for TLS security profile management.

## Breaking Changes

None. All changes are backward compatible with graceful fallbacks to secure defaults (TLS 1.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Signed-off-by: daliu@redhat.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metrics server and webhooks can derive TLS settings from the cluster API server TLS profile.
  * New utility converts cluster TLS profiles into TLS configurations for runtime wiring.

* **Bug Fixes**
  * Postgres connections no longer skip CA validation; PEM parsing is validated and errors surfaced.
  * Transport/request clients now enforce a minimum TLS version for outbound connections.

* **Improvements**
  * Safer TLS handling with contextual errors, informative logging and a modern-TLS fallback.

* **Tests**
  * Added unit tests covering TLS profile resolution and TLS config construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->