### PR TITLE
Security: Fix ACM-32653/32651/32649/32648/32646/32644 - CVE-2026-33815/33816 pgx memory-safety [multicluster-globalhub-1.6]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -138,7 +138,7 @@ require (
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/pgx/v5 v5.7.6
+	github.com/jackc/pgx/v5 v5.9.2
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jcmturner/aescts/v2 v2.0.0 // indirect
 	github.com/jcmturner/dnsutils/v2 v2.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2108,8 +2108,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.7.6 h1:rWQc5FwZSPX58r1OQmkuaNicxdmExaEz5A2DO2hUuTk=
-github.com/jackc/pgx/v5 v5.7.6/go.mod h1:aruU7o91Tc2q2cFp5h4uP3f6ztExVpyVv88Xl/8Vl8M=
+github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
+github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jcmturner/aescts/v2 v2.0.0 h1:9YKLH6ey7H4eDBXW8khjYslgyqG2xZikXP0EQFKrle8=


### PR DESCRIPTION
## Security Fix: ACM-32653 / ACM-32651 / ACM-32649 / ACM-32648 / ACM-32646 / ACM-32644

**JIRA Issues:** [ACM-32653](https://redhat.atlassian.net/browse/ACM-32653), [ACM-32651](https://redhat.atlassian.net/browse/ACM-32651), [ACM-32649](https://redhat.atlassian.net/browse/ACM-32649), [ACM-32648](https://redhat.atlassian.net/browse/ACM-32648), [ACM-32646](https://redhat.atlassian.net/browse/ACM-32646), [ACM-32644](https://redhat.atlassian.net/browse/ACM-32644)
**Priority:** Important

### Summary

- **CVE-2026-33815** (CVSS 8.3) — `github.com/jackc/pgx/v5` pgproto3: heap-based buffer overflow via crafted PostgreSQL protocol messages
  - [ACM-32653](https://redhat.atlassian.net/browse/ACM-32653): `multicluster-globalhub-rhel9-operator`
  - [ACM-32651](https://redhat.atlassian.net/browse/ACM-32651): `multicluster-globalhub-manager-rhel9`
  - [ACM-32649](https://redhat.atlassian.net/browse/ACM-32649): `multicluster-globalhub-agent-rhel9`

- **CVE-2026-33816** (CVSS 8.3) — `github.com/jackc/pgx/v5` pgproto3: memory-safety vulnerability
  - [ACM-32648](https://redhat.atlassian.net/browse/ACM-32648): `multicluster-globalhub-rhel9-operator`
  - [ACM-32646](https://redhat.atlassian.net/browse/ACM-32646): `multicluster-globalhub-manager-rhel9`
  - [ACM-32644](https://redhat.atlassian.net/browse/ACM-32644): `multicluster-globalhub-agent-rhel9`

### Changes Made

| Dependency | Before | After | Reason |
|---|---|---|---|
| github.com/jackc/pgx/v5 | v5.7.6 | v5.9.2 | CVE-2026-33815 + CVE-2026-33816 patch (fixed in v5.9.0) |

### Testing

1. Verify `go.mod` requires `github.com/jackc/pgx/v5 v5.9.2`: `go mod graph | grep jackc/pgx`
2. Build operator/manager/agent: `make build`
3. Run unit and integration tests: `make unit-tests && make integration-test`

---

**Type:** DEPENDENCY
**Automated Fix:** This PR was generated automatically by CVE automation service using Google Gemini AI.

Made with [Cursor](https://cursor.com)

[ACM-32653]: https://redhat.atlassian.net/browse/ACM-32653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-32651]: https://redhat.atlassian.net/browse/ACM-32651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-32649]: https://redhat.atlassian.net/browse/ACM-32649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-32648]: https://redhat.atlassian.net/browse/ACM-32648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-32646]: https://redhat.atlassian.net/browse/ACM-32646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-32644]: https://redhat.atlassian.net/browse/ACM-32644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-32653]: https://redhat.atlassian.net/browse/ACM-32653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-32651]: https://redhat.atlassian.net/browse/ACM-32651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-32649]: https://redhat.atlassian.net/browse/ACM-32649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-32648]: https://redhat.atlassian.net/browse/ACM-32648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