### PR TITLE
ACM-32454: Add DR migration labels and annotations for ZTP resources

### DIFF
--- a/agent/pkg/spec/migration/migration_from_syncer.go
+++ b/agent/pkg/spec/migration/migration_from_syncer.go
@@ -62,6 +62,9 @@ const (
 	// imageclusterinstall_controller.go#L118
 	VeleroRestoreNameLabel = "velero.io/restore-name"
 
+	// VeleroRestoreStatusAnnotation marks ImageClusterInstall as restored by velero during migration.
+	VeleroRestoreStatusAnnotation = "velero.io/restore-status"
+
 	GlobalHubRestoreName = "globalhub"
 )
 
@@ -442,23 +445,50 @@ func (s *MigrationSourceSyncer) processResourceByType(
 			delete(annotations, HivePauseAnnotation)
 		}
 		resource.SetAnnotations(annotations)
-	case "BareMetalHost", "DataImage":
-		// Remove pause annotation from BareMetalHost and DataImage
+	case "BareMetalHost":
+		// Remove pause annotation from BareMetalHost
+		annotations := resource.GetAnnotations()
+		if annotations != nil {
+			delete(annotations, Metal3PauseAnnotation)
+		}
+		resource.SetAnnotations(annotations)
+
+		// Add cluster backup label with correct value
+		labels := resource.GetLabels()
+		if labels == nil {
+			labels = make(map[string]string)
+		}
+		if labels[constants.BackupKey] != constants.BackupActivationValue {
+			labels[constants.BackupKey] = constants.BackupActivationValue
+		}
+		resource.SetLabels(labels)
+	case "DataImage":
+		// Remove pause annotation from DataImage
 		annotations := resource.GetAnnotations()
 		if annotations != nil {
 			delete(annotations, Metal3PauseAnnotation)
 		}
 		resource.SetAnnotations(annotations)
 	case "ImageClusterInstall":
-		// Add velero restore label if not present
+		// Add velero restore label with correct value
 		labels := resource.GetLabels()
 		if labels == nil {
 			labels = make(map[string]string)
 		}
-		if _, exists := labels[VeleroRestoreNameLabel]; !exists {
+		if labels[VeleroRestoreNameLabel] != GlobalHubRestoreName {
 			labels[VeleroRestoreNameLabel] = GlobalHubRestoreName
 		}
 		resource.SetLabels(labels)
+
+		// Add velero restore status annotation with correct value
+		annotations := resource.GetAnnotations()
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		if annotations[VeleroRestoreStatusAnnotation] != "true" {
+			annotations[VeleroRestoreStatusAnnotation] = "true"
+		}
+		resource.SetAnnotations(annotations)
 	}
 }
 

