### PR TITLE
fix: nil pointer panic + missing GetKafkaOwnerIdentity blocking test-integration on release-2.14 [multicluster-globalhub-1.5]

### DIFF
--- a/agent/pkg/controllers/clusterclaim_version_controller.go
+++ b/agent/pkg/controllers/clusterclaim_version_controller.go
@@ -36,12 +36,14 @@ func (c *versionClusterClaimController) Reconcile(ctx context.Context, request c
 		return ctrl.Result{}, err
 	}
 
-	if mch != nil && mch.Status.CurrentVersion != "" {
-		return ctrl.Result{}, updateClusterClaim(ctx, c.client,
-			constants.VersionClusterClaimName, mch.Status.CurrentVersion)
+	if mch != nil {
+		if mch.Status.CurrentVersion != "" {
+			return ctrl.Result{}, updateClusterClaim(ctx, c.client,
+				constants.VersionClusterClaimName, mch.Status.CurrentVersion)
+		}
+		configs.SetMCHVersion(mch.Status.CurrentVersion)
 	}
 
-	configs.SetMCHVersion(mch.Status.CurrentVersion)
 	// requeue to wait the acm version is available
 	return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 5}, nil
 }

--- a/pkg/transport/config/confluent_config.go
+++ b/pkg/transport/config/confluent_config.go
@@ -23,6 +23,16 @@ import (
 
 var log = logger.DefaultZapLogger()
 
+var kafkaOwnerIdentity string
+
+func SetKafkaOwnerIdentity(identity string) {
+	kafkaOwnerIdentity = identity
+}
+
+func GetKafkaOwnerIdentity() string {
+	return kafkaOwnerIdentity
+}
+
 func GetBasicConfigMap() *kafkav2.ConfigMap {
 	return &kafkav2.ConfigMap{
 		"socket.keepalive.enable": "true",


### PR DESCRIPTION
## Summary

Two pre-existing test failures on `release-2.14` that block **all PRs** targeting this branch from passing `test-integration`. Both bugs exist only on `release-2.14`; both are already fixed on `release-2.15`.

---

### Fix 1 — nil pointer panic in `clusterclaim_version_controller.go`

**File:** `agent/pkg/controllers/clusterclaim_version_controller.go`

When `updateHubClusterClaim` returns `mch == nil`, the guard `if mch != nil && mch.Status.CurrentVersion != ""` correctly skips the early return, but the very next line `configs.SetMCHVersion(mch.Status.CurrentVersion)` still dereferences the nil pointer, causing a panic that crashes the `test/integration/agent/spec` suite.

**Fix:** Wrap `SetMCHVersion` inside the `mch != nil` block (matches `release-2.15`).

---

### Fix 2 — undefined `config.GetKafkaOwnerIdentity` in manager/status tests

**File:** `pkg/transport/config/confluent_config.go`

`test/integration/manager/status/transport_offset_test.go` calls `config.GetKafkaOwnerIdentity()`, which was added to `pkg/transport/config/confluent_config.go` in `release-2.15` but never backported to `release-2.14`. This causes a **build failure** (`[build failed]`) for the entire `test/integration/manager/status` package.

**Fix:** Backport `SetKafkaOwnerIdentity` / `GetKafkaOwnerIdentity` from `release-2.15`.

---

### Evidence

Seen failing on every PR against `release-2.14`, e.g.:
- https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stolostron_multicluster-global-hub/2406/pull-ci-stolostron-multicluster-global-hub-release-2.14-test-integration/2052367800298639360

This PR must merge before security fix PRs targeting `release-2.14` can pass CI.

Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

Made with [Cursor](https://cursor.com)