### PR TITLE
chore: apply strict-fmt formatting on main [multicluster-globalhub-5.0]

### DIFF
--- a/agent/pkg/spec/migration/common.go
+++ b/agent/pkg/spec/migration/common.go
@@ -396,7 +396,8 @@ func collectMigrationResources(
 	// collect all defined migration resources
 	for _, migrateResource := range migrateResources {
 		resources, err := prepareUnstructuredResourceForMigration(
-			ctx, c, managedCluster, migrateResource)
+			ctx, c, managedCluster, migrateResource,
+		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to prepare %s %s for migration: %w", migrateResource.gvk.Kind, managedCluster, err)
 		}

--- a/agent/pkg/spec/migration/migration_from_syncer.go
+++ b/agent/pkg/spec/migration/migration_from_syncer.go
@@ -325,7 +325,8 @@ func (s *MigrationSourceSyncer) deploying(ctx context.Context, source *migration
 	for _, managedCluster := range source.ManagedClusters {
 		// Prepare resources for this cluster
 		resourcesList, err := collectMigrationResources(
-			ctx, s.client, managedCluster, migrateResources, s.cleanObjectMetadata, s.processResourceByType)
+			ctx, s.client, managedCluster, migrateResources, s.cleanObjectMetadata, s.processResourceByType,
+		)
 		if err != nil {
 			return err
 		}
@@ -406,7 +407,8 @@ func (s *MigrationSourceSyncer) sendMigrationBundle(
 		s.processingMigrationId, migrationv1alpha1.PhaseDeploying, expireAfter, payloadBytes)
 
 	if err := s.transportClient.GetProducer().SendEvent(
-		cecontext.WithTopic(ctx, s.transportConfig.KafkaCredential.SpecTopic), e); err != nil {
+		cecontext.WithTopic(ctx, s.transportConfig.KafkaCredential.SpecTopic), e,
+	); err != nil {
 		return fmt.Errorf(errFailedToSendEvent, eventType, fromHub, toHub, err)
 	}
 
@@ -890,7 +892,8 @@ func (s *MigrationSourceSyncer) rollbackRegistering(ctx context.Context, spec *m
 
 	timeout := remainingExpireTime(expireTimeFromContext(ctx))
 
-	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, timeout, true,
+	err := wait.PollUntilContextTimeout(
+		ctx, 5*time.Second, timeout, true,
 		func(context.Context) (done bool, err error) {
 			clusterErrors := map[string]string{}
 			defer func() {
@@ -951,7 +954,8 @@ func (s *MigrationSourceSyncer) reportStatus(ctx context.Context, spec *migratio
 			ClusterErrors:   s.clusterErrors,
 		},
 		s.bundleVersion,
-		expireTimeFromContext(ctx))
+		expireTimeFromContext(ctx),
+	)
 
 	if reportErr != nil {
 		log.Errorf("failed to report migration status for stage %s: %v", spec.Stage, reportErr)
@@ -1140,28 +1144,32 @@ func (s *MigrationSourceSyncer) validateSingleCluster(ctx context.Context, clust
 	if s.isHostedCluster(mc) {
 		return fmt.Errorf(
 			"managed cluster %v is imported as hosted mode in managed hub %v, it cannot be migrated",
-			clusterName, s.leafHubName)
+			clusterName, s.leafHubName,
+		)
 	}
 
 	// Check if cluster is local cluster
 	if mc.Labels != nil && mc.Labels[constants.LocalClusterName] == "true" {
 		return fmt.Errorf(
 			"managed cluster %v is local cluster in managed hub %v, it cannot be migrated",
-			clusterName, s.leafHubName)
+			clusterName, s.leafHubName,
+		)
 	}
 
 	// Check if cluster is available
 	if !s.isManagedClusterAvailable(mc) {
 		return fmt.Errorf(
 			"managed cluster %v is not available in managed hub %v, it cannot be migrated",
-			clusterName, s.leafHubName)
+			clusterName, s.leafHubName,
+		)
 	}
 
 	// Check if cluster is a managed hub
 	if s.isManagedHub(mc) {
 		return fmt.Errorf(
 			"managed cluster %v is a managed hub cluster in managed hub %v, it cannot be migrated",
-			clusterName, s.leafHubName)
+			clusterName, s.leafHubName,
+		)
 	}
 
 	return nil
@@ -1212,17 +1220,20 @@ func (s *MigrationSourceSyncer) collectReferencedResources(
 		switch kind {
 		case "BareMetalHost":
 			if err := s.collectBareMetalHostSecrets(
-				ctx, clusterName, &resource, secretNames, &referencedResources); err != nil {
+				ctx, clusterName, &resource, secretNames, &referencedResources,
+			); err != nil {
 				log.Warnf("failed to collect secrets for BareMetalHost %s: %v", resource.GetName(), err)
 			}
 		case "ClusterDeployment":
 			if err := s.collectClusterDeploymentSecrets(
-				ctx, clusterName, &resource, secretNames, &referencedResources); err != nil {
+				ctx, clusterName, &resource, secretNames, &referencedResources,
+			); err != nil {
 				log.Warnf("failed to collect secrets for ClusterDeployment %s: %v", resource.GetName(), err)
 			}
 		case "ImageClusterInstall":
 			if err := s.collectImageClusterInstallConfigMaps(
-				ctx, clusterName, &resource, configMapNames, &referencedResources); err != nil {
+				ctx, clusterName, &resource, configMapNames, &referencedResources,
+			); err != nil {
 				log.Warnf("failed to collect configmaps for ImageClusterInstall %s: %v", resource.GetName(), err)
 			}
 		}
@@ -1274,7 +1285,8 @@ func (s *MigrationSourceSyncer) collectClusterDeploymentSecrets(
 	referencedResources *[]unstructured.Unstructured,
 ) error {
 	pullSecretName, found, err := unstructured.NestedString(
-		resource.Object, "spec", "pullSecretRef", "name")
+		resource.Object, "spec", "pullSecretRef", "name",
+	)
 	if err != nil {
 		return fmt.Errorf("failed to get pullSecretRef: %w", err)
 	}

--- a/agent/pkg/spec/migration/migration_from_syncer_test.go
+++ b/agent/pkg/spec/migration/migration_from_syncer_test.go
@@ -599,7 +599,8 @@ func TestMigrationSourceHubSyncer(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(c.initObjects...).WithObjects(
-				c.initObjects...).Build()
+				c.initObjects...,
+			).Build()
 
 			producer := ProducerMock{}
 			transportClient := &controller.TransportClient{}
@@ -747,7 +748,8 @@ func TestGenerateKlusterletConfig(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(c.initObjects...).WithObjects(
-				c.initObjects...).Build()
+				c.initObjects...,
+			).Build()
 			obj, err := generateKlusterletConfig(fakeClient, c.targetHub, c.bootstrapSecretName)
 			if c.expectedError {
 				assert.NotNil(t, err)
@@ -1606,7 +1608,8 @@ func TestPrepareUnstructuredResourceForMigration(t *testing.T) {
 			}
 
 			resources, err := prepareUnstructuredResourceForMigration(
-				ctx, fakeClient, c.clusterName, c.migrateResource)
+				ctx, fakeClient, c.clusterName, c.migrateResource,
+			)
 
 			// Clean resources after collection
 			for i := range resources {

--- a/agent/pkg/spec/migration/migration_to_syncer.go
+++ b/agent/pkg/spec/migration/migration_to_syncer.go
@@ -450,7 +450,8 @@ func (s *MigrationTargetSyncer) registering(ctx context.Context,
 
 	timeout := remainingExpireTime(expireTimeFromContext(ctx))
 
-	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, timeout, true,
+	err := wait.PollUntilContextTimeout(
+		ctx, 5*time.Second, timeout, true,
 		func(context.Context) (done bool, err error) {
 			clear(clusterErrors)
 			for _, clusterName := range event.ManagedClusters {
@@ -767,7 +768,8 @@ func (s *MigrationTargetSyncer) ensureClusterManagerAutoApproval(ctx context.Con
 				operatorv1.FeatureGate{
 					Feature: "ManagedClusterAutoApproval",
 					Mode:    operatorv1.FeatureGateModeTypeEnable,
-				})
+				},
+			)
 			clusterManagerChanged = true
 		}
 
@@ -780,7 +782,8 @@ func (s *MigrationTargetSyncer) ensureClusterManagerAutoApproval(ctx context.Con
 		if !autoApproveUserAdded {
 			registrationConfiguration.AutoApproveUsers = append(
 				registrationConfiguration.AutoApproveUsers,
-				autoApproveUser)
+				autoApproveUser,
+			)
 			clusterManagerChanged = true
 		}
 	} else {
@@ -1139,7 +1142,8 @@ func (s *MigrationTargetSyncer) reportFailedClusters(ctx context.Context,
 
 	return ReportMigrationStatus(
 		cecontext.WithTopic(ctx, s.transportConfig.KafkaCredential.StatusTopic),
-		s.transportClient, migrationStatus, s.bundleVersion, expireTimeFromContext(ctx))
+		s.transportClient, migrationStatus, s.bundleVersion, expireTimeFromContext(ctx),
+	)
 }
 
 // queryFailedClusters checks which clusters failed to migrate.

--- a/agent/pkg/spec/migration/migration_to_syncer_test.go
+++ b/agent/pkg/spec/migration/migration_to_syncer_test.go
@@ -1220,7 +1220,8 @@ func TestMigrationDestinationHubSyncer(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(c.initObjects...).WithObjects(
-				c.initObjects...).Build()
+				c.initObjects...,
+			).Build()
 
 			producer := ProducerMock{}
 			transportClient := &controller.TransportClient{}

--- a/agent/pkg/status/generic/periodic_syncer_resync_test.go
+++ b/agent/pkg/status/generic/periodic_syncer_resync_test.go
@@ -395,12 +395,12 @@ func TestPeriodicSyncer_Resync(t *testing.T) {
 // Helper function to check if a string contains a substring
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) &&
-		(func() bool {
+		func() bool {
 			for i := 0; i <= len(s)-len(substr); i++ {
 				if s[i:i+len(substr)] == substr {
 					return true
 				}
 			}
 			return false
-		})()
+		}()
 }

--- a/agent/pkg/status/syncers/managedhub/cluster_info_syncer.go
+++ b/agent/pkg/status/syncers/managedhub/cluster_info_syncer.go
@@ -41,7 +41,8 @@ func LaunchHubClusterInfoSyncer(mgr ctrl.Manager, producer transport.Producer) e
 					func() client.Object { return &configv1.ClusterVersion{} },
 					predicate.NewPredicateFuncs(func(object client.Object) bool {
 						return object.GetName() == "version"
-					})),
+					}),
+				),
 				Handler: &infoClusterVersionHandler{eventData},
 			},
 			{
@@ -57,7 +58,8 @@ func LaunchHubClusterInfoSyncer(mgr ctrl.Manager, producer transport.Producer) e
 							return true
 						}
 						return false
