### PR TITLE
chore: apply strict-fmt formatting (gci + gofumpt upgrade) [multicluster-globalhub-1.6]

### DIFF
--- a/agent/pkg/spec/migration/migration_from_syncer.go
+++ b/agent/pkg/spec/migration/migration_from_syncer.go
@@ -232,7 +232,8 @@ func (s *MigrationSourceSyncer) deploying(ctx context.Context, source *migration
 
 	e := utils.ToCloudEvent(constants.MigrationTargetMsgKey, fromHub, toHub, payloadBytes)
 	if err := s.transportClient.GetProducer().SendEvent(
-		cecontext.WithTopic(ctx, s.transportConfig.KafkaCredential.SpecTopic), e); err != nil {
+		cecontext.WithTopic(ctx, s.transportConfig.KafkaCredential.SpecTopic), e,
+	); err != nil {
 		return fmt.Errorf(errFailedToSendEvent, constants.MigrationTargetMsgKey, fromHub, toHub, err)
 	}
 	return nil
@@ -666,7 +667,8 @@ func (s *MigrationSourceSyncer) rollbackRegistering(ctx context.Context, spec *m
 		timeout = time.Duration(spec.RollbackingTimeoutMinutes) * time.Minute
 	}
 
-	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, timeout, true,
+	err := wait.PollUntilContextTimeout(
+		ctx, 5*time.Second, timeout, true,
 		func(context.Context) (done bool, err error) {
 			clusterErrors := map[string]string{}
 			defer func() {
@@ -726,7 +728,8 @@ func (s *MigrationSourceSyncer) reportStatus(ctx context.Context, spec *migratio
 			ManagedClusters: allManagedClusterList,
 			ClusterErrors:   s.clusterErrors,
 		},
-		s.bundleVersion)
+		s.bundleVersion,
+	)
 
 	if reportErr != nil {
 		log.Errorf("failed to report migration status for stage %s: %v", spec.Stage, reportErr)
@@ -866,28 +869,32 @@ func (s *MigrationSourceSyncer) validateSingleCluster(ctx context.Context, clust
 	if s.isHostedCluster(mc) {
 		return fmt.Errorf(
 			"managed cluster %v is imported as hosted mode in managed hub %v, it cannot be migrated",
-			clusterName, s.leafHubName)
+			clusterName, s.leafHubName,
+		)
 	}
 
 	// Check if cluster is local cluster
 	if mc.Labels != nil && mc.Labels[constants.LocalClusterName] == "true" {
 		return fmt.Errorf(
 			"managed cluster %v is local cluster in managed hub %v, it cannot be migrated",
-			clusterName, s.leafHubName)
+			clusterName, s.leafHubName,
+		)
 	}
 
 	// Check if cluster is available
 	if !s.isManagedClusterAvailable(mc) {
 		return fmt.Errorf(
 			"managed cluster %v is not available in managed hub %v, it cannot be migrated",
-			clusterName, s.leafHubName)
+			clusterName, s.leafHubName,
+		)
 	}
 
 	// Check if cluster is a managed hub
 	if s.isManagedHub(mc) {
 		return fmt.Errorf(
 			"managed cluster %v is a managed hub cluster in managed hub %v, it cannot be migrated",
-			clusterName, s.leafHubName)
+			clusterName, s.leafHubName,
+		)
 	}
 
 	return nil

--- a/agent/pkg/spec/migration/migration_from_syncer_test.go
+++ b/agent/pkg/spec/migration/migration_from_syncer_test.go
@@ -471,7 +471,8 @@ func TestMigrationSourceHubSyncer(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(c.initObjects...).WithObjects(
-				c.initObjects...).Build()
+				c.initObjects...,
+			).Build()
 
 			producer := ProducerMock{}
 			transportClient := &controller.TransportClient{}
@@ -615,7 +616,8 @@ func TestGenerateKlusterletConfig(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(c.initObjects...).WithObjects(
-				c.initObjects...).Build()
+				c.initObjects...,
+			).Build()
 			obj, err := generateKlusterletConfig(fakeClient, c.targetHub, c.bootstrapSecretName)
 			if c.expectedError {
 				assert.NotNil(t, err)

--- a/agent/pkg/spec/migration/migration_to_syncer.go
+++ b/agent/pkg/spec/migration/migration_to_syncer.go
@@ -297,7 +297,8 @@ func (s *MigrationTargetSyncer) registering(ctx context.Context,
 		timeout = time.Duration(event.RegisteringTimeoutMinutes) * time.Minute
 	}
 
-	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, timeout, true,
+	err := wait.PollUntilContextTimeout(
+		ctx, 5*time.Second, timeout, true,
 		func(context.Context) (done bool, err error) {
 			clear(clusterErrors)
 			for _, clusterName := range event.ManagedClusters {
@@ -468,7 +469,8 @@ func (s *MigrationTargetSyncer) ensureClusterManagerAutoApproval(ctx context.Con
 				operatorv1.FeatureGate{
 					Feature: "ManagedClusterAutoApproval",
 					Mode:    operatorv1.FeatureGateModeTypeEnable,
-				})
+				},
+			)
 			clusterManagerChanged = true
 		}
 
@@ -481,7 +483,8 @@ func (s *MigrationTargetSyncer) ensureClusterManagerAutoApproval(ctx context.Con
 		if !autoApproveUserAdded {
 			registrationConfiguration.AutoApproveUsers = append(
 				registrationConfiguration.AutoApproveUsers,
-				autoApproveUser)
+				autoApproveUser,
+			)
 			clusterManagerChanged = true
 		}
 	} else {

--- a/agent/pkg/spec/migration/migration_to_syncer_test.go
+++ b/agent/pkg/spec/migration/migration_to_syncer_test.go
@@ -995,7 +995,8 @@ func TestMigrationDestinationHubSyncer(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(c.initObjects...).WithObjects(
-				c.initObjects...).Build()
+				c.initObjects...,
+			).Build()
 
 			producer := ProducerMock{}
 			transportClient := &controller.TransportClient{}

--- a/agent/pkg/status/generic/periodic_syncer_resync_test.go
+++ b/agent/pkg/status/generic/periodic_syncer_resync_test.go
@@ -395,12 +395,12 @@ func TestPeriodicSyncer_Resync(t *testing.T) {
 // Helper function to check if a string contains a substring
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) &&
-		(func() bool {
+		func() bool {
 			for i := 0; i <= len(s)-len(substr); i++ {
 				if s[i:i+len(substr)] == substr {
 					return true
 				}
 			}
 			return false
-		})()
+		}()
 }

--- a/agent/pkg/status/syncers/apps/subscription_report_sync.go
+++ b/agent/pkg/status/syncers/apps/subscription_report_sync.go
@@ -37,5 +37,6 @@ func LaunchSubscriptionReportSyncer(ctx context.Context, mgr ctrl.Manager, agent
 				Handler: generic.NewGenericHandler(&eventData),
 				Emitter: generic.NewGenericEmitter(enum.SubscriptionReportType),
 			},
-		})
+		},
+	)
 }

--- a/agent/pkg/status/syncers/apps/subscription_status_sync.go
+++ b/agent/pkg/status/syncers/apps/subscription_status_sync.go
@@ -37,5 +37,6 @@ func LaunchSubscriptionStatusSyncer(ctx context.Context, mgr ctrl.Manager, agent
 				Handler: generic.NewGenericHandler(&eventData),
 				Emitter: generic.NewGenericEmitter(enum.SubscriptionStatusType),
 			},
-		})
+		},
+	)
 }

