### PR TITLE
Add DR migration labels and annotations for ZTP resources

### DIFF
--- a/agent/pkg/spec/migration/migration_from_syncer.go
+++ b/agent/pkg/spec/migration/migration_from_syncer.go
@@ -62,7 +62,14 @@ const (
 	// imageclusterinstall_controller.go#L118
 	VeleroRestoreNameLabel = "velero.io/restore-name"
 
-	GlobalHubRestoreName = "globalhub"
+	// VeleroRestoreStatusAnnotation marks ImageClusterInstall as restored by velero during migration.
+	VeleroRestoreStatusAnnotation = "velero.io/restore-status"
+
+	// ClusterBackupLabel marks resources for cluster activation backup.
+	ClusterBackupLabel = "cluster.open-cluster-management.io/backup"
+
+	GlobalHubRestoreName    = "globalhub"
+	ClusterActivationBackup = "cluster-activation"
 )
 
 type MigrationSourceSyncer struct {
@@ -440,23 +447,50 @@ func (s *MigrationSourceSyncer) processResourceByType(
 			delete(annotations, HivePauseAnnotation)
 		}
 		resource.SetAnnotations(annotations)
-	case "BareMetalHost", "DataImage":
-		// Remove pause annotation from BareMetalHost and DataImage
+	case "BareMetalHost":
+		// Remove pause annotation from BareMetalHost
+		annotations := resource.GetAnnotations()
+		if annotations != nil {
+			delete(annotations, Metal3PauseAnnotation)
+		}
+		resource.SetAnnotations(annotations)
+
+		// Add cluster backup label with correct value
+		labels := resource.GetLabels()
+		if labels == nil {
+			labels = make(map[string]string)
+		}
+		if labels[ClusterBackupLabel] != ClusterActivationBackup {
+			labels[ClusterBackupLabel] = ClusterActivationBackup
+		}
+		resource.SetLabels(labels)
+	case "DataImage":
+		// Remove pause annotation from DataImage
 		annotations := resource.GetAnnotations()
 		if annotations != nil {
 			delete(annotations, Metal3PauseAnnotation)
 		}
 		resource.SetAnnotations(annotations)
 	case "ImageClusterInstall":
-		// Add velero restore label if not present
+		// Add velero restore label with correct value
 		labels := resource.GetLabels()
 		if labels == nil {
 			labels = make(map[string]string)
 		}
-		if _, exists := labels[VeleroRestoreNameLabel]; !exists {
+		if labels[VeleroRestoreNameLabel] != GlobalHubRestoreName {
 			labels[VeleroRestoreNameLabel] = GlobalHubRestoreName
 		}
 		resource.SetLabels(labels)
+
+		// Add velero restore status annotation with correct value
+		annotations := resource.GetAnnotations()
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		if annotations[VeleroRestoreStatusAnnotation] != "true" {
+			annotations[VeleroRestoreStatusAnnotation] = "true"
+		}
+		resource.SetAnnotations(annotations)
 	}
 }
 