-					})),
+					}),
+				),
 				Handler: &infoRouteHandler{eventData},
 			},
 		},

--- a/agent/pkg/status/syncers/policies/handlers/complete_compliance_handler.go
+++ b/agent/pkg/status/syncers/policies/handlers/complete_compliance_handler.go
@@ -44,7 +44,7 @@ func (h *completeComplianceHandler) Update(obj client.Object) bool {
 	originPolicyID := extractPolicyIdentity(obj)
 	newComplete := newCompleteCompliance(originPolicyID, policy)
 
-	index := getPayloadIndexByUID(originPolicyID, *(h.eventData))
+	index := getPayloadIndexByUID(originPolicyID, *h.eventData)
 	if index == -1 { // object not found, need to add it to the bundle (only in case it contains non-compliant/unknown)
 		// don't send in the bundle a policy where all clusters are compliant
 		if len(newComplete.UnknownComplianceClusters) == 0 && len(newComplete.NonCompliantClusters) == 0 &&
@@ -52,7 +52,7 @@ func (h *completeComplianceHandler) Update(obj client.Object) bool {
 			return false
 		}
 
-		*(h.eventData) = append(*(h.eventData), *newComplete)
+		*h.eventData = append(*h.eventData, *newComplete)
 		return true
 	}
 
@@ -87,13 +87,13 @@ func (h *completeComplianceHandler) Delete(obj client.Object) bool {
 		return false
 	}
 
-	index := getPayloadIndexByObj(obj, *(h.eventData))
+	index := getPayloadIndexByObj(obj, *h.eventData)
 	if index == -1 { // trying to delete object which doesn't exist
 		return false
 	}
 
 	// don't increase version, no need to send bundle when policy is removed (Compliance bundle is sent).
-	*(h.eventData) = append((*h.eventData)[:index], (*h.eventData)[index+1:]...) // remove from objects
+	*h.eventData = append((*h.eventData)[:index], (*h.eventData)[index+1:]...) // remove from objects
 	return false
 }
 