--- a/agent/pkg/status/syncers/managedhub/cluster_info_syncer.go
+++ b/agent/pkg/status/syncers/managedhub/cluster_info_syncer.go
@@ -41,7 +41,8 @@ func LaunchHubClusterInfoSyncer(mgr ctrl.Manager, producer transport.Producer) e
 					func() client.Object { return &configv1.ClusterVersion{} },
 					predicate.NewPredicateFuncs(func(object client.Object) bool {
 						return object.GetName() == "version"
-					})),
+					}),
+				),
 				Handler: &infoClusterVersionHandler{eventData},
 			},
 			{
@@ -57,7 +58,8 @@ func LaunchHubClusterInfoSyncer(mgr ctrl.Manager, producer transport.Producer) e
 							return true
 						}
 						return false
-					})),
+					}),
+				),
 				Handler: &infoRouteHandler{eventData},
 			},
 		},

--- a/agent/pkg/status/syncers/placement/placement_decision_syncer.go
+++ b/agent/pkg/status/syncers/placement/placement_decision_syncer.go
@@ -39,7 +39,8 @@ func LaunchPlacementDecisionSyncer(ctx context.Context, mgr ctrl.Manager, agentC
 				),
 				Emitter: generic.NewGenericEmitter(enum.PlacementDecisionType),
 			},
-		})
+		},
+	)
 }
 
 func cleanupManagedFields(obj client.Object) {

--- a/agent/pkg/status/syncers/placement/placement_rule_syncer.go
+++ b/agent/pkg/status/syncers/placement/placement_rule_syncer.go
@@ -54,5 +54,6 @@ func LaunchPlacementRuleSyncer(ctx context.Context, mgr ctrl.Manager, agentConfi
 					generic.WithShouldUpdate(localShouldUpdate)),
 				Emitter: generic.NewGenericEmitter(enum.LocalPlacementRuleSpecType),
 			},
-		})
+		},
+	)
 }

--- a/agent/pkg/status/syncers/placement/placement_syncer.go
+++ b/agent/pkg/status/syncers/placement/placement_syncer.go
@@ -23,8 +23,9 @@ func LaunchPlacementSyncer(ctx context.Context, mgr ctrl.Manager, agentConfig *c
 		"status.placement",
 		mgr,
 		generic.NewGenericController(
-			func() client.Object { return &clustersv1beta1.Placement{} },                  // instance
-			predicate.NewPredicateFuncs(func(object client.Object) bool { return true })), // predicate
+			func() client.Object { return &clustersv1beta1.Placement{} }, // instance
+			predicate.NewPredicateFuncs(func(object client.Object) bool { return true }),
+		), // predicate
 		producer,
 		configmap.GetPolicyDuration,
 		[]*generic.EmitterHandler{
@@ -34,5 +35,6 @@ func LaunchPlacementSyncer(ctx context.Context, mgr ctrl.Manager, agentConfig *c
 					generic.WithShouldUpdate(globalResource)),
 				Emitter: generic.NewGenericEmitter(enum.PlacementSpecType),
 			},
-		})
+		},
+	)
 }

--- a/agent/pkg/status/syncers/policies/handlers/complete_compliance_handler.go
+++ b/agent/pkg/status/syncers/policies/handlers/complete_compliance_handler.go
@@ -44,7 +44,7 @@ func (h *completeComplianceHandler) Update(obj client.Object) bool {
 	originPolicyID := extractPolicyIdentity(obj)
 	newComplete := newCompleteCompliance(originPolicyID, policy)
 
-	index := getPayloadIndexByUID(originPolicyID, *(h.eventData))
+	index := getPayloadIndexByUID(originPolicyID, *h.eventData)
 	if index == -1 { // object not found, need to add it to the bundle (only in case it contains non-compliant/unknown)
 		// don't send in the bundle a policy where all clusters are compliant
 		if len(newComplete.UnknownComplianceClusters) == 0 && len(newComplete.NonCompliantClusters) == 0 &&
@@ -52,7 +52,7 @@ func (h *completeComplianceHandler) Update(obj client.Object) bool {
 			return false
 		}
 
-		*(h.eventData) = append(*(h.eventData), *newComplete)
+		*h.eventData = append(*h.eventData, *newComplete)
 		return true
 	}
 
@@ -87,13 +87,13 @@ func (h *completeComplianceHandler) Delete(obj client.Object) bool {
 		return false
 	}
 
-	index := getPayloadIndexByObj(obj, *(h.eventData))
+	index := getPayloadIndexByObj(obj, *h.eventData)
 	if index == -1 { // trying to delete object which doesn't exist
 		return false
 	}
 
 	// don't increase version, no need to send bundle when policy is removed (Compliance bundle is sent).
-	*(h.eventData) = append((*h.eventData)[:index], (*h.eventData)[index+1:]...) // remove from objects
+	*h.eventData = append((*h.eventData)[:index], (*h.eventData)[index+1:]...) // remove from objects
 	return false
 }
 

