### PR TITLE
ACM-30175, ACM-34112: Implement OpenShift TLS security profile integration for Global Hub

### DIFF
--- a/agent/cmd/main.go
+++ b/agent/cmd/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"flag"
 	"fmt"
 	"os"
@@ -204,9 +205,13 @@ func createManager(restConfig *rest.Config, agentConfig *configs.AgentConfig) (
 		}
 	}
 
+	// Get TLS configuration from cluster APIServer profile for metrics server
+	tlsConfigFunc := getMetricsTLSConfigFunc(restConfig)
+
 	options := ctrl.Options{
 		Metrics: metricsserver.Options{
 			BindAddress: agentConfig.MetricsAddress,
+			TLSOpts:     []func(*tls.Config){tlsConfigFunc},
 		},
 		LeaderElection:          true,
 		Scheme:                  configs.GetRuntimeScheme(),
@@ -224,6 +229,40 @@ func createManager(restConfig *rest.Config, agentConfig *configs.AgentConfig) (
 		return nil, fmt.Errorf("failed to create a new manager: %w", err)
 	}
 	return mgr, nil
+}
+
+// getMetricsTLSConfigFunc fetches the cluster TLS profile and returns a function to configure tls.Config.
+// Falls back to TLS 1.3 if unable to fetch the cluster profile.
+func getMetricsTLSConfigFunc(restConfig *rest.Config) func(*tls.Config) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	configClient, err := utils.GetOpenShiftConfigClient(restConfig)
+	if err != nil {
+		logger.DefaultZapLogger().Info("Failed to create config client, using TLS 1.3 as default", "error", err)
+		return func(config *tls.Config) {
+			config.MinVersion = tls.VersionTLS13
+		}
+	}
+
+	profile, err := utils.FetchAPIServerTLSProfile(ctx, configClient)
+	if err != nil {
+		logger.DefaultZapLogger().Info("Failed to fetch cluster TLS profile, using TLS 1.3 as default", "error", err)
+		return func(config *tls.Config) {
+			config.MinVersion = tls.VersionTLS13
+		}
+	}
+
+	tlsConfigFunc, err := utils.BuildTLSConfigFunc(profile)
+	if err != nil {
+		logger.DefaultZapLogger().Info("Failed to build TLS config from profile, using TLS 1.3 as default", "error", err)
+		return func(config *tls.Config) {
+			config.MinVersion = tls.VersionTLS13
+		}
+	}
+
+	logger.DefaultZapLogger().Info("Configuring metrics server TLS from cluster APIServer profile", "profileType", profile.Type)
+	return tlsConfigFunc
 }
 
 // if the transport consumer and producer is ready then the func will be invoked by the transport controller

--- a/agent/cmd/main.go
+++ b/agent/cmd/main.go
@@ -205,8 +205,20 @@ func createManager(restConfig *rest.Config, agentConfig *configs.AgentConfig) (
 		}
 	}
 
-	// Get TLS configuration from cluster APIServer profile for metrics server
-	tlsConfigFunc := getMetricsTLSConfigFunc(restConfig)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	tlsConfigFunc, profileType, err := utils.BuildMetricsTLSConfigFunc(ctx, restConfig)
+	if err != nil {
+		return nil, err
+	}
+	if profileType != "" {
+		logger.DefaultZapLogger().Info(
+			"Configuring metrics server TLS from cluster APIServer profile",
+			"profileType", profileType,
+		)
+	} else {
+		logger.DefaultZapLogger().Info("Using TLS 1.3 for metrics server (cluster APIServer profile unavailable)")
+	}
 
 	options := ctrl.Options{
 		Metrics: metricsserver.Options{
@@ -229,40 +241,6 @@ func createManager(restConfig *rest.Config, agentConfig *configs.AgentConfig) (
 		return nil, fmt.Errorf("failed to create a new manager: %w", err)
 	}
 	return mgr, nil
-}
-
-// getMetricsTLSConfigFunc fetches the cluster TLS profile and returns a function to configure tls.Config.
-// Falls back to TLS 1.3 if unable to fetch the cluster profile.
-func getMetricsTLSConfigFunc(restConfig *rest.Config) func(*tls.Config) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	configClient, err := utils.GetOpenShiftConfigClient(restConfig)
-	if err != nil {
-		logger.DefaultZapLogger().Info("Failed to create config client, using TLS 1.3 as default", "error", err)
-		return func(config *tls.Config) {
-			config.MinVersion = tls.VersionTLS13
-		}
-	}
-
-	profile, err := utils.FetchAPIServerTLSProfile(ctx, configClient)
-	if err != nil {
-		logger.DefaultZapLogger().Info("Failed to fetch cluster TLS profile, using TLS 1.3 as default", "error", err)
-		return func(config *tls.Config) {
-			config.MinVersion = tls.VersionTLS13
-		}
-	}
-
-	tlsConfigFunc, err := utils.BuildTLSConfigFunc(profile)
-	if err != nil {
-		logger.DefaultZapLogger().Info("Failed to build TLS config from profile, using TLS 1.3 as default", "error", err)
-		return func(config *tls.Config) {
-			config.MinVersion = tls.VersionTLS13
-		}
-	}
-
-	logger.DefaultZapLogger().Info("Configuring metrics server TLS from cluster APIServer profile", "profileType", profile.Type)
-	return tlsConfigFunc
 }
 
 // if the transport consumer and producer is ready then the func will be invoked by the transport controller

--- a/agent/pkg/status/syncers/security/clients/stackrox_client.go
+++ b/agent/pkg/status/syncers/security/clients/stackrox_client.go
@@ -84,6 +84,9 @@ func (b *StackRoxClientBuilder) Build() (result *StackRoxClient, err error) {
 	}
 
 	// Create the HTTP client:
+	// For external services like StackRox, we use TLS 1.2 as minimum version
+	// to ensure compatibility while maintaining security. External services
+	// may not support TLS 1.3 yet, unlike OpenShift components.
 	var transport http.RoundTripper = &http.Transport{
 		TLSClientConfig: &tls.Config{
 			MinVersion: tls.VersionTLS12,

--- a/agent/pkg/status/syncers/security/clients/stackrox_client_test.go
+++ b/agent/pkg/status/syncers/security/clients/stackrox_client_test.go
@@ -1,6 +1,7 @@
 package clients
 
 import (
+	"crypto/tls"
 	"crypto/x509"
 	"errors"
 	"io"
@@ -23,6 +24,10 @@ var _ = Describe("StackRox client", func() {
 				Build()
 			Expect(client).ToNot(BeNil())
 			Expect(err).ToNot(HaveOccurred())
+			transport, ok := client.client.Transport.(*http.Transport)
+			Expect(ok).To(BeTrue())
+			Expect(transport.TLSClientConfig).ToNot(BeNil())
+			Expect(transport.TLSClientConfig.MinVersion).To(Equal(uint16(tls.VersionTLS12)))
 		})
 
 		It("Can be created without the optional CA", func() {

--- a/manager/cmd/main.go
+++ b/manager/cmd/main.go
@@ -136,8 +136,20 @@ func createManager(ctx context.Context,
 	renewDeadline := time.Duration(managerConfig.ElectionConfig.RenewDeadline) * time.Second
 	retryPeriod := time.Duration(managerConfig.ElectionConfig.RetryPeriod) * time.Second
 
-	// Get TLS configuration from cluster APIServer profile for metrics server
-	tlsConfigFunc := getMetricsTLSConfigFunc(restConfig)
+	tlsCtx, tlsCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer tlsCancel()
+	tlsConfigFunc, profileType, err := utils.BuildMetricsTLSConfigFunc(tlsCtx, restConfig)
+	if err != nil {
+		return nil, err
+	}
+	if profileType != "" {
+		logger.DefaultZapLogger().Info(
+			"Configuring metrics server TLS from cluster APIServer profile",
+			"profileType", profileType,
+		)
+	} else {
+		logger.DefaultZapLogger().Info("Using TLS 1.3 for metrics server (cluster APIServer profile unavailable)")
+	}
 
 	options := ctrl.Options{
 		Scheme: configs.GetRuntimeScheme(),
@@ -304,38 +316,4 @@ func initCache(config *rest.Config, cacheOpts cache.Options) (cache.Cache, error
 		},
 	}
 	return cache.New(config, cacheOpts)
-}
-
-// getMetricsTLSConfigFunc fetches the cluster TLS profile and returns a function to configure tls.Config.
-// Falls back to TLS 1.3 if unable to fetch the cluster profile.
-func getMetricsTLSConfigFunc(restConfig *rest.Config) func(*tls.Config) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	configClient, err := utils.GetOpenShiftConfigClient(restConfig)
-	if err != nil {
-		logger.DefaultZapLogger().Info("Failed to create config client, using TLS 1.3 as default", "error", err)
-		return func(config *tls.Config) {
-			config.MinVersion = tls.VersionTLS13
-		}
-	}
-
-	profile, err := utils.FetchAPIServerTLSProfile(ctx, configClient)
-	if err != nil {
-		logger.DefaultZapLogger().Info("Failed to fetch cluster TLS profile, using TLS 1.3 as default", "error", err)
-		return func(config *tls.Config) {
-			config.MinVersion = tls.VersionTLS13
-		}
-	}
-
-	tlsConfigFunc, err := utils.BuildTLSConfigFunc(profile)
-	if err != nil {
-		logger.DefaultZapLogger().Info("Failed to build TLS config from profile, using TLS 1.3 as default", "error", err)
-		return func(config *tls.Config) {
-			config.MinVersion = tls.VersionTLS13
-		}
-	}
-
-	logger.DefaultZapLogger().Info("Configuring metrics server TLS from cluster APIServer profile", "profileType", profile.Type)
-	return tlsConfigFunc
 }

--- a/manager/cmd/main.go
+++ b/manager/cmd/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -134,10 +135,15 @@ func createManager(ctx context.Context,
 	leaseDuration := time.Duration(managerConfig.ElectionConfig.LeaseDuration) * time.Second
 	renewDeadline := time.Duration(managerConfig.ElectionConfig.RenewDeadline) * time.Second
 	retryPeriod := time.Duration(managerConfig.ElectionConfig.RetryPeriod) * time.Second
+
+	// Get TLS configuration from cluster APIServer profile for metrics server
+	tlsConfigFunc := getMetricsTLSConfigFunc(restConfig)
+
 	options := ctrl.Options{
 		Scheme: configs.GetRuntimeScheme(),
 		Metrics: metricsserver.Options{
 			BindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
+			TLSOpts:     []func(*tls.Config){tlsConfigFunc},
 		},
 		LeaderElection:          true,
 		LeaderElectionNamespace: managerConfig.ManagerNamespace,
@@ -298,4 +304,38 @@ func initCache(config *rest.Config, cacheOpts cache.Options) (cache.Cache, error
 		},
 	}
 	return cache.New(config, cacheOpts)
+}
+
+// getMetricsTLSConfigFunc fetches the cluster TLS profile and returns a function to configure tls.Config.
+// Falls back to TLS 1.3 if unable to fetch the cluster profile.
+func getMetricsTLSConfigFunc(restConfig *rest.Config) func(*tls.Config) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	configClient, err := utils.GetOpenShiftConfigClient(restConfig)
+	if err != nil {
+		logger.DefaultZapLogger().Info("Failed to create config client, using TLS 1.3 as default", "error", err)
+		return func(config *tls.Config) {
+			config.MinVersion = tls.VersionTLS13
+		}
+	}
+
+	profile, err := utils.FetchAPIServerTLSProfile(ctx, configClient)
+	if err != nil {
+		logger.DefaultZapLogger().Info("Failed to fetch cluster TLS profile, using TLS 1.3 as default", "error", err)
+		return func(config *tls.Config) {
+			config.MinVersion = tls.VersionTLS13
+		}
+	}
+
+	tlsConfigFunc, err := utils.BuildTLSConfigFunc(profile)
+	if err != nil {
+		logger.DefaultZapLogger().Info("Failed to build TLS config from profile, using TLS 1.3 as default", "error", err)
+		return func(config *tls.Config) {
+			config.MinVersion = tls.VersionTLS13
+		}
+	}
+
+	logger.DefaultZapLogger().Info("Configuring metrics server TLS from cluster APIServer profile", "profileType", profile.Type)
+	return tlsConfigFunc
 }

--- a/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -355,6 +355,14 @@ spec:
           - list
           - watch
         - apiGroups:
+          - config.openshift.io
+          resources:
+          - apiservers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - addon.open-cluster-management.io
           resources:
           - addondeploymentconfigs
@@ -964,6 +972,7 @@ spec:
         - apiGroups:
           - config.openshift.io
           resources:
+          - apiservers
           - clusterversions
           - infrastructures
           verbs:

--- a/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -360,8 +360,6 @@ spec:
           - apiservers
           verbs:
           - get
-          - list
-          - watch
         - apiGroups:
           - addon.open-cluster-management.io
           resources:
@@ -973,6 +971,11 @@ spec:
           - config.openshift.io
           resources:
           - apiservers
+          verbs:
+          - get
+        - apiGroups:
+          - config.openshift.io
+          resources:
           - clusterversions
           - infrastructures
           verbs:

--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -141,6 +141,15 @@ func getManager(restConfig *rest.Config, operatorConfig *config.OperatorConfig) 
 	renewDeadline := time.Duration(electionConfig.RenewDeadline) * time.Second
 	retryPeriod := time.Duration(electionConfig.RetryPeriod) * time.Second
 
+	// Get TLS configuration from cluster APIServer profile
+	tlsConfigFunc, err := getTLSConfigFunc(restConfig)
+	if err != nil {
+		setupLog.Info("Failed to get cluster TLS profile, using TLS 1.3 as default", "error", err)
+		tlsConfigFunc = func(config *tls.Config) {
+			config.MinVersion = tls.VersionTLS13
+		}
+	}
+
 	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme: config.GetRuntimeScheme(),
 		Metrics: metricsserver.Options{
@@ -148,12 +157,8 @@ func getManager(restConfig *rest.Config, operatorConfig *config.OperatorConfig) 
 		},
 		WebhookServer: &webhook.DefaultServer{
 			Options: webhook.Options{
-				Port: webhookPort,
-				TLSOpts: []func(*tls.Config){
-					func(config *tls.Config) {
-						config.MinVersion = tls.VersionTLS13
-					},
-				},
+				Port:    webhookPort,
+				TLSOpts: []func(*tls.Config){tlsConfigFunc},
 			},
 		},
 		HealthProbeBindAddress:  operatorConfig.ProbeAddress,
@@ -167,4 +172,24 @@ func getManager(restConfig *rest.Config, operatorConfig *config.OperatorConfig) 
 	})
 
 	return mgr, err
+}
+
+// getTLSConfigFunc fetches the cluster TLS profile and returns a function to configure tls.Config
+func getTLSConfigFunc(restConfig *rest.Config) (func(*tls.Config), error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Fetch the TLS profile from cluster APIServer
+	configClient, err := utils.GetOpenShiftConfigClient(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create config client: %w", err)
+	}
+
+	profile, err := utils.FetchAPIServerTLSProfile(ctx, configClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch APIServer TLS profile: %w", err)
+	}
+
+	setupLog.Info("Configuring webhook server TLS from cluster APIServer profile", "profileType", profile.Type)
+	return utils.BuildTLSConfigFunc(profile)
 }

