### PR TITLE
Security: Fix ACM-32659/32658/32657/32656/32654/32652 - CVE-2026-33815/33816 pgx memory-safety [multicluster-globalhub-1.7]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -125,7 +125,7 @@ require (
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/pgx/v5 v5.7.6
+	github.com/jackc/pgx/v5 v5.9.2
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jcmturner/aescts/v2 v2.0.0 // indirect
 	github.com/jcmturner/dnsutils/v2 v2.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -318,8 +318,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.7.6 h1:rWQc5FwZSPX58r1OQmkuaNicxdmExaEz5A2DO2hUuTk=
-github.com/jackc/pgx/v5 v5.7.6/go.mod h1:aruU7o91Tc2q2cFp5h4uP3f6ztExVpyVv88Xl/8Vl8M=
+github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
+github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jcmturner/aescts/v2 v2.0.0 h1:9YKLH6ey7H4eDBXW8khjYslgyqG2xZikXP0EQFKrle8=


### PR DESCRIPTION
## Security Fix: ACM-32659 / ACM-32658 / ACM-32657 / ACM-32656 / ACM-32654 / ACM-32652

**JIRA Issues:** [ACM-32659](https://redhat.atlassian.net/browse/ACM-32659), [ACM-32658](https://redhat.atlassian.net/browse/ACM-32658), [ACM-32657](https://redhat.atlassian.net/browse/ACM-32657), [ACM-32656](https://redhat.atlassian.net/browse/ACM-32656), [ACM-32654](https://redhat.atlassian.net/browse/ACM-32654), [ACM-32652](https://redhat.atlassian.net/browse/ACM-32652)
**Priority:** Important

### Summary

- **CVE-2026-33815** (CVSS 8.3) — `github.com/jackc/pgx/v5` pgproto3: heap-based buffer overflow
  - [ACM-32659](https://redhat.atlassian.net/browse/ACM-32659): `multicluster-globalhub-rhel9-operator`
  - [ACM-32658](https://redhat.atlassian.net/browse/ACM-32658): `multicluster-globalhub-manager-rhel9`
  - [ACM-32657](https://redhat.atlassian.net/browse/ACM-32657): `multicluster-globalhub-agent-rhel9`

- **CVE-2026-33816** (CVSS 8.3) — `github.com/jackc/pgx/v5` pgproto3: memory-safety vulnerability
  - [ACM-32656](https://redhat.atlassian.net/browse/ACM-32656): `multicluster-globalhub-rhel9-operator`
  - [ACM-32654](https://redhat.atlassian.net/browse/ACM-32654): `multicluster-globalhub-manager-rhel9`
  - [ACM-32652](https://redhat.atlassian.net/browse/ACM-32652): `multicluster-globalhub-agent-rhel9`

### Changes Made

| Dependency | Before | After | Reason |
|---|---|---|---|
| github.com/jackc/pgx/v5 | v5.7.6 | v5.9.2 | CVE-2026-33815 + CVE-2026-33816 patch (fixed in v5.9.0) |

---

**Type:** DEPENDENCY
**Automated Fix:** This PR was generated automatically by CVE automation service using Google Gemini AI.

Made with [Cursor](https://cursor.com)

[ACM-32659]: https://redhat.atlassian.net/browse/ACM-32659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-32658]: https://redhat.atlassian.net/browse/ACM-32658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-32657]: https://redhat.atlassian.net/browse/ACM-32657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-32656]: https://redhat.atlassian.net/browse/ACM-32656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-32654]: https://redhat.atlassian.net/browse/ACM-32654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-32652]: https://redhat.atlassian.net/browse/ACM-32652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-32659]: https://redhat.atlassian.net/browse/ACM-32659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-32658]: https://redhat.atlassian.net/browse/ACM-32658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-32657]: https://redhat.atlassian.net/browse/ACM-32657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-32656]: https://redhat.atlassian.net/browse/ACM-32656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