### PR TITLE
fix: improve catalog release script for OCP version lifecycle

### DIFF
--- a/.claude/skills/new-release/scripts/04-catalog.sh
+++ b/.claude/skills/new-release/scripts/04-catalog.sh
@@ -546,7 +546,9 @@ if [[ -n "$PREV_CATALOG_TAG" ]]; then
     PREV_CONTAINERFILE="${PREV_OCP_DIR}/Containerfile.catalog"
     NEW_CONTAINERFILE="${NEW_OCP_DIR}/Containerfile.catalog"
 
-    if [[ -f "$PREV_CONTAINERFILE" ]]; then
+    if [[ -f "$NEW_CONTAINERFILE" ]]; then
+      echo "   ℹ️  Containerfile already exists: $NEW_CONTAINERFILE"
+    elif [[ -f "$PREV_CONTAINERFILE" ]]; then
       # Create new directory
       mkdir -p "$NEW_OCP_DIR"
 
@@ -566,8 +568,19 @@ if [[ -n "$PREV_CATALOG_TAG" ]]; then
       #   - Second FROM (runtime): updated to new OCP version (e.g., v4.20 -> v4.21)
       sed "${SED_INPLACE[@]}" "s|ose-operator-registry-rhel9:v4.$((PREV_OCP_MAX%100))|ose-operator-registry-rhel9:v4.${NEW_OCP_VER}|g" "$NEW_CONTAINERFILE"
 
+      # 4. Remove filter_catalog.py lines - new OCP platforms have no existing entries
+      #    in catalog.json, so filtering is unnecessary
+      if grep -q 'filter_catalog.py' "$NEW_CONTAINERFILE"; then
+        sed "${SED_INPLACE[@]}" '/# Copy filter script/d' "$NEW_CONTAINERFILE"
+        sed "${SED_INPLACE[@]}" '/COPY filter_catalog.py/d' "$NEW_CONTAINERFILE"
+        sed "${SED_INPLACE[@]}" '/# remove the existing entries in catalog.json file/d' "$NEW_CONTAINERFILE"
+        sed "${SED_INPLACE[@]}" '/RUN python3 \/filter_catalog.py/d' "$NEW_CONTAINERFILE"
+        echo "   ✅ Created new Containerfile: $NEW_CONTAINERFILE (filter_catalog.py lines removed)"
+      else
+        echo "   ✅ Created new Containerfile: $NEW_CONTAINERFILE"
+      fi
+
       git add "$NEW_CONTAINERFILE"
-      echo "   ✅ Created new Containerfile: $NEW_CONTAINERFILE"
     else
       echo "   ⚠️  Previous Containerfile not found: $PREV_CONTAINERFILE" >&2
     fi
@@ -664,12 +677,16 @@ echo "📍 Step 2.7: Updating README.md..."
 
 README_FILE="README.md"
 if [[ -f "$README_FILE" && -n "$PREV_CATALOG_TAG" ]]; then
-  echo "   Updating image references in $README_FILE"
-  echo "   Changing: ${PREV_CATALOG_TAG} → ${CATALOG_TAG}"
-
-  sed "${SED_INPLACE[@]}" "s/${PREV_CATALOG_TAG}/${CATALOG_TAG}/g" "$README_FILE"
-
-  echo "   ✅ Updated $README_FILE"
+  if grep -q "$PREV_CATALOG_TAG" "$README_FILE"; then
+    sed "${SED_INPLACE[@]}" "s/${PREV_CATALOG_TAG}/${CATALOG_TAG}/g" "$README_FILE"
+    # Also update version references like release-1.7 -> release-1.8 and 1-7 -> 1-8
+    sed "${SED_INPLACE[@]}" "s/${BASE_BRANCH}/${CATALOG_BRANCH}/g" "$README_FILE"
+    echo "   ✅ Updated $README_FILE"
+    echo "      - ${PREV_CATALOG_TAG} → ${CATALOG_TAG}"
+    echo "      - ${BASE_BRANCH} → ${CATALOG_BRANCH}"
+  else
+    echo "   ℹ️  $README_FILE already has correct version references"
+  fi
 elif [[ ! -f "$README_FILE" ]]; then
   echo "   ⚠️  File not found: $README_FILE" >&2
 fi

--- a/.claude/skills/new-release/scripts/04-catalog.sh
+++ b/.claude/skills/new-release/scripts/04-catalog.sh
@@ -549,40 +549,26 @@ if [[ -n "$PREV_CATALOG_TAG" ]]; then
     if [[ -f "$NEW_CONTAINERFILE" ]]; then
       echo "   ℹ️  Containerfile already exists: $NEW_CONTAINERFILE"
     elif [[ -f "$PREV_CONTAINERFILE" ]]; then
-      # Create new directory
       mkdir -p "$NEW_OCP_DIR"
-
-      # Copy Containerfile from previous version
       cp "$PREV_CONTAINERFILE" "$NEW_CONTAINERFILE"
 
-      # Replace version references in the new Containerfile
-      # 1. Update bundle reference (globalhub-1-6 -> globalhub-1-7)
       sed "${SED_INPLACE[@]}" "s/${PREV_CATALOG_TAG}/${CATALOG_TAG}/g" "$NEW_CONTAINERFILE"