--- a/agent/pkg/status/syncers/policies/handlers/status_event_handler.go
+++ b/agent/pkg/status/syncers/policies/handlers/status_event_handler.go
@@ -119,21 +119,23 @@ func (*policyStatusEventHandler) Delete(client.Object) bool {
 
 func NewPolicyStatusEventEmitter(eventType enum.EventType) interfaces.Emitter {
 	name := strings.ReplaceAll(string(eventType), enum.EventTypePrefix, "")
-	return generic.NewGenericEmitter(eventType, generic.WithPostSend(
-		// After sending the event, update the filter cache and clear the bundle from the handler cache.
-		func(data interface{}) {
-			events, ok := data.(*event.ReplicatedPolicyEventBundle)
-			if !ok {
-				return
-			}
-			// policyEvents, ok := data.([]event.ReplicatedPolicyEvent)
-			// update the time filter: with latest event
-			for _, evt := range *events {
-				filter.CacheTime(name, evt.CreatedAt)
-			}
-			// reset the payload
-			*events = (*events)[:0]
-		}),
+	return generic.NewGenericEmitter(
+		eventType, generic.WithPostSend(
+			// After sending the event, update the filter cache and clear the bundle from the handler cache.
+			func(data interface{}) {
+				events, ok := data.(*event.ReplicatedPolicyEventBundle)
+				if !ok {
+					return
+				}
+				// policyEvents, ok := data.([]event.ReplicatedPolicyEvent)
+				// update the time filter: with latest event
+				for _, evt := range *events {
+					filter.CacheTime(name, evt.CreatedAt)
+				}
+				// reset the payload
+				*events = (*events)[:0]
+			},
+		),
 	)
 }
 

--- a/agent/pkg/status/syncers/policies/handlers/status_event_handler_test.go
+++ b/agent/pkg/status/syncers/policies/handlers/status_event_handler_test.go
@@ -16,7 +16,8 @@ import (
 
 func TestPostSendFunc(t *testing.T) {
 	configs.SetAgentConfig(&configs.AgentConfig{LeafHubName: "leaf-hub-name"})
-	localStatusEventHandler := NewPolicyStatusEventHandler(context.TODO(), enum.LocalReplicatedPolicyEventType,
+	localStatusEventHandler := NewPolicyStatusEventHandler(
+		context.TODO(), enum.LocalReplicatedPolicyEventType,
 		func(obj client.Object) bool {
 			return true
 		},

--- a/agent/pkg/status/syncers/policies/policy_syncer.go
+++ b/agent/pkg/status/syncers/policies/policy_syncer.go
@@ -67,7 +67,8 @@ func LaunchPolicySyncer(ctx context.Context, mgr ctrl.Manager, agentConfig *conf
 				Handler: localCompleteHandler,
 				Emitter: localCompleteEmitter,
 			},
-		})
+		},
+	)
 }
 
 func AddPolicySyncer(ctx context.Context, mgr ctrl.Manager, p transport.Producer,

--- a/agent/pkg/status/syncers/security/stackrox_syncer.go
+++ b/agent/pkg/status/syncers/security/stackrox_syncer.go
@@ -421,7 +421,8 @@ func (s *StackRoxSyncer) sync(ctx context.Context, data *stackRoxData) error {
 		}
 
 		messageStruct, err := request.GenerateFromCache(
-			request.CacheStruct, data.consoleURL, data.key.Namespace, data.key.Name)
+			request.CacheStruct, data.consoleURL, data.key.Namespace, data.key.Name,
+		)
 		if err != nil {
 			return fmt.Errorf("failed to generate struct for kafka message: %v", err)
 		}

--- a/manager/cmd/main.go
+++ b/manager/cmd/main.go
@@ -174,7 +174,8 @@ func createManager(ctx context.Context,
 		return nil, fmt.Errorf("failed to add configmap controller to manager: %w", err)
 	}
 	configs.SetEnableInventoryAPI(managerConfig.EnableInventoryAPI)
-	err = controller.NewTransportCtrl(managerConfig.ManagerNamespace, constants.GHTransportConfigSecret,
+	err = controller.NewTransportCtrl(
+		managerConfig.ManagerNamespace, constants.GHTransportConfigSecret,
 		transportCallback(mgr, managerConfig),
 		managerConfig.TransportConfig, true,
 	).SetupWithManager(mgr)

--- a/manager/pkg/ha/config_controller.go
+++ b/manager/pkg/ha/config_controller.go
@@ -67,7 +67,8 @@ func AddToManager(mgr ctrl.Manager, producer transport.Producer) error {
 
 func (c *ConfigController) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).Named("ha-config-ctrl").
-		Watches(&clusterv1.ManagedCluster{},
+		Watches(
+			&clusterv1.ManagedCluster{},
 			&handler.EnqueueRequestForObject{},
 			builder.WithPredicates(predicate.Funcs{
 				CreateFunc: func(e event.CreateEvent) bool {
@@ -83,7 +84,8 @@ func (c *ConfigController) SetupWithManager(mgr ctrl.Manager) error {
 				},
 			}),
 		).
-		Watches(&corev1.Secret{},
+		Watches(
+			&corev1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
 				name := obj.GetName()
 				if !strings.HasPrefix(name, msaPrefix) {

--- a/manager/pkg/migration/migration_controller_test.go
+++ b/manager/pkg/migration/migration_controller_test.go
@@ -391,7 +391,8 @@ func TestSelectAndPrepareMigration(t *testing.T) {
 
 				if tt.expectedConditionType != "" {
 					condition := migrationv1alpha1.FindMigrationCondition(
-						selectedMigration.Status.Conditions, tt.expectedConditionType)
+						selectedMigration.Status.Conditions, tt.expectedConditionType,
+					)
 					assert.NotNil(t, condition, "Expected condition should exist")
 					if tt.expectedConditionStatus != "" {
 						assert.Equal(t, tt.expectedConditionStatus, condition.Status, "Expected condition status should match")

--- a/manager/pkg/migration/migration_deploying_test.go
+++ b/manager/pkg/migration/migration_deploying_test.go
@@ -266,7 +266,8 @@ func TestDeploying(t *testing.T) {
 			// Verify the condition status if expected
 			if tt.expectedConditionStatus != "" {
 				deployedCondition := migrationv1alpha1.FindMigrationCondition(
-					tt.migration.Status.Conditions, migrationv1alpha1.ConditionTypeDeployed)
+					tt.migration.Status.Conditions, migrationv1alpha1.ConditionTypeDeployed,
+				)
 				assert.NotNil(t, deployedCondition, "ResourceDeployed condition should exist")
 				assert.Equal(t, tt.expectedConditionStatus, deployedCondition.Status, "Expected condition status should match")
 			}
@@ -274,7 +275,8 @@ func TestDeploying(t *testing.T) {
 			// Verify the condition reason if expected
 			if tt.expectedConditionReason != "" {
 				deployedCondition := migrationv1alpha1.FindMigrationCondition(
-					tt.migration.Status.Conditions, migrationv1alpha1.ConditionTypeDeployed)
+					tt.migration.Status.Conditions, migrationv1alpha1.ConditionTypeDeployed,
+				)
 				assert.NotNil(t, deployedCondition, "ResourceDeployed condition should exist")
 				assert.Equal(t, tt.expectedConditionReason, deployedCondition.Reason, "Expected condition reason should match")
 			}

--- a/manager/pkg/migration/migration_initializing_test.go
+++ b/manager/pkg/migration/migration_initializing_test.go
@@ -383,7 +383,8 @@ func TestInitializing(t *testing.T) {
 			// Verify the condition status if expected
 			if tt.expectedConditionStatus != "" {
 				initializedCondition := migrationv1alpha1.FindMigrationCondition(
-					tt.migration.Status.Conditions, migrationv1alpha1.ConditionTypeInitialized)
+					tt.migration.Status.Conditions, migrationv1alpha1.ConditionTypeInitialized,
+				)
 				assert.NotNil(t, initializedCondition, "ResourceInitialized condition should exist")
 				assert.Equal(t, tt.expectedConditionStatus, initializedCondition.Status, "Expected condition status should match")
 			}
@@ -391,7 +392,8 @@ func TestInitializing(t *testing.T) {
 			// Verify the condition reason if expected
 			if tt.expectedConditionReason != "" {
 				initializedCondition := migrationv1alpha1.FindMigrationCondition(
-					tt.migration.Status.Conditions, migrationv1alpha1.ConditionTypeInitialized)
+					tt.migration.Status.Conditions, migrationv1alpha1.ConditionTypeInitialized,
+				)
 				assert.NotNil(t, initializedCondition, "ResourceInitialized condition should exist")
 				assert.Equal(t, tt.expectedConditionReason, initializedCondition.Reason, "Expected condition reason should match")
 			}

--- a/manager/pkg/migration/migration_pending.go
+++ b/manager/pkg/migration/migration_pending.go
@@ -66,7 +66,8 @@ func (m *ClusterMigrationController) selectAndPrepareMigration(ctx context.Conte
 	// select the instance, and initialize it if it's not validated yet
 	if nextMigration != nil &&
 		migrationv1alpha1.FindMigrationCondition(
-			nextMigration.Status.Conditions, migrationv1alpha1.ConditionTypeValidated) == nil {
+			nextMigration.Status.Conditions, migrationv1alpha1.ConditionTypeValidated,
+		) == nil {
 		if err := m.UpdateStatusWithRetry(ctx, nextMigration, metav1.Condition{
 			Type:    migrationv1alpha1.ConditionTypeStarted,
 			Status:  metav1.ConditionTrue,

--- a/manager/pkg/migration/migration_registering_test.go
+++ b/manager/pkg/migration/migration_registering_test.go
@@ -222,7 +222,8 @@ func TestRegistering(t *testing.T) {
 			// Verify the condition status if expected
 			if tt.expectedConditionStatus != "" {
 				registeredCondition := migrationv1alpha1.FindMigrationCondition(
-					tt.migration.Status.Conditions, migrationv1alpha1.ConditionTypeRegistered)
+					tt.migration.Status.Conditions, migrationv1alpha1.ConditionTypeRegistered,
+				)
 				assert.NotNil(t, registeredCondition, "ClusterRegistered condition should exist")
 				assert.Equal(t, tt.expectedConditionStatus, registeredCondition.Status, "Expected condition status should match")
 			}
@@ -230,7 +231,8 @@ func TestRegistering(t *testing.T) {
 			// Verify the condition reason if expected
 			if tt.expectedConditionReason != "" {
 				registeredCondition := migrationv1alpha1.FindMigrationCondition(
-					tt.migration.Status.Conditions, migrationv1alpha1.ConditionTypeRegistered)
+					tt.migration.Status.Conditions, migrationv1alpha1.ConditionTypeRegistered,
+				)
 				assert.NotNil(t, registeredCondition, "ClusterRegistered condition should exist")
 				assert.Equal(t, tt.expectedConditionReason, registeredCondition.Reason, "Expected condition reason should match")
 			}

--- a/manager/pkg/migration/migration_validating_test.go
+++ b/manager/pkg/migration/migration_validating_test.go
@@ -341,7 +341,8 @@ func TestValidating(t *testing.T) {
 			// Verify the condition status if expected
 			if tt.expectedConditionStatus != "" {
 				validatedCondition := migrationv1alpha1.FindMigrationCondition(
-					tt.migration.Status.Conditions, migrationv1alpha1.ConditionTypeValidated)
+					tt.migration.Status.Conditions, migrationv1alpha1.ConditionTypeValidated,
+				)
 				assert.NotNil(t, validatedCondition, "ResourceValidated condition should exist")
 				assert.Equal(t, tt.expectedConditionStatus, validatedCondition.Status, "Expected condition status should match")
 			}
@@ -349,7 +350,8 @@ func TestValidating(t *testing.T) {
 			// Verify the condition reason if expected
 			if tt.expectedConditionReason != "" {
 				validatedCondition := migrationv1alpha1.FindMigrationCondition(
-					tt.migration.Status.Conditions, migrationv1alpha1.ConditionTypeValidated)
+					tt.migration.Status.Conditions, migrationv1alpha1.ConditionTypeValidated,
+				)
 				assert.NotNil(t, validatedCondition, "ResourceValidated condition should exist")
 				assert.Equal(t, tt.expectedConditionReason, validatedCondition.Reason, "Expected condition reason should match")
 			}

--- a/manager/pkg/processes/cronjob/scheduler.go
+++ b/manager/pkg/processes/cronjob/scheduler.go
@@ -87,7 +87,8 @@ func AddSchedulerToManager(ctx context.Context, mgr ctrl.Manager,
 
 	return mgr.Add(NewGlobalHubScheduler(
 		scheduler,
-		strings.Split(managerConfig.LaunchJobNames, ",")))
+		strings.Split(managerConfig.LaunchJobNames, ","),
+	))
 }
 
 func (s *GlobalHubJobScheduler) Start(ctx context.Context) error {

--- a/manager/pkg/status/conflator/workerpool/worker.go
+++ b/manager/pkg/status/conflator/workerpool/worker.go
@@ -85,7 +85,8 @@ func (worker *Worker) handleJob(ctx context.Context, job *conflator.ConflationJo
 
 	// based on the handle result, update the element state
 	startTime := time.Now()
-	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true,
+	err = wait.PollUntilContextTimeout(
+		ctx, 5*time.Second, 1*time.Minute, true,
 		func(ctx context.Context) (bool, error) {
 			err := job.Handle(ctx, job.Event)
 			if err != nil {

--- a/manager/pkg/status/handlers/policy/local_complete_handler.go
+++ b/manager/pkg/status/handlers/policy/local_complete_handler.go
@@ -166,7 +166,8 @@ func (h *localPolicyCompleteHandler) handleCompleteCompliance(log *zap.SugaredLo
 			return fmt.Errorf("failed to update compliances by complete event - %w", err)
 		}
 		if configs.IsInventoryAPIEnabled() {
-			err = syncInventory(h.requester, leafHub,
+			err = syncInventory(
+				h.requester, leafHub,
 				models.ResourceVersion{
 					Key:  policyID,
 					Name: policyNamespacedName,

--- a/manager/pkg/status/handlers/policy/local_compliance_handler.go
+++ b/manager/pkg/status/handlers/policy/local_compliance_handler.go
@@ -139,7 +139,8 @@ func (h *localPolicyComplianceHandler) handleCompliance(ctx context.Context, evt
 
 		if configs.IsInventoryAPIEnabled() {
 			log.Debugf("sync to inventory api - %s", policyID)
-			err = syncInventory(h.requester, leafHub,
+			err = syncInventory(
+				h.requester, leafHub,
 				models.ResourceVersion{
 					Key:  policyID,
 					Name: policyNamespacedName,
@@ -241,7 +242,8 @@ func postCompliancesToInventoryApi(
 			if resp, err := requester.GetHttpClient().K8SPolicyIsPropagatedToK8SClusterServiceHTTPClient.
 				UpdateK8SPolicyIsPropagatedToK8SCluster(context.Background(), updateK8SPolicyIsPropagatedToK8SCluster(
 					policyNamespacedName, createCompliance.ClusterName, string(createCompliance.Compliance),
-					leafHub, mchVersion)); err != nil {
+					leafHub, mchVersion,
+				)); err != nil {
 				log.Errorf("failed to create k8s policy is propagated to k8s cluster -%v: %v", resp, err)
 			}
 		}
@@ -251,7 +253,8 @@ func postCompliancesToInventoryApi(
 			if resp, err := requester.GetHttpClient().K8SPolicyIsPropagatedToK8SClusterServiceHTTPClient.
 				UpdateK8SPolicyIsPropagatedToK8SCluster(context.Background(), updateK8SPolicyIsPropagatedToK8SCluster(
 					policyNamespacedName, updateCompliance.ClusterName, string(updateCompliance.Compliance),
-					leafHub, mchVersion)); err != nil {
+					leafHub, mchVersion,
+				)); err != nil {
 				log.Errorf("failed to update k8s policy is propagated to k8s cluster -%v: %v", resp, err)
 			}
 		}
@@ -260,7 +263,8 @@ func postCompliancesToInventoryApi(
 		for _, deleteCompliance := range deleteCompliances {
 			if resp, err := requester.GetHttpClient().K8SPolicyIsPropagatedToK8SClusterServiceHTTPClient.
 				DeleteK8SPolicyIsPropagatedToK8SCluster(context.Background(), deleteK8SPolicyIsPropagatedToK8SCluster(
-					policyNamespacedName, deleteCompliance.ClusterName, leafHub, mchVersion)); err != nil && !errors.IsNotFound(err) {
+					policyNamespacedName, deleteCompliance.ClusterName, leafHub, mchVersion,
+				)); err != nil && !errors.IsNotFound(err) {
 				log.Warnf("failed to delete k8s policy is propagated to k8s cluster -%v: %v", resp, err)
 			}
 		}
@@ -413,7 +417,8 @@ func getLocalComplianceClusterSets(db *gorm.DB, query interface{}, args ...inter
 			allPolicyComplianceRowsFromDB[compliance.PolicyID] = NewPolicyClusterSets()
 		}
 		allPolicyComplianceRowsFromDB[compliance.PolicyID].AddCluster(
-			compliance.ClusterName, compliance.Compliance)
+			compliance.ClusterName, compliance.Compliance,
+		)
 	}
 	return allPolicyComplianceRowsFromDB, nil
 }
@@ -425,7 +430,8 @@ func getPolicyNamespacedName(db *gorm.DB, policyID string) (string, error) {
 		return "", fmt.Errorf("db is nil")
 	}
 	err := db.Select(
-		"policy_id AS key, concat(payload->'metadata'->>'namespace', '/', payload->'metadata'->>'name') AS name").
+		"policy_id AS key, concat(payload->'metadata'->>'namespace', '/', payload->'metadata'->>'name') AS name",
+	).
 		Where(&models.LocalSpecPolicy{
 			PolicyID: policyID,
 		}).Find(&policyFromDB).Scan(&resourceVersions).Error

--- a/manager/pkg/status/handlers/policy/local_policy_spec_handler.go
+++ b/manager/pkg/status/handlers/policy/local_policy_spec_handler.go
@@ -226,7 +226,8 @@ func (h *localPolicySpecHandler) postPolicyToInventoryApi(
 		for _, policy := range bundle.Create {
 			k8sPolicy := generateK8SPolicy(&policy, leafHubName, clusterInfo.MchVersion)
 			if resp, err := h.requester.GetHttpClient().PolicyServiceClient.CreateK8SPolicy(
-				ctx, &kessel.CreateK8SPolicyRequest{K8SPolicy: k8sPolicy}); err != nil && !errors.IsAlreadyExists(err) {
+				ctx, &kessel.CreateK8SPolicyRequest{K8SPolicy: k8sPolicy},
+			); err != nil && !errors.IsAlreadyExists(err) {
 				return fmt.Errorf("failed to create k8sCluster %v: %w", resp, err)
 			}
 		}
@@ -235,7 +236,8 @@ func (h *localPolicySpecHandler) postPolicyToInventoryApi(
 		for _, policy := range bundle.Update {
 			k8sPolicy := generateK8SPolicy(&policy, leafHubName, clusterInfo.MchVersion)
 			if resp, err := h.requester.GetHttpClient().PolicyServiceClient.UpdateK8SPolicy(
-				ctx, &kessel.UpdateK8SPolicyRequest{K8SPolicy: k8sPolicy}); err != nil {
+				ctx, &kessel.UpdateK8SPolicyRequest{K8SPolicy: k8sPolicy},
+			); err != nil {
 				return fmt.Errorf("failed to update k8sCluster %v: %w", resp, err)
 			}
 		}
@@ -250,7 +252,8 @@ func (h *localPolicySpecHandler) postPolicyToInventoryApi(
 						ReporterVersion:    clusterInfo.MchVersion,
 						LocalResourceId:    policy.Name,
 					},
-				}); err != nil && !errors.IsNotFound(err) {
+				},
+			); err != nil && !errors.IsNotFound(err) {
 				return fmt.Errorf("failed to delete k8sCluster %v: %w", resp, err)
 			}
 			// delete the policy related compliance data in inventory when policy is deleted

--- a/operator/pkg/config/controller_config.go
+++ b/operator/pkg/config/controller_config.go
@@ -25,7 +25,8 @@ var controllerConfigMap *corev1.ConfigMap
 
 func LoadControllerConfig(ctx context.Context, kubeClient kubernetes.Interface) error {
 	config, err := kubeClient.CoreV1().ConfigMaps(utils.GetDefaultNamespace()).Get(
-		ctx, operatorconstants.ControllerConfig, metav1.GetOptions{})
+		ctx, operatorconstants.ControllerConfig, metav1.GetOptions{},
+	)
 	if err != nil && !errors.IsNotFound(err) {
 		return err
 	}

--- a/operator/pkg/config/multiclusterglobalhub_config_test.go
+++ b/operator/pkg/config/multiclusterglobalhub_config_test.go
@@ -149,7 +149,7 @@ func TestSetMulticlusterGlobalHubConfig(t *testing.T) {
 		t.Fatalf("oauth proxy image is not expected one")
 	}
 
-	imageClient := fakeimagev1client.FakeImageV1{Fake: &(fakeimageclient.NewSimpleClientset().Fake)}
+	imageClient := fakeimagev1client.FakeImageV1{Fake: &fakeimageclient.NewSimpleClientset().Fake}
 	err = SetMulticlusterGlobalHubConfig(context.Background(), mghInstance, nil, &imageClient)
 	if err != nil {
 		t.Fatal(err)

--- a/operator/pkg/controllers/agent/addon/addon_agent.go
+++ b/operator/pkg/controllers/agent/addon/addon_agent.go
@@ -215,7 +215,8 @@ func (a *GlobalHubAddonAgent) setImagePullSecret(mgh *globalhubv1alpha4.Multiclu
 	if len(imagePullSecret.Name) > 0 && len(imagePullSecret.Data[corev1.DockerConfigJsonKey]) > 0 {
 		manifestsConfig.ImagePullSecretName = imagePullSecret.GetName()
 		manifestsConfig.ImagePullSecretData = base64.StdEncoding.EncodeToString(
-			imagePullSecret.Data[corev1.DockerConfigJsonKey])
+			imagePullSecret.Data[corev1.DockerConfigJsonKey],
+		)
 	}
 	return nil
 }

--- a/operator/pkg/controllers/agent/addon/addon_manager.go
+++ b/operator/pkg/controllers/agent/addon/addon_manager.go
@@ -90,7 +90,8 @@ func StartGlobalHubAddonManager(ctx context.Context, kubeConfig *rest.Config, cl
 	}
 
 	factory := addonfactory.NewAgentAddonFactory(
-		constants.GHManagedClusterAddonName, FS, "manifests").
+		constants.GHManagedClusterAddonName, FS, "manifests",
+	).
 		WithScheme(addonAgentConfig.addonScheme).
 		WithAgentHealthProber(&addonframeworkagent.HealthProber{
 			Type: addonframeworkagent.HealthProberTypeLease,

--- a/operator/pkg/controllers/backup/backup_reconcile.go
+++ b/operator/pkg/controllers/backup/backup_reconcile.go
@@ -103,7 +103,8 @@ func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 	err = allResourcesBackup[req.Namespace].AddLabelToOneObj(
 		ctx, r.Client,
-		config.GetMGHNamespacedName().Namespace, req.Name)
+		config.GetMGHNamespacedName().Namespace, req.Name,
+	)
 	return addBackupCondition(ctx, r.Client, mgh, err)
 }
 

--- a/operator/pkg/controllers/backup/backup_start.go
+++ b/operator/pkg/controllers/backup/backup_start.go
@@ -82,7 +82,7 @@ func StartController(initOption config.ControllerOption) (config.ControllerInter
 		Client:  initOption.Manager.GetClient(),
 		Log:     logger.ZaprLogger(),
 	}
-	err := c.SetupWithManager((initOption.Manager))
+	err := c.SetupWithManager(initOption.Manager)
 	if err != nil {
 		return nil, err
 	}

--- a/operator/pkg/controllers/grafana/grafana_reconciler.go
+++ b/operator/pkg/controllers/grafana/grafana_reconciler.go
@@ -259,7 +259,8 @@ func (r *GrafanaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	var reconcileErr error
 	defer func() {
-		err = config.UpdateMGHComponent(ctx, r.GetClient(),
+		err = config.UpdateMGHComponent(
+			ctx, r.GetClient(),
 			config.GetComponentStatusWithReconcileError(ctx, r.GetClient(),
 				mgh.Namespace, config.COMPONENTS_GRAFANA_NAME, reconcileErr),
 			false,
@@ -619,7 +620,8 @@ func mergeAlertConfigMap(defaultAlertConfigMap, customAlertConfigMap *corev1.Con
 
 	mergedAlertYaml, err := mergeAlertYaml(
 		[]byte(defaultAlertConfigMap.Data[AlertConfigMapKey]),
-		[]byte(customAlertConfigMap.Data[AlertConfigMapKey]))
+		[]byte(customAlertConfigMap.Data[AlertConfigMapKey]),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/operator/pkg/controllers/inventory/inventory_reconciler.go
+++ b/operator/pkg/controllers/inventory/inventory_reconciler.go
@@ -140,7 +140,8 @@ func (r *InventoryReconciler) Reconcile(ctx context.Context,
 	var reconcileErr error
 
 	defer func() {
-		err = config.UpdateMGHComponent(ctx, r.GetClient(),
+		err = config.UpdateMGHComponent(
+			ctx, r.GetClient(),
 			config.GetComponentStatusWithReconcileError(ctx, r.GetClient(),
 				mgh.Namespace, config.COMPONENTS_INVENTORY_API_NAME, reconcileErr),
 			false,

--- a/operator/pkg/controllers/inventory/spicedb_controller.go
+++ b/operator/pkg/controllers/inventory/spicedb_controller.go
@@ -191,7 +191,8 @@ func (r *spiceDBClusterReconciler) reconcileStorageSecret(ctx context.Context,
 	// TODO: Currently using the 'disable' method to establish the connection.
 	// Other methods have not been validated. GH itself uses `required-ca`,
 	// so we might need to update both to support `verify-full`.
-	pgURI := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s",
+	pgURI := fmt.Sprintf(
+		"postgres://%s:%s@%s:%d/%s?sslmode=%s",
 		url.QueryEscape(pgConfig.User),
 		url.QueryEscape(pgConfig.Password),
 		pgConfig.Host,

--- a/operator/pkg/controllers/manager/manager_reconciler.go
+++ b/operator/pkg/controllers/manager/manager_reconciler.go
@@ -202,7 +202,8 @@ func (r *ManagerReconciler) Reconcile(ctx context.Context,
 		if mgh == nil {
 			return
 		}
-		err = config.UpdateMGHComponent(ctx, r.GetClient(),
+		err = config.UpdateMGHComponent(
+			ctx, r.GetClient(),
 			config.GetComponentStatusWithReconcileError(ctx, r.GetClient(),
 				mgh.Namespace, config.COMPONENTS_MANAGER_NAME, reconcileErr),
 			false,
@@ -290,7 +291,8 @@ func (r *ManagerReconciler) Reconcile(ctx context.Context,
 			ImagePullPolicy:    string(imagePullPolicy),
 			ProxySessionSecret: proxySessionSecret,
 			DatabaseURL: base64.StdEncoding.EncodeToString(
-				[]byte(storageConn.SuperuserDatabaseURI)),
+				[]byte(storageConn.SuperuserDatabaseURI),
+			),
 			PostgresCACert:            base64.StdEncoding.EncodeToString(storageConn.CACert),
 			TransportType:             string(transport.Kafka),
 			TransportConfigSecret:     constants.GHTransportConfigSecret,

--- a/operator/pkg/controllers/storage/storage_reconciler.go
+++ b/operator/pkg/controllers/storage/storage_reconciler.go
@@ -201,7 +201,8 @@ func (r *StorageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	var reconcileErr error
 	defer func() {
-		err = config.UpdateMGHComponent(ctx, r.GetClient(),
+		err = config.UpdateMGHComponent(
+			ctx, r.GetClient(),
 			getDatabaseComponentStatus(ctx, r.GetClient(), mgh.Namespace, config.COMPONENTS_POSTGRES_NAME, reconcileErr),
 			updateConnection,
 		)

--- a/operator/pkg/renderer/hoh_renderer_test.go
+++ b/operator/pkg/renderer/hoh_renderer_test.go
@@ -262,7 +262,8 @@ var _ = Describe("Render", func() {
 			nginxObjects, err := render.RenderWithFilter("testdata/app", profile,
 				filter, func(profile string) (interface{}, error) {
 					inputvalues, err := fs.ReadFile(fmt.Sprintf(
-						"testdata/input/%s-%s.yaml", profile, filter))
+						"testdata/input/%s-%s.yaml", profile, filter,
+					))
 					if err != nil {
 						return struct{}{}, err
 					}

--- a/operator/pkg/utils/utils.go
+++ b/operator/pkg/utils/utils.go
@@ -349,7 +349,8 @@ func AnnotateManagedHubCluster(ctx context.Context, c client.Client) error {
 		LabelSelector: labels.SelectorFromSet(
 			labels.Set{
 				constants.GlobalHubOwnerLabelKey: constants.GHOperatorOwnerLabelVal,
-			}),
+			},
+		),
 	}); err != nil {
 		return err
 	}

--- a/pkg/database/dao/generic_dao.go
+++ b/pkg/database/dao/generic_dao.go
@@ -30,7 +30,8 @@ func (dao *GenericDao) GetIdToVersionByHub(hubName string) (map[string]string, e
 		FROM 
 			%s 
 		WHERE 
-			leaf_hub_name = ?`, dao.table)
+			leaf_hub_name = ?`, dao.table,
+	)
 
 	var resourceVersions []models.ResourceVersion
 	err := dao.tx.Raw(sqlTemplate, hubName).Scan(&resourceVersions).Error
@@ -47,7 +48,8 @@ func (dao *GenericDao) GetIdToVersionByHub(hubName string) (map[string]string, e
 
 func (dao *GenericDao) Insert(hubName, id string, obj interface{}) error {
 	sqlTemplate := fmt.Sprintf(
-		`INSERT INTO %s (id, leaf_hub_name, payload) VALUES ($1::uuid, $2, $3::jsonb)`, dao.table)
+		`INSERT INTO %s (id, leaf_hub_name, payload) VALUES ($1::uuid, $2, $3::jsonb)`, dao.table,
+	)
 
 	payload, err := json.Marshal(obj)
 	if err != nil {
@@ -58,7 +60,8 @@ func (dao *GenericDao) Insert(hubName, id string, obj interface{}) error {
 
 func (dao *GenericDao) Update(hubName, id string, obj interface{}) error {
 	sqlTemplate := fmt.Sprintf(
-		`UPDATE %s SET payload = $1::jsonb WHERE leaf_hub_name = $2 AND id = $3::uuid`, dao.table)
+		`UPDATE %s SET payload = $1::jsonb WHERE leaf_hub_name = $2 AND id = $3::uuid`, dao.table,
+	)
 
 	payload, err := json.Marshal(obj)
 	if err != nil {
@@ -69,6 +72,7 @@ func (dao *GenericDao) Update(hubName, id string, obj interface{}) error {
 
 func (dao *GenericDao) Delete(hubName, id string) error {
 	sqlTemplate := fmt.Sprintf(
-		`DELETE FROM %s WHERE leaf_hub_name = $1 AND id = $2::uuid`, dao.table)
+		`DELETE FROM %s WHERE leaf_hub_name = $1 AND id = $2::uuid`, dao.table,
+	)
 	return dao.tx.Exec(sqlTemplate, hubName, id).Error
 }

--- a/pkg/transport/consumer/sarama_consumer_test.go
+++ b/pkg/transport/consumer/sarama_consumer_test.go
@@ -134,7 +134,8 @@ func MockSaramaCluster(t *testing.T, messages []string) *sarama.MockBroker {
 					Topics: map[string][]int32{
 						"my-topic": {0},
 					},
-				}),
+				},
+			),
 		),
 		"OffsetFetchRequest": sarama.NewMockOffsetFetchResponse(t).SetOffset(
 			"my-group", "my-topic", 0, oldestOffset, "", sarama.ErrNoError,

--- a/pkg/transport/controller/controller_test.go
+++ b/pkg/transport/controller/controller_test.go
@@ -305,16 +305,17 @@ func (m *mockManager) Add(runnable manager.Runnable) error {
 	return nil
 }
 
-func (m *mockManager) GetClient() client.Client                                 { return m.client }
-func (m *mockManager) GetScheme() *runtime.Scheme                               { return nil }
-func (m *mockManager) GetFieldIndexer() client.FieldIndexer                     { return nil }
-func (m *mockManager) GetCache() cache.Cache                                    { return nil }
-func (m *mockManager) GetEventRecorderFor(name string) record.EventRecorder     { return nil }
-func (m *mockManager) GetRESTMapper() meta.RESTMapper                           { return nil }
-func (m *mockManager) GetAPIReader() client.Reader                              { return nil }
-func (m *mockManager) Start(ctx context.Context) error                          { return nil }
-func (m *mockManager) GetWebhookServer() webhook.Server                         { return nil }
-func (m *mockManager) GetLogger() logr.Logger                                   { return logr.Discard() }
+func (m *mockManager) GetClient() client.Client                             { return m.client }
+func (m *mockManager) GetScheme() *runtime.Scheme                           { return nil }
+func (m *mockManager) GetFieldIndexer() client.FieldIndexer                 { return nil }
+func (m *mockManager) GetCache() cache.Cache                                { return nil }
+func (m *mockManager) GetEventRecorderFor(name string) record.EventRecorder { return nil }
+func (m *mockManager) GetRESTMapper() meta.RESTMapper                       { return nil }
+func (m *mockManager) GetAPIReader() client.Reader                          { return nil }
+func (m *mockManager) Start(ctx context.Context) error                      { return nil }
+func (m *mockManager) GetWebhookServer() webhook.Server                     { return nil }
+func (m *mockManager) GetLogger() logr.Logger                               { return logr.Discard() }
+
 func (m *mockManager) GetControllerOptions() config.Controller                  { return config.Controller{} }
 func (m *mockManager) Elected() <-chan struct{}                                 { return nil }
 func (m *mockManager) AddHealthzCheck(name string, check healthz.Checker) error { return nil }

--- a/pkg/transport/producer/generic_producer.go
+++ b/pkg/transport/producer/generic_producer.go
@@ -141,7 +141,7 @@ func (p *GenericProducer) initClient(transportConfig *transport.TransportInterna
 
 func (p *GenericProducer) splitPayloadIntoChunks(payload []byte) [][]byte {
 	var chunk []byte
-	chunks := make([][]byte, 0, len(payload)/(p.messageSizeLimit)+1)
+	chunks := make([][]byte, 0, len(payload)/p.messageSizeLimit+1)
 	for len(payload) >= p.messageSizeLimit {
 		chunk, payload = payload[:p.messageSizeLimit], payload[p.messageSizeLimit:]
 		chunks = append(chunks, chunk)

--- a/test/e2e/kessel/inventory_test.go
+++ b/test/e2e/kessel/inventory_test.go
@@ -40,7 +40,8 @@ var _ = Describe("kafka-event: inventory API", Ordered, func() {
 		relationship = generateK8SPolicyToCluster(
 			localPolicyId,
 			localClusterId,
-			"guest")
+			"guest",
+		)
 	})
 
 	It("Create a cluster", func() {

--- a/test/e2e/migration_test.go
+++ b/test/e2e/migration_test.go
@@ -179,7 +179,8 @@ var _ = Describe("Migration E2E", Label("e2e-test-migration"), Ordered, func() {
 				klog.Infof("[DEBUG] Migration phase: %s", mcm.Status.Phase)
 				return string(mcm.Status.Phase)
 			}, 2*time.Minute, migrationPollInterval).Should(
-				Or(Equal(migrationv1alpha1.PhaseInitializing), Equal(migrationv1alpha1.PhaseDeploying), Equal(migrationv1alpha1.PhaseRegistering)))
+				Or(Equal(migrationv1alpha1.PhaseInitializing), Equal(migrationv1alpha1.PhaseDeploying), Equal(migrationv1alpha1.PhaseRegistering)),
+			)
 
 			By("Waiting for bootstrap secret to be created in multicluster-engine namespace")
 			Eventually(func() error {

--- a/test/e2e/utils/client.go
+++ b/test/e2e/utils/client.go
@@ -167,7 +167,8 @@ func LoadConfig(url, kubeconfig, context string) (*rest.Config, error) {
 				&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig},
 				&clientcmd.ConfigOverrides{
 					CurrentContext: context,
-				}).ClientConfig()
+				},
+			).ClientConfig()
 		}
 	}
 	// If not, try the in-cluster config.

--- a/test/integration/agent/controller/version_clusterclaim_test.go
+++ b/test/integration/agent/controller/version_clusterclaim_test.go
@@ -58,7 +58,8 @@ var _ = Describe("claim controllers", Ordered, func() {
 			}, clusterClaim)
 		}, 3*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
 		Expect(clusterClaim.Spec.Value).Should(Equal(
-			constants.HubInstalledByUser))
+			constants.HubInstalledByUser,
+		))
 	})
 
 	It("clusterClaim testing clusterManager and mch are not installed", func() {
@@ -138,7 +139,8 @@ var _ = Describe("claim controllers", Ordered, func() {
 			return true
 		}, 1*time.Second, 100*time.Millisecond).Should(BeTrue())
 		Expect(clusterClaim.Spec.Value).Should(Equal(
-			constants.HubInstalledByUser))
+			constants.HubInstalledByUser,
+		))
 
 		By("Expect clusterClaim version to be updated")
 		mch.Status = mchv1.MultiClusterHubStatus{CurrentVersion: "2.7.0"}
@@ -189,7 +191,8 @@ var _ = Describe("claim controllers", Ordered, func() {
 			return true
 		}, 1*time.Second, 100*time.Millisecond).Should(BeTrue())
 		Expect(clusterClaim.Spec.Value).Should(Equal(
-			constants.HubInstalledByUser))
+			constants.HubInstalledByUser,
+		))
 	})
 })
 

--- a/test/integration/manager/controller/data_retention_job_test.go
+++ b/test/integration/manager/controller/data_retention_job_test.go
@@ -240,13 +240,15 @@ func createRetentionData(tableName string, date time.Time) error {
 		result = db.Exec(
 			fmt.Sprintf(`INSERT INTO status.managed_clusters (leaf_hub_name, cluster_id, payload, error, 
 				created_at, updated_at, deleted_at) VALUES ('leafhub1', '%s', '%s', 'none', '%s', '%s', '%s')`,
-				string(cluster.UID), payload, date.Format(task.TimeFormat), date.Format(task.TimeFormat), date.Format(task.TimeFormat)))
+				string(cluster.UID), payload, date.Format(task.TimeFormat), date.Format(task.TimeFormat), date.Format(task.TimeFormat)),
+		)
 
 	case "status.leaf_hubs":
 		result = db.Exec(
 			fmt.Sprintf(`INSERT INTO status.leaf_hubs (leaf_hub_name, cluster_id, payload, created_at, updated_at, deleted_at) 
 			VALUES ('leafhub1','a71a6b5c-8361-4f50-9890-3de9e2df0b1c', '{"consoleURL": "https://leafhub1.com", "leafHubName": "leafhub1"}', '%s', '%s', '%s')`,
-				date.Format(task.TimeFormat), date.Format(task.TimeFormat), date.Format(task.TimeFormat)))
+				date.Format(task.TimeFormat), date.Format(task.TimeFormat), date.Format(task.TimeFormat)),
+		)
 
 	case "local_spec.policies":
 		policy := policyv1.Policy{
@@ -262,7 +264,8 @@ func createRetentionData(tableName string, date time.Time) error {
 		result = db.Exec(
 			fmt.Sprintf(`INSERT INTO local_spec.policies (policy_id, leaf_hub_name, payload, created_at, 
 				updated_at, deleted_at) VALUES ('%s', 'leafhub1', '%s', '%s', '%s', '%s')`, policy.UID, payload,
-				date.Format(task.TimeFormat), date.Format(task.TimeFormat), date.Format(task.TimeFormat)))
+				date.Format(task.TimeFormat), date.Format(task.TimeFormat), date.Format(task.TimeFormat)),
+		)
 	}
 	if result.Error != nil {
 		return fmt.Errorf("failed to create retention data in table %s due to: %w", tableName, result.Error)

--- a/test/integration/manager/controller/scheduler_test.go
+++ b/test/integration/manager/controller/scheduler_test.go
@@ -25,7 +25,8 @@ var _ = Describe("scheduler", func() {
 
 		scheduler := gocron.NewScheduler(time.Local)
 		_, err := scheduler.Every(1).Day().At("00:00").Tag(task.LocalComplianceTaskName).DoWithJobDetails(
-			task.LocalComplianceHistory, ctx)
+			task.LocalComplianceHistory, ctx,
+		)
 		Expect(err).To(Succeed())
 
 		_, err = scheduler.Every(1).Month(1, 15).At("00:00").Tag(task.RetentionTaskName).

--- a/test/integration/operator/controllers/agent/cluster_none_addon_test.go
+++ b/test/integration/operator/controllers/agent/cluster_none_addon_test.go
@@ -95,7 +95,8 @@ var _ = Describe("none addon", func() {
 
 		By("By preparing an OCP with no deploy mode label")
 		clusterName3 := fmt.Sprintf("hub-ocp-no-deploy-mode-%s", rand.String(6))
-		prepareCluster(clusterName3,
+		prepareCluster(
+			clusterName3,
 			map[string]string{
 				"vendor": "OpenShift",
 				// No deploy mode label - should NOT create addon

--- a/test/integration/utils/testpostgres/cmd/main.go
+++ b/test/integration/utils/testpostgres/cmd/main.go
@@ -52,7 +52,8 @@ func main() {
 	postgresConfig = postgresConfig.BinariesPath(postgresDataPath)
 	postgresConfig = postgresConfig.DataPath(filepath.Join(postgresDataPath, "data"))
 	database := embeddedpostgres.NewDatabase(
-		postgresConfig.Database("hoh"))
+		postgresConfig.Database("hoh"),
+	)
 	if err := database.Start(); err != nil {
 		fmt.Printf("failed to start embedded postgres: %v", err)
 		os.Exit(1)


### PR DESCRIPTION
## Summary

Cherry-pick of #2433 onto `main` to restore fast-forward compatibility between `main` and `release-5.0`.

PR #2433 applied `gci v0.14.0` + `gofumpt v0.10.0` strict formatting directly to `release-5.0`, which caused the branch to diverge from `main` by 1 commit. The ffwd job can no longer fast-forward because `release-5.0` has commits `main` doesn't have.

This PR applies the identical formatting changes to `main` so the branches converge again.

- 50 files changed — pure import reordering and whitespace, no logic changes
- Same commit as #2433, cherry-picked onto `main`

Fixes: branch divergence reported by @tesshuflower

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactoring & Code Quality

* **Bug Fixes**
  * Improved context handling in configuration loading
  * Fixed resource predicates for accurate hub cluster info synchronization
  * Enhanced error handling in policy event processing

* **Refactor**
  * Optimized code formatting and structure across migration, status, and controller components
  * Improved test assertion clarity and maintainability
  * Updated configuration watchers for better resource tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->