--- a/agent/pkg/spec/migration/migration_from_syncer_test.go
+++ b/agent/pkg/spec/migration/migration_from_syncer_test.go
@@ -3196,7 +3196,7 @@ func TestProcessResourceByType(t *testing.T) {
 			}(),
 		},
 		{
-			name: "BareMetalHost: should remove pause annotation",
+			name: "BareMetalHost: should remove pause annotation and add backup label",
 			resource: func() *unstructured.Unstructured {
 				bmh := &unstructured.Unstructured{}
 				bmh.SetGroupVersionKind(schema.GroupVersionKind{
@@ -3230,6 +3230,9 @@ func TestProcessResourceByType(t *testing.T) {
 				bmh.SetNamespace("test-cluster")
 				bmh.SetAnnotations(map[string]string{
 					"other-annotation": "should-remain",
+				})
+				bmh.SetLabels(map[string]string{
+					constants.BackupKey: constants.BackupActivationValue,
 				})
 				return bmh
 			}(),
@@ -3274,7 +3277,7 @@ func TestProcessResourceByType(t *testing.T) {
 			}(),
 		},
 		{
-			name: "ImageClusterInstall: should add velero restore label when not present",
+			name: "ImageClusterInstall: should add velero restore label and annotation when not present",
 			resource: func() *unstructured.Unstructured {
 				ici := &unstructured.Unstructured{}
 				ici.SetGroupVersionKind(schema.GroupVersionKind{
@@ -3305,11 +3308,14 @@ func TestProcessResourceByType(t *testing.T) {
 				ici.SetLabels(map[string]string{
 					VeleroRestoreNameLabel: GlobalHubRestoreName,
 				})
+				ici.SetAnnotations(map[string]string{
+					VeleroRestoreStatusAnnotation: "true",
+				})
 				return ici
 			}(),
 		},
 		{
-			name: "ImageClusterInstall: should not override existing velero restore label",
+			name: "ImageClusterInstall: should correct existing velero restore label and annotation values",
 			resource: func() *unstructured.Unstructured {
 				ici := &unstructured.Unstructured{}
 				ici.SetGroupVersionKind(schema.GroupVersionKind{
@@ -3322,6 +3328,10 @@ func TestProcessResourceByType(t *testing.T) {
 				ici.SetLabels(map[string]string{
 					VeleroRestoreNameLabel: "existing-restore",
 					"other-label":          "should-remain",
+				})
+				ici.SetAnnotations(map[string]string{
+					VeleroRestoreStatusAnnotation: "false",
+					"other-annotation":            "should-remain",
 				})
 				return ici
 			}(),
@@ -3342,14 +3352,18 @@ func TestProcessResourceByType(t *testing.T) {
 				ici.SetName("test-ici")
 				ici.SetNamespace("test-cluster")
 				ici.SetLabels(map[string]string{
-					VeleroRestoreNameLabel: "existing-restore",
+					VeleroRestoreNameLabel: GlobalHubRestoreName,
 					"other-label":          "should-remain",
+				})
+				ici.SetAnnotations(map[string]string{
+					VeleroRestoreStatusAnnotation: "true",
+					"other-annotation":            "should-remain",
 				})
 				return ici
 			}(),
 		},
 		{
-			name: "ImageClusterInstall: should preserve existing labels when adding velero label",
+			name: "ImageClusterInstall: should preserve existing labels and annotations when adding velero label and annotation",
 			resource: func() *unstructured.Unstructured {
 				ici := &unstructured.Unstructured{}
 				ici.SetGroupVersionKind(schema.GroupVersionKind{
@@ -3361,6 +3375,9 @@ func TestProcessResourceByType(t *testing.T) {
 				ici.SetNamespace("test-cluster")
 				ici.SetLabels(map[string]string{
 					"existing-label": "value",
+				})
+				ici.SetAnnotations(map[string]string{
+					"existing-annotation": "value",
 				})
 				return ici
 			}(),
@@ -3383,6 +3400,10 @@ func TestProcessResourceByType(t *testing.T) {
 				ici.SetLabels(map[string]string{
 					"existing-label":       "value",
 					VeleroRestoreNameLabel: GlobalHubRestoreName,
+				})
+				ici.SetAnnotations(map[string]string{
+					"existing-annotation":         "value",
+					VeleroRestoreStatusAnnotation: "true",
 				})
 				return ici
 			}(),


### PR DESCRIPTION
## Summary

Rebased replacement for #2388. Adds missing DR migration labels and annotations for ZTP resources in \`processResourceByType\`, and validates both key **and** value when setting them.

Supersedes #2388.

## What this changes

During hub migration, the agent's \`MigrationSourceSyncer\` processes ZTP-related resources before they are synced to the target hub. On current \`main\`, that processing is incomplete for two resource types:

| Resource | Current \`main\` behavior | After this PR |
|---|---|---|
| **ImageClusterInstall** | Adds \`velero.io/restore-name\` only if the key is missing (no value check); no restore-status annotation | Sets \`velero.io/restore-name: globalhub\` and \`velero.io/restore-status: "true"\`, correcting wrong values |
| **BareMetalHost** | Combined with DataImage — only removes the Metal3 pause annotation | Removes pause annotation **and** sets \`cluster.open-cluster-management.io/backup: cluster-activation\` |
| **DataImage** | Same combined case as BareMetalHost | Split out; only pause annotation removal (unchanged intent) |

### ImageClusterInstall — \`velero.io/restore-name\` and \`velero.io/restore-status\`

**Context (confirmed with the IBIO team):** The image-based-install-operator uses the \`velero.io/restore-name\` **label** to detect whether an ImageClusterInstall is being restored. When this label is present and the ICI status is empty, IBIO pauses reconciliation and waits ([source](https://github.com/openshift/image-based-install-operator/blob/ba0f5200b1ea07c59f0e059e99d9deebbf4d70c2/controllers/imageclusterinstall_controller.go#L1529)). IBIO separately sets the \`velero.io/restore-status: "true"\` annotation itself during reconcile if it is absent ([source](https://github.com/openshift/image-based-install-operator/blob/ba0f5200b1ea07c59f0e059e99d9deebbf4d70c2/controllers/imageclusterinstall_controller.go#L1538)).

**Why Global Hub must set these during migration:** During hub migration, Global Hub suppresses IBI and BMH resources from being processed through ClusterInstance. This means the SiteConfig operator's default templates (ACM-26864, ACM-26603) never fire for these resources, leaving them without the required DR metadata. Global Hub's \`MigrationSourceSyncer\` must therefore set them directly.

- \`velero.io/restore-name: globalhub\` — **required**: this is the label IBIO checks to pause reconciliation while migration is in progress. Without it, IBIO would begin reconciling the ICI concurrently with Global Hub's migration sync, causing conflicts.
- \`velero.io/restore-status: "true"\` — **pre-set for consistency**: IBIO will set this itself during its first reconcile, but setting it here aligns with the SiteConfig default templates (ACM-26864) and ensures the annotation is present before IBIO runs.

The existing code already set \`velero.io/restore-name: globalhub\`, but only when the label key was absent (no value validation). This PR also validates the value is correct, and adds the missing restore-status annotation.

### BareMetalHost — \`cluster.open-cluster-management.io/backup\`

This label marks resources for inclusion in cluster activation backup workflows. BareMetalHost resources need it so they are properly captured during DR scenarios. Without it, BMH resources are excluded from Velero backup snapshots. The label constants already exist in \`pkg/constants/constants.go\` (\`BackupKey\` / \`BackupActivationValue\`) and are used elsewhere in the backup controller — this PR reuses them rather than redefining local copies.

### Value validation

Previously, label/annotation logic only checked whether a key existed. Resources with the right key but wrong value would pass through unchanged. This PR enforces the expected values, ensuring correct DR configuration even when resources arrive with stale or incorrect metadata.

## Files changed

- \`agent/pkg/spec/migration/migration_from_syncer.go\` — split BareMetalHost/DataImage cases, add backup label and restore-status annotation, value validation
- \`agent/pkg/spec/migration/migration_from_syncer_test.go\` — updated \`TestProcessResourceByType\` expectations

## Why this is still needed

None of the above behavior exists on \`main\` today. The migration syncer still handles these ZTP resource types, but without the DR-specific labels/annotations that downstream operators and backup workflows expect. This gap affects ZTP cluster migration and DR recovery scenarios tracked in ACM-32454.

## Test plan

- [x] \`go test ./agent/pkg/spec/migration/ -run TestProcessResourceByType\`
- [ ] CI: unit, integration, e2e, Konflux

## Related Issues

- https://issues.redhat.com/browse/ACM-32454
- Supersedes #2388