--- a/agent/pkg/status/syncers/policies/handlers/status_event_handler.go
+++ b/agent/pkg/status/syncers/policies/handlers/status_event_handler.go
@@ -119,21 +119,23 @@ func (*policyStatusEventHandler) Delete(client.Object) bool {
 
 func NewPolicyStatusEventEmitter(eventType enum.EventType) interfaces.Emitter {
 	name := strings.ReplaceAll(string(eventType), enum.EventTypePrefix, "")
-	return generic.NewGenericEmitter(eventType, generic.WithPostSend(
-		// After sending the event, update the filter cache and clear the bundle from the handler cache.
-		func(data interface{}) {
-			events, ok := data.(*event.ReplicatedPolicyEventBundle)
-			if !ok {
-				return
-			}
-			// policyEvents, ok := data.([]event.ReplicatedPolicyEvent)
-			// update the time filter: with latest event
-			for _, evt := range *events {
-				filter.CacheTime(name, evt.CreatedAt)
-			}
-			// reset the payload
-			*events = (*events)[:0]
-		}),
+	return generic.NewGenericEmitter(
+		eventType, generic.WithPostSend(
+			// After sending the event, update the filter cache and clear the bundle from the handler cache.
+			func(data interface{}) {
+				events, ok := data.(*event.ReplicatedPolicyEventBundle)
+				if !ok {
+					return
+				}
+				// policyEvents, ok := data.([]event.ReplicatedPolicyEvent)
+				// update the time filter: with latest event
+				for _, evt := range *events {
+					filter.CacheTime(name, evt.CreatedAt)
+				}
+				// reset the payload
+				*events = (*events)[:0]
+			},
+		),
 	)
 }
 

--- a/agent/pkg/status/syncers/policies/handlers/status_event_handler_test.go
+++ b/agent/pkg/status/syncers/policies/handlers/status_event_handler_test.go
@@ -16,7 +16,8 @@ import (
 
 func TestPostSendFunc(t *testing.T) {
 	configs.SetAgentConfig(&configs.AgentConfig{LeafHubName: "leaf-hub-name"})
-	localStatusEventHandler := NewPolicyStatusEventHandler(context.TODO(), enum.LocalReplicatedPolicyEventType,
+	localStatusEventHandler := NewPolicyStatusEventHandler(
+		context.TODO(), enum.LocalReplicatedPolicyEventType,
 		func(obj client.Object) bool {
 			return true
 		},

--- a/agent/pkg/status/syncers/policies/policy_syncer.go
+++ b/agent/pkg/status/syncers/policies/policy_syncer.go
@@ -93,7 +93,8 @@ func LaunchPolicySyncer(ctx context.Context, mgr ctrl.Manager, agentConfig *conf
 				Handler: globalCompleteHandler,
 				Emitter: globalCompleteEmitter,
 			},
-		})
+		},
+	)
 }
 
 func AddPolicySyncer(ctx context.Context, mgr ctrl.Manager, p transport.Producer,

--- a/agent/pkg/status/syncers/security/stackrox_syncer.go
+++ b/agent/pkg/status/syncers/security/stackrox_syncer.go
@@ -421,7 +421,8 @@ func (s *StackRoxSyncer) sync(ctx context.Context, data *stackRoxData) error {
 		}
 
 		messageStruct, err := request.GenerateFromCache(
-			request.CacheStruct, data.consoleURL, data.key.Namespace, data.key.Name)
+			request.CacheStruct, data.consoleURL, data.key.Namespace, data.key.Name,
+		)
 		if err != nil {
 			return fmt.Errorf("failed to generate struct for kafka message: %v", err)
 		}

--- a/manager/cmd/main.go
+++ b/manager/cmd/main.go
@@ -204,7 +204,8 @@ func createManager(ctx context.Context,
 		return nil, fmt.Errorf("failed to add configmap controller to manager: %w", err)
 	}
 	configs.SetEnableInventoryAPI(managerConfig.EnableInventoryAPI)
-	err = controller.NewTransportCtrl(managerConfig.ManagerNamespace, constants.GHTransportConfigSecret,
+	err = controller.NewTransportCtrl(
+		managerConfig.ManagerNamespace, constants.GHTransportConfigSecret,
 		transportCallback(mgr, managerConfig),
 		managerConfig.TransportConfig, true,
 	).SetupWithManager(mgr)

--- a/manager/pkg/processes/cronjob/scheduler.go
+++ b/manager/pkg/processes/cronjob/scheduler.go
@@ -79,7 +79,8 @@ func AddSchedulerToManager(ctx context.Context, mgr ctrl.Manager,
 
 	return mgr.Add(NewGlobalHubScheduler(
 		scheduler,
-		strings.Split(managerConfig.LaunchJobNames, ",")))
+		strings.Split(managerConfig.LaunchJobNames, ","),
+	))
 }
 
 func (s *GlobalHubJobScheduler) Start(ctx context.Context) error {

--- a/manager/pkg/restapis/managedclusters/list.go
+++ b/manager/pkg/restapis/managedclusters/list.go
@@ -105,7 +105,8 @@ func ListManagedClusters() gin.HandlerFunc {
 		LastResourceCompareCondition := fmt.Sprintf(
 			"(payload -> 'metadata' ->> 'name', cluster_id) > ('%s', '%s') ",
 			lastManagedClusterName,
-			lastManagedClusterUID)
+			lastManagedClusterUID,
+		)
 
 		// managed cluster list query order by name and uid with limit if set
 		managedClusterListQuery := "SELECT payload FROM status.managed_clusters WHERE deleted_at is NULL AND " +

--- a/manager/pkg/restapis/policies/get.go
+++ b/manager/pkg/restapis/policies/get.go
@@ -198,7 +198,8 @@ func queryPolicyStatus(ctx context.Context, policyID, policyQuery, policyMapping
 	}
 
 	compliancePerClusterStatuses, hasNonCompliantClusters, err := getComplianceStatus(
-		ctx, policyComplianceQuery, policyID)
+		ctx, policyComplianceQuery, policyID,
+	)
 	if err != nil {
 		_, _ = fmt.Fprintf(gin.DefaultWriter, QueryPolicyComplianceFailureFormatMsg, err)
 		return &unstructured.Unstructured{}, err

--- a/manager/pkg/restapis/policies/list.go
+++ b/manager/pkg/restapis/policies/list.go
@@ -109,7 +109,8 @@ func ListPolicies() gin.HandlerFunc {
 		LastResourceCompareCondition := fmt.Sprintf(
 			"(payload -> 'metadata' ->> 'name', payload -> 'metadata' ->> 'uid') > ('%s', '%s') ",
 			lastPolicyName,
-			lastPolicyUID)
+			lastPolicyUID,
+		)
 
 		// policy list query order by name and uid
 		policyListQuery := "SELECT id, payload FROM spec.policies WHERE deleted = FALSE AND " +
@@ -272,7 +273,8 @@ func sendPolicyWatchEvent(ctx context.Context, writer io.Writer, policy *policyv
 	}
 
 	compliancePerClusterStatuses, hasNonCompliantClusters, err := getComplianceStatus(
-		ctx, policyComplianceQuery, policyID)
+		ctx, policyComplianceQuery, policyID,
+	)
 	if err != nil {
 		return fmt.Errorf("error in querying compliance status of a policy with UID: %s - %w", policyID, err)
 	}

--- a/manager/pkg/restapis/subscriptions/list.go
+++ b/manager/pkg/restapis/subscriptions/list.go
@@ -96,7 +96,8 @@ func ListSubscriptions() gin.HandlerFunc {
 		LastResourceCompareCondition := fmt.Sprintf(
 			"(payload -> 'metadata' ->> 'name', payload -> 'metadata' ->> 'uid') > ('%s', '%s') ",
 			lastSubscriptionName,
-			lastSubscriptionUID)
+			lastSubscriptionUID,
+		)
 
 		// the last subscription query order by subscription name and uid
 		lastSubscriptionQuery := "SELECT payload FROM spec.subscriptions WHERE deleted = FALSE " +

--- a/manager/pkg/restapis/util/crd.go
+++ b/manager/pkg/restapis/util/crd.go
@@ -85,7 +85,8 @@ func convertColumnsToColumnsV1(columns []apiextensions.CustomResourceColumnDefin
 
 		// nolint:lll
 		err := apiextensionsv1.Convert_apiextensions_CustomResourceColumnDefinition_To_v1_CustomResourceColumnDefinition(
-			columnCopy, &columnv1, nil)
+			columnCopy, &columnv1, nil,
+		)
 		if err != nil {
 			return nil, fmt.Errorf("unable to convert column: %w", err)
 		}

--- a/manager/pkg/spec/syncers/managedcluster_labels_watcher.go
+++ b/manager/pkg/spec/syncers/managedcluster_labels_watcher.go
@@ -147,7 +147,8 @@ func (watcher *managedClusterLabelsStatusWatcher) updateDeletedLabelsByManagedCl
 
 			err = updateDeletedKeysToLabelTable(
 				managedClusterLabelsSpec.Version, managedClusterLabelsSpecBundle.LeafHubName,
-				managedClusterLabelsSpec.ClusterName, deletedLabelKeysStillInStatus)
+				managedClusterLabelsSpec.ClusterName, deletedLabelKeysStillInStatus,
+			)
 			if err != nil {
 				watcher.log.Error(err, "failed to sync deleted_label_keys to label tables")
 				result = false

--- a/manager/pkg/status/conflator/workerpool/worker.go
+++ b/manager/pkg/status/conflator/workerpool/worker.go
@@ -84,7 +84,8 @@ func (worker *Worker) handleJob(ctx context.Context, job *conflator.ConflationJo
 
 	// based on the handle result, update the element state
 	startTime := time.Now()
-	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true,
+	err = wait.PollUntilContextTimeout(
+		ctx, 5*time.Second, 1*time.Minute, true,
 		func(ctx context.Context) (bool, error) {
 			err := job.Handle(ctx, job.Event)
 			if err != nil {

--- a/manager/pkg/status/handlers/handlers.go
+++ b/manager/pkg/status/handlers/handlers.go
@@ -44,7 +44,8 @@ func RegisterHandlers(mgr ctrl.Manager, cmr *conflator.ConflationManager, enable
 		string(enum.LocalPlacementRuleSpecType),
 		conflator.LocalPlacementRulesSpecPriority,
 		enum.CompleteStateMode,
-		fmt.Sprintf("%s.%s", database.LocalSpecSchema, database.PlacementRulesTableName))
+		fmt.Sprintf("%s.%s", database.LocalSpecSchema, database.PlacementRulesTableName),
+	)
 
 	// security
 	security.RegisterSecurityAlertCountsHandler(cmr)
@@ -62,34 +63,39 @@ func RegisterHandlers(mgr ctrl.Manager, cmr *conflator.ConflationManager, enable
 			string(enum.PlacementRuleSpecType),
 			conflator.PlacementRulePriority,
 			enum.CompleteStateMode,
-			fmt.Sprintf("%s.%s", database.StatusSchema, database.PlacementRulesTableName))
+			fmt.Sprintf("%s.%s", database.StatusSchema, database.PlacementRulesTableName),
+		)
 
 		generic.RegisterGenericHandler[*clustersv1beta1.Placement](
 			cmr,
 			string(enum.PlacementSpecType),
 			conflator.PlacementPriority,
 			enum.CompleteStateMode,
-			fmt.Sprintf("%s.%s", database.StatusSchema, database.PlacementsTableName))
+			fmt.Sprintf("%s.%s", database.StatusSchema, database.PlacementsTableName),
+		)
 
 		generic.RegisterGenericHandler[*clustersv1beta1.PlacementDecision](
 			cmr,
 			string(enum.PlacementDecisionType),
 			conflator.PlacementDecisionPriority,
 			enum.CompleteStateMode,
-			fmt.Sprintf("%s.%s", database.StatusSchema, database.PlacementDecisionsTableName))
+			fmt.Sprintf("%s.%s", database.StatusSchema, database.PlacementDecisionsTableName),
+		)
 
 		generic.RegisterGenericHandler[*appsv1alpha1.SubscriptionReport](
 			cmr,
 			string(enum.SubscriptionReportType),
 			conflator.SubscriptionReportPriority,
 			enum.CompleteStateMode,
-			fmt.Sprintf("%s.%s", database.StatusSchema, database.SubscriptionReportsTableName))
+			fmt.Sprintf("%s.%s", database.StatusSchema, database.SubscriptionReportsTableName),
+		)
 
 		generic.RegisterGenericHandler[*appsv1alpha1.SubscriptionStatus](
 			cmr,
 			string(enum.SubscriptionStatusType),
 			conflator.SubscriptionStatusPriority,
 			enum.CompleteStateMode,
-			fmt.Sprintf("%s.%s", database.StatusSchema, database.SubscriptionStatusesTableName))
+			fmt.Sprintf("%s.%s", database.StatusSchema, database.SubscriptionStatusesTableName),
+		)
 	}
 }

