### PR TITLE
fix: retry hub status sync when ManagedCluster not found yet

### DIFF
--- a/agent/pkg/spec/hubstatus/hub_status_syncer.go
+++ b/agent/pkg/spec/hubstatus/hub_status_syncer.go
@@ -91,23 +91,32 @@ func (s *HubStatusSyncer) Sync(ctx context.Context, evt *cloudevents.Event) erro
 func (s *HubStatusSyncer) updateManagedClusterHubAcceptsClient(ctx context.Context, clusterName string,
 	hubAcceptsClient bool,
 ) error {
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		// Get the ManagedCluster
-		managedCluster := &clusterv1.ManagedCluster{}
-		if err := s.client.Get(ctx, client.ObjectKey{Name: clusterName}, managedCluster); err != nil {
-			if errors.IsNotFound(err) {
-				log.Debugw("ManagedCluster not found, skipping update", "cluster", clusterName)
-				return nil
-			}
-			return fmt.Errorf("failed to get ManagedCluster: %w", err)
+	// First, try to get the cluster without retry to check if it exists
+	managedCluster := &clusterv1.ManagedCluster{}
+	if err := s.client.Get(ctx, client.ObjectKey{Name: clusterName}, managedCluster); err != nil {
+		if errors.IsNotFound(err) {
+			// Return NotFound error - this will cause Sync() to return error
+			// triggering message-level retry with proper backoff, giving cache time to sync
+			log.Debugw("ManagedCluster not found, will retry message later",
+				"cluster", clusterName)
+			return fmt.Errorf("ManagedCluster not found (may be cache sync delay): %s", clusterName)
 		}
+		return fmt.Errorf("failed to get ManagedCluster: %w", err)
+	}
 
-		// Check if update is needed
-		if managedCluster.Spec.HubAcceptsClient == hubAcceptsClient {
-			log.Debugw("ManagedCluster hubAcceptsClient already set to desired value",
-				"cluster", clusterName,
-				"hubAcceptsClient", hubAcceptsClient)
-			return nil
+	// Check if update is needed
+	if managedCluster.Spec.HubAcceptsClient == hubAcceptsClient {
+		log.Debugw("ManagedCluster hubAcceptsClient already set to desired value",
+			"cluster", clusterName,
+			"hubAcceptsClient", hubAcceptsClient)
+		return nil
+	}
+
+	// Use retry for update conflicts only
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		// Re-get the latest version before update
+		if err := s.client.Get(ctx, client.ObjectKey{Name: clusterName}, managedCluster); err != nil {
+			return fmt.Errorf("failed to get ManagedCluster: %w", err)
 		}
 
 		// Set hubAcceptsClient
@@ -118,12 +127,15 @@ func (s *HubStatusSyncer) updateManagedClusterHubAcceptsClient(ctx context.Conte
 			return fmt.Errorf("failed to update ManagedCluster: %w", err)
 		}
 
-		log.Infow("updated ManagedCluster hubAcceptsClient",
-			"cluster", clusterName,
-			"hubAcceptsClient", hubAcceptsClient)
-
 		return nil
 	})
+	if err != nil {
+		return err
+	}
 
-	return err
+	log.Infow("updated ManagedCluster hubAcceptsClient",
+		"cluster", clusterName,
+		"hubAcceptsClient", hubAcceptsClient)
+
+	return nil
 }

