### PR TITLE
Bump to 1.4.6

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.4.5
+VERSION ?= 1.4.6
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -70,7 +70,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: multicluster-global-hub-operator.v1.4.5
+  name: multicluster-global-hub-operator.v1.4.6
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1016,5 +1016,5 @@ spec:
   provider:
     name: Red Hat, Inc
     url: https://github.com/stolostron/multicluster-global-hub
-  replaces: multicluster-global-hub-operator.v1.4.4
-  version: 1.4.5
+  replaces: multicluster-global-hub-operator.v1.4.5
+  version: 1.4.6

--- a/operator/config/manifests/bases/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -224,5 +224,5 @@ spec:
   provider:
     name: Red Hat, Inc
     url: https://github.com/stolostron/multicluster-global-hub
-  replaces: multicluster-global-hub-operator.v1.4.4
+  replaces: multicluster-global-hub-operator.v1.4.5
   version: 0.0.1


### PR DESCRIPTION
## Summary

Bump version from 1.4.5 to 1.4.6 for z-stream release v1.4.6.

Replaces closed #2368. The operator-bundle ([#886](https://github.com/stolostron/multicluster-global-hub-operator-bundle/pull/886)) and operator-catalog already ship 1.4.6; this aligns `multicluster-global-hub` on `release-2.13`.

## Changes

- `operator/Makefile` — `VERSION ?= 1.4.6`
- Bundle CSV — name/version/replaces updated to 1.4.6 / replaces 1.4.5
- Base CSV — `replaces` updated to 1.4.5

## Test plan

- [ ] `/ok-to-test`
- [ ] `ci/prow/test-unit`, `test-integration`, bundle checks pass
- [ ] After merge: Konflux push builds on `release-2.13` complete (~30–60 min)
- [ ] Then stage-release `RC_TAG=rc6` for v1.4.6