-
-      # 2. Update configs path (v4.20 -> v4.21)
       sed "${SED_INPLACE[@]}" "s|configs/v4.$((PREV_OCP_MAX%100))/|configs/v4.${NEW_OCP_VER}/|g" "$NEW_CONTAINERFILE"
-
-      # 3. Update ose-operator-registry image tag (runtime stage only)
-      # Note: Containerfile has two FROM instructions:
-      #   - First FROM (builder): keeps the version from previous Containerfile (not updated)
-      #   - Second FROM (runtime): updated to new OCP version (e.g., v4.20 -> v4.21)
       sed "${SED_INPLACE[@]}" "s|ose-operator-registry-rhel9:v4.$((PREV_OCP_MAX%100))|ose-operator-registry-rhel9:v4.${NEW_OCP_VER}|g" "$NEW_CONTAINERFILE"
+      echo "   ✅ Created new Containerfile: $NEW_CONTAINERFILE"
+    else
+      echo "   ⚠️  Previous Containerfile not found: $PREV_CONTAINERFILE" >&2
+    fi
 
-      # 4. Remove filter_catalog.py lines - new OCP platforms have no existing entries
-      #    in catalog.json, so filtering is unnecessary
-      if grep -q 'filter_catalog.py' "$NEW_CONTAINERFILE"; then
+    if [[ -f "$NEW_CONTAINERFILE" ]]; then
+      if grep -qF 'filter_catalog.py' "$NEW_CONTAINERFILE"; then
         sed "${SED_INPLACE[@]}" '/# Copy filter script/d' "$NEW_CONTAINERFILE"
         sed "${SED_INPLACE[@]}" '/COPY filter_catalog.py/d' "$NEW_CONTAINERFILE"
         sed "${SED_INPLACE[@]}" '/# remove the existing entries in catalog.json file/d' "$NEW_CONTAINERFILE"
         sed "${SED_INPLACE[@]}" '/RUN python3 \/filter_catalog.py/d' "$NEW_CONTAINERFILE"
-        echo "   ✅ Created new Containerfile: $NEW_CONTAINERFILE (filter_catalog.py lines removed)"
-      else
-        echo "   ✅ Created new Containerfile: $NEW_CONTAINERFILE"
+        echo "   ✅ Normalized $NEW_CONTAINERFILE (filter_catalog.py lines removed)"
       fi
-
       git add "$NEW_CONTAINERFILE"
-    else
-      echo "   ⚠️  Previous Containerfile not found: $PREV_CONTAINERFILE" >&2
     fi
   fi
 
@@ -677,13 +663,19 @@ echo "📍 Step 2.7: Updating README.md..."
 
 README_FILE="README.md"
 if [[ -f "$README_FILE" && -n "$PREV_CATALOG_TAG" ]]; then
-  if grep -q "$PREV_CATALOG_TAG" "$README_FILE"; then
+  README_UPDATED=false
+  if grep -qF "$PREV_CATALOG_TAG" "$README_FILE"; then
     sed "${SED_INPLACE[@]}" "s/${PREV_CATALOG_TAG}/${CATALOG_TAG}/g" "$README_FILE"
-    # Also update version references like release-1.7 -> release-1.8 and 1-7 -> 1-8
-    sed "${SED_INPLACE[@]}" "s/${BASE_BRANCH}/${CATALOG_BRANCH}/g" "$README_FILE"
-    echo "   ✅ Updated $README_FILE"
+    README_UPDATED=true
     echo "      - ${PREV_CATALOG_TAG} → ${CATALOG_TAG}"
+  fi
+  if grep -qF "$BASE_BRANCH" "$README_FILE"; then
+    sed "${SED_INPLACE[@]}" "s/${BASE_BRANCH}/${CATALOG_BRANCH}/g" "$README_FILE"
+    README_UPDATED=true
     echo "      - ${BASE_BRANCH} → ${CATALOG_BRANCH}"
+  fi
+  if [[ "$README_UPDATED" = true ]]; then
+    echo "   ✅ Updated $README_FILE"
   else
     echo "   ℹ️  $README_FILE already has correct version references"
   fi


### PR DESCRIPTION
## Summary
- Remove `filter_catalog.py` lines from new OCP platform Containerfiles (new platforms have no existing catalog entries to filter)
- Clean up all OCP version directories and pipelines below OCP_MIN (not just the single previous version)
- Add README.md version update step (Step 2.7)
- Skip Containerfile creation if it already exists on the branch (avoids spurious trailing newline diffs)

## Test plan
- [x] Ran `04-catalog.sh` with `RELEASE_BRANCH=release-2.17` and verified:
  - v4.22 Containerfile created without filter_catalog.py lines
  - v4.16 directory and pipelines cleaned up
  - README.md updated with correct version references
  - Existing v4.22 Containerfile not touched on re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Prefer existing catalog output and skip regenerating when present; otherwise copy and adapt from the previous version.
  * Normalize auxiliary catalog content only when specific filters are detected, and log normalization or pre-existing outputs.
  * Perform README/version replacements only when exact mismatches are found; otherwise log that references are already correct.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->