--- a/agent/pkg/spec/migration/migration_from_syncer_test.go
+++ b/agent/pkg/spec/migration/migration_from_syncer_test.go
@@ -3193,7 +3193,7 @@ func TestProcessResourceByType(t *testing.T) {
 			}(),
 		},
 		{
-			name: "BareMetalHost: should remove pause annotation",
+			name: "BareMetalHost: should remove pause annotation and add backup label",
 			resource: func() *unstructured.Unstructured {
 				bmh := &unstructured.Unstructured{}
 				bmh.SetGroupVersionKind(schema.GroupVersionKind{
@@ -3227,6 +3227,9 @@ func TestProcessResourceByType(t *testing.T) {
 				bmh.SetNamespace("test-cluster")
 				bmh.SetAnnotations(map[string]string{
 					"other-annotation": "should-remain",
+				})
+				bmh.SetLabels(map[string]string{
+					ClusterBackupLabel: ClusterActivationBackup,
 				})
 				return bmh
 			}(),
@@ -3271,7 +3274,7 @@ func TestProcessResourceByType(t *testing.T) {
 			}(),
 		},
 		{
-			name: "ImageClusterInstall: should add velero restore label when not present",
+			name: "ImageClusterInstall: should add velero restore label and annotation when not present",
 			resource: func() *unstructured.Unstructured {
 				ici := &unstructured.Unstructured{}
 				ici.SetGroupVersionKind(schema.GroupVersionKind{
@@ -3302,11 +3305,14 @@ func TestProcessResourceByType(t *testing.T) {
 				ici.SetLabels(map[string]string{
 					VeleroRestoreNameLabel: GlobalHubRestoreName,
 				})
+				ici.SetAnnotations(map[string]string{
+					VeleroRestoreStatusAnnotation: "true",
+				})
 				return ici
 			}(),
 		},
 		{
-			name: "ImageClusterInstall: should not override existing velero restore label",
+			name: "ImageClusterInstall: should correct existing velero restore label and annotation values",
 			resource: func() *unstructured.Unstructured {
 				ici := &unstructured.Unstructured{}
 				ici.SetGroupVersionKind(schema.GroupVersionKind{
@@ -3319,6 +3325,10 @@ func TestProcessResourceByType(t *testing.T) {
 				ici.SetLabels(map[string]string{
 					VeleroRestoreNameLabel: "existing-restore",
 					"other-label":          "should-remain",
+				})
+				ici.SetAnnotations(map[string]string{
+					VeleroRestoreStatusAnnotation: "false",
+					"other-annotation":            "should-remain",
 				})
 				return ici
 			}(),
@@ -3339,14 +3349,18 @@ func TestProcessResourceByType(t *testing.T) {
 				ici.SetName("test-ici")
 				ici.SetNamespace("test-cluster")
 				ici.SetLabels(map[string]string{
-					VeleroRestoreNameLabel: "existing-restore",
+					VeleroRestoreNameLabel: GlobalHubRestoreName,
 					"other-label":          "should-remain",
+				})
+				ici.SetAnnotations(map[string]string{
+					VeleroRestoreStatusAnnotation: "true",
+					"other-annotation":            "should-remain",
 				})
 				return ici
 			}(),
 		},
 		{
-			name: "ImageClusterInstall: should preserve existing labels when adding velero label",
+			name: "ImageClusterInstall: should preserve existing labels and annotations when adding velero label and annotation",
 			resource: func() *unstructured.Unstructured {
 				ici := &unstructured.Unstructured{}
 				ici.SetGroupVersionKind(schema.GroupVersionKind{
@@ -3358,6 +3372,9 @@ func TestProcessResourceByType(t *testing.T) {
 				ici.SetNamespace("test-cluster")
 				ici.SetLabels(map[string]string{
 					"existing-label": "value",
+				})
+				ici.SetAnnotations(map[string]string{
+					"existing-annotation": "value",
 				})
 				return ici
 			}(),
@@ -3380,6 +3397,10 @@ func TestProcessResourceByType(t *testing.T) {
 				ici.SetLabels(map[string]string{
 					"existing-label":       "value",
 					VeleroRestoreNameLabel: GlobalHubRestoreName,
+				})
+				ici.SetAnnotations(map[string]string{
+					"existing-annotation":         "value",
+					VeleroRestoreStatusAnnotation: "true",
 				})
 				return ici
 			}(),


### PR DESCRIPTION
## Summary

- Add `velero.io/restore-status` annotation to ImageClusterInstall resources
- Add `cluster.open-cluster-management.io/backup` label to BareMetalHost resources
- Validate both key and value when setting labels/annotations during migration

## Changes

### Agent (agent/pkg/spec/migration/migration_from_syncer.go)

**Constants Added:**
- `VeleroRestoreStatusAnnotation = "velero.io/restore-status"`
- `ClusterBackupLabel = "cluster.open-cluster-management.io/backup"`
- `ClusterActivationBackup = "cluster-activation"`

**ImageClusterInstall Processing:**
- Add `velero.io/restore-status: "true"` annotation to prevent image-based-install-operator reconciliation
- Add `velero.io/restore-name: globalhub` label (existing, now validates value)
- Check both key existence AND value correctness

**BareMetalHost Processing:**
- Add `cluster.open-cluster-management.io/backup: cluster-activation` label
- Ensures resources are included in cluster activation backups
- Separated from DataImage case for clearer logic
- Check label value, not just existence

## Why These Changes

**velero.io/restore-status annotation:**
The image-based-install-operator checks for this annotation to determine if a resource was restored by Velero during DR recovery. Without it, the operator may attempt to reconcile ImageClusterInstall resources inappropriately during migration, causing conflicts.

**cluster.open-cluster-management.io/backup label:**
This label marks BareMetalHost resources for inclusion in cluster activation backup workflows, ensuring they're properly captured during DR scenarios.

**Value validation:**
Previously, the code only checked if keys existed. Now it validates values match expected constants, preventing issues where resources have the annotation/label but with incorrect values.

## Test plan

- [ ] Unit tests pass: `make unit-tests-agent`
- [ ] Migration E2E tests verify labels/annotations are set correctly
- [ ] ImageClusterInstall resources have both label and annotation
- [ ] BareMetalHost resources have backup label with correct value
- [ ] Existing migrations continue to work without issues

## Related Issues

https://issues.redhat.com/browse/ACM-32454

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Signed-off-by: daliu@redhat.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration handling to correctly set/remove backup labels and pause annotations per resource type.
  * Consistently enforce the standardized restore name and add a restore-status annotation to improve restore tracking and visibility.

* **Tests**
  * Updated unit tests to reflect the revised migration behaviors and annotation/label expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->