### PR TITLE
fix(test): stabilize webhook integration Eventually timeouts (release-2.14)

### DIFF
--- a/test/integration/manager/webhook/admission_handler_test.go
+++ b/test/integration/manager/webhook/admission_handler_test.go
@@ -17,6 +17,11 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
+const (
+	webhookEventuallyTimeout  = 10 * time.Second
+	webhookEventuallyInterval = 100 * time.Millisecond
+)
+
 var _ = Describe("Multicluster hub manager webhook", func() {
 	Context("Test Placement and placementrule are handled by the global hub manager webhook", Ordered, func() {
 		It("Should add cluster.open-cluster-management.io/experimental-scheduling-disable annotation to placement", func() {
@@ -29,16 +34,14 @@ var _ = Describe("Multicluster hub manager webhook", func() {
 				Spec: clusterv1beta1.PlacementSpec{},
 			}
 
+			Expect(c.Create(ctx, testPlacement, &client.CreateOptions{})).To(Succeed())
 			Eventually(func() bool {
-				if err := c.Create(ctx, testPlacement, &client.CreateOptions{}); err != nil {
-					return false
-				}
 				placement := &clusterv1beta1.Placement{}
 				if err := c.Get(ctx, client.ObjectKeyFromObject(testPlacement), placement); err != nil {
 					return false
 				}
 				return placement.Annotations[clusterv1beta1.PlacementDisableAnnotation] == "true"
-			}, 5*time.Second).Should(BeTrue())
+			}, webhookEventuallyTimeout, webhookEventuallyInterval).Should(BeTrue())
 		})
 
 		It("Should not add cluster.open-cluster-management.io/experimental-scheduling-disable annotation to placement", func() {
@@ -50,16 +53,14 @@ var _ = Describe("Multicluster hub manager webhook", func() {
 				Spec: clusterv1beta1.PlacementSpec{},
 			}
 
+			Expect(c.Create(ctx, testPlacement, &client.CreateOptions{})).To(Succeed())
 			Eventually(func() bool {
-				if err := c.Create(ctx, testPlacement, &client.CreateOptions{}); err != nil {
-					return false
-				}
 				placement := &clusterv1beta1.Placement{}
 				if err := c.Get(ctx, client.ObjectKeyFromObject(testPlacement), placement); err != nil {
 					return false
 				}
 				return placement.Annotations == nil
-			}, 1*time.Second, 5*time.Second).Should(BeTrue())
+			}, webhookEventuallyTimeout, webhookEventuallyInterval).Should(BeTrue())
 		})
 
 		It("Should set global-hub as scheduler name for the placementrule", func() {
@@ -72,16 +73,14 @@ var _ = Describe("Multicluster hub manager webhook", func() {
 				Spec: placementrulesv1.PlacementRuleSpec{},
 			}
 
+			Expect(c.Create(ctx, testPlacementRule, &client.CreateOptions{})).To(Succeed())
 			Eventually(func() bool {
-				if err := c.Create(ctx, testPlacementRule, &client.CreateOptions{}); err != nil {
-					return false
-				}
 				placementrule := &placementrulesv1.PlacementRule{}
 				if err := c.Get(ctx, client.ObjectKeyFromObject(testPlacementRule), placementrule); err != nil {
 					return false
 				}
 				return placementrule.Spec.SchedulerName == constants.GlobalHubSchedulerName
-			}, 1*time.Second, 5*time.Second).Should(BeTrue())
+			}, webhookEventuallyTimeout, webhookEventuallyInterval).Should(BeTrue())
 		})
 
 		It("Should not set global-hub as scheduler name for the placementrule", func() {
@@ -94,16 +93,14 @@ var _ = Describe("Multicluster hub manager webhook", func() {
 				Spec: placementrulesv1.PlacementRuleSpec{},
 			}
 
+			Expect(c.Create(ctx, testPlacementRule, &client.CreateOptions{})).To(Succeed())
 			Eventually(func() bool {
-				if err := c.Create(ctx, testPlacementRule, &client.CreateOptions{}); err != nil {
-					return false
-				}
 				placementrule := &placementrulesv1.PlacementRule{}
 				if err := c.Get(ctx, client.ObjectKeyFromObject(testPlacementRule), placementrule); err != nil {
 					return false
 				}
 				return placementrule.Spec.SchedulerName != constants.GlobalHubSchedulerName
-			}, 1*time.Second, 5*time.Second).Should(BeTrue())
+			}, webhookEventuallyTimeout, webhookEventuallyInterval).Should(BeTrue())
 		})
 	})
 })

