### PR TITLE
Security: Fix ACM-31131/32761/32839/32853 - CVE-2026-25679 Go net/url + CVE-2026-33810/32280/32283 Go crypto [multicluster-globalhub-1.4]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/multicluster-global-hub
 
-go 1.25.7
+go 1.25.8
 
 require (
 	github.com/IBM/sarama v1.44.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/multicluster-global-hub
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/IBM/sarama v1.44.0

--- a/test/script/e2e_kafka.sh
+++ b/test/script/e2e_kafka.sh
@@ -36,12 +36,25 @@ retry "(kubectl get pods -n $kafka_namespace --kubeconfig $KAFKA_KUBECONFIG -l n
 
 echo "Kafka operator is ready"
 
+# Wait for Strimzi CRDs to be fully established before applying Kafka resources.
+# Without this, "kubectl apply -k kafka-cluster" fails with "no matches for kind Kafka"
+# because the CRDs are created but not yet registered with the API server.
+kubectl wait --for=condition=Established crd/kafkas.kafka.strimzi.io \
+  --kubeconfig "$KAFKA_KUBECONFIG" --timeout=120s
+kubectl wait --for=condition=Established crd/kafkatopics.kafka.strimzi.io \
+  --kubeconfig "$KAFKA_KUBECONFIG" --timeout=120s
+kubectl wait --for=condition=Established crd/kafkausers.kafka.strimzi.io \
+  --kubeconfig "$KAFKA_KUBECONFIG" --timeout=120s
+kubectl wait --for=condition=Established crd/kafkanodepools.kafka.strimzi.io \
+  --kubeconfig "$KAFKA_KUBECONFIG" --timeout=120s
+
 node_port_host=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}' --kubeconfig "$KAFKA_KUBECONFIG" | sed -e 's#^https\?://##' -e 's/:.*//')
 sed -i -e "s;NODE_PORT_HOST;$node_port_host;" "$TEST_DIR"/manifest/kafka/kafka-cluster/kafka-cluster.yaml
+
 # deploy kafka cluster
 kubectl apply -k "$TEST_DIR"/manifest/kafka/kafka-cluster -n "$kafka_namespace" --kubeconfig "$KAFKA_KUBECONFIG"
 
-wait_cmd "kubectl get kafka kafka -n $kafka_namespace --kubeconfig $KAFKA_KUBECONFIG -o jsonpath='{.status.listeners[0]}' | grep bootstrapServers"
+wait_cmd "kubectl get kafka kafka -n $kafka_namespace --kubeconfig $KAFKA_KUBECONFIG -o jsonpath='{.status.listeners[0]}' | grep bootstrapServers" 1200
 echo "Kafka cluster is ready"
 
 # generate resource for standalone agent

--- a/test/script/e2e_kafka.sh
+++ b/test/script/e2e_kafka.sh
@@ -30,8 +30,18 @@ fi
 # create all the resource in cluster KUBECONFIG
 kubectl create namespace "$kafka_namespace" --kubeconfig "$KAFKA_KUBECONFIG" --dry-run=client -o yaml | kubectl apply -f - --kubeconfig "$KAFKA_KUBECONFIG"
 
-# deploy kafka operator
-kubectl -n "$kafka_namespace" create -f "https://strimzi.io/install/latest?namespace=$kafka_namespace" --kubeconfig "$KAFKA_KUBECONFIG"
+# Pin to a specific Strimzi version to avoid breakage when "latest" changes.
+# The test manifests use kafka.strimzi.io/v1beta2 and Kafka 4.0.0.
+# Strimzi 1.0.0 (released April 2026) dropped v1beta2 support.
+# Strimzi 0.51.0 dropped Kafka 4.0.0 support.
+# Strimzi 0.50.1 is the last version that supports both v1beta2 and Kafka 4.0.0.
+STRIMZI_VERSION="0.50.1"
+
+# The strimzi.io/install URL replaces "namespace: myproject" with the target namespace.
+# Replicate that behaviour when downloading the pinned release directly from GitHub.
+curl -sL "https://github.com/strimzi/strimzi-kafka-operator/releases/download/${STRIMZI_VERSION}/strimzi-cluster-operator-${STRIMZI_VERSION}.yaml" \
+  | sed "s/namespace: myproject/namespace: ${kafka_namespace}/g" \
+  | kubectl create -f - -n "$kafka_namespace" --kubeconfig "$KAFKA_KUBECONFIG"
 retry "(kubectl get pods -n $kafka_namespace --kubeconfig $KAFKA_KUBECONFIG -l name=strimzi-cluster-operator | grep Running)" 60
 
 echo "Kafka operator is ready"

--- a/test/script/event_exporter_kafka.sh
+++ b/test/script/event_exporter_kafka.sh
@@ -18,7 +18,7 @@ standalone_user=global-hub-standalone-agent-user
 status_topic="gh-status.standalone-agent"
 
 kubectl apply -f "$TEST_DIR/manifest/standalone-agent/standalone-agent-resources.yaml" -n "$kafka_namespace"
-kubectl wait --for=condition=Ready kafkauser/$standalone_user --timeout=500s
+kubectl wait --for=condition=Ready kafkauser/$standalone_user -n "$kafka_namespace" --timeout=500s
 
 # Define a 5-minute timeout
 timeout=300


### PR DESCRIPTION
## Security Fix: ACM-31131 / ACM-32761 / ACM-32839 / ACM-32853

**JIRA Issues:** [ACM-31131](https://redhat.atlassian.net/browse/ACM-31131), [ACM-32761](https://redhat.atlassian.net/browse/ACM-32761), [ACM-32839](https://redhat.atlassian.net/browse/ACM-32839), [ACM-32853](https://redhat.atlassian.net/browse/ACM-32853)
**Priority:** Medium / High

### Summary

| Jira | CVE | Description |
|------|-----|-------------|
| ACM-31131 | CVE-2026-25679 | Go net/url: Incorrect parsing of IPv6 host literals |
| ACM-32761 | CVE-2026-33810 | Go crypto/x509: DNS constraint bypass |
| ACM-32839 | CVE-2026-32280 | Go crypto/x509: chain building DoS |
| ACM-32853 | CVE-2026-32283 | Go crypto/tls: TLS 1.3 KeyUpdate deadlock DoS |

### Root Cause

All four CVEs are Go standard library vulnerabilities fixed by upgrading the Go toolchain:
- CVE-2026-25679: Fixed in Go **1.25.8**
- CVE-2026-33810, CVE-2026-32280, CVE-2026-32283: Fixed in Go **1.25.9**

`release-2.13` was using Go `1.25.7`.

### Fix

* Upgraded Go from `1.25.7` → `1.25.8` (CVE-2026-25679)
* Upgraded Go from `1.25.8` → `1.25.9` (CVE-2026-33810, CVE-2026-32280, CVE-2026-32283)

Also includes the gRPC-Go upgrade to `v1.79.3` (from stacked PR #2404).

### References

* https://www.cve.org/CVERecord?id=CVE-2026-25679
* https://www.cve.org/CVERecord?id=CVE-2026-33810
* https://www.cve.org/CVERecord?id=CVE-2026-32280 (GO-2026-4860)
* https://www.cve.org/CVERecord?id=CVE-2026-32283 (GO-2026-4870)

Made with Cursor

[ACM-31131]: https://redhat.atlassian.net/browse/ACM-31131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-32761]: https://redhat.atlassian.net/browse/ACM-32761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-32839]: https://redhat.atlassian.net/browse/ACM-32839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-32853]: https://redhat.atlassian.net/browse/ACM-32853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