### PR TITLE
fix(ci): skip bundle repo sync check on main branch

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -47,15 +47,32 @@ jobs:
       - name: bundle
         run: cd operator && make bundle
 
-      - name: compare bundle with stolostron/multicluster-global-hub-operator-bundle
+      # main uses dev bundle versions (e.g. 1.8.0-dev) while release-* bundle
+      # repos carry GA z-stream versions — skip external sync on main.
+      - name: resolve bundle comparison branch
+        id: bundle-branch
         run: |
-          # This comparation ensures the bundle keeps consistent.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            TARGET="${{ github.base_ref }}"
+          else
+            TARGET="${GITHUB_REF#refs/heads/}"
+          fi
+          echo "target=${TARGET}" >> "$GITHUB_OUTPUT"
+          if [ "${TARGET}" = "main" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: compare bundle with stolostron/multicluster-global-hub-operator-bundle
+        if: steps.bundle-branch.outputs.skip != 'true'
+        run: |
+          # Ensure the committed bundle matches the release branch in the bundle repo.
           # ignore createdAt updated in csv by `make bundle`
           git checkout . -f
-          # clone multicluster-global-hub-operator-bundle repo
-          git clone https://github.com/stolostron/multicluster-global-hub-operator-bundle.git -b release-1.8
+          git clone https://github.com/stolostron/multicluster-global-hub-operator-bundle.git \
+            -b "${{ steps.bundle-branch.outputs.target }}"
 
-          # compare the bundle dir
           diff -I 'createdAt' -ruN operator/bundle multicluster-global-hub-operator-bundle/bundle
 
   scorecard-test:


### PR DESCRIPTION
## Summary

- Skip the external `multicluster-global-hub-operator-bundle` diff on **`main`** — dev bundle versions (`1.8.0-dev`) intentionally differ from GA on `release-1.8` (since [operator-bundle#1053](https://github.com/stolostron/multicluster-global-hub-operator-bundle/pull/1053))
- For **`release-*`** branches/PRs, compare against the matching branch in the bundle repo (replaces hardcoded `release-1.8`)
- `make bundle` still runs on all branches (validates generated bundle matches committed tree)

Fixes verify bundle failures blocking PRs like #2466 (MintMaker RPM lockfile refresh).

## Root cause

| When | main bundle | bundle repo `release-1.8` | verify bundle |
|------|-------------|----------------------------|---------------|
| Before May 19 | `1.8.0-dev` | `1.8.0-dev` | ✅ |
| After May 19 (#1053) | `1.8.0-dev` | `1.8.0` GA | ❌ |

## Test plan

- [ ] Merge this PR
- [ ] Rebase/re-run [MintMaker PR #2466](https://github.com/stolostron/multicluster-global-hub/pull/2466) — `verify bundle` should pass
- [ ] Confirm a future `release-*` PR still runs the bundle repo diff against the matching branch


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow now conditionally compares generated bundles against the reference repo only when appropriate for the target branch.
  * Commits targeting the main branch skip the bundle comparison step to reduce unnecessary validations and speed up runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->