### PR TITLE
fix: backport KONFLUX-6210 name/cpe label fix to release-2.12 [multicluster-globalhub-1.3]

### DIFF
--- a/agent/Containerfile.agent
+++ b/agent/Containerfile.agent
@@ -21,12 +21,13 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 # Red Hat annotations.
 LABEL com.redhat.component="multicluster-global-hub-agent"
+LABEL cpe="cpe:/a:redhat:multicluster_globalhub:1.3::el9"
 LABEL org.label-schema.vendor="Red Hat"
 LABEL org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA"
 LABEL org.label-schema.schema-version="1.0"
 
 # Bundle metadata
-LABEL name="multicluster-global-hub/multicluster-global-hub-agent"
+LABEL name="multicluster-globalhub/multicluster-globalhub-agent-rhel9"
 LABEL version="release-1.3"
 LABEL summary="multicluster global hub agent"
 LABEL io.openshift.expose-services=""

--- a/manager/Containerfile.manager
+++ b/manager/Containerfile.manager
@@ -27,7 +27,8 @@ LABEL org.label-schema.license="Red Hat Advanced Cluster Management for Kubernet
 LABEL org.label-schema.schema-version="1.0"
 
 # Bundle metadata
-LABEL name="multicluster-global-hub/multicluster-global-hub-manager"
+LABEL name="multicluster-globalhub/multicluster-globalhub-manager-rhel9"
+LABEL cpe="cpe:/a:redhat:multicluster_globalhub:1.3::el9"
 LABEL version="release-1.3"
 LABEL summary="multicluster global hub manager"
 LABEL io.openshift.expose-services=""

--- a/operator/Containerfile.operator
+++ b/operator/Containerfile.operator
@@ -17,12 +17,13 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 # Red Hat annotations.
 LABEL com.redhat.component="multicluster-global-hub-operator-container"
+LABEL cpe="cpe:/a:redhat:multicluster_globalhub:1.3::el9"
 LABEL org.label-schema.vendor="Red Hat"
 LABEL org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA"
 LABEL org.label-schema.schema-version="1.0"
 
 # Bundle metadata
-LABEL name="multicluster-global-hub/multicluster-global-hub-operator"
+LABEL name="multicluster-globalhub/multicluster-globalhub-rhel9-operator"
 LABEL version="release-1.3"
 LABEL summary="multicluster global hub operator"
 LABEL io.openshift.expose-services=""


### PR DESCRIPTION
## Summary

Backport of the container image label fixes originally applied to `release-2.13` in [#1952 (KONFLUX-6210)](https://github.com/stolostron/multicluster-global-hub/pull/1952).

## Problem

The Konflux managed release pipeline `stage-publish-globalhub-1-3-4-rc0` failed with:

```
task check-labels failed: "step-enforce-name-label" exited with code 1: Error
```

The `step-enforce-name-label` Enterprise Contract task validates each image's `name` label against the Konflux registered component name. The `release-2.12` Containerfiles still used the old naming convention (with a slash and no `-rhel9` suffix), which no longer passes the stricter policy enforcement.

## Changes

All three Containerfiles updated:

| File | Label | Before | After |
|------|-------|--------|-------|
| `agent/Containerfile.agent` | `name` | `multicluster-global-hub/multicluster-global-hub-agent` | `multicluster-globalhub/multicluster-globalhub-agent-rhel9` |
| `agent/Containerfile.agent` | `cpe` | _(missing)_ | `cpe:/a:redhat:multicluster_globalhub:1.3::el9` |
| `manager/Containerfile.manager` | `name` | `multicluster-global-hub/multicluster-global-hub-manager` | `multicluster-globalhub/multicluster-globalhub-manager-rhel9` |
| `manager/Containerfile.manager` | `cpe` | _(missing)_ | `cpe:/a:redhat:multicluster_globalhub:1.3::el9` |
| `operator/Containerfile.operator` | `name` | `multicluster-global-hub/multicluster-global-hub-operator` | `multicluster-globalhub/multicluster-globalhub-rhel9-operator` |
| `operator/Containerfile.operator` | `cpe` | _(missing)_ | `cpe:/a:redhat:multicluster_globalhub:1.3::el9` |

No logic changes — pure label/annotation updates.

## Related

- Jira: KONFLUX-6210 (original fix for release-2.13)
- Blocked release: `stage-publish-globalhub-1-3-4-rc0`

Made with [Cursor](https://cursor.com)