### PR TITLE
Bump to 1.7.1

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.7.1-dev
+VERSION ?= 1.7.1
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -71,7 +71,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: multicluster-global-hub-operator.v1.7.1-dev
+  name: multicluster-global-hub-operator.v1.7.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1145,4 +1145,4 @@ spec:
   provider:
     name: Red Hat, Inc
     url: https://github.com/stolostron/multicluster-global-hub
-  version: 1.7.1-dev
+  version: 1.7.1

--- a/operator/config/manifests/bases/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -36,7 +36,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: multicluster-global-hub-operator.v0.0.0
+  name: multicluster-global-hub-operator.v1.7.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}


### PR DESCRIPTION
## Summary

Align `release-2.16` (GH 1.7) with GA **1.7.1** — same approach as #2465 for 1.8.

- `operator/Makefile`: `VERSION` `1.7.1-dev` → `1.7.1`
- Regenerated bundle CSV name/version to match `multicluster-global-hub-operator-bundle` `release-1.7`

Fixes **`verify bundle`** failures on Mintmaker/deps PRs (e.g. #2438, #2412) caused by `1.7.1-dev` vs `1.7.1` skew.

## Test plan

- [ ] `verify bundle` passes (diff vs operator-bundle `release-1.7` is clean)
- [ ] Konflux 1.7 builds pass
- [ ] After merge, re-run / retest #2438 (ini.v1) and #2412 (librdkafka)