### PR TITLE
Security: Fix CVE-2026-32282 + CVE-2026-32281 - bump Go 1.25.7 → 1.25.9 [multicluster-globalhub-1.8]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/multicluster-global-hub
 
-go 1.25.7
+go 1.25.9
 
 require (
 	github.com/IBM/sarama v1.46.3


### PR DESCRIPTION
## Security Fix: CVE-2026-32282 + CVE-2026-32281

**Note:** No Jira tickets filed yet — release 1.8 is pre-GA. Proactive fix mirroring what was done for 1.7 in PR #2409. `release-2.17` is currently at `go 1.25.7` and needs the Go 1.25.9 toolchain bump.

### CVE-2026-32282 (CVSS 6.4 MEDIUM) — Go os/root: Root.Chmod symlink escape
**Package:** Go toolchain | `1.25.7` → `1.25.9`

`os.Root.Chmod` on Linux has a TOCTOU race: a symlink substituted between the pre-check and `fchmodat` call escapes the root. Fixed in Go 1.25.9 (GO-2026-4864).

### CVE-2026-32281 (CVSS 7.5 MODERATE) — Go crypto/x509: policy chain DoS
**Package:** Go toolchain | `1.25.7` → `1.25.9`

`crypto/x509` policy validation is unexpectedly inefficient with certificates containing large numbers of policy mappings, causing DoS. Fixed in Go 1.25.9 (GO-2026-4946).

### Changes

- `go.mod`: `go 1.25.7` → `go 1.25.9`
- `go.sum`: updated via `go mod tidy`

### References

- https://www.cve.org/CVERecord?id=CVE-2026-32282 (GO-2026-4864)
- https://www.cve.org/CVERecord?id=CVE-2026-32281 (GO-2026-4946)

Made with Cursor

Made with [Cursor](https://cursor.com)