--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -141,13 +141,16 @@ func getManager(restConfig *rest.Config, operatorConfig *config.OperatorConfig) 
 	renewDeadline := time.Duration(electionConfig.RenewDeadline) * time.Second
 	retryPeriod := time.Duration(electionConfig.RetryPeriod) * time.Second
 
-	// Get TLS configuration from cluster APIServer profile
-	tlsConfigFunc, err := getTLSConfigFunc(restConfig)
+	tlsCtx, tlsCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer tlsCancel()
+	tlsConfigFunc, profileType, err := utils.BuildMetricsTLSConfigFunc(tlsCtx, restConfig)
 	if err != nil {
-		setupLog.Info("Failed to get cluster TLS profile, using TLS 1.3 as default", "error", err)
-		tlsConfigFunc = func(config *tls.Config) {
-			config.MinVersion = tls.VersionTLS13
-		}
+		return nil, err
+	}
+	if profileType != "" {
+		setupLog.Info("Configuring webhook server TLS from cluster APIServer profile", "profileType", profileType)
+	} else {
+		setupLog.Info("Using TLS 1.3 for webhook server (cluster APIServer profile unavailable)")
 	}
 
 	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
@@ -172,24 +175,4 @@ func getManager(restConfig *rest.Config, operatorConfig *config.OperatorConfig) 
 	})
 
 	return mgr, err
-}
-
-// getTLSConfigFunc fetches the cluster TLS profile and returns a function to configure tls.Config
-func getTLSConfigFunc(restConfig *rest.Config) (func(*tls.Config), error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	// Fetch the TLS profile from cluster APIServer
-	configClient, err := utils.GetOpenShiftConfigClient(restConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create config client: %w", err)
-	}
-
-	profile, err := utils.FetchAPIServerTLSProfile(ctx, configClient)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch APIServer TLS profile: %w", err)
-	}
-
-	setupLog.Info("Configuring webhook server TLS from cluster APIServer profile", "profileType", profile.Type)
-	return utils.BuildTLSConfigFunc(profile)
 }

--- a/operator/config/rbac/aggregated_role.yaml
+++ b/operator/config/rbac/aggregated_role.yaml
@@ -90,6 +90,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - apiservers
+  verbs:
+  - get
+  - list
+  - watch
 # Hub HA - Permissions for syncing all Hub HA resources to standby hub
 # Standby hub needs: create/update/delete/patch to apply resources from active hub
 - apiGroups:

--- a/operator/config/rbac/aggregated_role.yaml
+++ b/operator/config/rbac/aggregated_role.yaml
@@ -96,8 +96,6 @@ rules:
   - apiservers
   verbs:
   - get
-  - list
-  - watch
 # Hub HA - Permissions for syncing all Hub HA resources to standby hub
 # Standby hub needs: create/update/delete/patch to apply resources from active hub
 - apiGroups:

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -323,6 +323,7 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - apiservers
   - clusterversions
   - infrastructures
   verbs:

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -324,6 +324,11 @@ rules:
   - config.openshift.io
   resources:
   - apiservers
+  verbs:
+  - get
+- apiGroups:
+  - config.openshift.io
+  resources:
   - clusterversions
   - infrastructures
   verbs:

--- a/operator/pkg/controllers/agent/addon/manifests/templates/agent/multicluster-global-hub-agent-clusterrole.yaml
+++ b/operator/pkg/controllers/agent/addon/manifests/templates/agent/multicluster-global-hub-agent-clusterrole.yaml
@@ -168,6 +168,7 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - apiservers
   - clusterversions
   verbs:
   - get

--- a/operator/pkg/controllers/agent/addon/manifests/templates/agent/multicluster-global-hub-agent-clusterrole.yaml
+++ b/operator/pkg/controllers/agent/addon/manifests/templates/agent/multicluster-global-hub-agent-clusterrole.yaml
@@ -169,6 +169,11 @@ rules:
   - config.openshift.io
   resources:
   - apiservers
+  verbs:
+  - get
+- apiGroups:
+  - config.openshift.io
+  resources:
   - clusterversions
   verbs:
   - get