--- a/test/integration/operator/webhook/admission_handler_test.go
+++ b/test/integration/operator/webhook/admission_handler_test.go
@@ -10,12 +10,16 @@ import (
 	. "github.com/onsi/gomega"
 	addonv1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
+)
+
+const (
+	webhookEventuallyTimeout  = 10 * time.Second
+	webhookEventuallyInterval = 100 * time.Millisecond
 )
 
 var _ = Describe("Multicluster hub webhook", func() {
@@ -33,10 +37,8 @@ var _ = Describe("Multicluster hub webhook", func() {
 				},
 			}
 
+			Expect(c.Create(ctx, testmanagedcluster, &client.CreateOptions{})).To(Succeed())
 			Eventually(func() bool {
-				if err := c.Create(ctx, testmanagedcluster, &client.CreateOptions{}); err != nil {
-					return false
-				}
 				mc := &clusterv1.ManagedCluster{}
 				if err := c.Get(ctx, client.ObjectKeyFromObject(testmanagedcluster), mc); err != nil {
 					return false
@@ -48,7 +50,7 @@ var _ = Describe("Multicluster hub webhook", func() {
 					return false
 				}
 				return true
-			}, 1*time.Second, 5*time.Second).Should(BeTrue())
+			}, webhookEventuallyTimeout, webhookEventuallyInterval).Should(BeTrue())
 		})
 	})
 
@@ -72,14 +74,10 @@ var _ = Describe("Multicluster hub webhook", func() {
 				},
 			}
 
+			Expect(c.Create(ctx, klusterletConfig, &client.CreateOptions{})).To(Succeed())
 			Eventually(func() bool {
-				if err := c.Create(ctx, klusterletConfig, &client.CreateOptions{}); err != nil {
-					klog.Errorf("Failed to create klusterletAddonConfig, err:%v", err)
-					return false
-				}
 				kac := &addonv1.KlusterletAddonConfig{}
 				if err := c.Get(ctx, client.ObjectKeyFromObject(klusterletConfig), kac); err != nil {
-					klog.Errorf("Failed to get klusterletAddonConfig, err:%v", err)
 					return false
 				}
 				if kac.Spec.PolicyController.Enabled == true {
@@ -92,7 +90,7 @@ var _ = Describe("Multicluster hub webhook", func() {
 					return false
 				}
 				return true
-			}, 1*time.Second, 5*time.Second).Should(BeTrue())
+			}, webhookEventuallyTimeout, webhookEventuallyInterval).Should(BeTrue())
 		})
 	})
 })


### PR DESCRIPTION
## Summary

Reduce flaky `ci/prow/test-integration` failures on `release-2.14` by fixing webhook envtest polling.

Several manager/operator webhook integration tests used `Eventually(..., 1*time.Second, 5*time.Second)` — a 1s timeout with a 5s poll interval, so retries could not run reliably. Tests also retried `Create` inside `Eventually`, which fails once the object already exists.

- Create the test resource once
- Poll for mutating webhook effects with 10s timeout / 100ms interval

Touches:
- `test/integration/manager/webhook/admission_handler_test.go`
- `test/integration/operator/webhook/admission_handler_test.go`

## Test plan

- [ ] `ci/prow/test-integration` on this PR
- [ ] Cherry-pick equivalent fix to `release-2.15`