### PR TITLE
fix: standalone agent e2e Kafka setup failures on release-2.12

### DIFF
--- a/test/script/e2e_kafka.sh
+++ b/test/script/e2e_kafka.sh
@@ -36,12 +36,25 @@ retry "(kubectl get pods -n $kafka_namespace --kubeconfig $KAFKA_KUBECONFIG -l n
 
 echo "Kafka operator is ready"
 
+# Wait for Strimzi CRDs to be fully established before applying Kafka resources.
+# Without this, "kubectl apply -k kafka-cluster" fails with "no matches for kind Kafka"
+# because the CRDs are created but not yet registered with the API server.
+kubectl wait --for=condition=Established crd/kafkas.kafka.strimzi.io \
+  --kubeconfig "$KAFKA_KUBECONFIG" --timeout=120s
+kubectl wait --for=condition=Established crd/kafkatopics.kafka.strimzi.io \
+  --kubeconfig "$KAFKA_KUBECONFIG" --timeout=120s
+kubectl wait --for=condition=Established crd/kafkausers.kafka.strimzi.io \
+  --kubeconfig "$KAFKA_KUBECONFIG" --timeout=120s
+kubectl wait --for=condition=Established crd/kafkanodepools.kafka.strimzi.io \
+  --kubeconfig "$KAFKA_KUBECONFIG" --timeout=120s
+
 node_port_host=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}' --kubeconfig "$KAFKA_KUBECONFIG" | sed -e 's#^https\?://##' -e 's/:.*//')
 sed -i -e "s;NODE_PORT_HOST;$node_port_host;" "$TEST_DIR"/manifest/kafka/kafka-cluster/kafka-cluster.yaml
+
 # deploy kafka cluster
 kubectl apply -k "$TEST_DIR"/manifest/kafka/kafka-cluster -n "$kafka_namespace" --kubeconfig "$KAFKA_KUBECONFIG"
 
-wait_cmd "kubectl get kafka kafka -n $kafka_namespace --kubeconfig $KAFKA_KUBECONFIG -o jsonpath='{.status.listeners[1]}' | grep bootstrapServers"
+wait_cmd "kubectl get kafka kafka -n $kafka_namespace --kubeconfig $KAFKA_KUBECONFIG -o jsonpath='{.status.listeners[1]}' | grep bootstrapServers" 1200
 echo "Kafka cluster is ready"
 
 # generate resource for standalone agent

--- a/test/script/e2e_kafka.sh
+++ b/test/script/e2e_kafka.sh
@@ -30,8 +30,18 @@ fi
 # create all the resource in cluster KUBECONFIG
 kubectl create namespace "$kafka_namespace" --kubeconfig "$KAFKA_KUBECONFIG" --dry-run=client -o yaml | kubectl apply -f - --kubeconfig "$KAFKA_KUBECONFIG"
 
-# deploy kafka operator
-kubectl -n "$kafka_namespace" create -f "https://strimzi.io/install/latest?namespace=$kafka_namespace" --kubeconfig "$KAFKA_KUBECONFIG"
+# Pin to a specific Strimzi version to avoid breakage when "latest" changes.
+# The test manifests use kafka.strimzi.io/v1beta2 and Kafka 4.0.0.
+# Strimzi 1.0.0 (released April 2026) dropped v1beta2 support.
+# Strimzi 0.51.0 dropped Kafka 4.0.0 support.
+# Strimzi 0.50.1 is the last version that supports both v1beta2 and Kafka 4.0.0.
+STRIMZI_VERSION="0.50.1"
+
+# The strimzi.io/install URL replaces "namespace: myproject" with the target namespace.
+# Replicate that behaviour when downloading the pinned release directly from GitHub.
+curl -sL "https://github.com/strimzi/strimzi-kafka-operator/releases/download/${STRIMZI_VERSION}/strimzi-cluster-operator-${STRIMZI_VERSION}.yaml" \
+  | sed "s/namespace: myproject/namespace: ${kafka_namespace}/g" \
+  | kubectl create -f - -n "$kafka_namespace" --kubeconfig "$KAFKA_KUBECONFIG"
 retry "(kubectl get pods -n $kafka_namespace --kubeconfig $KAFKA_KUBECONFIG -l name=strimzi-cluster-operator | grep Running)" 60
 
 echo "Kafka operator is ready"

