### PR TITLE
Bump to 1.8.0

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.8.0-dev
+VERSION ?= 1.8.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -71,7 +71,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: multicluster-global-hub-operator.v1.8.0-dev
+  name: multicluster-global-hub-operator.v1.8.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1436,4 +1436,5 @@ spec:
   provider:
     name: Red Hat, Inc
     url: https://github.com/stolostron/multicluster-global-hub
-  version: 1.8.0-dev
+  replaces: multicluster-global-hub-operator.v1.7.0
+  version: 1.8.0

--- a/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -1436,5 +1436,4 @@ spec:
   provider:
     name: Red Hat, Inc
     url: https://github.com/stolostron/multicluster-global-hub
-  replaces: multicluster-global-hub-operator.v1.7.0
   version: 1.8.0

--- a/operator/config/manifests/bases/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -36,7 +36,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: multicluster-global-hub-operator.v0.0.0
+  name: multicluster-global-hub-operator.v1.8.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}


### PR DESCRIPTION
## Summary

1.8.0 GA version bump: `1.8.0-dev` → `1.8.0`.

Changes:
- `operator/Makefile`: `VERSION ?= 1.8.0`
- `operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml`:
  - `name: multicluster-global-hub-operator.v1.8.0`
  - `version: 1.8.0`
- `operator/config/manifests/bases/multicluster-global-hub-operator.clusterserviceversion.yaml`:
  - `name: multicluster-global-hub-operator.v1.8.0`

> **Note**: `replaces` is not set in the bundle CSV — upgrade path is handled by `skipRange: '>=1.7.0 <1.8.0'` in the operator-catalog. See commit note for details.

Companion PR: [multicluster-global-hub-operator-bundle #1053](https://github.com/stolostron/multicluster-global-hub-operator-bundle/pull/1053) — ✅ merged.

Part of the 1.8.0 GA release — tracked in `pre-release/1.8.0-GA-version-bump.md`.