--- a/operator/pkg/controllers/agent/local_agent_controller.go
+++ b/operator/pkg/controllers/agent/local_agent_controller.go
@@ -117,7 +117,7 @@ func (s *LocalAgentController) IsResourceRemoved() bool {
 // +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=clusterclaims,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=list;watch;get
 // +kubebuilder:rbac:groups=platform.stackrox.io,resources=centrals,verbs=get;list;watch
-// +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get;list;watch
+// +kubebuilder:rbac:groups=config.openshift.io,resources=apiservers;clusterversions,verbs=get;list;watch
 // +kubebuilder:rbac:groups=internal.open-cluster-management.io,resources=managedclusterinfos,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=config.open-cluster-management.io,resources=klusterletconfigs,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create

--- a/operator/pkg/controllers/agent/local_agent_controller.go
+++ b/operator/pkg/controllers/agent/local_agent_controller.go
@@ -117,7 +117,8 @@ func (s *LocalAgentController) IsResourceRemoved() bool {
 // +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=clusterclaims,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=list;watch;get
 // +kubebuilder:rbac:groups=platform.stackrox.io,resources=centrals,verbs=get;list;watch
-// +kubebuilder:rbac:groups=config.openshift.io,resources=apiservers;clusterversions,verbs=get;list;watch
+// +kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=get
+// +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get;list;watch
 // +kubebuilder:rbac:groups=internal.open-cluster-management.io,resources=managedclusterinfos,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=config.open-cluster-management.io,resources=klusterletconfigs,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create

--- a/operator/pkg/controllers/agent/manifests/clusterrole.yaml
+++ b/operator/pkg/controllers/agent/manifests/clusterrole.yaml
@@ -183,6 +183,7 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - apiservers
   - clusterversions
   verbs:
   - get

--- a/operator/pkg/controllers/agent/manifests/clusterrole.yaml
+++ b/operator/pkg/controllers/agent/manifests/clusterrole.yaml
@@ -184,6 +184,11 @@ rules:
   - config.openshift.io
   resources:
   - apiservers
+  verbs:
+  - get
+- apiGroups:
+  - config.openshift.io
+  resources:
   - clusterversions
   verbs:
   - get

--- a/operator/pkg/controllers/agent/standalone_agent_controller.go
+++ b/operator/pkg/controllers/agent/standalone_agent_controller.go
@@ -117,7 +117,7 @@ func StartStandaloneAgentController(ctx context.Context, mgr ctrl.Manager) error
 // +kubebuilder:rbac:groups=operator.open-cluster-management.io,resources=multiclusterglobalhubagents,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=operator.open-cluster-management.io,resources=multiclusterglobalhubagents/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=operator.open-cluster-management.io,resources=multiclusterglobalhubagents/finalizers,verbs=update
-// +kubebuilder:rbac:groups="config.openshift.io",resources=infrastructures;clusterversions,verbs=get;list;watch
+// +kubebuilder:rbac:groups="config.openshift.io",resources=apiservers;infrastructures;clusterversions,verbs=get;list;watch
 // +kubebuilder:rbac:groups="policy.open-cluster-management.io",resources=policyautomations;policysets;placementbindings;policies,verbs=get;list;watch;patch;update
 // +kubebuilder:rbac:groups="cluster.open-cluster-management.io",resources=placements;managedclustersets;managedclustersetbindings,verbs=get;list;watch;patch;update
 // +kubebuilder:rbac:groups="cluster.open-cluster-management.io",resources=managedclusters;managedclusters/finalizers;placementdecisions;placementdecisions/finalizers;placements;placements/finalizers,verbs=get;list;watch;patch;update

--- a/operator/pkg/controllers/agent/standalone_agent_controller.go
+++ b/operator/pkg/controllers/agent/standalone_agent_controller.go
@@ -117,7 +117,8 @@ func StartStandaloneAgentController(ctx context.Context, mgr ctrl.Manager) error
 // +kubebuilder:rbac:groups=operator.open-cluster-management.io,resources=multiclusterglobalhubagents,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=operator.open-cluster-management.io,resources=multiclusterglobalhubagents/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=operator.open-cluster-management.io,resources=multiclusterglobalhubagents/finalizers,verbs=update
-// +kubebuilder:rbac:groups="config.openshift.io",resources=apiservers;infrastructures;clusterversions,verbs=get;list;watch
+// +kubebuilder:rbac:groups="config.openshift.io",resources=apiservers,verbs=get
+// +kubebuilder:rbac:groups="config.openshift.io",resources=infrastructures;clusterversions,verbs=get;list;watch
 // +kubebuilder:rbac:groups="policy.open-cluster-management.io",resources=policyautomations;policysets;placementbindings;policies,verbs=get;list;watch;patch;update
 // +kubebuilder:rbac:groups="cluster.open-cluster-management.io",resources=placements;managedclustersets;managedclustersetbindings,verbs=get;list;watch;patch;update
 // +kubebuilder:rbac:groups="cluster.open-cluster-management.io",resources=managedclusters;managedclusters/finalizers;placementdecisions;placementdecisions/finalizers;placements;placements/finalizers,verbs=get;list;watch;patch;update

--- a/operator/pkg/controllers/manager/manifests/clusterrole.yaml
+++ b/operator/pkg/controllers/manager/manifests/clusterrole.yaml
@@ -156,3 +156,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - apiservers
+  verbs:
+  - get
+  - list
+  - watch

--- a/operator/pkg/controllers/manager/manifests/clusterrole.yaml
+++ b/operator/pkg/controllers/manager/manifests/clusterrole.yaml
@@ -162,5 +162,3 @@ rules:
   - apiservers
   verbs:
   - get
-  - list
-  - watch

--- a/pkg/database/pgx_conn.go
+++ b/pkg/database/pgx_conn.go
@@ -40,14 +40,19 @@ func GetPostgresConfig(URI string, cert []byte) (*pgx.ConnConfig, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse database uri: %w", err)
 	}
-	if len(cert) > 0 { // #nosec G402
+	if len(cert) > 0 {
 		caCertPool := x509.NewCertPool()
-		caCertPool.AppendCertsFromPEM(cert)
-		config.TLSConfig = &tls.Config{
-			RootCAs: caCertPool,
-			// nolint:gosec
-			InsecureSkipVerify: true, // #nosec G402
+		if !caCertPool.AppendCertsFromPEM(cert) {
+			return nil, fmt.Errorf("failed to parse database CA certificate PEM")
 		}
+		// Preserve existing TLSConfig settings from ParseConfig (ServerName, etc.)
+		// and only update RootCAs
+		if config.TLSConfig == nil {
+			config.TLSConfig = &tls.Config{
+				MinVersion: tls.VersionTLS12,
+			}
+		}
+		config.TLSConfig.RootCAs = caCertPool
 	}
 	return config, nil
 }
@@ -63,13 +68,19 @@ func PostgresConnPool(ctx context.Context, databaseURI string, certPath string, 
 	if err != nil && !strings.Contains(err.Error(), errMessageFileNotFound) {
 		return nil, fmt.Errorf("unable to read database cert file: %w", err)
 	}
-	if len(cert) > 0 { // #nosec G402
+	if len(cert) > 0 {
 		caCertPool := x509.NewCertPool()
-		caCertPool.AppendCertsFromPEM(cert)
-		config.ConnConfig.TLSConfig = &tls.Config{
-			RootCAs:            caCertPool,
-			InsecureSkipVerify: true, // #nosec G402
+		if !caCertPool.AppendCertsFromPEM(cert) {
+			return nil, fmt.Errorf("failed to parse database CA certificate PEM")
 		}
+		// Preserve existing TLSConfig settings from ParseConfig (ServerName, etc.)
+		// and only update RootCAs
+		if config.ConnConfig.TLSConfig == nil {
+			config.ConnConfig.TLSConfig = &tls.Config{
+				MinVersion: tls.VersionTLS12,
+			}
+		}
+		config.ConnConfig.TLSConfig.RootCAs = caCertPool
 	}
 
 	if size > 0 {

--- a/pkg/database/pgx_conn_test.go
+++ b/pkg/database/pgx_conn_test.go
@@ -1,0 +1,132 @@
+package database
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+const testPostgresURI = "postgres://user:pass@localhost:5432/db"
+
+func TestGetPostgresConfigWithoutCert(t *testing.T) {
+	cfg, err := GetPostgresConfig(testPostgresURI, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.TLSConfig != nil && cfg.TLSConfig.RootCAs != nil {
+		t.Fatal("expected no custom RootCAs without cert")
+	}
+}
+
+func TestGetPostgresConfigWithValidCA(t *testing.T) {
+	caPEM := generateTestCAPEM(t)
+
+	cfg, err := GetPostgresConfig(testPostgresURI, caPEM)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.TLSConfig == nil {
+		t.Fatal("expected TLSConfig to be set")
+	}
+	if cfg.TLSConfig.RootCAs == nil {
+		t.Fatal("expected RootCAs to be set")
+	}
+}
+
+func TestGetPostgresConfigSetsMinVersionWhenTLSUnset(t *testing.T) {
+	caPEM := generateTestCAPEM(t)
+	config, err := pgx.ParseConfig(testPostgresURI)
+	if err != nil {
+		t.Fatalf("failed to parse uri: %v", err)
+	}
+	config.TLSConfig = nil
+
+	caCertPool := x509.NewCertPool()
+	if !caCertPool.AppendCertsFromPEM(caPEM) {
+		t.Fatal("failed to parse generated CA")
+	}
+	config.TLSConfig = &tls.Config{MinVersion: tls.VersionTLS12}
+	config.TLSConfig.RootCAs = caCertPool
+
+	if config.TLSConfig.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("expected MinVersion TLS 1.2, got %d", config.TLSConfig.MinVersion)
+	}
+}
+
+func TestGetPostgresConfigWithInvalidCA(t *testing.T) {
+	_, err := GetPostgresConfig(testPostgresURI, []byte("not-a-pem-cert"))
+	if err == nil {
+		t.Fatal("expected error for invalid CA PEM")
+	}
+	if !strings.Contains(err.Error(), "failed to parse database CA certificate PEM") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetPostgresConfigPreservesExistingTLSConfig(t *testing.T) {
+	caPEM := generateTestCAPEM(t)
+
+	config, err := pgx.ParseConfig(testPostgresURI)
+	if err != nil {
+		t.Fatalf("failed to parse uri: %v", err)
+	}
+	config.TLSConfig = &tls.Config{
+		MinVersion: tls.VersionTLS13,
+		ServerName: "db.example.com",
+	}
+
+	caCertPool := x509.NewCertPool()
+	if !caCertPool.AppendCertsFromPEM(caPEM) {
+		t.Fatal("failed to parse generated CA")
+	}
+	config.TLSConfig.RootCAs = caCertPool
+
+	if config.TLSConfig.MinVersion != tls.VersionTLS13 {
+		t.Fatalf("expected preserved MinVersion TLS 1.3, got %d", config.TLSConfig.MinVersion)
+	}
+	if config.TLSConfig.ServerName != "db.example.com" {
+		t.Fatalf("expected preserved ServerName, got %q", config.TLSConfig.ServerName)
+	}
+}
+
+func TestGetPostgresConfigInvalidURI(t *testing.T) {
+	_, err := GetPostgresConfig("not-a-valid-uri", nil)
+	if err == nil {
+		t.Fatal("expected error for invalid URI")
+	}
+	if !strings.Contains(err.Error(), "failed to parse database uri") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func generateTestCAPEM(t *testing.T) []byte {
+	t.Helper()
+
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate CA key: %v", err)
+	}
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("failed to create CA cert: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+}

--- a/pkg/database/pgx_conn_test.go
+++ b/pkg/database/pgx_conn_test.go
@@ -17,6 +17,8 @@ import (
 
 const testPostgresURI = "postgres://user:pass@localhost:5432/db"
 
+const testPostgresURIRequireSSL = "postgres://user:pass@localhost:5432/db?sslmode=require"
+
 func TestGetPostgresConfigWithoutCert(t *testing.T) {
 	cfg, err := GetPostgresConfig(testPostgresURI, nil)
 	if err != nil {
@@ -44,21 +46,24 @@ func TestGetPostgresConfigWithValidCA(t *testing.T) {
 
 func TestGetPostgresConfigSetsMinVersionWhenTLSUnset(t *testing.T) {
 	caPEM := generateTestCAPEM(t)
-	config, err := pgx.ParseConfig(testPostgresURI)
+
+	parsed, err := pgx.ParseConfig(testPostgresURI)
 	if err != nil {
 		t.Fatalf("failed to parse uri: %v", err)
 	}
-	config.TLSConfig = nil
-
-	caCertPool := x509.NewCertPool()
-	if !caCertPool.AppendCertsFromPEM(caPEM) {
-		t.Fatal("failed to parse generated CA")
+	if parsed.TLSConfig != nil {
+		t.Skip("pgx sets TLSConfig for this URI; MinVersion branch requires nil TLSConfig")
 	}
-	config.TLSConfig = &tls.Config{MinVersion: tls.VersionTLS12}
-	config.TLSConfig.RootCAs = caCertPool
 
-	if config.TLSConfig.MinVersion != tls.VersionTLS12 {
-		t.Fatalf("expected MinVersion TLS 1.2, got %d", config.TLSConfig.MinVersion)
+	cfg, err := GetPostgresConfig(testPostgresURI, caPEM)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.TLSConfig == nil {
+		t.Fatal("expected TLSConfig to be set when CA is provided")
+	}
+	if cfg.TLSConfig.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("expected MinVersion TLS 1.2, got %d", cfg.TLSConfig.MinVersion)
 	}
 }
 
@@ -75,26 +80,28 @@ func TestGetPostgresConfigWithInvalidCA(t *testing.T) {
 func TestGetPostgresConfigPreservesExistingTLSConfig(t *testing.T) {
 	caPEM := generateTestCAPEM(t)
 
-	config, err := pgx.ParseConfig(testPostgresURI)
+	baseline, err := pgx.ParseConfig(testPostgresURIRequireSSL)
 	if err != nil {
 		t.Fatalf("failed to parse uri: %v", err)
 	}
-	config.TLSConfig = &tls.Config{
-		MinVersion: tls.VersionTLS13,
-		ServerName: "db.example.com",
+	if baseline.TLSConfig == nil {
+		t.Fatal("expected pgx to set TLSConfig for sslmode=require")
 	}
+	expectedServerName := baseline.TLSConfig.ServerName
+	expectedMinVersion := baseline.TLSConfig.MinVersion
 
-	caCertPool := x509.NewCertPool()
-	if !caCertPool.AppendCertsFromPEM(caPEM) {
-		t.Fatal("failed to parse generated CA")
+	cfg, err := GetPostgresConfig(testPostgresURIRequireSSL, caPEM)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	config.TLSConfig.RootCAs = caCertPool
-
-	if config.TLSConfig.MinVersion != tls.VersionTLS13 {
-		t.Fatalf("expected preserved MinVersion TLS 1.3, got %d", config.TLSConfig.MinVersion)
+	if cfg.TLSConfig == nil || cfg.TLSConfig.RootCAs == nil {
+		t.Fatal("expected TLSConfig with RootCAs")
 	}
-	if config.TLSConfig.ServerName != "db.example.com" {
-		t.Fatalf("expected preserved ServerName, got %q", config.TLSConfig.ServerName)
+	if cfg.TLSConfig.ServerName != expectedServerName {
+		t.Fatalf("expected ServerName %q, got %q", expectedServerName, cfg.TLSConfig.ServerName)
+	}
+	if cfg.TLSConfig.MinVersion != expectedMinVersion {
+		t.Fatalf("expected MinVersion %d, got %d", expectedMinVersion, cfg.TLSConfig.MinVersion)
 	}
 }
 

--- a/pkg/transport/config/saram_config.go
+++ b/pkg/transport/config/saram_config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -30,32 +31,32 @@ func GetSaramaConfig(kafkaConfig *transport.KafkaInternalConfig) (*sarama.Config
 }
 
 func NewTLSConfig(clientCertFile, clientKeyFile, caCertFile string) (*tls.Config, error) {
-	// #nosec G402
-	tlsConfig := tls.Config{}
+	tlsConfig := tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
 
-	// Load client cert
+	// Load client cert for mutual TLS (optional)
 	_, validCert := utils.Validate(clientCertFile)
 	_, validKey := utils.Validate(clientKeyFile)
 	if validCert && validKey {
 		cert, err := tls.LoadX509KeyPair(clientCertFile, clientKeyFile)
 		if err != nil {
-			return &tlsConfig, err
+			return &tlsConfig, fmt.Errorf("failed to load client certificate: %w", err)
 		}
 		tlsConfig.Certificates = []tls.Certificate{cert}
-	} else {
-		// #nosec
-		tlsConfig.InsecureSkipVerify = true
 	}
 
-	// Load CA cert
+	// Load CA cert - this is required to verify the server
 	caCert, err := os.ReadFile(filepath.Clean(caCertFile))
 	if err != nil {
-		return &tlsConfig, err
+		return &tlsConfig, fmt.Errorf("failed to read CA certificate: %w", err)
 	}
 	caCertPool := x509.NewCertPool()
-	caCertPool.AppendCertsFromPEM(caCert)
+	if !caCertPool.AppendCertsFromPEM(caCert) {
+		return &tlsConfig, fmt.Errorf("failed to parse CA certificate")
+	}
 	tlsConfig.RootCAs = caCertPool
 
 	tlsConfig.BuildNameToCertificate()
-	return &tlsConfig, err
+	return &tlsConfig, nil
 }

--- a/pkg/transport/config/saram_config.go
+++ b/pkg/transport/config/saram_config.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
+const errClientCertKeyMismatch = "client certificate and key must be provided together"
+
 func GetSaramaConfig(kafkaConfig *transport.KafkaInternalConfig) (*sarama.Config, error) {
 	saramaConfig := sarama.NewConfig()
 	saramaConfig.Version = sarama.V2_0_0_0
@@ -39,7 +41,7 @@ func NewTLSConfig(clientCertFile, clientKeyFile, caCertFile string) (*tls.Config
 	_, validCert := utils.Validate(clientCertFile)
 	_, validKey := utils.Validate(clientKeyFile)
 	if validCert != validKey {
-		return &tlsConfig, fmt.Errorf("client certificate and key must be provided together")
+		return &tlsConfig, fmt.Errorf("%s", errClientCertKeyMismatch)
 	}
 	if validCert && validKey {
 		cert, err := tls.LoadX509KeyPair(clientCertFile, clientKeyFile)

--- a/pkg/transport/config/saram_config.go
+++ b/pkg/transport/config/saram_config.go
@@ -38,6 +38,9 @@ func NewTLSConfig(clientCertFile, clientKeyFile, caCertFile string) (*tls.Config
 	// Load client cert for mutual TLS (optional)
 	_, validCert := utils.Validate(clientCertFile)
 	_, validKey := utils.Validate(clientKeyFile)
+	if validCert != validKey {
+		return &tlsConfig, fmt.Errorf("client certificate and key must be provided together")
+	}
 	if validCert && validKey {
 		cert, err := tls.LoadX509KeyPair(clientCertFile, clientKeyFile)
 		if err != nil {

--- a/pkg/transport/config/saram_config_test.go
+++ b/pkg/transport/config/saram_config_test.go
@@ -1,0 +1,26 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewTLSConfigMismatchedClientCertAndKey(t *testing.T) {
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, "tls.crt")
+	keyFile := filepath.Join(dir, "tls.key")
+	caFile := filepath.Join(dir, "ca.crt")
+
+	if err := os.WriteFile(certFile, []byte("cert"), 0o600); err != nil {
+		t.Fatalf("failed to write cert file: %v", err)
+	}
+	if err := os.WriteFile(caFile, []byte("-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----"), 0o600); err != nil {
+		t.Fatalf("failed to write ca file: %v", err)
+	}
+
+	_, err := NewTLSConfig(certFile, keyFile, caFile)
+	if err == nil {
+		t.Fatal("expected error when only client certificate is provided")
+	}
+}

--- a/pkg/transport/config/saram_config_test.go
+++ b/pkg/transport/config/saram_config_test.go
@@ -1,9 +1,19 @@
 package config
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 )
 
 func TestNewTLSConfigMismatchedClientCertAndKey(t *testing.T) {
@@ -15,12 +25,125 @@ func TestNewTLSConfigMismatchedClientCertAndKey(t *testing.T) {
 	if err := os.WriteFile(certFile, []byte("cert"), 0o600); err != nil {
 		t.Fatalf("failed to write cert file: %v", err)
 	}
-	if err := os.WriteFile(caFile, []byte("-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----"), 0o600); err != nil {
+	caPEM := []byte("-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----")
+	if err := os.WriteFile(caFile, caPEM, 0o600); err != nil {
 		t.Fatalf("failed to write ca file: %v", err)
 	}
 
 	_, err := NewTLSConfig(certFile, keyFile, caFile)
 	if err == nil {
 		t.Fatal("expected error when only client certificate is provided")
+	}
+	if !strings.Contains(err.Error(), errClientCertKeyMismatch) {
+		t.Fatalf("expected error %q, got %v", errClientCertKeyMismatch, err)
+	}
+}
+
+func TestNewTLSConfigMismatchedKeyOnly(t *testing.T) {
+	dir := t.TempDir()
+	keyFile := filepath.Join(dir, "tls.key")
+	caFile := filepath.Join(dir, "ca.crt")
+
+	if err := os.WriteFile(keyFile, []byte("key"), 0o600); err != nil {
+		t.Fatalf("failed to write key file: %v", err)
+	}
+	caPEM := []byte("-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----")
+	if err := os.WriteFile(caFile, caPEM, 0o600); err != nil {
+		t.Fatalf("failed to write ca file: %v", err)
+	}
+
+	_, err := NewTLSConfig("", keyFile, caFile)
+	if err == nil {
+		t.Fatal("expected error when only client key is provided")
+	}
+	if !strings.Contains(err.Error(), errClientCertKeyMismatch) {
+		t.Fatalf("expected error %q, got %v", errClientCertKeyMismatch, err)
+	}
+}
+
+func TestNewTLSConfigWithClientCertAndCA(t *testing.T) {
+	dir := t.TempDir()
+	certPEM, keyPEM, caPEM := generateTestCertKeyAndCA(t)
+
+	certFile := filepath.Join(dir, "tls.crt")
+	keyFile := filepath.Join(dir, "tls.key")
+	caFile := filepath.Join(dir, "ca.crt")
+	writeFile(t, certFile, certPEM)
+	writeFile(t, keyFile, keyPEM)
+	writeFile(t, caFile, caPEM)
+
+	cfg, err := NewTLSConfig(certFile, keyFile, caFile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.Certificates) != 1 {
+		t.Fatalf("expected one client certificate, got %d", len(cfg.Certificates))
+	}
+	if cfg.RootCAs == nil {
+		t.Fatal("expected RootCAs to be set")
+	}
+}
+
+func TestGetSaramaConfigWithoutTLS(t *testing.T) {
+	cfg, err := GetSaramaConfig(&transport.KafkaInternalConfig{EnableTLS: false})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Net.TLS.Enable {
+		t.Fatal("expected TLS to be disabled")
+	}
+}
+
+func generateTestCertKeyAndCA(t *testing.T) (certPEM, keyPEM, caPEM []byte) {
+	t.Helper()
+
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate CA key: %v", err)
+	}
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("failed to create CA cert: %v", err)
+	}
+	caPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+
+	clientKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate client key: %v", err)
+	}
+	clientTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "test-client"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	clientDER, err := x509.CreateCertificate(rand.Reader, clientTemplate, caTemplate, &clientKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("failed to create client cert: %v", err)
+	}
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientDER})
+	keyDER, err := x509.MarshalPKCS8PrivateKey(clientKey)
+	if err != nil {
+		t.Fatalf("failed to marshal client key: %v", err)
+	}
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+	return certPEM, keyPEM, caPEM
+}
+
+func writeFile(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("failed to write %s: %v", path, err)
 	}
 }

--- a/pkg/transport/config/saram_config_test.go
+++ b/pkg/transport/config/saram_config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
@@ -91,6 +92,37 @@ func TestGetSaramaConfigWithoutTLS(t *testing.T) {
 	}
 	if cfg.Net.TLS.Enable {
 		t.Fatal("expected TLS to be disabled")
+	}
+}
+
+func TestGetSaramaConfigWithTLS(t *testing.T) {
+	dir := t.TempDir()
+	certPEM, keyPEM, caPEM := generateTestCertKeyAndCA(t)
+
+	certFile := filepath.Join(dir, "tls.crt")
+	keyFile := filepath.Join(dir, "tls.key")
+	caFile := filepath.Join(dir, "ca.crt")
+	writeFile(t, certFile, certPEM)
+	writeFile(t, keyFile, keyPEM)
+	writeFile(t, caFile, caPEM)
+
+	cfg, err := GetSaramaConfig(&transport.KafkaInternalConfig{
+		EnableTLS:      true,
+		CaCertPath:     caFile,
+		ClientCertPath: certFile,
+		ClientKeyPath:  keyFile,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cfg.Net.TLS.Enable {
+		t.Fatal("expected TLS to be enabled")
+	}
+	if cfg.Net.TLS.Config == nil {
+		t.Fatal("expected TLS config to be set")
+	}
+	if cfg.Net.TLS.Config.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("expected MinVersion TLS 1.2, got %d", cfg.Net.TLS.Config.MinVersion)
 	}
 }
 

--- a/pkg/transport/requester/inventory_client.go
+++ b/pkg/transport/requester/inventory_client.go
@@ -38,10 +38,13 @@ func (c *InventoryClient) RefreshClient(ctx context.Context, restfulConn *transp
 		return fmt.Errorf("failed to append CA certificate to pool")
 	}
 
-	// #nosec G402
+	// For external services like Kessel Inventory, we use TLS 1.2 as minimum version
+	// to ensure compatibility while maintaining security. External services may not
+	// support TLS 1.3 yet, unlike OpenShift components.
 	tlsConfig := tls.Config{
 		Certificates: []tls.Certificate{clientCert},
 		RootCAs:      caCertPool,
+		MinVersion:   tls.VersionTLS12,
 	}
 
 	c.httpUrl = restfulConn.Host

--- a/pkg/transport/requester/inventory_client_test.go
+++ b/pkg/transport/requester/inventory_client_test.go
@@ -1,0 +1,104 @@
+package requester
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/transport"
+)
+
+func TestRefreshClientSetsTLS12MinVersion(t *testing.T) {
+	certPEM, keyPEM, caPEM := generateInventoryTestCerts(t)
+	restfulConn := &transport.RestfulConfig{
+		Host:       "https://127.0.0.1:65530",
+		ClientCert: string(certPEM),
+		ClientKey:  string(keyPEM),
+		CACert:     string(caPEM),
+	}
+
+	client := &InventoryClient{}
+	if err := client.RefreshClient(context.Background(), restfulConn); err != nil {
+		t.Fatalf("unexpected error building inventory client: %v", err)
+	}
+	if client.tlsConfig == nil {
+		t.Fatal("expected tls config to be set before client init failure")
+	}
+	if client.tlsConfig.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("expected MinVersion TLS 1.2, got %d", client.tlsConfig.MinVersion)
+	}
+}
+
+func TestRefreshClientInvalidClientCert(t *testing.T) {
+	_, keyPEM, caPEM := generateInventoryTestCerts(t)
+	restfulConn := &transport.RestfulConfig{
+		Host:       "https://127.0.0.1:65530",
+		ClientCert: "invalid-cert",
+		ClientKey:  string(keyPEM),
+		CACert:     string(caPEM),
+	}
+
+	client := &InventoryClient{}
+	err := client.RefreshClient(context.Background(), restfulConn)
+	if err == nil {
+		t.Fatal("expected error for invalid client cert")
+	}
+	if !strings.Contains(err.Error(), "failed the load client cert") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func generateInventoryTestCerts(t *testing.T) (certPEM, keyPEM, caPEM []byte) {
+	t.Helper()
+
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate CA key: %v", err)
+	}
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "inventory-test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("failed to create CA cert: %v", err)
+	}
+	caPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+
+	clientKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate client key: %v", err)
+	}
+	clientTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "inventory-test-client"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	clientDER, err := x509.CreateCertificate(rand.Reader, clientTemplate, caTemplate, &clientKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("failed to create client cert: %v", err)
+	}
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientDER})
+	keyDER, err := x509.MarshalPKCS8PrivateKey(clientKey)
+	if err != nil {
+		t.Fatalf("failed to marshal client key: %v", err)
+	}
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+	return certPEM, keyPEM, caPEM
+}

--- a/pkg/utils/tlsprofile.go
+++ b/pkg/utils/tlsprofile.go
@@ -1,0 +1,235 @@
+package utils
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configclientset "github.com/openshift/client-go/config/clientset/versioned"
+	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	errMsgFailedToGetAPIServer = "failed to get APIServer config: %w"
+)
+
+// GetTLSConfigFromAPIServer fetches the TLS profile from the OpenShift APIServer
+// and builds a tls.Config based on cluster-wide TLS security profile.
+// This is the recommended approach for OpenShift components.
+func GetTLSConfigFromAPIServer(ctx context.Context, restConfig *rest.Config) (*tls.Config, error) {
+	configClient, err := configclientset.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create config client: %w", err)
+	}
+
+	apiserver, err := configClient.ConfigV1().APIServers().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf(errMsgFailedToGetAPIServer, err)
+	}
+
+	profile := apiserver.Spec.TLSSecurityProfile
+	if profile == nil {
+		// Use Intermediate profile as default when no profile is specified
+		profile = &configv1.TLSSecurityProfile{Type: configv1.TLSProfileIntermediateType}
+	}
+
+	return BuildTLSConfig(profile)
+}
+
+// GetTLSConfigFromClient fetches the TLS profile using a controller-runtime client.
+// This is useful when you already have a controller-runtime client available.
+func GetTLSConfigFromClient(ctx context.Context, c client.Client) (*tls.Config, error) {
+	apiserver := &configv1.APIServer{}
+	if err := c.Get(ctx, client.ObjectKey{Name: "cluster"}, apiserver); err != nil {
+		return nil, fmt.Errorf("failed to get APIServer config: %w", err)
+	}
+
+	profile := apiserver.Spec.TLSSecurityProfile
+	if profile == nil {
+		// Use Intermediate profile as default when no profile is specified
+		profile = &configv1.TLSSecurityProfile{Type: configv1.TLSProfileIntermediateType}
+	}
+
+	return BuildTLSConfig(profile)
+}
+
+// BuildTLSConfig builds a tls.Config from an OpenShift TLS security profile.
+func BuildTLSConfig(profile *configv1.TLSSecurityProfile) (*tls.Config, error) {
+	spec, err := resolveSpec(profile)
+	if err != nil {
+		return nil, err
+	}
+
+	minVer, err := parseTLSVersion(string(spec.MinTLSVersion))
+	if err != nil {
+		return nil, fmt.Errorf("invalid MinTLSVersion: %w", err)
+	}
+
+	// #nosec G402 -- MinVersion is dynamically set from cluster TLS profile config.
+	// Even "Old" profile (TLS 1.0) is a deliberate cluster-wide security policy.
+	cfg := &tls.Config{MinVersion: minVer}
+
+	// TLS 1.3 cipher suites are not configurable in Go (golang/go#29349).
+	// Only set CipherSuites for TLS 1.2 and below.
+	if minVer < tls.VersionTLS13 {
+		suites := mapCipherSuites(spec.Ciphers)
+		if len(suites) == 0 && len(spec.Ciphers) > 0 {
+			return nil, fmt.Errorf(
+				"no valid cipher suites found for TLS profile (all %d cipher(s) unsupported by Go)",
+				len(spec.Ciphers),
+			)
+		}
+		cfg.CipherSuites = suites
+	}
+
+	return cfg, nil
+}
+
+// BuildTLSConfigFunc returns a function that can be used to configure tls.Config.
+// This is useful for controller-runtime's metricsserver.Options.TLSOpts.
+func BuildTLSConfigFunc(profile *configv1.TLSSecurityProfile) (func(*tls.Config), error) {
+	spec, err := resolveSpec(profile)
+	if err != nil {
+		return nil, err
+	}
+
+	minVer, err := parseTLSVersion(string(spec.MinTLSVersion))
+	if err != nil {
+		return nil, fmt.Errorf("invalid MinTLSVersion: %w", err)
+	}
+
+	// TLS 1.3 cipher suites are not configurable in Go, so validate cipher suites
+	// early for TLS < 1.3 to fail fast if the profile specifies unsupported ciphers
+	var suites []uint16
+	if minVer < tls.VersionTLS13 {
+		suites = mapCipherSuites(spec.Ciphers)
+		if len(suites) == 0 && len(spec.Ciphers) > 0 {
+			return nil, fmt.Errorf(
+				"no valid cipher suites found for TLS profile (all %d cipher(s) unsupported by Go)",
+				len(spec.Ciphers),
+			)
+		}
+	}
+
+	return func(cfg *tls.Config) {
+		cfg.MinVersion = minVer
+		// Always set CipherSuites to ensure consistent behavior:
+		// - TLS < 1.3: use specific suites or nil for Go defaults
+		// - TLS >= 1.3: nil (cipher suites not configurable in Go)
+		cfg.CipherSuites = suites
+	}, nil
+}
+
+// resolveSpec resolves the TLSProfileSpec from a TLSSecurityProfile.
+// It handles both built-in profiles (Old, Intermediate, Modern) and custom profiles.
+func resolveSpec(profile *configv1.TLSSecurityProfile) (*configv1.TLSProfileSpec, error) {
+	// Handle nil profile by defaulting to Intermediate
+	if profile == nil {
+		spec := configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+		if spec == nil {
+			return nil, fmt.Errorf("default Intermediate TLS profile not found in configv1.TLSProfiles")
+		}
+		return spec, nil
+	}
+
+	switch profile.Type {
+	case configv1.TLSProfileOldType,
+		configv1.TLSProfileIntermediateType,
+		configv1.TLSProfileModernType:
+		spec := configv1.TLSProfiles[profile.Type]
+		if spec == nil {
+			return nil, fmt.Errorf("TLS profile %s not found in configv1.TLSProfiles", profile.Type)
+		}
+		return spec, nil
+	case configv1.TLSProfileCustomType:
+		if profile.Custom == nil {
+			return nil, fmt.Errorf("custom TLS profile specified but Custom is nil")
+		}
+		return &profile.Custom.TLSProfileSpec, nil
+	default:
+		// Return error for unknown/unsupported profile types instead of silently defaulting
+		return nil, fmt.Errorf("unsupported TLS profile type %q", profile.Type)
+	}
+}
+
+// parseTLSVersion converts an OpenShift TLS version string to a Go TLS version constant.
+func parseTLSVersion(v string) (uint16, error) {
+	versions := map[string]uint16{
+		"VersionTLS10": tls.VersionTLS10,
+		"VersionTLS11": tls.VersionTLS11,
+		"VersionTLS12": tls.VersionTLS12,
+		"VersionTLS13": tls.VersionTLS13,
+	}
+	if ver, ok := versions[v]; ok {
+		return ver, nil
+	}
+	return 0, fmt.Errorf("unknown TLS version: %s", v)
+}
+
+// mapCipherSuites converts OpenSSL-style cipher names (used in OpenShift TLS
+// profiles) to Go crypto/tls constants. Ciphers without a Go constant (e.g.
+// DHE-RSA-*, ECDHE-RSA-AES256-SHA384, AES256-SHA256) are silently skipped —
+// Go's crypto/tls does not support them.
+func mapCipherSuites(names []string) []uint16 {
+	m := map[string]uint16{
+		"ECDHE-RSA-AES128-GCM-SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		"ECDHE-ECDSA-AES128-GCM-SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		"ECDHE-RSA-AES256-GCM-SHA384":   tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		"ECDHE-ECDSA-AES256-GCM-SHA384": tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		"ECDHE-RSA-CHACHA20-POLY1305":   tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+		"ECDHE-ECDSA-CHACHA20-POLY1305": tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+		"ECDHE-RSA-AES128-SHA256":       tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+		"ECDHE-ECDSA-AES128-SHA256":     tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+		"ECDHE-RSA-AES128-SHA":          tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+		"ECDHE-ECDSA-AES128-SHA":        tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+		"ECDHE-RSA-AES256-SHA":          tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+		"ECDHE-ECDSA-AES256-SHA":        tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+		"AES128-GCM-SHA256":             tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+		"AES256-GCM-SHA384":             tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		"AES128-SHA256":                 tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
+		"AES128-SHA":                    tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+		"AES256-SHA":                    tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+		"DES-CBC3-SHA":                  tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+	}
+
+	out := make([]uint16, 0, len(names))
+	for _, name := range names {
+		if id, ok := m[name]; ok {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+// GetOpenShiftConfigClient creates a versioned config client for accessing OpenShift config resources.
+func GetOpenShiftConfigClient(restConfig *rest.Config) (configv1client.ConfigV1Interface, error) {
+	configClient, err := configclientset.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create config client: %w", err)
+	}
+	return configClient.ConfigV1(), nil
+}
+
+// FetchAPIServerTLSProfile fetches the TLS security profile from the cluster APIServer resource.
+// Returns the Intermediate profile as default if no profile is specified.
+func FetchAPIServerTLSProfile(
+	ctx context.Context,
+	configClient configv1client.ConfigV1Interface,
+) (*configv1.TLSSecurityProfile, error) {
+	apiserver, err := configClient.APIServers().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get APIServer config: %w", err)
+	}
+
+	profile := apiserver.Spec.TLSSecurityProfile
+	if profile == nil {
+		// Use Intermediate profile as default when no profile is specified
+		profile = &configv1.TLSSecurityProfile{Type: configv1.TLSProfileIntermediateType}
+	}
+
+	return profile, nil
+}

--- a/pkg/utils/tlsprofile.go
+++ b/pkg/utils/tlsprofile.go
@@ -26,17 +26,10 @@ func GetTLSConfigFromAPIServer(ctx context.Context, restConfig *rest.Config) (*t
 		return nil, fmt.Errorf("failed to create config client: %w", err)
 	}
 
-	apiserver, err := configClient.ConfigV1().APIServers().Get(ctx, "cluster", metav1.GetOptions{})
+	profile, err := FetchAPIServerTLSProfile(ctx, configClient.ConfigV1().APIServers())
 	if err != nil {
-		return nil, fmt.Errorf(errMsgFailedToGetAPIServer, err)
+		return nil, err
 	}
-
-	profile := apiserver.Spec.TLSSecurityProfile
-	if profile == nil {
-		// Use Intermediate profile as default when no profile is specified
-		profile = &configv1.TLSSecurityProfile{Type: configv1.TLSProfileIntermediateType}
-	}
-
 	return BuildTLSConfig(profile)
 }
 
@@ -45,7 +38,7 @@ func GetTLSConfigFromAPIServer(ctx context.Context, restConfig *rest.Config) (*t
 func GetTLSConfigFromClient(ctx context.Context, c client.Client) (*tls.Config, error) {
 	apiserver := &configv1.APIServer{}
 	if err := c.Get(ctx, client.ObjectKey{Name: "cluster"}, apiserver); err != nil {
-		return nil, fmt.Errorf("failed to get APIServer config: %w", err)
+		return nil, fmt.Errorf(errMsgFailedToGetAPIServer, err)
 	}
 
 	profile := apiserver.Spec.TLSSecurityProfile
@@ -217,15 +210,17 @@ func GetOpenShiftConfigClient(restConfig *rest.Config) (configv1client.ConfigV1I
 	return configClient.ConfigV1(), nil
 }
 
+// apiserverGetter reads the cluster APIServer singleton used for TLS profile discovery.
+type apiserverGetter interface {
+	Get(ctx context.Context, name string, opts metav1.GetOptions) (*configv1.APIServer, error)
+}
+
 // FetchAPIServerTLSProfile fetches the TLS security profile from the cluster APIServer resource.
 // Returns the Intermediate profile as default if no profile is specified.
-func FetchAPIServerTLSProfile(
-	ctx context.Context,
-	configClient configv1client.ConfigV1Interface,
-) (*configv1.TLSSecurityProfile, error) {
-	apiserver, err := configClient.APIServers().Get(ctx, "cluster", metav1.GetOptions{})
+func FetchAPIServerTLSProfile(ctx context.Context, client apiserverGetter) (*configv1.TLSSecurityProfile, error) {
+	apiserver, err := client.Get(ctx, "cluster", metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get APIServer config: %w", err)
+		return nil, fmt.Errorf(errMsgFailedToGetAPIServer, err)
 	}
 
 	profile := apiserver.Spec.TLSSecurityProfile
@@ -256,14 +251,14 @@ func BuildMetricsTLSConfigFunc(
 	if err != nil {
 		return TLS13OnlyConfigFunc(), "", nil
 	}
-	return buildTLSConfigFuncFromAPIServer(ctx, configClient)
+	return buildTLSConfigFuncFromAPIServer(ctx, configClient.APIServers())
 }
 
 func buildTLSConfigFuncFromAPIServer(
 	ctx context.Context,
-	configClient configv1client.ConfigV1Interface,
+	getter apiserverGetter,
 ) (func(*tls.Config), configv1.TLSProfileType, error) {
-	profile, err := FetchAPIServerTLSProfile(ctx, configClient)
+	profile, err := FetchAPIServerTLSProfile(ctx, getter)
 	if err != nil {
 		return TLS13OnlyConfigFunc(), "", nil
 	}

--- a/pkg/utils/tlsprofile.go
+++ b/pkg/utils/tlsprofile.go
@@ -58,6 +58,8 @@ func GetTLSConfigFromClient(ctx context.Context, c client.Client) (*tls.Config, 
 }
 
 // BuildTLSConfig builds a tls.Config from an OpenShift TLS security profile.
+// When the profile omits cipher suites for TLS versions below 1.3, CipherSuites is left nil
+// so Go applies its safe defaults.
 func BuildTLSConfig(profile *configv1.TLSSecurityProfile) (*tls.Config, error) {
 	spec, err := resolveSpec(profile)
 	if err != nil {
@@ -74,10 +76,11 @@ func BuildTLSConfig(profile *configv1.TLSSecurityProfile) (*tls.Config, error) {
 	cfg := &tls.Config{MinVersion: minVer}
 
 	// TLS 1.3 cipher suites are not configurable in Go (golang/go#29349).
-	// Only set CipherSuites for TLS 1.2 and below.
-	if minVer < tls.VersionTLS13 {
+	// Only set CipherSuites for TLS 1.2 and below when the profile lists ciphers.
+	// Leave CipherSuites nil when omitted so Go uses its safe defaults.
+	if minVer < tls.VersionTLS13 && len(spec.Ciphers) > 0 {
 		suites := mapCipherSuites(spec.Ciphers)
-		if len(suites) == 0 && len(spec.Ciphers) > 0 {
+		if len(suites) == 0 {
 			return nil, fmt.Errorf(
 				"no valid cipher suites found for TLS profile (all %d cipher(s) unsupported by Go)",
 				len(spec.Ciphers),
@@ -89,8 +92,8 @@ func BuildTLSConfig(profile *configv1.TLSSecurityProfile) (*tls.Config, error) {
 	return cfg, nil
 }
 
-// BuildTLSConfigFunc returns a function that can be used to configure tls.Config.
-// This is useful for controller-runtime's metricsserver.Options.TLSOpts.
+// BuildTLSConfigFunc returns a function that applies an OpenShift TLS security profile to tls.Config.
+// This is useful for controller-runtime metricsserver.Options.TLSOpts and webhook TLSOpts.
 func BuildTLSConfigFunc(profile *configv1.TLSSecurityProfile) (func(*tls.Config), error) {
 	spec, err := resolveSpec(profile)
 	if err != nil {
@@ -103,11 +106,11 @@ func BuildTLSConfigFunc(profile *configv1.TLSSecurityProfile) (func(*tls.Config)
 	}
 
 	// TLS 1.3 cipher suites are not configurable in Go, so validate cipher suites
-	// early for TLS < 1.3 to fail fast if the profile specifies unsupported ciphers
+	// early for TLS < 1.3 to fail fast if the profile specifies unsupported ciphers.
 	var suites []uint16
-	if minVer < tls.VersionTLS13 {
+	if minVer < tls.VersionTLS13 && len(spec.Ciphers) > 0 {
 		suites = mapCipherSuites(spec.Ciphers)
-		if len(suites) == 0 && len(spec.Ciphers) > 0 {
+		if len(suites) == 0 {
 			return nil, fmt.Errorf(
 				"no valid cipher suites found for TLS profile (all %d cipher(s) unsupported by Go)",
 				len(spec.Ciphers),
@@ -117,10 +120,9 @@ func BuildTLSConfigFunc(profile *configv1.TLSSecurityProfile) (func(*tls.Config)
 
 	return func(cfg *tls.Config) {
 		cfg.MinVersion = minVer
-		// Always set CipherSuites to ensure consistent behavior:
-		// - TLS < 1.3: use specific suites or nil for Go defaults
-		// - TLS >= 1.3: nil (cipher suites not configurable in Go)
-		cfg.CipherSuites = suites
+		if len(suites) > 0 {
+			cfg.CipherSuites = suites
+		}
 	}, nil
 }
 
@@ -170,10 +172,8 @@ func parseTLSVersion(v string) (uint16, error) {
 	return 0, fmt.Errorf("unknown TLS version: %s", v)
 }
 
-// mapCipherSuites converts OpenSSL-style cipher names (used in OpenShift TLS
-// profiles) to Go crypto/tls constants. Ciphers without a Go constant (e.g.
-// DHE-RSA-*, ECDHE-RSA-AES256-SHA384, AES256-SHA256) are silently skipped —
-// Go's crypto/tls does not support them.
+// mapCipherSuites converts OpenShift/OpenSSL cipher names to Go crypto/tls constants.
+// Ciphers without a Go constant are skipped because crypto/tls does not support them.
 func mapCipherSuites(names []string) []uint16 {
 	m := map[string]uint16{
 		"ECDHE-RSA-AES128-GCM-SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
@@ -207,6 +207,9 @@ func mapCipherSuites(names []string) []uint16 {
 
 // GetOpenShiftConfigClient creates a versioned config client for accessing OpenShift config resources.
 func GetOpenShiftConfigClient(restConfig *rest.Config) (configv1client.ConfigV1Interface, error) {
+	if restConfig == nil {
+		return nil, fmt.Errorf("rest config is nil")
+	}
 	configClient, err := configclientset.NewForConfig(restConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create config client: %w", err)
@@ -232,4 +235,47 @@ func FetchAPIServerTLSProfile(
 	}
 
 	return profile, nil
+}
+
+// TLS13OnlyConfigFunc returns a function that sets the minimum TLS version to 1.3.
+func TLS13OnlyConfigFunc() func(*tls.Config) {
+	return func(cfg *tls.Config) {
+		cfg.MinVersion = tls.VersionTLS13
+	}
+}
+
+// BuildMetricsTLSConfigFunc builds a TLS applier from the cluster APIServer profile.
+// When the profile cannot be fetched (config client or APIServer get failure), it returns
+// a TLS 1.3-only applier and an empty profile type. When the profile is fetched but
+// cannot be translated, it returns an error.
+func BuildMetricsTLSConfigFunc(
+	ctx context.Context,
+	restConfig *rest.Config,
+) (func(*tls.Config), configv1.TLSProfileType, error) {
+	configClient, err := GetOpenShiftConfigClient(restConfig)
+	if err != nil {
+		return TLS13OnlyConfigFunc(), "", nil
+	}
+	return buildTLSConfigFuncFromAPIServer(ctx, configClient)
+}
+
+func buildTLSConfigFuncFromAPIServer(
+	ctx context.Context,
+	configClient configv1client.ConfigV1Interface,
+) (func(*tls.Config), configv1.TLSProfileType, error) {
+	profile, err := FetchAPIServerTLSProfile(ctx, configClient)
+	if err != nil {
+		return TLS13OnlyConfigFunc(), "", nil
+	}
+	return buildTLSConfigFuncFromProfile(profile)
+}
+
+func buildTLSConfigFuncFromProfile(
+	profile *configv1.TLSSecurityProfile,
+) (func(*tls.Config), configv1.TLSProfileType, error) {
+	tlsConfigFunc, err := BuildTLSConfigFunc(profile)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to build TLS config from APIServer profile %q: %w", profile.Type, err)
+	}
+	return tlsConfigFunc, profile.Type, nil
 }

--- a/pkg/utils/tlsprofile_api_test.go
+++ b/pkg/utils/tlsprofile_api_test.go
@@ -1,0 +1,106 @@
+package utils
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+)
+
+func newTestAPIServerHTTPServer(t *testing.T, profileType configv1.TLSProfileType) *httptest.Server {
+	t.Helper()
+	apiserver := configv1.APIServer{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: configv1.SchemeGroupVersion.String(),
+			Kind:       "APIServer",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec: configv1.APIServerSpec{
+			TLSSecurityProfile: &configv1.TLSSecurityProfile{Type: profileType},
+		},
+	}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet ||
+			r.URL.Path != "/apis/config.openshift.io/v1/apiservers/cluster" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(apiserver); err != nil {
+			t.Errorf("failed to encode APIServer: %v", err)
+		}
+	}))
+}
+
+func testRestConfig(host string) *rest.Config {
+	return &rest.Config{
+		Host: host,
+		ContentConfig: rest.ContentConfig{
+			GroupVersion: &configv1.SchemeGroupVersion,
+		},
+	}
+}
+
+func TestGetTLSConfigFromAPIServer(t *testing.T) {
+	srv := newTestAPIServerHTTPServer(t, configv1.TLSProfileModernType)
+	defer srv.Close()
+
+	cfg, err := GetTLSConfigFromAPIServer(context.Background(), testRestConfig(srv.URL))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.MinVersion != tls.VersionTLS13 {
+		t.Fatalf("expected MinVersion TLS 1.3, got %d", cfg.MinVersion)
+	}
+}
+
+func TestGetOpenShiftConfigClientSuccess(t *testing.T) {
+	srv := newTestAPIServerHTTPServer(t, configv1.TLSProfileIntermediateType)
+	defer srv.Close()
+
+	client, err := GetOpenShiftConfigClient(testRestConfig(srv.URL))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	profile, err := FetchAPIServerTLSProfile(context.Background(), client.APIServers())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if profile.Type != configv1.TLSProfileIntermediateType {
+		t.Fatalf("expected Intermediate profile, got %q", profile.Type)
+	}
+}
+
+func TestBuildMetricsTLSConfigFuncWithAPIServer(t *testing.T) {
+	srv := newTestAPIServerHTTPServer(t, configv1.TLSProfileIntermediateType)
+	defer srv.Close()
+
+	tlsConfigFunc, profileType, err := BuildMetricsTLSConfigFunc(
+		context.Background(),
+		testRestConfig(srv.URL),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if profileType != configv1.TLSProfileIntermediateType {
+		t.Fatalf("expected Intermediate profile, got %q", profileType)
+	}
+	cfg := &tls.Config{}
+	tlsConfigFunc(cfg)
+	if cfg.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("expected MinVersion TLS 1.2, got %d", cfg.MinVersion)
+	}
+}
+
+func TestGetTLSConfigFromAPIServerInvalidHost(t *testing.T) {
+	_, err := GetTLSConfigFromAPIServer(context.Background(), &rest.Config{Host: "://invalid-host"})
+	if err == nil {
+		t.Fatal("expected error for invalid rest config host")
+	}
+}

--- a/pkg/utils/tlsprofile_test.go
+++ b/pkg/utils/tlsprofile_test.go
@@ -1,0 +1,484 @@
+package utils
+
+import (
+	"crypto/tls"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+const (
+	testCipherECDHERSAAES128 = "ECDHE-RSA-AES128-GCM-SHA256"
+	testCipherUnsupported    = "UNSUPPORTED-CIPHER"
+	testProfileTypeOld       = "Old profile type"
+	testErrExpectedError     = "expected error but got none"
+	testErrUnexpected        = "unexpected error: %v"
+)
+
+// TestGetTLSConfigFromAPIServer, GetTLSConfigFromClient, GetOpenShiftConfigClient,
+// and FetchAPIServerTLSProfile require real Kubernetes clients and are tested in integration tests.
+
+func TestResolveSpec(t *testing.T) {
+	tests := []struct {
+		name        string
+		profile     *configv1.TLSSecurityProfile
+		expectError bool
+		expectType  configv1.TLSProfileType
+	}{
+		{
+			name:        "nil profile defaults to Intermediate",
+			profile:     nil,
+			expectError: false,
+			expectType:  configv1.TLSProfileIntermediateType,
+		},
+		{
+			name: testProfileTypeOld,
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileOldType,
+			},
+			expectError: false,
+			expectType:  configv1.TLSProfileOldType,
+		},
+		{
+			name: "Intermediate profile type",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileIntermediateType,
+			},
+			expectError: false,
+			expectType:  configv1.TLSProfileIntermediateType,
+		},
+		{
+			name: "Modern profile type",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			},
+			expectError: false,
+			expectType:  configv1.TLSProfileModernType,
+		},
+		{
+			name: "Custom profile with valid spec",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						Ciphers:       []string{testCipherECDHERSAAES128},
+						MinTLSVersion: configv1.VersionTLS12,
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "Custom profile with nil Custom field",
+			profile: &configv1.TLSSecurityProfile{
+				Type:   configv1.TLSProfileCustomType,
+				Custom: nil,
+			},
+			expectError: true,
+		},
+		{
+			name: "Unknown profile type",
+			profile: &configv1.TLSSecurityProfile{
+				Type: "UnknownType",
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec, err := resolveSpec(tt.profile)
+			if tt.expectError {
+				if err == nil {
+					t.Error(testErrExpectedError)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf(testErrUnexpected, err)
+				return
+			}
+			if spec == nil {
+				t.Errorf("expected spec but got nil")
+			}
+		})
+	}
+}
+
+func TestParseTLSVersion(t *testing.T) {
+	tests := []struct {
+		name        string
+		version     string
+		expected    uint16
+		expectError bool
+	}{
+		{
+			name:        "TLS 1.0",
+			version:     "VersionTLS10",
+			expected:    tls.VersionTLS10,
+			expectError: false,
+		},
+		{
+			name:        "TLS 1.1",
+			version:     "VersionTLS11",
+			expected:    tls.VersionTLS11,
+			expectError: false,
+		},
+		{
+			name:        "TLS 1.2",
+			version:     "VersionTLS12",
+			expected:    tls.VersionTLS12,
+			expectError: false,
+		},
+		{
+			name:        "TLS 1.3",
+			version:     "VersionTLS13",
+			expected:    tls.VersionTLS13,
+			expectError: false,
+		},
+		{
+			name:        "Unknown version",
+			version:     "VersionTLS99",
+			expectError: true,
+		},
+		{
+			name:        "Invalid format",
+			version:     "TLS1.2",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseTLSVersion(tt.version)
+			if tt.expectError {
+				if err == nil {
+					t.Error(testErrExpectedError)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf(testErrUnexpected, err)
+				return
+			}
+			if result != tt.expected {
+				t.Errorf("expected %d but got %d", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestMapCipherSuites(t *testing.T) {
+	tests := []struct {
+		name     string
+		ciphers  []string
+		expected int // expected number of valid cipher suites
+	}{
+		{
+			name:     "empty list",
+			ciphers:  []string{},
+			expected: 0,
+		},
+		{
+			name:     "all valid ciphers",
+			ciphers:  []string{testCipherECDHERSAAES128, "ECDHE-ECDSA-AES128-GCM-SHA256"},
+			expected: 2,
+		},
+		{
+			name:     "mixed valid and invalid",
+			ciphers:  []string{testCipherECDHERSAAES128, testCipherUnsupported},
+			expected: 1,
+		},
+		{
+			name:     "all unsupported",
+			ciphers:  []string{"DHE-RSA-AES256-SHA", testCipherUnsupported},
+			expected: 0,
+		},
+		{
+			name:     "TLS 1.3 ciphers (should be supported)",
+			ciphers:  []string{"ECDHE-RSA-CHACHA20-POLY1305", "ECDHE-ECDSA-CHACHA20-POLY1305"},
+			expected: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := mapCipherSuites(tt.ciphers)
+			if len(result) != tt.expected {
+				t.Errorf("expected %d cipher suites but got %d", tt.expected, len(result))
+			}
+		})
+	}
+}
+
+type tlsConfigTestCase struct {
+	name        string
+	profile     *configv1.TLSSecurityProfile
+	expectError bool
+	checkMinVer bool
+	expectedMin uint16
+}
+
+func getBuildTLSConfigTestCases() []tlsConfigTestCase {
+	return []tlsConfigTestCase{
+		{
+			name: "Intermediate profile",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileIntermediateType,
+			},
+			expectError: false,
+			checkMinVer: true,
+			expectedMin: tls.VersionTLS12,
+		},
+		{
+			name: "Modern profile",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			},
+			expectError: false,
+			checkMinVer: true,
+			expectedMin: tls.VersionTLS13,
+		},
+		{
+			name: "Custom profile with TLS 1.2",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						Ciphers:       []string{testCipherECDHERSAAES128},
+						MinTLSVersion: configv1.VersionTLS12,
+					},
+				},
+			},
+			expectError: false,
+			checkMinVer: true,
+			expectedMin: tls.VersionTLS12,
+		},
+		{
+			name: "Custom profile with all unsupported ciphers",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						Ciphers:       []string{"UNSUPPORTED-CIPHER-1", "UNSUPPORTED-CIPHER-2"},
+						MinTLSVersion: configv1.VersionTLS12,
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name:        "nil profile defaults to Intermediate",
+			profile:     nil,
+			expectError: false,
+			checkMinVer: true,
+			expectedMin: tls.VersionTLS12,
+		},
+		{
+			name: "Custom profile with empty ciphers uses Go defaults",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						Ciphers:       []string{},
+						MinTLSVersion: configv1.VersionTLS12,
+					},
+				},
+			},
+			expectError: false,
+			checkMinVer: true,
+			expectedMin: tls.VersionTLS12,
+		},
+		{
+			name: "Invalid TLS version",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						Ciphers:       []string{testCipherECDHERSAAES128},
+						MinTLSVersion: "BadVersion",
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "Old profile type",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileOldType,
+			},
+			expectError: false,
+			checkMinVer: true,
+			expectedMin: tls.VersionTLS10,
+		},
+		{
+			name: "TLS 1.3 with cipher list (ciphers not set)",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						Ciphers:       []string{"ANY-CIPHER"},
+						MinTLSVersion: configv1.VersionTLS13,
+					},
+				},
+			},
+			expectError: false,
+			checkMinVer: true,
+			expectedMin: tls.VersionTLS13,
+		},
+	}
+}
+
+func TestBuildTLSConfig(t *testing.T) {
+	tests := getBuildTLSConfigTestCases()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := BuildTLSConfig(tt.profile)
+			if tt.expectError {
+				if err == nil {
+					t.Error(testErrExpectedError)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf(testErrUnexpected, err)
+				return
+			}
+			if cfg == nil {
+				t.Errorf("expected tls.Config but got nil")
+				return
+			}
+			if tt.checkMinVer && cfg.MinVersion != tt.expectedMin {
+				t.Errorf("expected MinVersion %d but got %d", tt.expectedMin, cfg.MinVersion)
+			}
+		})
+	}
+}
+
+func getBuildTLSConfigFuncTestCases() []tlsConfigTestCase {
+	return []tlsConfigTestCase{
+		{
+			name: "Intermediate profile",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileIntermediateType,
+			},
+			expectError: false,
+			checkMinVer: true,
+			expectedMin: tls.VersionTLS12,
+		},
+		{
+			name: "Modern profile",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			},
+			expectError: false,
+			checkMinVer: true,
+			expectedMin: tls.VersionTLS13,
+		},
+		{
+			name: "Custom profile with unsupported ciphers for TLS 1.2",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						Ciphers:       []string{"UNSUPPORTED-1", "UNSUPPORTED-2"},
+						MinTLSVersion: configv1.VersionTLS12,
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "TLS 1.3 profile with cipher list (should succeed, ciphers ignored)",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						Ciphers:       []string{testCipherUnsupported},
+						MinTLSVersion: configv1.VersionTLS13,
+					},
+				},
+			},
+			expectError: false,
+			checkMinVer: true,
+			expectedMin: tls.VersionTLS13,
+		},
+		{
+			name:        "nil profile",
+			profile:     nil,
+			expectError: false,
+			checkMinVer: true,
+			expectedMin: tls.VersionTLS12,
+		},
+		{
+			name: "Invalid TLS version in profile",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						Ciphers:       []string{testCipherECDHERSAAES128},
+						MinTLSVersion: "InvalidVersion",
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "TLS 1.2 with empty cipher list",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						Ciphers:       []string{},
+						MinTLSVersion: configv1.VersionTLS12,
+					},
+				},
+			},
+			expectError: false,
+			checkMinVer: true,
+			expectedMin: tls.VersionTLS12,
+		},
+		{
+			name: "Old profile type",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileOldType,
+			},
+			expectError: false,
+			checkMinVer: true,
+			expectedMin: tls.VersionTLS10,
+		},
+	}
+}
+
+func TestBuildTLSConfigFunc(t *testing.T) {
+	tests := getBuildTLSConfigFuncTestCases()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configFunc, err := BuildTLSConfigFunc(tt.profile)
+			if tt.expectError {
+				if err == nil {
+					t.Error(testErrExpectedError)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf(testErrUnexpected, err)
+				return
+			}
+			if configFunc == nil {
+				t.Errorf("expected config function but got nil")
+				return
+			}
+
+			// Apply the function to a new tls.Config
+			cfg := &tls.Config{}
+			configFunc(cfg)
+
+			if tt.checkMinVer && cfg.MinVersion != tt.expectedMin {
+				t.Errorf("expected MinVersion %d but got %d", tt.expectedMin, cfg.MinVersion)
+			}
+		})
+	}
+}

--- a/pkg/utils/tlsprofile_test.go
+++ b/pkg/utils/tlsprofile_test.go
@@ -3,9 +3,14 @@ package utils
 import (
 	"context"
 	"crypto/tls"
+	"errors"
+	"strings"
 	"testing"
 
 	configv1 "github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 const (
@@ -16,8 +21,26 @@ const (
 	testErrUnexpected        = "unexpected error: %v"
 )
 
-// TestGetTLSConfigFromAPIServer, GetTLSConfigFromClient, GetOpenShiftConfigClient,
-// and FetchAPIServerTLSProfile require real Kubernetes clients and are tested in integration tests.
+// stubAPIServerGetter implements apiserverGetter for unit tests.
+type stubAPIServerGetter struct {
+	apiserver *configv1.APIServer
+	err       error
+}
+
+func (s *stubAPIServerGetter) Get(
+	_ context.Context, name string, _ metav1.GetOptions,
+) (*configv1.APIServer, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	if s.apiserver == nil {
+		return &configv1.APIServer{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec:       configv1.APIServerSpec{},
+		}, nil
+	}
+	return s.apiserver, nil
+}
 
 func TestResolveSpec(t *testing.T) {
 	tests := []struct {
@@ -558,3 +581,115 @@ func TestBuildMetricsTLSConfigFuncFallback(t *testing.T) {
 		t.Fatalf("expected MinVersion TLS 1.3, got %d", cfg.MinVersion)
 	}
 }
+
+func TestFetchAPIServerTLSProfileDefaultsToIntermediate(t *testing.T) {
+	getter := &stubAPIServerGetter{
+		apiserver: &configv1.APIServer{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+			Spec:       configv1.APIServerSpec{TLSSecurityProfile: nil},
+		},
+	}
+	profile, err := FetchAPIServerTLSProfile(context.Background(), getter)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if profile.Type != configv1.TLSProfileIntermediateType {
+		t.Fatalf("expected Intermediate profile, got %q", profile.Type)
+	}
+}
+
+func TestFetchAPIServerTLSProfileGetError(t *testing.T) {
+	getter := &stubAPIServerGetter{err: errors.New("apiserver unavailable")}
+	_, err := FetchAPIServerTLSProfile(context.Background(), getter)
+	if err == nil {
+		t.Fatal("expected error when APIServer get fails")
+	}
+	if !strings.Contains(err.Error(), "failed to get APIServer config") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBuildTLSConfigFuncFromAPIServerFetchFallback(t *testing.T) {
+	getter := &stubAPIServerGetter{err: errors.New("apiserver unavailable")}
+	tlsConfigFunc, profileType, err := buildTLSConfigFuncFromAPIServer(context.Background(), getter)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if profileType != "" {
+		t.Fatalf("expected empty profile type on fallback, got %q", profileType)
+	}
+	cfg := &tls.Config{}
+	tlsConfigFunc(cfg)
+	if cfg.MinVersion != tls.VersionTLS13 {
+		t.Fatalf("expected MinVersion TLS 1.3, got %d", cfg.MinVersion)
+	}
+}
+
+func TestGetOpenShiftConfigClientNilRestConfig(t *testing.T) {
+	_, err := GetOpenShiftConfigClient(nil)
+	if err == nil {
+		t.Fatal("expected error for nil rest config")
+	}
+	if !strings.Contains(err.Error(), "rest config is nil") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetTLSConfigFromClient(t *testing.T) {
+	apiserver := &configv1.APIServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec: configv1.APIServerSpec{
+			TLSSecurityProfile: &configv1.TLSSecurityProfile{Type: configv1.TLSProfileModernType},
+		},
+	}
+	scheme := runtime.NewScheme()
+	if err := configv1.Install(scheme); err != nil {
+		t.Fatalf("failed to install config scheme: %v", err)
+	}
+	c := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(apiserver).Build()
+
+	cfg, err := GetTLSConfigFromClient(context.Background(), c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.MinVersion != tls.VersionTLS13 {
+		t.Fatalf("expected MinVersion TLS 1.3, got %d", cfg.MinVersion)
+	}
+}
+
+func TestGetTLSConfigFromClientMissingAPIServer(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := configv1.Install(scheme); err != nil {
+		t.Fatalf("failed to install config scheme: %v", err)
+	}
+	c := fakeclient.NewClientBuilder().WithScheme(scheme).Build()
+
+	_, err := GetTLSConfigFromClient(context.Background(), c)
+	if err == nil {
+		t.Fatal("expected error when APIServer is missing")
+	}
+	if !strings.Contains(err.Error(), "failed to get APIServer config") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBuildTLSConfigCustomProfileSetsCipherSuites(t *testing.T) {
+	profile := &configv1.TLSSecurityProfile{
+		Type: configv1.TLSProfileCustomType,
+		Custom: &configv1.CustomTLSProfile{
+			TLSProfileSpec: configv1.TLSProfileSpec{
+				Ciphers:       []string{testCipherECDHERSAAES128},
+				MinTLSVersion: configv1.VersionTLS12,
+			},
+		},
+	}
+	cfg, err := BuildTLSConfig(profile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.CipherSuites) == 0 {
+		t.Fatal("expected non-empty CipherSuites")
+	}
+}
+
+var _ apiserverGetter = (*stubAPIServerGetter)(nil)

--- a/pkg/utils/tlsprofile_test.go
+++ b/pkg/utils/tlsprofile_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"crypto/tls"
 	"testing"
 
@@ -100,6 +101,13 @@ func TestResolveSpec(t *testing.T) {
 			}
 			if spec == nil {
 				t.Errorf("expected spec but got nil")
+				return
+			}
+			if tt.expectType != "" {
+				expected := configv1.TLSProfiles[tt.expectType]
+				if spec.MinTLSVersion != expected.MinTLSVersion {
+					t.Fatalf("expected MinTLSVersion %q, got %q", expected.MinTLSVersion, spec.MinTLSVersion)
+				}
 			}
 		})
 	}
@@ -212,11 +220,13 @@ func TestMapCipherSuites(t *testing.T) {
 }
 
 type tlsConfigTestCase struct {
-	name        string
-	profile     *configv1.TLSSecurityProfile
-	expectError bool
-	checkMinVer bool
-	expectedMin uint16
+	name              string
+	profile           *configv1.TLSSecurityProfile
+	expectError       bool
+	checkMinVer       bool
+	expectedMin       uint16
+	checkCipherNil    bool
+	checkCipherNonNil bool
 }
 
 func getBuildTLSConfigTestCases() []tlsConfigTestCase {
@@ -285,9 +295,10 @@ func getBuildTLSConfigTestCases() []tlsConfigTestCase {
 					},
 				},
 			},
-			expectError: false,
-			checkMinVer: true,
-			expectedMin: tls.VersionTLS12,
+			expectError:    false,
+			checkMinVer:    true,
+			expectedMin:    tls.VersionTLS12,
+			checkCipherNil: true,
 		},
 		{
 			name: "Invalid TLS version",
@@ -351,6 +362,12 @@ func TestBuildTLSConfig(t *testing.T) {
 			}
 			if tt.checkMinVer && cfg.MinVersion != tt.expectedMin {
 				t.Errorf("expected MinVersion %d but got %d", tt.expectedMin, cfg.MinVersion)
+			}
+			if tt.checkCipherNil && cfg.CipherSuites != nil {
+				t.Errorf("expected nil CipherSuites for Go defaults, got %v", cfg.CipherSuites)
+			}
+			if tt.checkCipherNonNil && len(cfg.CipherSuites) == 0 {
+				t.Error("expected non-empty CipherSuites")
 			}
 		})
 	}
@@ -435,9 +452,10 @@ func getBuildTLSConfigFuncTestCases() []tlsConfigTestCase {
 					},
 				},
 			},
-			expectError: false,
-			checkMinVer: true,
-			expectedMin: tls.VersionTLS12,
+			expectError:    false,
+			checkMinVer:    true,
+			expectedMin:    tls.VersionTLS12,
+			checkCipherNil: true,
 		},
 		{
 			name: "Old profile type",
@@ -479,6 +497,64 @@ func TestBuildTLSConfigFunc(t *testing.T) {
 			if tt.checkMinVer && cfg.MinVersion != tt.expectedMin {
 				t.Errorf("expected MinVersion %d but got %d", tt.expectedMin, cfg.MinVersion)
 			}
+			if tt.checkCipherNil && cfg.CipherSuites != nil {
+				t.Errorf("expected nil CipherSuites for Go defaults, got %v", cfg.CipherSuites)
+			}
 		})
+	}
+}
+
+func TestTLS13OnlyConfigFunc(t *testing.T) {
+	cfg := &tls.Config{}
+	TLS13OnlyConfigFunc()(cfg)
+	if cfg.MinVersion != tls.VersionTLS13 {
+		t.Fatalf("expected MinVersion TLS 1.3, got %d", cfg.MinVersion)
+	}
+}
+
+func TestBuildTLSConfigFuncFromProfile(t *testing.T) {
+	profile := &configv1.TLSSecurityProfile{Type: configv1.TLSProfileIntermediateType}
+	tlsConfigFunc, profileType, err := buildTLSConfigFuncFromProfile(profile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if profileType != configv1.TLSProfileIntermediateType {
+		t.Fatalf("expected profile type %q, got %q", configv1.TLSProfileIntermediateType, profileType)
+	}
+	cfg := &tls.Config{}
+	tlsConfigFunc(cfg)
+	if cfg.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("expected MinVersion TLS 1.2, got %d", cfg.MinVersion)
+	}
+}
+
+func TestBuildTLSConfigFuncFromProfileUnsupportedCiphers(t *testing.T) {
+	profile := &configv1.TLSSecurityProfile{
+		Type: configv1.TLSProfileCustomType,
+		Custom: &configv1.CustomTLSProfile{
+			TLSProfileSpec: configv1.TLSProfileSpec{
+				Ciphers:       []string{"UNSUPPORTED-CIPHER"},
+				MinTLSVersion: configv1.VersionTLS12,
+			},
+		},
+	}
+	_, _, err := buildTLSConfigFuncFromProfile(profile)
+	if err == nil {
+		t.Fatal("expected error for unsupported cipher profile")
+	}
+}
+
+func TestBuildMetricsTLSConfigFuncFallback(t *testing.T) {
+	tlsConfigFunc, profileType, err := BuildMetricsTLSConfigFunc(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if profileType != "" {
+		t.Fatalf("expected empty profile type on fallback, got %q", profileType)
+	}
+	cfg := &tls.Config{}
+	tlsConfigFunc(cfg)
+	if cfg.MinVersion != tls.VersionTLS13 {
+		t.Fatalf("expected MinVersion TLS 1.3, got %d", cfg.MinVersion)
 	}
 }

--- a/pkg/utils/tlsprofile_test.go
+++ b/pkg/utils/tlsprofile_test.go
@@ -657,6 +657,26 @@ func TestGetTLSConfigFromClient(t *testing.T) {
 	}
 }
 
+func TestGetTLSConfigFromClientNilProfileDefaultsIntermediate(t *testing.T) {
+	apiserver := &configv1.APIServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec:       configv1.APIServerSpec{TLSSecurityProfile: nil},
+	}
+	scheme := runtime.NewScheme()
+	if err := configv1.Install(scheme); err != nil {
+		t.Fatalf("failed to install config scheme: %v", err)
+	}
+	c := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(apiserver).Build()
+
+	cfg, err := GetTLSConfigFromClient(context.Background(), c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("expected MinVersion TLS 1.2, got %d", cfg.MinVersion)
+	}
+}
+
 func TestGetTLSConfigFromClientMissingAPIServer(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := configv1.Install(scheme); err != nil {

--- a/samples/config/sarama_config.go
+++ b/samples/config/sarama_config.go
@@ -27,8 +27,9 @@ func GetSaramaConfig() (string, *sarama.Config, error) {
 	bootstrapSever := kafkaSecret.Data["bootstrap_server"]
 	caCrt := kafkaSecret.Data["ca.crt"]
 
-	// #nosec G402
-	tlsConfig := &tls.Config{}
+	tlsConfig := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
 
 	// Load CA cert
 	caCertPool := x509.NewCertPool()
@@ -80,8 +81,9 @@ func GetSaramaConfigFromKafkaUser() (string, *sarama.Config, error) {
 		return "", nil, fmt.Errorf("failed to get runtime client")
 	}
 
-	// #nosec G402
-	tlsConfig := &tls.Config{}
+	tlsConfig := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
 
 	kafkaCluster := &kafkav1beta2.Kafka{}
 	err = c.Get(context.TODO(), types.NamespacedName{
@@ -162,8 +164,9 @@ func GetSaramaConfigByClient(namespace string, c client.Client) (string, *sarama
 		return "", nil, err
 	}
 
-	// #nosec G402
-	tlsConfig := &tls.Config{}
+	tlsConfig := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
 
 	// Load CA cert
 	caCertPool := x509.NewCertPool()

--- a/test/integration/agent/spec/hubstatus_syncer_test.go
+++ b/test/integration/agent/spec/hubstatus_syncer_test.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -15,6 +16,34 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
+
+func waitForManagedClusters(names ...string) {
+	Eventually(func() error {
+		for _, name := range names {
+			mc := &clusterv1.ManagedCluster{}
+			if err := runtimeClient.Get(ctx, client.ObjectKey{Name: name}, mc); err != nil {
+				return err
+			}
+		}
+		return nil
+	}, 5*time.Second, 50*time.Millisecond).Should(Succeed())
+}
+
+func waitForManagedClustersDeleted(names ...string) {
+	Eventually(func() error {
+		for _, name := range names {
+			mc := &clusterv1.ManagedCluster{}
+			err := runtimeClient.Get(ctx, client.ObjectKey{Name: name}, mc)
+			if err == nil {
+				return fmt.Errorf("managed cluster %s still exists", name)
+			}
+			if !errors.IsNotFound(err) {
+				return err
+			}
+		}
+		return nil
+	}, 5*time.Second, 50*time.Millisecond).Should(Succeed())
+}
 
 var _ = Describe("HubStatusSyncer", func() {
 	var (
@@ -55,30 +84,32 @@ var _ = Describe("HubStatusSyncer", func() {
 			},
 		}
 		Expect(runtimeClient.Create(ctx, cluster3)).To(Succeed())
+		waitForManagedClusters(cluster1Name, cluster2Name, cluster3Name)
 	})
 
 	AfterEach(func() {
-		// Clean up test ManagedClusters
+		// Clean up test ManagedClusters and wait for deletion so the next spec gets fresh objects in cache.
 		cluster1 := &clusterv1.ManagedCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: cluster1Name,
 			},
 		}
-		_ = runtimeClient.Delete(ctx, cluster1)
+		Expect(runtimeClient.Delete(ctx, cluster1)).To(Succeed())
 
 		cluster2 := &clusterv1.ManagedCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: cluster2Name,
 			},
 		}
-		_ = runtimeClient.Delete(ctx, cluster2)
+		Expect(runtimeClient.Delete(ctx, cluster2)).To(Succeed())
 
 		cluster3 := &clusterv1.ManagedCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: cluster3Name,
 			},
 		}
-		_ = runtimeClient.Delete(ctx, cluster3)
+		Expect(runtimeClient.Delete(ctx, cluster3)).To(Succeed())
+		waitForManagedClustersDeleted(cluster1Name, cluster2Name, cluster3Name)
 	})
 
 	It("should update hubAcceptsClient when active hub goes inactive (failover)", func() {
@@ -217,6 +248,11 @@ var _ = Describe("HubStatusSyncer", func() {
 	})
 
 	It("should handle multiple clusters in one message", func() {
+		// Confirm initial state before sending the event (cluster2 must start false).
+		mc2 := &clusterv1.ManagedCluster{}
+		Expect(runtimeClient.Get(ctx, client.ObjectKey{Name: cluster2Name}, mc2)).To(Succeed())
+		Expect(mc2.Spec.HubAcceptsClient).To(BeFalse())
+
 		// Send hub status update for all three clusters
 		update := hubha.HubStatusUpdate{
 			HubName:         activeHub,

--- a/test/integration/operator/controllers/storage_test.go
+++ b/test/integration/operator/controllers/storage_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	postgresv1beta1 "github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
@@ -290,7 +291,22 @@ var _ = Describe("storage", Ordered, func() {
 				"postgresql.conf": "wal_level = logical\nmax_wal_size = 2GB\n",
 			},
 		}
-		Expect(runtimeClient.Create(ctx, cm)).To(Succeed())
+		// Use the manager client so the reconciler cache sees the custom config before reconcile runs.
+		managerClient := runtimeManager.GetClient()
+		Expect(managerClient.Create(ctx, cm)).To(Succeed())
+		Eventually(func() error {
+			got := &corev1.ConfigMap{}
+			if err := managerClient.Get(ctx, types.NamespacedName{
+				Namespace: namespace,
+				Name:      storage.BuiltinPostgresCustomizedConfigName,
+			}, got); err != nil {
+				return err
+			}
+			if !strings.Contains(got.Data["postgresql.conf"], "max_wal_size = 2GB") {
+				return fmt.Errorf("custom postgres config not visible in manager cache yet")
+			}
+			return nil
+		}, 5*time.Second, 50*time.Millisecond).ShouldNot(HaveOccurred())
 
 		storageReconciler := storage.NewStorageReconciler(runtimeManager, true)
 
@@ -314,12 +330,20 @@ var _ = Describe("storage", Ordered, func() {
 			return nil
 		}, 10*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
 
-		// verify the customized configuration
-		cm = &corev1.ConfigMap{}
-		err = runtimeClient.Get(ctx, types.NamespacedName{Namespace: mgh.Namespace, Name: "multicluster-global-hub-postgresql-config"}, cm)
-		Expect(err).To(Succeed())
-		Expect(cm.Data["postgresql.conf"]).To(ContainSubstring("max_wal_size = 2GB"))
-		utils.PrettyPrint(cm.Data["postgresql.conf"])
+		// verify the customized configuration is merged into the rendered configmap
+		Eventually(func() error {
+			got := &corev1.ConfigMap{}
+			if err := runtimeClient.Get(ctx, types.NamespacedName{
+				Namespace: mgh.Namespace,
+				Name:      "multicluster-global-hub-postgresql-config",
+			}, got); err != nil {
+				return err
+			}
+			if !strings.Contains(got.Data["postgresql.conf"], "max_wal_size = 2GB") {
+				return fmt.Errorf("postgresql.conf missing customized max_wal_size: %q", got.Data["postgresql.conf"])
+			}
+			return nil
+		}, 10*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
 
 		// cleanup
 		Eventually(func() error {


### PR DESCRIPTION
## Summary

**JIRA Issue:** [ACM-30175](https://redhat.atlassian.net/browse/ACM-30175)
**Epic:** [ACM-26882](https://redhat.atlassian.net/browse/ACM-26882) — Central TLS Profile consistency
**Related:** [ACM-30826](https://redhat.atlassian.net/browse/ACM-30826) — Global hub 5.0
**Also addresses:** [ACM-34112](https://redhat.atlassian.net/browse/ACM-34112) — Weakness: use of `InsecureSkipVerify` in multicluster globalhub (GH 5.0 / `main`)

Implements OpenShift cluster-wide TLS security profile integration for Global Hub. Components now fetch TLS policy from the APIServer resource instead of using hardcoded local settings.

Supersedes [#2384](https://github.com/stolostron/multicluster-global-hub/pull/2384) (stalled on CI/review).

### Changes

- Add `pkg/utils/tlsprofile.go` utilities to resolve OpenShift TLS profiles (Old, Intermediate, Modern, Custom) into `tls.Config`
- Wire operator webhook, agent metrics, and manager metrics servers to cluster APIServer TLS profile (TLS 1.3 fallback on fetch failure)
- Remove `InsecureSkipVerify` from Postgres (`pkg/database/pgx_conn.go`) and Kafka (`pkg/transport/config/saram_config.go`) production paths
- Add RBAC to read `apiservers.config.openshift.io` for operator, manager, agent, and local agent
- Regenerate operator bundle CSV with updated RBAC permissions
- Add unit tests for TLS profile resolution and config building

### Security improvements

- Certificate validation enforced for database and Kafka connections
- Components honor cluster-wide OpenShift TLS security profiles
- Improved error handling for malformed CA PEM and unsupported cipher suites

### ACM-34112 context (GH 5.0 only)

[ACM-34112](https://redhat.atlassian.net/browse/ACM-34112) was filed from an ACM-14869 validation sweep (`InsecureSkipVerify: true` search across stolostron). On **`main` (GH 5.0)** the finding is valid in production code:

| File | Impact |
|------|--------|
| `pkg/database/pgx_conn.go` | Operator pgx Postgres client — `InsecureSkipVerify` accepts any server cert, so the mounted CA is effectively ignored |
| `pkg/transport/config/saram_config.go` | Kafka client — skips verification when client cert/key are missing |

**In active use on 5.0:** operator storage reconcilers call `PostgresConnection` / `PostgresDBConn` with `sslmode=verify-ca` and the cluster CA from `postgres-cert` secrets. `InsecureSkipVerify` undermines that TLS mode.

**Not the same path as the manager DB client:** manager uses GORM + `lib/pq` via `gorm_conn.go` (`sslrootcert` in the URI). That path does **not** go through `pgx_conn.go`.

**Out of scope for this PR / ACM-34112:**
- `test/e2e/*` — test-only
- `operator/config/prometheus/monitor.yaml` — ServiceMonitor scrape TLS (separate concern)
- `samples/*` — dev samples

This PR is the intended remediation for ACM-34112 on GH 5.0 — no separate fix PR needed. After merge to `main`, ACM-34112 can be resolved as fixed-in-5.0.

## Test plan

- [x] `go test ./pkg/utils/...` passes
- [x] CI: format, verify bundle, sonarcloud, e2e
- [ ] Functional testing with Old / Intermediate / Modern / Custom APIServer TLS profiles
- [ ] tls-scanner re-scan per ACM-30175 acceptance criteria

[ACM-30175]: https://redhat.atlassian.net/browse/ACM-30175
[ACM-26882]: https://redhat.atlassian.net/browse/ACM-26882
[ACM-30826]: https://redhat.atlassian.net/browse/ACM-30826
[ACM-34112]: https://redhat.atlassian.net/browse/ACM-34112

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metrics, webhooks and agents can derive TLS settings from the cluster API server TLS profile.

* **Security**
  * Enforced minimum TLS versions (TLS 1.2+/TLS 1.3 where applicable) across metrics, webhooks, Kafka/Sarama, DB and external clients.
  * Stricter certificate/CA validation and preservation of existing TLS fields when updating roots.
  * RBAC expanded to allow reading the cluster API server TLS profile (apiservers).

* **Documentation**
  * Clarified TLS compatibility notes for external service clients.

* **Tests**
  * Added extensive tests covering TLS profiles, DB TLS handling, Sarama, clients and failure modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->