--- a/test/script/event_exporter_kafka.sh
+++ b/test/script/event_exporter_kafka.sh
@@ -18,7 +18,7 @@ standalone_user=global-hub-standalone-agent-user
 status_topic="gh-status.standalone-agent"
 
 kubectl apply -f "$TEST_DIR/manifest/standalone-agent/standalone-agent-resources.yaml" -n "$kafka_namespace"
-kubectl wait --for=condition=Ready kafkauser/$standalone_user --timeout=500s
+kubectl wait --for=condition=Ready kafkauser/$standalone_user -n "$kafka_namespace" --timeout=500s
 
 # Define a 5-minute timeout
 timeout=300


### PR DESCRIPTION
## Summary

Fix three root causes that prevented the standalone agent e2e test from running on \`release-2.12\`. All changes are confined to \`test/script/\`.

## Root Causes and Fixes

### 1. Missing \`-n\` namespace flag on \`kubectl wait\` (`event_exporter_kafka.sh`)

\`kubectl wait\` for the standalone agent \`KafkaUser\` was missing the \`-n "$kafka_namespace"\` flag, causing it to look in the \`default\` namespace. This produced a 500-second timeout on every run before falling through to the while-loop fallback. When the fallback also failed, the \`transport-config\` secret was never created in \`open-cluster-management\`, and the test failed with:

\`\`\`
secrets "transport-config" not found  (agent_test.go:45)
\`\`\`

**Fix:** Add \`-n "$kafka_namespace"\` to the \`kubectl wait\` call.

### 2. Race condition: CRDs not Established before \`kubectl apply\` (`e2e_kafka.sh`)

\`kubectl apply -k kafka-cluster\` was running immediately after the Strimzi operator pod became Running, before the Kafka CRDs (\`kafkas\`, \`kafkatopics\`, \`kafkausers\`, \`kafkanodepools\`) were fully registered with the API server. This caused:

\`\`\`
no matches for kind "Kafka" in version "kafka.strimzi.io/v1beta2"
\`\`\`

Also, Kafka 4.0.0 with KRaft mode needs more than the previous 600s to fully populate \`status.listeners\` in a Kind cluster.

**Fix:** Add \`kubectl wait --for=condition=Established\` for all four Strimzi CRDs with a 120s timeout, and increase the Kafka readiness timeout from 600s to 1200s.

### 3. Strimzi `latest` now points to 1.0.0 which removed `v1beta2` (`e2e_kafka.sh`)

Strimzi 1.0.0 (released April 2026) removed the \`v1beta2\` CRD API entirely. Strimzi 0.51.0 also dropped support for Kafka 4.0.x. The test script installed \`https://strimzi.io/install/latest\`, which now resolves to Strimzi 1.0.0 — so \`kafka.strimzi.io/v1beta2\` is never registered on the API server regardless of CRD wait guards.

**Fix:** Pin to **Strimzi 0.50.1**, the last version that supports both \`v1beta2\` and Kafka 4.0.0, by downloading the pinned YAML directly from the GitHub release with the same namespace substitution that the \`strimzi.io/install\` URL used to perform.

## Files Changed

| File | Change |
|------|--------|
| \`test/script/event_exporter_kafka.sh\` | Add \`-n\` flag to \`kubectl wait\` |
| \`test/script/e2e_kafka.sh\` | Pin Strimzi to 0.50.1; add CRD waits; increase Kafka timeout |

## Test Plan

The fix will be validated when \`ci/prow/test-e2e\` runs on this PR — the standalone agent test (\`Standalone Agent [It] should receive the cluster event from the standalone agent\`) should now pass.

Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

Made with [Cursor](https://cursor.com)