### PR TITLE
fix(deps): update cloudevents kafka_confluent and confluent-kafka-go (release-2.16)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,11 @@ require (
 	github.com/IBM/sarama v1.46.3
 	github.com/RedHatInsights/strimzi-client-go v0.40.0
 	github.com/authzed/spicedb-operator v1.20.1
-	github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2 v2.0.0-20251125184210-ee1cae0e0f5d
+	github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2 v2.0.0-20260427070847-5e02117f4fa1
 	github.com/cloudevents/sdk-go/protocol/kafka_sarama/v2 v2.16.2
 	github.com/cloudevents/sdk-go/v2 v2.16.2
 	github.com/cloudflare/cfssl v1.6.5
-	github.com/confluentinc/confluent-kafka-go/v2 v2.12.0
+	github.com/confluentinc/confluent-kafka-go/v2 v2.14.1
 	github.com/crunchydata/postgres-operator v1.3.3-0.20230629151007-94ebcf2df74d
 	github.com/deckarep/golang-set v1.8.0
 	github.com/evanphx/json-patch v5.9.11+incompatible

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,8 @@ github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d/go.mod h1:sGbDF6
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2 v2.0.0-20251125184210-ee1cae0e0f5d h1:zVoaYyK/Tpwcg0wNTT5vCmg9+NjXdW7KPDIdg+6kHzM=
-github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2 v2.0.0-20251125184210-ee1cae0e0f5d/go.mod h1:Yfya9IJ/9mQ9eUmC5xwMS4XsGxS51oqh0EqNsCx8bzc=
+github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2 v2.0.0-20260427070847-5e02117f4fa1 h1:GGgRblnj5rL6WyfxrAc/fDt3lvHrOR59SgsxEyIRgzU=
+github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2 v2.0.0-20260427070847-5e02117f4fa1/go.mod h1:Tcig2CO79HG0rf7anEx4NpRjEq1qGln3MUrWATkHiwQ=
 github.com/cloudevents/sdk-go/protocol/kafka_sarama/v2 v2.16.2 h1:Y6CQbQm1BKl4e94K3vDar+1deS+7rw0F+ZaiM4wMc9A=
 github.com/cloudevents/sdk-go/protocol/kafka_sarama/v2 v2.16.2/go.mod h1:NI/N1O/24UIEEZrGL5dUTYFfPsQaX3j0LcAAXSHDziM=
 github.com/cloudevents/sdk-go/v2 v2.16.2 h1:ZYDFrYke4FD+jM8TZTJJO6JhKHzOQl2oqpFK1D+NnQM=
@@ -90,8 +90,8 @@ github.com/cloudflare/cfssl v1.6.5/go.mod h1:Bk1si7sq8h2+yVEDrFJiz3d7Aw+pfjjJSZV
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/compose-spec/compose-go/v2 v2.1.3 h1:bD67uqLuL/XgkAK6ir3xZvNLFPxPScEi1KW7R5esrLE=
 github.com/compose-spec/compose-go/v2 v2.1.3/go.mod h1:lFN0DrMxIncJGYAXTfWuajfwj5haBJqrBkarHcnjJKc=
-github.com/confluentinc/confluent-kafka-go/v2 v2.12.0 h1:If5Bi+oJVehEdjuhHa7QEFppQtyexvBXJiuZIloJtIw=
-github.com/confluentinc/confluent-kafka-go/v2 v2.12.0/go.mod h1:6ypM/bldGVG8gf1s9/05ICQU76BmXcbhF6K2jtznock=
+github.com/confluentinc/confluent-kafka-go/v2 v2.14.1 h1:DOm/3yIL7L8GOEa7TFDht6MiNa/FiOeb8kNjHr28S/4=
+github.com/confluentinc/confluent-kafka-go/v2 v2.14.1/go.mod h1:aR1aciwbULyLhKkv9eq88JhS4XmGOusEnHZx1R93XZI=
 github.com/containerd/console v1.0.4 h1:F2g4+oChYvBTsASRTz8NP6iIAi97J3TtSAsLbIFn4ro=
 github.com/containerd/console v1.0.4/go.mod h1:YynlIjWYF8myEu6sdkwKIvGQq+cOckRm6So2avqoYAk=
 github.com/containerd/containerd v1.7.29 h1:90fWABQsaN9mJhGkoVnuzEY+o1XDPbg9BTC9QTAHnuE=


### PR DESCRIPTION
## Summary

Replaces #2413 with the same dependency bump, rebased on current `release-2.16`.

The MintMaker PR (#2413) was based on an older `release-2.16` SHA (before #2412 librdkafka digest and other recent merges). Its Konflux agent/manager builds failed, and e2e failed due to invalid AWS credentials (infra flake, not a code regression).

This PR applies the same updates on top of latest `release-2.16`:

| Package | Change |
|---|---|
| `github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2` | `v2.0.0-20251125184210-ee1cae0e0f5d` → `v2.0.0-20260427070847-5e02117f4fa1` |
| `github.com/confluentinc/confluent-kafka-go/v2` | `v2.12.0` → `v2.14.1` |

## Test plan

- [ ] `/ok-to-test`
- [ ] Konflux agent/manager/operator builds pass
- [ ] `ci/prow/test-unit` and `ci/prow/test-integration` pass
- [ ] `ci/prow/test-e2e` pass (retest if AWS cred flake)
- [ ] Close #2413 once this PR is green