--- a/manager/pkg/status/handlers/policy/local_complete_handler.go
+++ b/manager/pkg/status/handlers/policy/local_complete_handler.go
@@ -166,7 +166,8 @@ func (h *localPolicyCompleteHandler) handleCompleteCompliance(log *zap.SugaredLo
 			return fmt.Errorf("failed to update compliances by complete event - %w", err)
 		}
 		if configs.IsInventoryAPIEnabled() {
-			err = syncInventory(h.requester, leafHub,
+			err = syncInventory(
+				h.requester, leafHub,
 				models.ResourceVersion{
 					Key:  policyID,
 					Name: policyNamespacedName,

--- a/manager/pkg/status/handlers/policy/local_compliance_handler.go
+++ b/manager/pkg/status/handlers/policy/local_compliance_handler.go
@@ -139,7 +139,8 @@ func (h *localPolicyComplianceHandler) handleCompliance(ctx context.Context, evt
 
 		if configs.IsInventoryAPIEnabled() {
 			log.Debugf("sync to inventory api - %s", policyID)
-			err = syncInventory(h.requester, leafHub,
+			err = syncInventory(
+				h.requester, leafHub,
 				models.ResourceVersion{
 					Key:  policyID,
 					Name: policyNamespacedName,
@@ -241,7 +242,8 @@ func postCompliancesToInventoryApi(
 			if resp, err := requester.GetHttpClient().K8SPolicyIsPropagatedToK8SClusterServiceHTTPClient.
 				UpdateK8SPolicyIsPropagatedToK8SCluster(context.Background(), updateK8SPolicyIsPropagatedToK8SCluster(
 					policyNamespacedName, createCompliance.ClusterName, string(createCompliance.Compliance),
-					leafHub, mchVersion)); err != nil {
+					leafHub, mchVersion,
+				)); err != nil {
 				log.Errorf("failed to create k8s policy is propagated to k8s cluster -%v: %v", resp, err)
 			}
 		}
@@ -251,7 +253,8 @@ func postCompliancesToInventoryApi(
 			if resp, err := requester.GetHttpClient().K8SPolicyIsPropagatedToK8SClusterServiceHTTPClient.
 				UpdateK8SPolicyIsPropagatedToK8SCluster(context.Background(), updateK8SPolicyIsPropagatedToK8SCluster(
 					policyNamespacedName, updateCompliance.ClusterName, string(updateCompliance.Compliance),
-					leafHub, mchVersion)); err != nil {
+					leafHub, mchVersion,
+				)); err != nil {
 				log.Errorf("failed to update k8s policy is propagated to k8s cluster -%v: %v", resp, err)
 			}
 		}
@@ -260,7 +263,8 @@ func postCompliancesToInventoryApi(
 		for _, deleteCompliance := range deleteCompliances {
 			if resp, err := requester.GetHttpClient().K8SPolicyIsPropagatedToK8SClusterServiceHTTPClient.
 				DeleteK8SPolicyIsPropagatedToK8SCluster(context.Background(), deleteK8SPolicyIsPropagatedToK8SCluster(
-					policyNamespacedName, deleteCompliance.ClusterName, leafHub, mchVersion)); err != nil && !errors.IsNotFound(err) {
+					policyNamespacedName, deleteCompliance.ClusterName, leafHub, mchVersion,
+				)); err != nil && !errors.IsNotFound(err) {
 				log.Warnf("failed to delete k8s policy is propagated to k8s cluster -%v: %v", resp, err)
 			}
 		}
@@ -413,7 +417,8 @@ func getLocalComplianceClusterSets(db *gorm.DB, query interface{}, args ...inter
 			allPolicyComplianceRowsFromDB[compliance.PolicyID] = NewPolicyClusterSets()
 		}
 		allPolicyComplianceRowsFromDB[compliance.PolicyID].AddCluster(
-			compliance.ClusterName, compliance.Compliance)
+			compliance.ClusterName, compliance.Compliance,
+		)
 	}
 	return allPolicyComplianceRowsFromDB, nil
 }
@@ -425,7 +430,8 @@ func getPolicyNamespacedName(db *gorm.DB, policyID string) (string, error) {
 		return "", fmt.Errorf("db is nil")
 	}
 	err := db.Select(
-		"policy_id AS key, concat(payload->'metadata'->>'namespace', '/', payload->'metadata'->>'name') AS name").
+		"policy_id AS key, concat(payload->'metadata'->>'namespace', '/', payload->'metadata'->>'name') AS name",
+	).
 		Where(&models.LocalSpecPolicy{
 			PolicyID: policyID,
 		}).Find(&policyFromDB).Scan(&resourceVersions).Error

--- a/manager/pkg/status/handlers/policy/local_policy_spec_handler.go
+++ b/manager/pkg/status/handlers/policy/local_policy_spec_handler.go
@@ -226,7 +226,8 @@ func (h *localPolicySpecHandler) postPolicyToInventoryApi(
 		for _, policy := range bundle.Create {
 			k8sPolicy := generateK8SPolicy(&policy, leafHubName, clusterInfo.MchVersion)
 			if resp, err := h.requester.GetHttpClient().PolicyServiceClient.CreateK8SPolicy(
-				ctx, &kessel.CreateK8SPolicyRequest{K8SPolicy: k8sPolicy}); err != nil && !errors.IsAlreadyExists(err) {
+				ctx, &kessel.CreateK8SPolicyRequest{K8SPolicy: k8sPolicy},
+			); err != nil && !errors.IsAlreadyExists(err) {
 				return fmt.Errorf("failed to create k8sCluster %v: %w", resp, err)
 			}
 		}
@@ -235,7 +236,8 @@ func (h *localPolicySpecHandler) postPolicyToInventoryApi(
 		for _, policy := range bundle.Update {
 			k8sPolicy := generateK8SPolicy(&policy, leafHubName, clusterInfo.MchVersion)
 			if resp, err := h.requester.GetHttpClient().PolicyServiceClient.UpdateK8SPolicy(
-				ctx, &kessel.UpdateK8SPolicyRequest{K8SPolicy: k8sPolicy}); err != nil {
+				ctx, &kessel.UpdateK8SPolicyRequest{K8SPolicy: k8sPolicy},
+			); err != nil {
 				return fmt.Errorf("failed to update k8sCluster %v: %w", resp, err)
 			}
 		}
@@ -250,7 +252,8 @@ func (h *localPolicySpecHandler) postPolicyToInventoryApi(
 						ReporterVersion:    clusterInfo.MchVersion,
 						LocalResourceId:    policy.Name,
 					},
-				}); err != nil && !errors.IsNotFound(err) {
+				},
+			); err != nil && !errors.IsNotFound(err) {
 				return fmt.Errorf("failed to delete k8sCluster %v: %w", resp, err)
 			}
 			// delete the policy related compliance data in inventory when policy is deleted

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.6.2
+VERSION ?= 1.6.3
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -70,7 +70,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: multicluster-global-hub-operator.v1.6.2
+  name: multicluster-global-hub-operator.v1.6.3
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1167,5 +1167,5 @@ spec:
   provider:
     name: Red Hat, Inc
     url: https://github.com/stolostron/multicluster-global-hub
-  replaces: multicluster-global-hub-operator.v1.6.1
-  version: 1.6.2
+  replaces: multicluster-global-hub-operator.v1.6.2
+  version: 1.6.3

--- a/operator/config/manifests/bases/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -256,5 +256,5 @@ spec:
   provider:
     name: Red Hat, Inc
     url: https://github.com/stolostron/multicluster-global-hub
-  replaces: multicluster-global-hub-operator.v1.6.1
+  replaces: multicluster-global-hub-operator.v1.6.2
   version: 0.0.1

--- a/operator/pkg/config/controller_config.go
+++ b/operator/pkg/config/controller_config.go
@@ -25,7 +25,8 @@ var controllerConfigMap *corev1.ConfigMap
 
 func LoadControllerConfig(ctx context.Context, kubeClient kubernetes.Interface) error {
 	config, err := kubeClient.CoreV1().ConfigMaps(utils.GetDefaultNamespace()).Get(
-		ctx, operatorconstants.ControllerConfig, metav1.GetOptions{})
+		ctx, operatorconstants.ControllerConfig, metav1.GetOptions{},
+	)
 	if err != nil && !errors.IsNotFound(err) {
 		return err
 	}

--- a/operator/pkg/config/multiclusterglobalhub_config_test.go
+++ b/operator/pkg/config/multiclusterglobalhub_config_test.go
@@ -149,7 +149,7 @@ func TestSetMulticlusterGlobalHubConfig(t *testing.T) {
 		t.Fatalf("oauth proxy image is not expected one")
 	}
 
-	imageClient := fakeimagev1client.FakeImageV1{Fake: &(fakeimageclient.NewSimpleClientset().Fake)}
+	imageClient := fakeimagev1client.FakeImageV1{Fake: &fakeimageclient.NewSimpleClientset().Fake}
 	err = SetMulticlusterGlobalHubConfig(context.Background(), mghInstance, nil, &imageClient)
 	if err != nil {
 		t.Fatal(err)

--- a/operator/pkg/controllers/agent/addon/addon_agent.go
+++ b/operator/pkg/controllers/agent/addon/addon_agent.go
@@ -195,7 +195,8 @@ func (a *GlobalHubAddonAgent) setImagePullSecret(mgh *globalhubv1alpha4.Multiclu
 	if len(imagePullSecret.Name) > 0 && len(imagePullSecret.Data[corev1.DockerConfigJsonKey]) > 0 {
 		manifestsConfig.ImagePullSecretName = imagePullSecret.GetName()
 		manifestsConfig.ImagePullSecretData = base64.StdEncoding.EncodeToString(
-			imagePullSecret.Data[corev1.DockerConfigJsonKey])
+			imagePullSecret.Data[corev1.DockerConfigJsonKey],
+		)
 	}
 	return nil
 }

--- a/operator/pkg/controllers/agent/addon/addon_manager.go
+++ b/operator/pkg/controllers/agent/addon/addon_manager.go
@@ -89,7 +89,8 @@ func StartGlobalHubAddonManager(ctx context.Context, kubeConfig *rest.Config, cl
 	}
 
 	factory := addonfactory.NewAgentAddonFactory(
-		constants.GHManagedClusterAddonName, FS, "manifests").
+		constants.GHManagedClusterAddonName, FS, "manifests",
+	).
 		WithScheme(addonAgentConfig.addonScheme).
 		WithAgentHealthProber(&addonframeworkagent.HealthProber{
 			Type: addonframeworkagent.HealthProberTypeLease,

--- a/operator/pkg/controllers/backup/backup_reconcile.go
+++ b/operator/pkg/controllers/backup/backup_reconcile.go
@@ -103,7 +103,8 @@ func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 	err = allResourcesBackup[req.Namespace].AddLabelToOneObj(
 		ctx, r.Client,
-		config.GetMGHNamespacedName().Namespace, req.Name)
+		config.GetMGHNamespacedName().Namespace, req.Name,
+	)
 	return addBackupCondition(ctx, r.Client, mgh, err)
 }
 

--- a/operator/pkg/controllers/backup/backup_start.go
+++ b/operator/pkg/controllers/backup/backup_start.go
@@ -82,7 +82,7 @@ func StartController(initOption config.ControllerOption) (config.ControllerInter
 		Client:  initOption.Manager.GetClient(),
 		Log:     logger.ZaprLogger(),
 	}
-	err := c.SetupWithManager((initOption.Manager))
+	err := c.SetupWithManager(initOption.Manager)
 	if err != nil {
 		return nil, err
 	}

--- a/operator/pkg/controllers/grafana/grafana_reconciler.go
+++ b/operator/pkg/controllers/grafana/grafana_reconciler.go
@@ -259,7 +259,8 @@ func (r *GrafanaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	var reconcileErr error
 	defer func() {
-		err = config.UpdateMGHComponent(ctx, r.GetClient(),
+		err = config.UpdateMGHComponent(
+			ctx, r.GetClient(),
 			config.GetComponentStatusWithReconcileError(ctx, r.GetClient(),
 				mgh.Namespace, config.COMPONENTS_GRAFANA_NAME, reconcileErr),
 			false,
@@ -619,7 +620,8 @@ func mergeAlertConfigMap(defaultAlertConfigMap, customAlertConfigMap *corev1.Con
 
 	mergedAlertYaml, err := mergeAlertYaml(
 		[]byte(defaultAlertConfigMap.Data[AlertConfigMapKey]),
-		[]byte(customAlertConfigMap.Data[AlertConfigMapKey]))
+		[]byte(customAlertConfigMap.Data[AlertConfigMapKey]),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/operator/pkg/controllers/inventory/inventory_reconciler.go
+++ b/operator/pkg/controllers/inventory/inventory_reconciler.go
@@ -142,7 +142,8 @@ func (r *InventoryReconciler) Reconcile(ctx context.Context,
 	var reconcileErr error
 
 	defer func() {
-		err = config.UpdateMGHComponent(ctx, r.GetClient(),
+		err = config.UpdateMGHComponent(
+			ctx, r.GetClient(),
 			config.GetComponentStatusWithReconcileError(ctx, r.GetClient(),
 				mgh.Namespace, config.COMPONENTS_INVENTORY_API_NAME, reconcileErr),
 			false,

--- a/operator/pkg/controllers/inventory/spicedb_controller.go
+++ b/operator/pkg/controllers/inventory/spicedb_controller.go
@@ -191,7 +191,8 @@ func (r *spiceDBClusterReconciler) reconcileStorageSecret(ctx context.Context,
 	// TODO: Currently using the 'disable' method to establish the connection.
 	// Other methods have not been validated. GH itself uses `required-ca`,
 	// so we might need to update both to support `verify-full`.
-	pgURI := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s",
+	pgURI := fmt.Sprintf(
+		"postgres://%s:%s@%s:%d/%s?sslmode=%s",
 		url.QueryEscape(pgConfig.User),
 		url.QueryEscape(pgConfig.Password),
 		pgConfig.Host,

--- a/operator/pkg/controllers/manager/manager_reconciler.go
+++ b/operator/pkg/controllers/manager/manager_reconciler.go
@@ -206,7 +206,8 @@ func (r *ManagerReconciler) Reconcile(ctx context.Context,
 	isResourceRemoved = false
 	var reconcileErr error
 	defer func() {
-		err = config.UpdateMGHComponent(ctx, r.GetClient(),
+		err = config.UpdateMGHComponent(
+			ctx, r.GetClient(),
 			config.GetComponentStatusWithReconcileError(ctx, r.GetClient(),
 				mgh.Namespace, config.COMPONENTS_MANAGER_NAME, reconcileErr),
 			false,
@@ -311,7 +312,8 @@ func (r *ManagerReconciler) Reconcile(ctx context.Context,
 			ImagePullPolicy:    string(imagePullPolicy),
 			ProxySessionSecret: proxySessionSecret,
 			DatabaseURL: base64.StdEncoding.EncodeToString(
-				[]byte(storageConn.SuperuserDatabaseURI)),
+				[]byte(storageConn.SuperuserDatabaseURI),
+			),
 			PostgresCACert:            base64.StdEncoding.EncodeToString(storageConn.CACert),
 			TransportType:             string(transport.Kafka),
 			TransportConfigSecret:     constants.GHTransportConfigSecret,

--- a/operator/pkg/controllers/storage/storage_reconciler.go
+++ b/operator/pkg/controllers/storage/storage_reconciler.go
@@ -206,7 +206,8 @@ func (r *StorageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	var reconcileErr error
 	defer func() {
-		err = config.UpdateMGHComponent(ctx, r.GetClient(),
+		err = config.UpdateMGHComponent(
+			ctx, r.GetClient(),
 			getDatabaseComponentStatus(ctx, r.GetClient(), mgh.Namespace, config.COMPONENTS_POSTGRES_NAME, reconcileErr),
 			updateConnection,
 		)

--- a/operator/pkg/controllers/transporter/protocol/strimzi_kafka_controller.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_kafka_controller.go
@@ -93,7 +93,8 @@ func (r *KafkaController) Reconcile(ctx context.Context, request ctrl.Request) (
 	}
 	var reconcileErr error
 	defer func() {
-		err = config.UpdateMGHComponent(ctx, r.c,
+		err = config.UpdateMGHComponent(
+			ctx, r.c,
 			r.getKafkaComponentStatus(reconcileErr, r.kafkaStatus),
 			updateConn,
 		)

--- a/operator/pkg/controllers/transporter/transport_reconciler.go
+++ b/operator/pkg/controllers/transporter/transport_reconciler.go
@@ -133,7 +133,8 @@ func (r *TransportReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			return
 		}
 
-		err = config.UpdateMGHComponent(ctx, r.GetClient(),
+		err = config.UpdateMGHComponent(
+			ctx, r.GetClient(),
 			getTransportComponentStatus(reconcileErr),
 			updateConn,
 		)

--- a/operator/pkg/renderer/hoh_renderer_test.go
+++ b/operator/pkg/renderer/hoh_renderer_test.go
@@ -262,7 +262,8 @@ var _ = Describe("Render", func() {
 			nginxObjects, err := render.RenderWithFilter("testdata/app", profile,
 				filter, func(profile string) (interface{}, error) {
 					inputvalues, err := fs.ReadFile(fmt.Sprintf(
-						"testdata/input/%s-%s.yaml", profile, filter))
+						"testdata/input/%s-%s.yaml", profile, filter,
+					))
 					if err != nil {
 						return struct{}{}, err
 					}

--- a/operator/pkg/utils/utils.go
+++ b/operator/pkg/utils/utils.go
@@ -371,7 +371,8 @@ func AnnotateManagedHubCluster(ctx context.Context, c client.Client) error {
 		LabelSelector: labels.SelectorFromSet(
 			labels.Set{
 				constants.GlobalHubOwnerLabelKey: constants.GHOperatorOwnerLabelVal,
-			}),
+			},
+		),
 	}); err != nil {
 		return err
 	}

--- a/pkg/database/dao/generic_dao.go
+++ b/pkg/database/dao/generic_dao.go
@@ -30,7 +30,8 @@ func (dao *GenericDao) GetIdToVersionByHub(hubName string) (map[string]string, e
 		FROM 
 			%s 
 		WHERE 
-			leaf_hub_name = ?`, dao.table)
+			leaf_hub_name = ?`, dao.table,
+	)
 
 	var resourceVersions []models.ResourceVersion
 	err := dao.tx.Raw(sqlTemplate, hubName).Scan(&resourceVersions).Error
@@ -47,7 +48,8 @@ func (dao *GenericDao) GetIdToVersionByHub(hubName string) (map[string]string, e
 
 func (dao *GenericDao) Insert(hubName, id string, obj interface{}) error {
 	sqlTemplate := fmt.Sprintf(
-		`INSERT INTO %s (id, leaf_hub_name, payload) VALUES ($1::uuid, $2, $3::jsonb)`, dao.table)
+		`INSERT INTO %s (id, leaf_hub_name, payload) VALUES ($1::uuid, $2, $3::jsonb)`, dao.table,
+	)
 
 	payload, err := json.Marshal(obj)
 	if err != nil {
@@ -58,7 +60,8 @@ func (dao *GenericDao) Insert(hubName, id string, obj interface{}) error {
 
 func (dao *GenericDao) Update(hubName, id string, obj interface{}) error {
 	sqlTemplate := fmt.Sprintf(
-		`UPDATE %s SET payload = $1::jsonb WHERE leaf_hub_name = $2 AND id = $3::uuid`, dao.table)
+		`UPDATE %s SET payload = $1::jsonb WHERE leaf_hub_name = $2 AND id = $3::uuid`, dao.table,
+	)
 
 	payload, err := json.Marshal(obj)
 	if err != nil {
@@ -69,6 +72,7 @@ func (dao *GenericDao) Update(hubName, id string, obj interface{}) error {
 
 func (dao *GenericDao) Delete(hubName, id string) error {
 	sqlTemplate := fmt.Sprintf(
-		`DELETE FROM %s WHERE leaf_hub_name = $1 AND id = $2::uuid`, dao.table)
+		`DELETE FROM %s WHERE leaf_hub_name = $1 AND id = $2::uuid`, dao.table,
+	)
 	return dao.tx.Exec(sqlTemplate, hubName, id).Error
 }

--- a/pkg/transport/consumer/sarama_consumer_test.go
+++ b/pkg/transport/consumer/sarama_consumer_test.go
@@ -134,7 +134,8 @@ func MockSaramaCluster(t *testing.T, messages []string) *sarama.MockBroker {
 					Topics: map[string][]int32{
 						"my-topic": {0},
 					},
-				}),
+				},
+			),
 		),
 		"OffsetFetchRequest": sarama.NewMockOffsetFetchResponse(t).SetOffset(
 			"my-group", "my-topic", 0, oldestOffset, "", sarama.ErrNoError,

--- a/pkg/transport/producer/generic_producer.go
+++ b/pkg/transport/producer/generic_producer.go
@@ -141,7 +141,7 @@ func (p *GenericProducer) initClient(transportConfig *transport.TransportInterna
 
 func (p *GenericProducer) splitPayloadIntoChunks(payload []byte) [][]byte {
 	var chunk []byte
-	chunks := make([][]byte, 0, len(payload)/(p.messageSizeLimit)+1)
+	chunks := make([][]byte, 0, len(payload)/p.messageSizeLimit+1)
 	for len(payload) >= p.messageSizeLimit {
 		chunk, payload = payload[:p.messageSizeLimit], payload[p.messageSizeLimit:]
 		chunks = append(chunks, chunk)

--- a/test/e2e/kessel/inventory_test.go
+++ b/test/e2e/kessel/inventory_test.go
@@ -40,7 +40,8 @@ var _ = Describe("kafka-event: inventory API", Ordered, func() {
 		relationship = generateK8SPolicyToCluster(
 			localPolicyId,
 			localClusterId,
-			"guest")
+			"guest",
+		)
 	})
 
 	It("Create a cluster", func() {

--- a/test/e2e/utils/client.go
+++ b/test/e2e/utils/client.go
@@ -167,7 +167,8 @@ func LoadConfig(url, kubeconfig, context string) (*rest.Config, error) {
 				&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig},
 				&clientcmd.ConfigOverrides{
 					CurrentContext: context,
-				}).ClientConfig()
+				},
+			).ClientConfig()
 		}
 	}
 	// If not, try the in-cluster config.

--- a/test/integration/agent/controller/version_clusterclaim_test.go
+++ b/test/integration/agent/controller/version_clusterclaim_test.go
@@ -58,7 +58,8 @@ var _ = Describe("claim controllers", Ordered, func() {
 			}, clusterClaim)
 		}, 3*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
 		Expect(clusterClaim.Spec.Value).Should(Equal(
-			constants.HubInstalledByUser))
+			constants.HubInstalledByUser,
+		))
 	})
 
 	It("clusterClaim testing clusterManager and mch are not installed", func() {
@@ -138,7 +139,8 @@ var _ = Describe("claim controllers", Ordered, func() {
 			return true
 		}, 1*time.Second, 100*time.Millisecond).Should(BeTrue())
 		Expect(clusterClaim.Spec.Value).Should(Equal(
-			constants.HubInstalledByUser))
+			constants.HubInstalledByUser,
+		))
 
 		By("Expect clusterClaim version to be updated")
 		mch.Status = mchv1.MultiClusterHubStatus{CurrentVersion: "2.7.0"}
@@ -189,7 +191,8 @@ var _ = Describe("claim controllers", Ordered, func() {
 			return true
 		}, 1*time.Second, 100*time.Millisecond).Should(BeTrue())
 		Expect(clusterClaim.Spec.Value).Should(Equal(
-			constants.HubInstalledByUser))
+			constants.HubInstalledByUser,
+		))
 	})
 })
 

--- a/test/integration/manager/api/api_test.go
+++ b/test/integration/manager/api/api_test.go
@@ -150,7 +150,8 @@ var _ = Describe("Nonk8s API Server", Ordered, func() {
 		Expect(err).ToNot(HaveOccurred())
 		err = db.Exec(
 			`INSERT INTO status.managed_clusters (cluster_id,leaf_hub_name,payload,error) VALUES (?, ?, ?, 'none');`,
-			mc2Id, hub1, mc2).Error
+			mc2Id, hub1, mc2,
+		).Error
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Check the managedcclusters can be listed without parameters")
@@ -170,7 +171,8 @@ var _ = Describe("Nonk8s API Server", Ordered, func() {
 		]
 }`
 		Expect(w1.Body.String()).Should(MatchJSON(
-			fmt.Sprintf(managedClusterListFormatStr, mc1, mc2)))
+			fmt.Sprintf(managedClusterListFormatStr, mc1, mc2),
+		))
 
 		By("Check the managedclusters can be list with continue")
 		w21 := httptest.NewRecorder()
@@ -178,12 +180,14 @@ var _ = Describe("Nonk8s API Server", Ordered, func() {
 		Expect(err).ToNot(HaveOccurred())
 		req21, err := http.NewRequest("GET", fmt.Sprintf(
 			"/global-hub-api/v1/managedclusters?continue=%s",
-			continueToken), nil)
+			continueToken,
+		), nil)
 		Expect(err).ToNot(HaveOccurred())
 		router.ServeHTTP(w21, req21)
 		Expect(w21.Code).To(Equal(200))
 		Expect(w21.Body.String()).Should(MatchJSON(
-			fmt.Sprintf(managedClusterListFormatStr, mc1, mc2)))
+			fmt.Sprintf(managedClusterListFormatStr, mc1, mc2),
+		))
 
 		By("Check the managedclusters can be listed with limit and labelSelector")
 		w2 := httptest.NewRecorder()
@@ -195,7 +199,8 @@ var _ = Describe("Nonk8s API Server", Ordered, func() {
 		router.ServeHTTP(w2, req2)
 		Expect(w2.Code).To(Equal(200))
 		Expect(w2.Body.String()).Should(MatchJSON(
-			fmt.Sprintf(managedClusterListFormatStr, mc1, mc2)))
+			fmt.Sprintf(managedClusterListFormatStr, mc1, mc2),
+		))
 
 		By("Check the managedcclusters can be listed as table")
 		// mclTable := `
@@ -667,7 +672,8 @@ var _ = Describe("Nonk8s API Server", Ordered, func() {
 		]
 }`
 		Expect(w1.Body.String()).Should(MatchJSON(
-			fmt.Sprintf(policyListFormatStr, expectedPolicy1)))
+			fmt.Sprintf(policyListFormatStr, expectedPolicy1),
+		))
 
 		By("Check the policies can be listed with limit and labelSelector")
 		w2 := httptest.NewRecorder()
@@ -679,7 +685,8 @@ var _ = Describe("Nonk8s API Server", Ordered, func() {
 		router.ServeHTTP(w2, req2)
 		Expect(w2.Code).To(Equal(200))
 		Expect(w2.Body.String()).Should(MatchJSON(
-			fmt.Sprintf(policyListFormatStr, expectedPolicy1)))
+			fmt.Sprintf(policyListFormatStr, expectedPolicy1),
+		))
 
 		By("Check the policies can be listed as table")
 		// 		plcTable := `
@@ -885,7 +892,8 @@ var _ = Describe("Nonk8s API Server", Ordered, func() {
 		By("Check the policy status can be retrieved with policy ID")
 		w1 := httptest.NewRecorder()
 		req1, err := http.NewRequest("GET", fmt.Sprintf(
-			"/global-hub-api/v1/policy/%s/status", plc1ID), nil)
+			"/global-hub-api/v1/policy/%s/status", plc1ID,
+		), nil)
 		Expect(err).ToNot(HaveOccurred())
 		router.ServeHTTP(w1, req1)
 		Expect(w1.Code).To(Equal(200))
@@ -968,7 +976,8 @@ var _ = Describe("Nonk8s API Server", Ordered, func() {
 		// `
 		w2 := httptest.NewRecorder()
 		req2, err := http.NewRequest("GET", fmt.Sprintf(
-			"/global-hub-api/v1/policy/%s/status", plc1ID), nil)
+			"/global-hub-api/v1/policy/%s/status", plc1ID,
+		), nil)
 		Expect(err).ToNot(HaveOccurred())
 		req2.Header.Set("Accept", "application/json;as=Table;g=meta.k8s.io;v=v1")
 		router.ServeHTTP(w2, req2)
@@ -1104,7 +1113,8 @@ var _ = Describe("Nonk8s API Server", Ordered, func() {
 		]
 }`
 		Expect(w1.Body.String()).Should(MatchJSON(
-			fmt.Sprintf(subscriptionListFormatStr, subscription1, subscription2)))
+			fmt.Sprintf(subscriptionListFormatStr, subscription1, subscription2),
+		))
 
 		By("Check the subscriptions can be listed with limit and labelSelector")
 		w2 := httptest.NewRecorder()
@@ -1125,7 +1135,8 @@ var _ = Describe("Nonk8s API Server", Ordered, func() {
 			]
 		}`
 		Expect(w2.Body.String()).Should(MatchJSON(
-			fmt.Sprintf(subscriptionListFormatStr, subscription2)))
+			fmt.Sprintf(subscriptionListFormatStr, subscription2),
+		))
 
 		By("Check the subscriptions can be listed as table")
 		// subscriptionTable := `{
@@ -1376,7 +1387,8 @@ var _ = Describe("Nonk8s API Server", Ordered, func() {
 		By("Check the subscriptionreport can be retrieved")
 		w1 := httptest.NewRecorder()
 		req1, err := http.NewRequest("GET", fmt.Sprintf(
-			"/global-hub-api/v1/subscriptionreport/%s", sub2ID), nil)
+			"/global-hub-api/v1/subscriptionreport/%s", sub2ID,
+		), nil)
 		Expect(err).ToNot(HaveOccurred())
 		router.ServeHTTP(w1, req1)
 		Expect(w1.Code).To(Equal(200))

--- a/test/integration/manager/controller/data_retention_job_test.go
+++ b/test/integration/manager/controller/data_retention_job_test.go
@@ -223,13 +223,15 @@ func createRetentionData(tableName string, date time.Time) error {
 		result = db.Exec(
 			fmt.Sprintf(`INSERT INTO status.managed_clusters (leaf_hub_name, cluster_id, payload, error, 
 				created_at, updated_at, deleted_at) VALUES ('leafhub1', '%s', '%s', 'none', '%s', '%s', '%s')`,
-				string(cluster.UID), payload, date.Format(task.TimeFormat), date.Format(task.TimeFormat), date.Format(task.TimeFormat)))
+				string(cluster.UID), payload, date.Format(task.TimeFormat), date.Format(task.TimeFormat), date.Format(task.TimeFormat)),
+		)
 
 	case "status.leaf_hubs":
 		result = db.Exec(
 			fmt.Sprintf(`INSERT INTO status.leaf_hubs (leaf_hub_name, cluster_id, payload, created_at, updated_at, deleted_at) 
 			VALUES ('leafhub1','a71a6b5c-8361-4f50-9890-3de9e2df0b1c', '{"consoleURL": "https://leafhub1.com", "leafHubName": "leafhub1"}', '%s', '%s', '%s')`,
-				date.Format(task.TimeFormat), date.Format(task.TimeFormat), date.Format(task.TimeFormat)))
+				date.Format(task.TimeFormat), date.Format(task.TimeFormat), date.Format(task.TimeFormat)),
+		)
 
 	case "local_spec.policies":
 		policy := policyv1.Policy{
@@ -245,7 +247,8 @@ func createRetentionData(tableName string, date time.Time) error {
 		result = db.Exec(
 			fmt.Sprintf(`INSERT INTO local_spec.policies (policy_id, leaf_hub_name, payload, created_at, 
 				updated_at, deleted_at) VALUES ('%s', 'leafhub1', '%s', '%s', '%s', '%s')`, policy.UID, payload,
-				date.Format(task.TimeFormat), date.Format(task.TimeFormat), date.Format(task.TimeFormat)))
+				date.Format(task.TimeFormat), date.Format(task.TimeFormat), date.Format(task.TimeFormat)),
+		)
 	}
 	if result.Error != nil {
 		return fmt.Errorf("failed to create retention data in table %s due to: %w", tableName, result.Error)

--- a/test/integration/manager/controller/scheduler_test.go
+++ b/test/integration/manager/controller/scheduler_test.go
@@ -25,7 +25,8 @@ var _ = Describe("scheduler", func() {
 
 		scheduler := gocron.NewScheduler(time.Local)
 		_, err := scheduler.Every(1).Day().At("00:00").Tag(task.LocalComplianceTaskName).DoWithJobDetails(
-			task.LocalComplianceHistory, ctx)
+			task.LocalComplianceHistory, ctx,
+		)
 		Expect(err).To(Succeed())
 
 		_, err = scheduler.Every(1).Month(1, 15, 28).At("00:00").Tag(task.RetentionTaskName).

--- a/test/integration/manager/spec/db2transport_test.go
+++ b/test/integration/manager/spec/db2transport_test.go
@@ -110,12 +110,14 @@ var _ = Describe("Database to Transport Syncer", Ordered, func() {
 
 		By("Placement")
 		err = db.Exec(
-			"INSERT INTO spec.placements (id,payload) VALUES(?, ?)", placementUID, &placementJSONBytes).Error
+			"INSERT INTO spec.placements (id,payload) VALUES(?, ?)", placementUID, &placementJSONBytes,
+		).Error
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Application")
 		err = db.Exec(
-			"INSERT INTO spec.applications (id,payload) VALUES(?, ?)", applicationUID, &applicationJSONBytes).Error
+			"INSERT INTO spec.applications (id,payload) VALUES(?, ?)", applicationUID, &applicationJSONBytes,
+		).Error
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Subscription")

--- a/test/integration/manager/status/suite_test.go
+++ b/test/integration/manager/status/suite_test.go
@@ -110,7 +110,8 @@ var _ = BeforeSuite(func() {
 		managerConfig.TransportConfig.KafkaCredential.StatusTopic, nil)
 	Expect(err).NotTo(HaveOccurred())
 
-	consumer, err := genericconsumer.NewGenericConsumer(managerConfig.TransportConfig,
+	consumer, err := genericconsumer.NewGenericConsumer(
+		managerConfig.TransportConfig,
 		[]string{managerConfig.TransportConfig.KafkaCredential.StatusTopic},
 		[]genericconsumer.GenericConsumeOption{genericconsumer.SetTopicMetadataRefreshInterval(constants.TopicMetadataRefreshInterval)}...,
 	)

--- a/test/integration/operator/controllers/agent/cluster_none_addon_test.go
+++ b/test/integration/operator/controllers/agent/cluster_none_addon_test.go
@@ -95,7 +95,8 @@ var _ = Describe("none addon", func() {
 
 		By("By preparing an OCP with no deploy mode label")
 		clusterName3 := fmt.Sprintf("hub-ocp-no-deploy-mode-%s", rand.String(6))
-		prepareCluster(clusterName3,
+		prepareCluster(
+			clusterName3,
 			map[string]string{
 				"vendor": "OpenShift",
 				// No deploy mode label - should NOT create addon

--- a/test/integration/utils/testpostgres/cmd/main.go
+++ b/test/integration/utils/testpostgres/cmd/main.go
@@ -52,7 +52,8 @@ func main() {
 	postgresConfig = postgresConfig.BinariesPath(postgresDataPath)
 	postgresConfig = postgresConfig.DataPath(filepath.Join(postgresDataPath, "data"))
 	database := embeddedpostgres.NewDatabase(
-		postgresConfig.Database("hoh"))
+		postgresConfig.Database("hoh"),
+	)
 	if err := database.Start(); err != nil {
 		fmt.Printf("failed to start embedded postgres: %v", err)
 		os.Exit(1)


### PR DESCRIPTION
## Summary

`gci v0.14.0` and `gofumpt v0.10.0` (released early May 2026) enforce stricter import ordering and formatting rules than the previous versions. The `format` GitHub Actions check started failing on all PRs targeting `release-2.15` because `go install gci@latest` and `go install gofumpt@latest` in the workflow now pull these newer versions.

This PR applies a blanket reformatting across `agent/`, `manager/`, `operator/`, `pkg/`, and `test/` to bring the codebase in line with the new tool versions.

**57 files changed — pure import reordering and whitespace. No logic changes.**

### Root cause

The workflow installs tools with `@latest`, which started pulling breaking versions after May 5, 2026.

### Fix

Run `gci write` + `gofumpt -w` with the new tool versions on the entire codebase.

See also: same fix already merged for `release-2.12` in #2426.

Made with Cursor
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

Made with [Cursor](https://cursor.com)