--- a/agent/pkg/spec/hubstatus/hub_status_syncer_test.go
+++ b/agent/pkg/spec/hubstatus/hub_status_syncer_test.go
@@ -172,9 +172,11 @@ func TestHubStatusSyncer_Sync_ClusterNotFound(t *testing.T) {
 	err := evt.SetData(cloudevents.ApplicationJSON, payload)
 	assert.NoError(t, err)
 
-	// Sync should not error even if cluster doesn't exist (it's logged and skipped)
+	// Sync should return error so the message is retried (cache sync delay)
 	err = syncer.Sync(context.TODO(), &evt)
-	assert.NoError(t, err)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "nonexistent-cluster")
+	assert.Contains(t, err.Error(), "not found")
 }
 
 func TestHubStatusSyncer_Sync_NoUpdateNeeded(t *testing.T) {
@@ -265,11 +267,12 @@ func TestHubStatusSyncer_Sync_PartialFailure(t *testing.T) {
 	err := evt.SetData(cloudevents.ApplicationJSON, payload)
 	assert.NoError(t, err)
 
-	// Sync should succeed - NotFound errors are ignored
+	// Sync should return error for missing cluster2, triggering message retry
 	err = syncer.Sync(context.TODO(), &evt)
-	assert.NoError(t, err)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cluster2")
 
-	// Verify cluster1 was updated
+	// cluster1 should still have been updated before the aggregate error is returned
 	result := &clusterv1.ManagedCluster{}
 	err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: "cluster1"}, result)
 	assert.NoError(t, err)

--- a/test/e2e/hubha_test.go
+++ b/test/e2e/hubha_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"

--- a/test/e2e/hubha_test.go
+++ b/test/e2e/hubha_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -25,7 +26,8 @@ import (
 const (
 	// With list-watch pattern + immediate send, changes are detected and sent immediately
 	// Wait time accounts for: controller event processing + Kafka transport + standby agent apply
-	hubHASyncWait = 10 * time.Second
+	hubHASyncWait       = 10 * time.Second
+	hubHAUpdateSyncWait = 2 * time.Minute // ManagedCluster updates can lag on loaded Prow e2e clusters
 )
 
 var _ = Describe("Hub HA Sync", Label("e2e-test-hubha"), Ordered, func() {
@@ -780,6 +782,10 @@ var _ = Describe("Hub HA Sync", Label("e2e-test-hubha"), Ordered, func() {
 					_ = standbyHubClient.Delete(ctx, &clusterv1.ManagedCluster{
 						ObjectMeta: metav1.ObjectMeta{Name: testClusterName},
 					})
+					Eventually(func() bool {
+						err := standbyHubClient.Get(ctx, types.NamespacedName{Name: testClusterName}, &clusterv1.ManagedCluster{})
+						return apierrors.IsNotFound(err)
+					}, hubHAUpdateSyncWait, 5*time.Second).Should(BeTrue())
 				}
 			})
 
@@ -1086,7 +1092,7 @@ var _ = Describe("Hub HA Sync", Label("e2e-test-hubha"), Ordered, func() {
 
 					klog.Infof("ManagedCluster %s update synced correctly with hubAcceptsClient=false maintained", testClusterName)
 					return nil
-				}, hubHASyncWait+30*time.Second, 5*time.Second).Should(Succeed())
+				}, hubHAUpdateSyncWait, 5*time.Second).Should(Succeed())
 			})
 		})
 	})


### PR DESCRIPTION
## Summary
Replacement for stale #2379 (rebased on current `main`).

Fixes hub HA failover race in `HubStatusSyncer.updateManagedClusterHubAcceptsClient`:

- When `ManagedCluster` is **NotFound** (cache sync delay), return an error so the message is retried instead of silently skipping
- Check desired `hubAcceptsClient` value before entering conflict-retry loop
- Only use `RetryOnConflict` for the actual update

## Related issue(s)

Fixes #2378

Supersedes #2379

## Tests
- [x] Existing integration coverage in `test/integration/agent/spec/hubstatus_syncer_test.go`
- [ ] `/ok-to-test`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Missing managed-cluster resources now surface errors to trigger retries instead of being silently skipped.
  * Retry scope narrowed to conflict retries so available clusters are updated reliably even when others are temporarily unavailable.

* **Tests**
  * Unit and e2e tests updated to expect error-on-missing-cluster behavior and to improve timing and cleanup checks for failover scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->