### PR TITLE
Security: Fix ACM-32641/32639/32637/32636/32634/32632 - CVE-2026-33815/33816 pgx memory-safety [multicluster-globalhub-1.4]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -143,7 +143,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/pgx/v5 v5.7.6
+	github.com/jackc/pgx/v5 v5.9.2
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jcmturner/aescts/v2 v2.0.0 // indirect
 	github.com/jcmturner/dnsutils/v2 v2.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -484,8 +484,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.7.6 h1:rWQc5FwZSPX58r1OQmkuaNicxdmExaEz5A2DO2hUuTk=
-github.com/jackc/pgx/v5 v5.7.6/go.mod h1:aruU7o91Tc2q2cFp5h4uP3f6ztExVpyVv88Xl/8Vl8M=
+github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
+github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jcmturner/aescts/v2 v2.0.0 h1:9YKLH6ey7H4eDBXW8khjYslgyqG2xZikXP0EQFKrle8=


### PR DESCRIPTION
## Security Fix: ACM-32641 / ACM-32639 / ACM-32637 / ACM-32636 / ACM-32634 / ACM-32632

**JIRA Issues:** [ACM-32641](https://redhat.atlassian.net/browse/ACM-32641), [ACM-32639](https://redhat.atlassian.net/browse/ACM-32639), [ACM-32637](https://redhat.atlassian.net/browse/ACM-32637), [ACM-32636](https://redhat.atlassian.net/browse/ACM-32636), [ACM-32634](https://redhat.atlassian.net/browse/ACM-32634), [ACM-32632](https://redhat.atlassian.net/browse/ACM-32632)
**Priority:** Critical / Important

### Summary

- **CVE-2026-33815** (CVSS 9.8) — `github.com/jackc/pgx/v5` pgproto3: heap-based buffer overflow via crafted PostgreSQL protocol messages
  - [ACM-32641](https://redhat.atlassian.net/browse/ACM-32641): `multicluster-globalhub-rhel9-operator`
  - [ACM-32639](https://redhat.atlassian.net/browse/ACM-32639): `multicluster-globalhub-manager-rhel9`
  - [ACM-32637](https://redhat.atlassian.net/browse/ACM-32637): `multicluster-globalhub-agent-rhel9`

- **CVE-2026-33816** (CVSS 8.3) — `github.com/jackc/pgx/v5` pgproto3: memory-safety vulnerability
  - [ACM-32636](https://redhat.atlassian.net/browse/ACM-32636): `multicluster-globalhub-rhel9-operator`
  - [ACM-32634](https://redhat.atlassian.net/browse/ACM-32634): `multicluster-globalhub-manager-rhel9`
  - [ACM-32632](https://redhat.atlassian.net/browse/ACM-32632): `multicluster-globalhub-agent-rhel9`

### Changes Made

| Dependency | Before | After | Reason |
|---|---|---|---|
| github.com/jackc/pgx/v5 | v5.7.6 | v5.9.2 | CVE-2026-33815 + CVE-2026-33816 patch (fixed in v5.9.0) |

### Fix Commands

```bash
go get github.com/jackc/pgx/v5@v5.9.2
go mod tidy
```

### Testing

1. Verify `go.mod` requires `github.com/jackc/pgx/v5 v5.9.2`: `go mod graph | grep jackc/pgx`
2. Build operator/manager/agent: `make build`
3. Run unit and integration tests: `make unit-tests && make integration-test`

---

**Type:** DEPENDENCY
**Automated Fix:** This PR was generated automatically by CVE automation service using Google Gemini AI.

[ACM-32641]: https://redhat.atlassian.net/browse/ACM-32641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-32639]: https://redhat.atlassian.net/browse/ACM-32639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-32637]: https://redhat.atlassian.net/browse/ACM-32637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-32636]: https://redhat.atlassian.net/browse/ACM-32636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-32634]: https://redhat.atlassian.net/browse/ACM-32634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-32632]: https://redhat.atlassian.net/browse/ACM-32632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-32641]: https://redhat.atlassian.net/browse/ACM-32641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-32639]: https://redhat.atlassian.net/browse/ACM-32639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-32637]: https://redhat.atlassian.net/browse/ACM-32637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-32636]: https://redhat.atlassian.net/browse/ACM-32636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