### PR TITLE
chore: update copyright year in operator Containerfile (release-2.12)

### DIFF
--- a/operator/Containerfile.operator
+++ b/operator/Containerfile.operator
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Red Hat, Inc.
+# Copyright (c) 2024-2026 Red Hat, Inc.
 # Copyright Contributors to the Open Cluster Management project
 
 # Stage 1: build the target binaries


### PR DESCRIPTION
Triggers a fresh Konflux build of \`multicluster-global-hub-operator-globalhub-1-3\` ahead of the 1.3.4 z-stream release.

The current operator images were built months ago and the \`sast-snyk-check-oci-ta\` task errored during that build — this error is baked into the attestation and causes an EC \`test.no_erred_tests\` violation. A fresh build clears it.

/ok-to-test

Made with [Cursor](https://cursor.com)