### PR TITLE
ACM-32308: docs: update VolSync backup copyMethod to Direct

### DIFF
--- a/doc/simulation/backup_restore/backup/volsync-config.yaml
+++ b/doc/simulation/backup_restore/backup/volsync-config.yaml
@@ -7,7 +7,7 @@ metadata:
    cluster.open-cluster-management.io/backup: cluster-activation
 data:
  cacheCapacity: 1Gi
- copyMethod: Snapshot
+ copyMethod: Direct
  pruneIntervalDays: '2'
  repository: restic-secret
  retain_daily: '2'


### PR DESCRIPTION
## Summary
- Replaces #2381 — same one-line doc fix (`copyMethod: Snapshot` → `Direct` in VolSync backup simulation config)

## Context
- **ACM-32308** / [policy-collection#544](https://github.com/open-cluster-management-io/policy-collection/pull/544) (merged) — Direct copy is the recommended DR backup approach
- #2381 had `lgtm`/`approved` but was on `/hold` until May 30; Konflux never went green on the stale branch (25 commits behind main)

## Test plan
- [ ] `/ok-to-test`
- [ ] Konflux + doc-only checks green
- [ ] Close #2381 after merge

Supersedes #2381

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Updated backup configuration settings for volume synchronization copy method in backup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->