### PR TITLE
ACM-31409/ACM-32313/ACM-36414: Add NetworkPolicy support for multicluster-global-hub

### DIFF
--- a/ai-doc/NETWORKPOLICY.md
+++ b/ai-doc/NETWORKPOLICY.md
@@ -1,0 +1,634 @@
+# NetworkPolicy Guide for Multicluster Global Hub
+
+## Overview
+This document describes the NetworkPolicy resources deployed in the `multicluster-global-hub` namespace to enhance security by controlling network traffic between components and external systems.
+
+Policies are **operator-managed**: the multicluster-global-hub operator reconciles them when a `MulticlusterGlobalHub` CR is created or updated, and removes them when the CR is deleted. Entry points include `HoHDeployer.deployNetworkPolicy()` and per-component reconcilers.
+
+**Reference:** [ACM-19479](https://redhat.atlassian.net/browse/ACM-19479)
+
+## Components and Ports
+
+### Components in multicluster-global-hub namespace:
+
+1. **multicluster-global-hub-operator**
+   - Webhook server: Port 9443
+   - Metrics: Port 8081
+   - Needs: Kubernetes API access
+
+2. **multicluster-global-hub-manager**
+   - HTTP API server: Port 8080
+   - Metrics: Port 8384
+   - Needs: PostgreSQL (5432), Kafka, Kubernetes API access
+
+3. **multicluster-global-hub-grafana**
+   - Grafana: Port 3001 (internal)
+   - Grafana alerts: Port 9094
+   - OAuth proxy: Port 9443 (external)
+   - Needs: PostgreSQL (5432), Kubernetes API
+
+4. **PostgreSQL StatefulSet**
+   - Database: Port 5432
+   - Prometheus exporter: Port 9187
+
+5. **Kafka (Strimzi)**
+   - Bootstrap: Port 9092/9093
+   - JMX Prometheus metrics: Port 9404 (`tcp-prometheus`)
+   - Needs: Internal cluster communication, Kubernetes API
+
+6. **Inventory API**
+   - HTTP/gRPC: Ports 8081, 9081
+   - Needs: PostgreSQL (5432), Kafka (9093), SpiceDB, relations-api, Kubernetes API
+
+7. **Relations API**
+   - HTTP/gRPC: Ports 8000, 9000
+   - Needs: SpiceDB (50051), Kubernetes API
+
+8. **SpiceDB**
+   - gRPC: 50051; HTTP gateway: 8443; metrics: 9090; dispatch: 50053
+   - Needs: PostgreSQL (5432), Kubernetes API
+
+9. **Strimzi Cluster Operator**
+   - Needs: Kafka pods (9090/9091/8443/9093), DNS, Kubernetes API
+
+10. **Agent (local and addon deployments)**
+    - Egress-only policy
+    - Needs: DNS, Kubernetes API (443), Kafka (9092–9095), webhooks (8443)
+
+## Deployed NetworkPolicies
+
+### 1. Default Deny All Policy
+Blocks all ingress and egress cluster-wide in the namespace. Component-specific policies below then explicitly allow required traffic.
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: multicluster-global-hub
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+```
+
+### 2. Allow DNS and Kubernetes API Access (All Pods)
+All pods need DNS resolution and Kubernetes API access. The deployed policy is named `allow-dns-and-api`.
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-and-api
+  namespace: multicluster-global-hub
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  # Allow access to Kubernetes API server
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: default
+    ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-dns
+    ports:
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+  # Also allow kube-dns for non-OpenShift clusters
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    podSelector:
+      matchLabels:
+        k8s-app: kube-dns
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+```
+
+### 3. Operator NetworkPolicy
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: multicluster-global-hub-operator
+  namespace: multicluster-global-hub
+spec:
+  podSelector:
+    matchLabels:
+      name: multicluster-global-hub-operator
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow webhook traffic from K8s API server
+  - from:
+    - namespaceSelector: {}
+    ports:
+    - protocol: TCP
+      port: 9443
+  # Allow metrics scraping from Prometheus
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-monitoring
+    ports:
+    - protocol: TCP
+      port: 8081
+  egress:
+  # Allow access to Kubernetes API server
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: default
+    ports:
+    - protocol: TCP
+      port: 443
+  # Allow access to manage resources in the same namespace
+  - to:
+    - podSelector: {}
+  # Allow access to other namespaces for operator operations (e.g., managed hub namespaces)
+  - to:
+    - namespaceSelector: {}
+    ports:
+    - protocol: TCP
+      port: 443
+```
+
+### 4. Manager NetworkPolicy
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: multicluster-global-hub-manager
+  namespace: multicluster-global-hub
+spec:
+  podSelector:
+    matchLabels:
+      name: multicluster-global-hub-manager
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow API server access from within cluster
+  - from:
+    - namespaceSelector: {}
+    ports:
+    - protocol: TCP
+      port: 8080
+  # Allow metrics scraping
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-monitoring
+    ports:
+    - protocol: TCP
+      port: 8384
+  egress:
+  # Allow access to PostgreSQL
+  - to:
+    - podSelector:
+        matchLabels:
+          name: multicluster-global-hub-postgres
+    ports:
+    - protocol: TCP
+      port: 5432
+  # Allow access to Kafka
+  - to:
+    - podSelector:
+        matchLabels:
+          strimzi.io/cluster: kafka
+    ports:
+    - protocol: TCP
+      port: 9092
+    - protocol: TCP
+      port: 9093
+    - protocol: TCP
+      port: 9094
+  # Allow access to Kubernetes API
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: default
+    ports:
+    - protocol: TCP
+      port: 443
+  # Allow access to other namespaces (for managing resources)
+  - to:
+    - namespaceSelector: {}
+```
+
+### 5. Grafana NetworkPolicy
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: multicluster-global-hub-grafana
+  namespace: multicluster-global-hub
+spec:
+  podSelector:
+    matchLabels:
+      name: multicluster-global-hub-grafana
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow external access via OpenShift router
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: ingress
+    ports:
+    - protocol: TCP
+      port: 9443
+  # Allow metrics scraping
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-monitoring
+    ports:
+    - protocol: TCP
+      port: 3001
+    - protocol: TCP
+      port: 9443
+  egress:
+  # Allow access to PostgreSQL
+  - to:
+    - podSelector:
+        matchLabels:
+          name: multicluster-global-hub-postgres
+    ports:
+    - protocol: TCP
+      port: 5432
+  # Allow OAuth token validation with OpenShift OAuth
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-authentication
+  # Allow access to Kubernetes API for OAuth
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: default
+    ports:
+    - protocol: TCP
+      port: 443
+  # Allow HTTPS to external services for grafana proxy
+  - ports:
+    - protocol: TCP
+      port: 443
+```
+
+### 6. PostgreSQL NetworkPolicy
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: multicluster-global-hub-postgres
+  namespace: multicluster-global-hub
+spec:
+  podSelector:
+    matchLabels:
+      name: multicluster-global-hub-postgres
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow connections from manager
+  - from:
+    - podSelector:
+        matchLabels:
+          name: multicluster-global-hub-manager
+    ports:
+    - protocol: TCP
+      port: 5432
+  # Allow connections from grafana
+  - from:
+    - podSelector:
+        matchLabels:
+          name: multicluster-global-hub-grafana
+    ports:
+    - protocol: TCP
+      port: 5432
+  # Allow Prometheus exporter scraping
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-monitoring
+    ports:
+    - protocol: TCP
+      port: 9187
+    - protocol: TCP
+      port: 80
+  egress:
+  # PostgreSQL typically doesn't need egress, but allow for certificate verification
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: default
+    ports:
+    - protocol: TCP
+      port: 443
+```
+
+### 7. Kafka NetworkPolicy
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kafka
+  namespace: multicluster-global-hub
+spec:
+  podSelector:
+    matchLabels:
+      strimzi.io/cluster: kafka
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow connections from manager
+  - from:
+    - podSelector:
+        matchLabels:
+          name: multicluster-global-hub-manager
+    ports:
+    - protocol: TCP
+      port: 9092
+    - protocol: TCP
+      port: 9093
+    - protocol: TCP
+      port: 9094
+  # Allow Kafka internal communication (between brokers, ZooKeeper, etc.)
+  - from:
+    - podSelector:
+        matchLabels:
+          strimzi.io/cluster: kafka
+  # Allow from agents in managed hub namespaces
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          global-hub.open-cluster-management.io/managed-hub: "true"
+    podSelector:
+      matchLabels:
+        name: multicluster-global-hub-agent
+    ports:
+    - protocol: TCP
+      port: 9093
+  # Allow metrics scraping
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-monitoring
+  egress:
+  # Allow Kafka internal communication
+  - to:
+    - podSelector:
+        matchLabels:
+          strimzi.io/cluster: kafka
+  # Allow Kafka to access Kubernetes API (for Strimzi operator coordination)
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: default
+    ports:
+    - protocol: TCP
+      port: 443
+```
+
+### 8. Inventory API NetworkPolicy
+
+Managed by the inventory reconciler. See `operator/pkg/controllers/inventory/manifests/inventory-api/networkpolicy.yaml`.
+
+- **Ingress:** TCP 8081, 9081
+- **Egress:** PostgreSQL (5432), Kafka (9093), SpiceDB, relations-api, Kubernetes API (443)
+
+### 9. Relations API NetworkPolicy
+
+Managed by the inventory reconciler. See `operator/pkg/controllers/inventory/manifests/relations-api/networkpolicy.yaml`.
+
+- **Ingress:** TCP 8000, 9000
+- **Egress:** SpiceDB (50051), Kubernetes API and other dependencies
+
+### 10. SpiceDB NetworkPolicy
+
+Managed by the SpiceDB reconciler. See `operator/pkg/controllers/inventory/manifests/spicedb-operator/spicedb-networkpolicy.yaml`.
+
+- **Ingress:** TCP 50051 (gRPC), 8443 (HTTP), 9090 (metrics), 50053 (dispatch)
+- **Egress:** PostgreSQL (5432), Kubernetes API
+
+### 11. Strimzi Cluster Operator NetworkPolicy
+
+Managed by the transporter reconciler. See `operator/pkg/controllers/transporter/protocol/manifests/strimzi-cluster-operator-networkpolicy.yaml`.
+
+- **Egress-only:** DNS, Kafka pods (9090/9091/8443/9093), Kubernetes API
+
+### 12. Agent NetworkPolicy (local and addon)
+
+Managed by the agent controllers. Manifests:
+
+- `operator/pkg/controllers/agent/manifests/networkpolicy.yaml` (local agent)
+- `operator/pkg/controllers/agent/addon/manifests/templates/agent/multicluster-global-hub-agent-networkpolicy.yaml` (addon)
+
+- **Egress-only:** DNS, Kubernetes API (443), in-cluster Kafka (9092–9095), external Kafka/bootstrap (9092/9093), webhooks (8443)
+
+## Operator Lifecycle
+
+NetworkPolicies are fully managed by the multicluster-global-hub operator:
+
+- **Create/Update:** The operator reconciles all policies whenever the `MulticlusterGlobalHub` CR is created or updated. No manual `kubectl apply` is required.
+- **Delete:** Policies are removed when the `MulticlusterGlobalHub` CR is deleted.
+- **Upgrade:** Rolling out a new operator version automatically applies any policy changes.
+
+To verify policies are present after install:
+
+```bash
+kubectl get networkpolicies -n multicluster-global-hub
+```
+
+To verify pod label selectors are working correctly:
+
+```bash
+kubectl get pods -n multicluster-global-hub -l name=multicluster-global-hub-operator
+kubectl get pods -n multicluster-global-hub -l name=multicluster-global-hub-manager
+kubectl get pods -n multicluster-global-hub -l name=multicluster-global-hub-grafana
+kubectl get pods -n multicluster-global-hub -l strimzi.io/cluster=kafka
+kubectl get pods -n multicluster-global-hub -l authzed.com/cluster=spicedb
+kubectl get pods -n multicluster-global-hub -l app=relations-api
+```
+
+If using hosted mode, label managed hub namespaces so the Kafka ingress rule matches agent traffic:
+
+```bash
+kubectl label namespace <managed-hub-namespace> global-hub.open-cluster-management.io/managed-hub=true
+```
+
+## File Structure
+
+NetworkPolicy YAML is **co-located with each component's controller manifests**, not in a single central directory:
+
+```text
+operator/pkg/controllers/
+├── networkpolicy/manifests/           # Shared baseline policies
+│   ├── default-deny-all.yaml
+│   ├── allow-dns-and-api.yaml
+│   └── operator-networkpolicy.yaml
+├── manager/manifests/networkpolicy.yaml
+├── grafana/manifests/networkpolicy.yaml
+├── storage/manifests.sts/postgres-networkpolicy.yaml
+├── transporter/protocol/manifests/
+│   ├── kafka-networkpolicy.yaml
+│   └── strimzi-cluster-operator-networkpolicy.yaml
+├── inventory/manifests/
+│   ├── inventory-api/networkpolicy.yaml
+│   ├── relations-api/networkpolicy.yaml
+│   └── spicedb-operator/spicedb-networkpolicy.yaml
+└── agent/
+    ├── manifests/networkpolicy.yaml                          # local agent
+    └── addon/manifests/templates/agent/
+        └── multicluster-global-hub-agent-networkpolicy.yaml  # addon agent
+```
+
+Controllers embed these manifests via `//go:embed` and reconcile them into the MGH namespace.
+
+## Deployment
+
+NetworkPolicies are deployed automatically by the operator. No standalone `kubectl apply -k` step is required.
+
+To verify after install:
+
+```bash
+kubectl get networkpolicies -n multicluster-global-hub
+kubectl describe networkpolicy -n multicluster-global-hub default-deny-all
+```
+
+## Important Considerations
+
+### 1. Label Requirements
+Ensure the operator deployment manifests apply these labels correctly:
+- **Operator pods**: `name: multicluster-global-hub-operator`
+- **Manager pods**: `name: multicluster-global-hub-manager`
+- **Grafana pods**: `name: multicluster-global-hub-grafana`
+- **PostgreSQL pods**: `name: multicluster-global-hub-postgres`
+- **Kafka pods**: `strimzi.io/cluster: kafka` (set by Strimzi)
+
+### 2. OpenShift vs Kubernetes
+The policies assume OpenShift. For vanilla Kubernetes:
+- Replace `openshift-monitoring` with your monitoring namespace
+- Replace `network.openshift.io/policy-group: ingress` with your ingress controller namespace
+- Replace `openshift-dns` with `kube-system` for DNS
+
+### 3. Managed Hub Agents
+For agents in managed hub clusters:
+- If agents are in the same cluster (hosted mode), label their namespaces with:
+  ```
+  global-hub.open-cluster-management.io/managed-hub: "true"
+  ```
+- If agents are in remote clusters, Kafka needs external exposure (not covered by these policies)
+
+### 4. External Kafka Access
+If using external Kafka bootstrap servers:
+- Add egress rules to allow manager to connect to external Kafka
+- Configure appropriate authentication/TLS
+
+### 5. Backup Considerations
+If using backup solutions (Velero, OADP):
+- Add egress rules for manager/postgres to access backup namespace
+- Allow backup namespace ingress to postgres for data backup
+
+## Testing Commands
+
+```bash
+# Confirm operator created NetworkPolicies
+kubectl get networkpolicies -n multicluster-global-hub
+
+# Test manager to postgres connectivity
+kubectl exec -n multicluster-global-hub deployment/multicluster-global-hub-manager -- \
+  pg_isready -h multicluster-global-hub-postgres -p 5432
+
+# Test manager to kafka connectivity
+kubectl exec -n multicluster-global-hub deployment/multicluster-global-hub-manager -- \
+  nc -zv kafka-kafka-bootstrap 9092
+
+# Test Grafana route access
+GRAFANA_ROUTE=$(kubectl get route -n multicluster-global-hub multicluster-global-hub-grafana -o jsonpath='{.spec.host}')
+curl -k -I https://$GRAFANA_ROUTE
+
+# Test webhook
+kubectl get validatingwebhookconfigurations
+kubectl get mutatingwebhookconfigurations
+
+# Check for denied connections in OVN logs
+kubectl logs -n openshift-ovn-kubernetes -l app=ovnkube-node --tail=100 | grep -i "drop\|reject"
+```
+
+## Monitoring for Issues
+
+```bash
+# Check manager logs for connection issues
+kubectl logs -n multicluster-global-hub deployment/multicluster-global-hub-manager | \
+  grep -i "connection refused\|timeout\|dial tcp"
+
+# Check grafana logs
+kubectl logs -n multicluster-global-hub deployment/multicluster-global-hub-grafana | \
+  grep -i "connection refused\|timeout"
+
+# Check operator logs
+kubectl logs -n multicluster-global-hub deployment/multicluster-global-hub-operator | \
+  grep -i "connection refused\|timeout"
+
+# Monitor network policy drops (OpenShift OVN-Kubernetes)
+kubectl logs -n openshift-ovn-kubernetes -l app=ovnkube-node --tail=100 | grep -i "drop\|reject"
+```
+
+## Rollback Plan
+
+If issues occur:
+
+```bash
+# Quick rollback - delete all NetworkPolicies
+kubectl delete networkpolicies -n multicluster-global-hub --all
+
+# Or delete specific policy
+kubectl delete networkpolicy -n multicluster-global-hub <policy-name>
+```
+
+## Security Benefits
+
+1. **Least Privilege**: Each component can only communicate with necessary services
+2. **Defense in Depth**: Even if a pod is compromised, network access is restricted
+3. **Compliance**: Meets security requirements for network segmentation
+4. **Blast Radius Reduction**: Limits lateral movement in case of security breach
+
+## Known Limitations and Follow-ups
+
+Remaining items are tracked in [ACM-32313](https://redhat.atlassian.net/browse/ACM-32313) (child story of epic [ACM-31409](https://redhat.atlassian.net/browse/ACM-31409)).
+
+- **OVN-Kubernetes enforcement:** Policies are created on KinD (used in product CI) but are only enforced on clusters running OVN-Kubernetes (e.g. OpenShift). Manual soak testing on OVN is tracked in [ACM-32494](https://redhat.atlassian.net/browse/ACM-32494); HoH automation in [ACM-32495](https://redhat.atlassian.net/browse/ACM-32495).
+- **Kafka `ipBlock` egress:** Agent egress to external Kafka bootstrap currently uses a broad `namespaceSelector`. Tightening to a specific CIDR `ipBlock` requires the operator to resolve the broker address at runtime — follow-up in [ACM-32313](https://redhat.atlassian.net/browse/ACM-32313).
+- **API server `ipBlock`:** The `allow-dns-and-api` policy allows egress to the `default` namespace broadly. Narrowing to the exact API server IP requires runtime address resolution — follow-up in [ACM-32313](https://redhat.atlassian.net/browse/ACM-32313).
+
+## References
+- **Jira Ticket**: [ACM-19479](https://redhat.atlassian.net/browse/ACM-19479)
+- **Kubernetes NetworkPolicy**: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+- **OpenShift NetworkPolicy**: https://docs.openshift.com/container-platform/latest/networking/network_policy/about-network-policy.html
+- **Strimzi Kafka Security**: https://strimzi.io/docs/operators/latest/configuring.html#assembly-securing-kafka-str

--- a/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -1104,6 +1104,17 @@ spec:
           - get
           - update
         - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
           - observability.open-cluster-management.io
           resources:
           - observabilityaddons

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -457,6 +457,17 @@ rules:
   - get
   - update
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - observability.open-cluster-management.io
   resources:
   - observabilityaddons

--- a/operator/pkg/controllers/agent/addon/manifests/templates/agent/multicluster-global-hub-agent-networkpolicy.yaml
+++ b/operator/pkg/controllers/agent/addon/manifests/templates/agent/multicluster-global-hub-agent-networkpolicy.yaml
@@ -1,0 +1,70 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: multicluster-global-hub-agent
+  namespace: {{ .AddonInstallNamespace }}
+  labels:
+    addon.open-cluster-management.io/hosted-manifest-location: none
+    global-hub.open-cluster-management.io/managed-by: global-hub-agent
+spec:
+  podSelector:
+    matchLabels:
+      name: multicluster-global-hub-agent
+  policyTypes:
+  - Egress
+  egress:
+  # Allow DNS resolution (OpenShift)
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-dns
+    ports:
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+  # Allow DNS resolution (Kubernetes)
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  # Allow access to Kubernetes API server
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: default
+    ports:
+    - protocol: TCP
+      port: 443
+  # Allow connections to Kafka (Strimzi)
+  - to:
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          strimzi.io/cluster: kafka
+    ports:
+    - protocol: TCP
+      port: 9093
+    - protocol: TCP
+      port: 9094
+    - protocol: TCP
+      port: 9095
+  # Allow connections to external Kafka via LoadBalancer/NodePort
+  - to:
+    - namespaceSelector: {}
+    ports:
+    - protocol: TCP
+      port: 9092
+    - protocol: TCP
+      port: 9093
+  # Allow HTTPS egress for internal Kubernetes services (webhooks, admission controllers)
+  - to:
+    - namespaceSelector: {}
+    ports:
+    - protocol: TCP
+      port: 8443

--- a/operator/pkg/controllers/agent/local_agent_controller.go
+++ b/operator/pkg/controllers/agent/local_agent_controller.go
@@ -47,11 +47,6 @@ func StartLocalAgentController(initOption config.ControllerOption) (config.Contr
 
 	log.Info("start local agent controller")
 
-	if !config.IsTransportConfigReady(initOption.Ctx, initOption.MulticlusterGlobalHub.Namespace,
-		initOption.Manager.GetClient()) {
-		return nil, nil
-	}
-
 	localAgentReconciler = &LocalAgentController{
 		Manager: initOption.Manager,
 	}
@@ -146,6 +141,12 @@ func (s *LocalAgentController) Reconcile(ctx context.Context, req ctrl.Request) 
 		err = utils.HandleMghDelete(ctx, &isResourceRemoved, mgh.Namespace, s.pruneAgentResources)
 		log.Debugf("deleted local agent resources, isResourceRemoved:%v", isResourceRemoved)
 		return ctrl.Result{}, err
+	}
+	if !config.IsACMResourceReady() {
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	}
+	if !config.IsTransportConfigReady(ctx, mgh.Namespace, s.GetClient()) {
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 	currentClusterName, err := getCurrentClusterName(ctx, s.GetClient(), mgh.Namespace)
 	if err != nil {
@@ -258,12 +259,11 @@ func (s *LocalAgentController) pruneAgentResources(ctx context.Context, namespac
 	}
 
 	trans := config.GetTransporter()
-	if trans == nil {
-		return fmt.Errorf("failed to get the transporter")
-	}
-	err = trans.Prune(clusterName)
-	if err != nil {
-		return err
+	if trans != nil {
+		err = trans.Prune(clusterName)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/operator/pkg/controllers/agent/manifests/networkpolicy.yaml
+++ b/operator/pkg/controllers/agent/manifests/networkpolicy.yaml
@@ -1,0 +1,70 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: multicluster-global-hub-agent
+  namespace: {{.Namespace}}
+  labels:
+    component: multicluster-global-hub-agent
+    global-hub.open-cluster-management.io/managed-by: global-hub-operator
+spec:
+  podSelector:
+    matchLabels:
+      name: multicluster-global-hub-agent
+  policyTypes:
+  - Egress
+  egress:
+  # Allow DNS resolution (OpenShift)
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-dns
+    ports:
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+  # Allow DNS resolution (Kubernetes)
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  # Allow access to Kubernetes API server
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: default
+    ports:
+    - protocol: TCP
+      port: 443
+  # Allow connections to Kafka (Strimzi)
+  - to:
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          strimzi.io/cluster: kafka
+    ports:
+    - protocol: TCP
+      port: 9093
+    - protocol: TCP
+      port: 9094
+    - protocol: TCP
+      port: 9095
+  # Allow connections to external Kafka via LoadBalancer/NodePort
+  - to:
+    - namespaceSelector: {}
+    ports:
+    - protocol: TCP
+      port: 9092
+    - protocol: TCP
+      port: 9093
+  # Allow HTTPS egress for internal Kubernetes services (webhooks, admission controllers)
+  - to:
+    - namespaceSelector: {}
+    ports:
+    - protocol: TCP
+      port: 8443

--- a/operator/pkg/controllers/grafana/grafana_reconciler.go
+++ b/operator/pkg/controllers/grafana/grafana_reconciler.go
@@ -15,6 +15,7 @@ import (
 	"gopkg.in/yaml.v2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -58,6 +59,7 @@ import (
 // +kubebuilder:rbac:groups="apps",resources=deployments,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheuses/api,resourceNames=k8s,verbs=get;create;update
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;delete
 
 //go:embed manifests
 var fs embed.FS
@@ -169,7 +171,9 @@ func (r *GrafanaReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&rbacv1.ClusterRoleBinding{},
 			&handler.EnqueueRequestForObject{}, builder.WithPredicates(config.GeneralPredicate)).
 		Watches(&routev1.Route{},
-			&handler.EnqueueRequestForObject{}, builder.WithPredicates(config.GeneralPredicate))
+			&handler.EnqueueRequestForObject{}, builder.WithPredicates(config.GeneralPredicate)).
+		Watches(&networkingv1.NetworkPolicy{},
+			&handler.EnqueueRequestForObject{}, builder.WithPredicates(networkPolicyPred))
 
 	if _, err := mgr.GetRESTMapper().KindFor(schema.GroupVersionResource{
 		Group:    "image.openshift.io",
@@ -186,6 +190,21 @@ func (r *GrafanaReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 var deploymentPred = predicate.Funcs{
+	CreateFunc: func(e event.CreateEvent) bool {
+		return e.Object.GetNamespace() == commonutils.GetDefaultNamespace() &&
+			e.Object.GetName() == config.COMPONENTS_GRAFANA_NAME
+	},
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		return e.ObjectNew.GetNamespace() == commonutils.GetDefaultNamespace() &&
+			e.ObjectNew.GetName() == config.COMPONENTS_GRAFANA_NAME
+	},
+	DeleteFunc: func(e event.DeleteEvent) bool {
+		return e.Object.GetNamespace() == commonutils.GetDefaultNamespace() &&
+			e.Object.GetName() == config.COMPONENTS_GRAFANA_NAME
+	},
+}
+
+var networkPolicyPred = predicate.Funcs{
 	CreateFunc: func(e event.CreateEvent) bool {
 		return e.Object.GetNamespace() == commonutils.GetDefaultNamespace() &&
 			e.Object.GetName() == config.COMPONENTS_GRAFANA_NAME

--- a/operator/pkg/controllers/grafana/grafana_reconciler_test.go
+++ b/operator/pkg/controllers/grafana/grafana_reconciler_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/ini.v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -16,8 +17,10 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	"github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
 	operatorutils "github.com/stolostron/multicluster-global-hub/operator/pkg/utils"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
@@ -908,6 +911,25 @@ pass = true
 			}
 		})
 	}
+}
+
+func TestNetworkPolicyPred_Grafana(t *testing.T) {
+	ns := utils.GetDefaultNamespace()
+	grafanaName := config.COMPONENTS_GRAFANA_NAME
+
+	np := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: grafanaName, Namespace: ns},
+	}
+	otherNP := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "other", Namespace: ns},
+	}
+
+	assert.True(t, networkPolicyPred.Create(event.CreateEvent{Object: np}), "Create: grafana NP should match")
+	assert.False(t, networkPolicyPred.Create(event.CreateEvent{Object: otherNP}), "Create: other NP should not match")
+	assert.True(t, networkPolicyPred.Update(event.UpdateEvent{ObjectNew: np}), "Update: grafana NP should match")
+	assert.False(t, networkPolicyPred.Update(event.UpdateEvent{ObjectNew: otherNP}), "Update: other NP should not match")
+	assert.True(t, networkPolicyPred.Delete(event.DeleteEvent{Object: np}), "Delete: grafana NP should match")
+	assert.False(t, networkPolicyPred.Delete(event.DeleteEvent{Object: otherNP}), "Delete: other NP should not match")
 }
 
 func sectionCount(a []byte) int {

--- a/operator/pkg/controllers/grafana/manifests/networkpolicy.yaml
+++ b/operator/pkg/controllers/grafana/manifests/networkpolicy.yaml
@@ -1,0 +1,80 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: multicluster-global-hub-grafana
+  namespace: {{.Namespace}}
+  labels:
+    name: multicluster-global-hub-grafana
+spec:
+  podSelector:
+    matchLabels:
+      name: multicluster-global-hub-grafana
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow external access via OpenShift router
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: ingress
+    ports:
+    - protocol: TCP
+      port: 9443
+  # Allow metrics scraping from Prometheus
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-monitoring
+    ports:
+    - protocol: TCP
+      port: 3001
+    - protocol: TCP
+      port: 9443
+  # Allow Grafana HA alerting between replicas
+  - from:
+    - podSelector:
+        matchLabels:
+          name: multicluster-global-hub-grafana
+    ports:
+    - protocol: TCP
+      port: 9094
+  egress:
+  # Allow DNS resolution
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-dns
+    ports:
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+  # Allow access to PostgreSQL (in-cluster or external)
+  - ports:
+    - protocol: TCP
+      port: 5432
+  # Allow OAuth token validation with OpenShift OAuth
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-authentication
+    ports:
+    - protocol: TCP
+      port: 443
+  # Allow access to Kubernetes API for OAuth
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: default
+    ports:
+    - protocol: TCP
+      port: 443
+  # Allow Grafana HA alerting between replicas
+  - to:
+    - podSelector:
+        matchLabels:
+          name: multicluster-global-hub-grafana
+    ports:
+    - protocol: TCP
+      port: 9094

--- a/operator/pkg/controllers/inventory/inventory_reconciler.go
+++ b/operator/pkg/controllers/inventory/inventory_reconciler.go
@@ -239,6 +239,7 @@ func (r *InventoryReconciler) Reconcile(ctx context.Context,
 
 	inventoryObjects, err := hohRenderer.Render("inventory-api", "", func(profile string) (interface{}, error) {
 		return struct {
+			Name                  string
 			Image                 string
 			Replicas              int32
 			ImagePullSecret       string
@@ -249,6 +250,7 @@ func (r *InventoryReconciler) Reconcile(ctx context.Context,
 			PostgresPassword      string
 			PostgresCACert        string
 			PostgresDBName        string
+			PostgresName          string
 			Namespace             string
 			NodeSelector          map[string]string
 			Tolerations           []corev1.Toleration
@@ -258,6 +260,7 @@ func (r *InventoryReconciler) Reconcile(ctx context.Context,
 			KafkaSSLKeyPEM        string
 			InventoryAPIRouteHost string
 		}{
+			Name:                  config.COMPONENTS_INVENTORY_API_NAME,
 			Image:                 config.GetImage(config.InventoryImageKey),
 			Replicas:              replicas,
 			ImagePullSecret:       mgh.Spec.ImagePullSecret,
@@ -268,6 +271,7 @@ func (r *InventoryReconciler) Reconcile(ctx context.Context,
 			PostgresPassword:      postgresPassword,
 			PostgresDBName:        InventoryDatabaseName,
 			PostgresCACert:        base64.StdEncoding.EncodeToString(storageConn.CACert),
+			PostgresName:          config.COMPONENTS_POSTGRES_NAME,
 			Namespace:             mgh.Namespace,
 			NodeSelector:          mgh.Spec.NodeSelector,
 			Tolerations:           mgh.Spec.Tolerations,

--- a/operator/pkg/controllers/inventory/manifests/inventory-api/networkpolicy.yaml
+++ b/operator/pkg/controllers/inventory/manifests/inventory-api/networkpolicy.yaml
@@ -1,0 +1,62 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{.Name}}
+  namespace: {{.Namespace}}
+  labels:
+    global-hub.open-cluster-management.io/managed-by: global-hub-operator
+spec:
+  podSelector:
+    matchLabels:
+      name: {{.Name}}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow incoming connections to HTTP and gRPC ports
+  - ports:
+    - protocol: TCP
+      port: 8081
+    - protocol: TCP
+      port: 9081
+  egress:
+  # Allow connections to PostgreSQL
+  - to:
+    - podSelector:
+        matchLabels:
+          name: {{.PostgresName}}
+    ports:
+    - protocol: TCP
+      port: 5432
+  # Allow connections to Kafka
+  - to:
+    - podSelector:
+        matchLabels:
+          strimzi.io/cluster: kafka
+    ports:
+    - protocol: TCP
+      port: 9093
+  # Allow access to Kubernetes API
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: default
+    ports:
+    - protocol: TCP
+      port: 443
+  # Allow connections to SpiceDB
+  - to:
+    - podSelector:
+        matchLabels:
+          authzed.com/cluster: spicedb
+    ports:
+    - protocol: TCP
+      port: 50051
+  # Allow connections to relations-api
+  - to:
+    - podSelector:
+        matchLabels:
+          app: relations-api
+    ports:
+    - protocol: TCP
+      port: 8000

--- a/operator/pkg/controllers/inventory/manifests/relations-api/networkpolicy.yaml
+++ b/operator/pkg/controllers/inventory/manifests/relations-api/networkpolicy.yaml
@@ -1,0 +1,33 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: relations-api
+  namespace: {{.Namespace}}
+  labels:
+    global-hub.open-cluster-management.io/managed-by: global-hub-operator
+spec:
+  podSelector:
+    matchLabels:
+      app: relations-api
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow incoming connections to HTTP and gRPC ports
+  - ports:
+    - protocol: TCP
+      port: 8000
+    - protocol: TCP
+      port: 9000
+  egress:
+  # Allow connections to SpiceDB
+  - to:
+    - podSelector:
+        matchLabels:
+          authzed.com/cluster: spicedb
+    ports:
+    - protocol: TCP
+      port: 50051
+  # Allow all other egress for external dependencies
+  - to:
+    - namespaceSelector: {}

--- a/operator/pkg/controllers/inventory/manifests/spicedb-operator/spicedb-networkpolicy.yaml
+++ b/operator/pkg/controllers/inventory/manifests/spicedb-operator/spicedb-networkpolicy.yaml
@@ -1,0 +1,37 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: spicedb
+  namespace: {{.Namespace}}
+  labels:
+    global-hub.open-cluster-management.io/managed-by: global-hub-operator
+spec:
+  podSelector:
+    matchLabels:
+      authzed.com/cluster: spicedb
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow incoming connections to SpiceDB ports
+  - ports:
+    - protocol: TCP
+      port: 50051  # gRPC API
+    - protocol: TCP
+      port: 8443   # HTTP Gateway
+    - protocol: TCP
+      port: 9090   # Metrics
+    - protocol: TCP
+      port: 50053  # Dispatch cluster
+  egress:
+  # Allow connections to PostgreSQL
+  - to:
+    - podSelector:
+        matchLabels:
+          name: {{.PostgresName}}
+    ports:
+    - protocol: TCP
+      port: 5432
+  # Allow all other egress for external dependencies
+  - to:
+    - namespaceSelector: {}

--- a/operator/pkg/controllers/inventory/spicedb_reconciler.go
+++ b/operator/pkg/controllers/inventory/spicedb_reconciler.go
@@ -135,6 +135,7 @@ func (r *SpiceDBReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			Image           string
 			ImagePullPolicy string
 			ImagePullSecret string
+			PostgresName    string
 			NodeSelector    map[string]string
 			Tolerations     []corev1.Toleration
 		}{
@@ -143,6 +144,7 @@ func (r *SpiceDBReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			Image:           config.GetImage(config.SpiceDBOperatorImageKey),
 			ImagePullPolicy: string(operandConfig.ImagePullPolicy),
 			ImagePullSecret: operandConfig.ImagePullSecret,
+			PostgresName:    config.COMPONENTS_POSTGRES_NAME,
 			NodeSelector:    operandConfig.NodeSelector,
 			Tolerations:     operandConfig.Tolerations,
 		}, nil

--- a/operator/pkg/controllers/manager/manager_reconciler.go
+++ b/operator/pkg/controllers/manager/manager_reconciler.go
@@ -13,6 +13,7 @@ import (
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -66,6 +67,7 @@ import (
 // +kubebuilder:rbac:groups=policy.open-cluster-management.io,resources=placementbindings,verbs=get;list;patch;update
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=kafka.strimzi.io,resources=kafkausers,verbs=get;watch;update
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;delete
 
 //go:embed manifests
 var fs embed.FS
@@ -143,7 +145,9 @@ func (r *ManagerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&rbacv1.RoleBinding{},
 			&handler.EnqueueRequestForObject{}, builder.WithPredicates(config.GeneralPredicate)).
 		Watches(&routev1.Route{},
-			&handler.EnqueueRequestForObject{}, builder.WithPredicates(config.GeneralPredicate))
+			&handler.EnqueueRequestForObject{}, builder.WithPredicates(config.GeneralPredicate)).
+		Watches(&networkingv1.NetworkPolicy{},
+			&handler.EnqueueRequestForObject{}, builder.WithPredicates(networkPolicyPred))
 
 	if config.IsACMResourceReady() {
 		mgrBuilder = mgrBuilder.
@@ -154,6 +158,21 @@ func (r *ManagerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 var deploymentPred = predicate.Funcs{
+	CreateFunc: func(e event.CreateEvent) bool {
+		return e.Object.GetNamespace() == commonutils.GetDefaultNamespace() &&
+			e.Object.GetName() == config.COMPONENTS_MANAGER_NAME
+	},
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		return e.ObjectNew.GetNamespace() == commonutils.GetDefaultNamespace() &&
+			e.ObjectNew.GetName() == config.COMPONENTS_MANAGER_NAME
+	},
+	DeleteFunc: func(e event.DeleteEvent) bool {
+		return e.Object.GetNamespace() == commonutils.GetDefaultNamespace() &&
+			e.Object.GetName() == config.COMPONENTS_MANAGER_NAME
+	},
+}
+
+var networkPolicyPred = predicate.Funcs{
 	CreateFunc: func(e event.CreateEvent) bool {
 		return e.Object.GetNamespace() == commonutils.GetDefaultNamespace() &&
 			e.Object.GetName() == config.COMPONENTS_MANAGER_NAME
@@ -312,6 +331,8 @@ func (r *ManagerReconciler) Reconcile(ctx context.Context,
 			Resources:                 utils.GetResources(operatorconstants.Manager, mgh.Spec.AdvancedSpec),
 			WithACM:                   config.IsACMResourceReady(),
 			TransportFailureThreshold: r.operatorConfig.TransportFailureThreshold,
+			StorageLabel:              config.COMPONENTS_POSTGRES_NAME,
+			KafkaCluster:              "kafka",
 		}, nil
 	})
 	if err != nil {
@@ -464,4 +485,6 @@ type ManagerVariables struct {
 	Resources                 *corev1.ResourceRequirements
 	WithACM                   bool
 	TransportFailureThreshold int
+	StorageLabel              string
+	KafkaCluster              string
 }

--- a/operator/pkg/controllers/manager/manager_reconciler_test.go
+++ b/operator/pkg/controllers/manager/manager_reconciler_test.go
@@ -1,0 +1,32 @@
+package manager
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
+)
+
+func TestNetworkPolicyPred_Manager(t *testing.T) {
+	ns := utils.GetDefaultNamespace()
+	managerName := config.COMPONENTS_MANAGER_NAME
+
+	np := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: managerName, Namespace: ns},
+	}
+	otherNP := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "other-np", Namespace: ns},
+	}
+
+	assert.True(t, networkPolicyPred.Create(event.CreateEvent{Object: np}), "Create: manager NP should match")
+	assert.False(t, networkPolicyPred.Create(event.CreateEvent{Object: otherNP}), "Create: other NP should not match")
+	assert.True(t, networkPolicyPred.Update(event.UpdateEvent{ObjectNew: np}), "Update: manager NP should match")
+	assert.False(t, networkPolicyPred.Update(event.UpdateEvent{ObjectNew: otherNP}), "Update: other NP should not match")
+	assert.True(t, networkPolicyPred.Delete(event.DeleteEvent{Object: np}), "Delete: manager NP should match")
+	assert.False(t, networkPolicyPred.Delete(event.DeleteEvent{Object: otherNP}), "Delete: other NP should not match")
+}

--- a/operator/pkg/controllers/manager/manifests/networkpolicy.yaml
+++ b/operator/pkg/controllers/manager/manifests/networkpolicy.yaml
@@ -1,0 +1,67 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: multicluster-global-hub-manager
+  namespace: {{.Namespace}}
+  labels:
+    name: multicluster-global-hub-manager
+spec:
+  podSelector:
+    matchLabels:
+      name: multicluster-global-hub-manager
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow API server access from within cluster
+  - from:
+    - namespaceSelector: {}
+    ports:
+    - protocol: TCP
+      port: 8080
+  # Allow metrics scraping from Prometheus
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-monitoring
+    ports:
+    - protocol: TCP
+      port: 8384
+  egress:
+  # Allow DNS resolution
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-dns
+    ports:
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+  # Allow access to PostgreSQL in same namespace
+  - to:
+    - podSelector:
+        matchLabels:
+          name: {{.StorageLabel}}
+    ports:
+    - protocol: TCP
+      port: 5432
+  # Allow access to Kafka in same namespace
+  - to:
+    - podSelector:
+        matchLabels:
+          strimzi.io/cluster: {{.KafkaCluster}}
+    ports:
+    - protocol: TCP
+      port: 9093
+  # Allow access to Kubernetes API server
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: default
+    ports:
+    - protocol: TCP
+      port: 443
+  # Allow access to other namespaces (for managing resources)
+  - to:
+    - namespaceSelector: {}

--- a/operator/pkg/controllers/meta.go
+++ b/operator/pkg/controllers/meta.go
@@ -48,6 +48,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/managedhub"
 	globalhubmanager "github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/manager"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/mceaddons"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/networkpolicy"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/storage"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/transporter"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/webhook"
@@ -69,6 +70,7 @@ var controllerStartFuncMap = map[string]Func{
 	"webhook":          webhook.StartController,
 	"storage":          storage.StartController,
 	"transporter":      transporter.StartController,
+	"networkpolicy":    networkpolicy.StartController,
 	"managedhub":       managedhub.StartController,
 	"acm":              acm.StartController,
 	"backup":           backup.StartController,

--- a/operator/pkg/controllers/networkpolicy/manifests/allow-dns-and-api.yaml
+++ b/operator/pkg/controllers/networkpolicy/manifests/allow-dns-and-api.yaml
@@ -1,0 +1,41 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-and-api
+  namespace: {{.Namespace}}
+  labels:
+    global-hub.open-cluster-management.io/managed-by: global-hub-operator
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  # Allow DNS resolution to OpenShift DNS
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-dns
+    ports:
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+  # Also allow kube-dns for non-OpenShift clusters
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    podSelector:
+      matchLabels:
+        k8s-app: kube-dns
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  # Allow access to Kubernetes API server service IP
+  - ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443

--- a/operator/pkg/controllers/networkpolicy/manifests/default-deny-all.yaml
+++ b/operator/pkg/controllers/networkpolicy/manifests/default-deny-all.yaml
@@ -1,0 +1,12 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: {{.Namespace}}
+  labels:
+    global-hub.open-cluster-management.io/managed-by: global-hub-operator
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress

--- a/operator/pkg/controllers/networkpolicy/manifests/operator-networkpolicy.yaml
+++ b/operator/pkg/controllers/networkpolicy/manifests/operator-networkpolicy.yaml
@@ -1,0 +1,77 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: multicluster-global-hub-operator
+  namespace: {{.Namespace}}
+  labels:
+    global-hub.open-cluster-management.io/managed-by: global-hub-operator
+spec:
+  podSelector:
+    matchLabels:
+      name: multicluster-global-hub-operator
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow health check probes from kubelet (runs on node, not in a pod)
+  - ports:
+    - protocol: TCP
+      port: 8081
+  # Allow webhook traffic from API server
+  - ports:
+    - protocol: TCP
+      port: 9443
+  egress:
+  # Allow DNS resolution
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-dns
+    ports:
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  # Allow connections to PostgreSQL
+  - to:
+    - podSelector:
+        matchLabels:
+          name: {{.PostgresName}}
+    ports:
+    - protocol: TCP
+      port: 5432
+  # Allow connections to Kafka
+  - to:
+    - podSelector:
+        matchLabels:
+          strimzi.io/cluster: kafka
+    ports:
+    - protocol: TCP
+      port: 9093
+    - protocol: TCP
+      port: 9091
+  # Allow connections to SpiceDB
+  - to:
+    - podSelector:
+        matchLabels:
+          authzed.com/cluster: spicedb
+    ports:
+    - protocol: TCP
+      port: 50051
+  # Allow connections to relations-api
+  - to:
+    - podSelector:
+        matchLabels:
+          app: relations-api
+    ports:
+    - protocol: TCP
+      port: 8000

--- a/operator/pkg/controllers/networkpolicy/networkpolicy_controller.go
+++ b/operator/pkg/controllers/networkpolicy/networkpolicy_controller.go
@@ -1,0 +1,159 @@
+package networkpolicy
+
+import (
+	"context"
+	"embed"
+	"fmt"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/restmapper"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/deployer"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/renderer"
+	operatorutils "github.com/stolostron/multicluster-global-hub/operator/pkg/utils"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
+	commonutils "github.com/stolostron/multicluster-global-hub/pkg/utils"
+)
+
+// +kubebuilder:rbac:groups=operator.open-cluster-management.io,resources=multiclusterglobalhubs,verbs=get;list;watch;
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;delete
+
+//go:embed manifests
+var fs embed.FS
+
+var log = logger.DefaultZapLogger()
+
+const (
+	NetworkPolicyDefaultDenyAll = "default-deny-all"
+	NetworkPolicyAllowDNSAndAPI = "allow-dns-and-api"
+	NetworkPolicyOperator       = "multicluster-global-hub-operator"
+)
+
+type NetworkPolicyReconciler struct {
+	ctrl.Manager
+	kubeClient kubernetes.Interface
+}
+
+var (
+	networkPolicyController     *NetworkPolicyReconciler
+	networkPolicyWatchNamespace string
+)
+
+func isWatchedNetworkPolicy(obj client.Object) bool {
+	ns := networkPolicyWatchNamespace
+	if ns == "" {
+		ns = commonutils.GetDefaultNamespace()
+	}
+	return obj.GetNamespace() == ns &&
+		(obj.GetName() == NetworkPolicyDefaultDenyAll ||
+			obj.GetName() == NetworkPolicyAllowDNSAndAPI ||
+			obj.GetName() == NetworkPolicyOperator)
+}
+
+func StartController(initOption config.ControllerOption) (config.ControllerInterface, error) {
+	if networkPolicyController != nil {
+		return networkPolicyController, nil
+	}
+	log.Info("start networkpolicy controller")
+
+	if initOption.MulticlusterGlobalHub != nil {
+		networkPolicyWatchNamespace = initOption.MulticlusterGlobalHub.Namespace
+	} else {
+		networkPolicyWatchNamespace = commonutils.GetDefaultNamespace()
+	}
+
+	networkPolicyController = &NetworkPolicyReconciler{
+		Manager:    initOption.Manager,
+		kubeClient: initOption.KubeClient,
+	}
+	err := networkPolicyController.SetupWithManager(initOption.Manager)
+	if err != nil {
+		networkPolicyController = nil
+		return networkPolicyController, err
+	}
+	log.Info("initialized networkpolicy controller")
+	return networkPolicyController, nil
+}
+
+func (r *NetworkPolicyReconciler) IsResourceRemoved() bool {
+	return true
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *NetworkPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("networkpolicyController").
+		For(&v1alpha4.MulticlusterGlobalHub{},
+			builder.WithPredicates(config.MGHPred)).
+		Watches(&networkingv1.NetworkPolicy{},
+			&handler.EnqueueRequestForObject{}, builder.WithPredicates(networkPolicyPred)).
+		Complete(r)
+}
+
+var networkPolicyPred = predicate.Funcs{
+	CreateFunc: func(e event.CreateEvent) bool {
+		return isWatchedNetworkPolicy(e.Object)
+	},
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		return isWatchedNetworkPolicy(e.ObjectNew)
+	},
+	DeleteFunc: func(e event.DeleteEvent) bool {
+		return isWatchedNetworkPolicy(e.Object)
+	},
+}
+
+func (r *NetworkPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log.Debug("reconcile networkpolicy controller")
+
+	mgh, err := config.GetMulticlusterGlobalHub(ctx, r.GetClient())
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if mgh == nil || config.IsPaused(mgh) || mgh.DeletionTimestamp != nil {
+		return ctrl.Result{}, nil
+	}
+
+	// Render NetworkPolicy manifests
+	npRenderer := renderer.NewHoHRenderer(fs)
+	npDeployer := deployer.NewHoHDeployer(r.GetClient())
+
+	networkPolicyObjects, err := npRenderer.Render("manifests", "", func(profile string) (interface{}, error) {
+		return struct {
+			Namespace    string
+			PostgresName string
+		}{
+			Namespace:    mgh.Namespace,
+			PostgresName: config.COMPONENTS_POSTGRES_NAME,
+		}, nil
+	})
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to render networkpolicy manifests: %w", err)
+	}
+
+	// Create restmapper for deployer to find GVR
+	dc, err := discovery.NewDiscoveryClientForConfig(r.GetConfig())
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to create discovery client: %w", err)
+	}
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(dc))
+
+	// Deploy NetworkPolicies
+	if err = operatorutils.ManipulateGlobalHubObjects(networkPolicyObjects, mgh, npDeployer,
+		mapper, r.GetScheme()); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to deploy networkpolicy: %w", err)
+	}
+
+	log.Info("networkpolicy reconciliation completed successfully")
+	return ctrl.Result{}, nil
+}

--- a/operator/pkg/controllers/networkpolicy/networkpolicy_controller_test.go
+++ b/operator/pkg/controllers/networkpolicy/networkpolicy_controller_test.go
@@ -1,0 +1,161 @@
+package networkpolicy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
+)
+
+// assertPredicateAllEvents asserts Create, Update, and Delete predicate results for the same expected value.
+func assertPredicateAllEvents(t *testing.T, pred predicate.Funcs, obj client.Object, want bool) {
+	t.Helper()
+	assert.Equal(t, want, pred.Create(event.CreateEvent{Object: obj}), "CreateFunc")
+	assert.Equal(t, want, pred.Update(event.UpdateEvent{ObjectNew: obj}), "UpdateFunc")
+	assert.Equal(t, want, pred.Delete(event.DeleteEvent{Object: obj}), "DeleteFunc")
+}
+
+func TestNetworkPolicyPredicate(t *testing.T) {
+	namespace := utils.GetDefaultNamespace()
+
+	tests := []struct {
+		name     string
+		obj      *networkingv1.NetworkPolicy
+		wantBool bool
+	}{
+		{
+			name: "default-deny-all network policy should match",
+			obj: &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      NetworkPolicyDefaultDenyAll,
+					Namespace: namespace,
+				},
+			},
+			wantBool: true,
+		},
+		{
+			name: "allow-dns-and-api network policy should match",
+			obj: &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      NetworkPolicyAllowDNSAndAPI,
+					Namespace: namespace,
+				},
+			},
+			wantBool: true,
+		},
+		{
+			name: "multicluster-global-hub-operator network policy should match",
+			obj: &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      NetworkPolicyOperator,
+					Namespace: namespace,
+				},
+			},
+			wantBool: true,
+		},
+		{
+			name: "other network policy should not match",
+			obj: &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "other-policy",
+					Namespace: namespace,
+				},
+			},
+			wantBool: false,
+		},
+		{
+			name: "wrong namespace should not match",
+			obj: &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      NetworkPolicyDefaultDenyAll,
+					Namespace: "wrong-namespace",
+				},
+			},
+			wantBool: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertPredicateAllEvents(t, networkPolicyPred, tt.obj, tt.wantBool)
+		})
+	}
+}
+
+func TestIsResourceRemoved(t *testing.T) {
+	r := &NetworkPolicyReconciler{}
+	assert.True(t, r.IsResourceRemoved())
+}
+
+func TestStartControllerSingleton(t *testing.T) {
+	// Save and restore the singleton so we don't affect other tests.
+	original := networkPolicyController
+	t.Cleanup(func() { networkPolicyController = original })
+
+	existing := &NetworkPolicyReconciler{}
+	networkPolicyController = existing
+
+	// Second call must return the pre-existing instance without error.
+	controller, err := StartController(config.ControllerOption{})
+	assert.NoError(t, err)
+	assert.Equal(t, existing, controller)
+}
+
+func TestIsWatchedNetworkPolicyCustomNamespace(t *testing.T) {
+	// Set a custom watch namespace and verify predicate uses it instead of the default.
+	originalNS := networkPolicyWatchNamespace
+	t.Cleanup(func() { networkPolicyWatchNamespace = originalNS })
+
+	customNamespace := "custom-namespace"
+	networkPolicyWatchNamespace = customNamespace
+
+	tests := []struct {
+		name     string
+		obj      *networkingv1.NetworkPolicy
+		wantBool bool
+	}{
+		{
+			name: "watched NP in custom namespace should match",
+			obj: &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      NetworkPolicyDefaultDenyAll,
+					Namespace: customNamespace,
+				},
+			},
+			wantBool: true,
+		},
+		{
+			name: "watched NP in default namespace should NOT match when custom namespace is set",
+			obj: &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      NetworkPolicyDefaultDenyAll,
+					Namespace: utils.GetDefaultNamespace(),
+				},
+			},
+			wantBool: false,
+		},
+		{
+			name: "unknown NP in custom namespace should not match",
+			obj: &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "unrelated-policy",
+					Namespace: customNamespace,
+				},
+			},
+			wantBool: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantBool, isWatchedNetworkPolicy(tt.obj))
+		})
+	}
+}

--- a/operator/pkg/controllers/storage/manifests.sts/postgres-networkpolicy.yaml
+++ b/operator/pkg/controllers/storage/manifests.sts/postgres-networkpolicy.yaml
@@ -1,0 +1,90 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{.Name}}
+  namespace: {{.Namespace}}
+  labels:
+    name: {{.Name}}
+spec:
+  podSelector:
+    matchLabels:
+      name: {{.Name}}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+      # Allow connections from operator (for database verification)
+  - from:
+    - podSelector:
+        matchLabels:
+          name: multicluster-global-hub-operator
+    ports:
+    - protocol: TCP
+      port: 5432
+  # Allow connections from manager
+  - from:
+    - podSelector:
+        matchLabels:
+          name: multicluster-global-hub-manager
+    ports:
+    - protocol: TCP
+      port: 5432
+  # Allow connections from grafana
+  - from:
+    - podSelector:
+        matchLabels:
+          name: multicluster-global-hub-grafana
+    ports:
+    - protocol: TCP
+      port: 5432
+  # Allow connections from inventory-api
+  - from:
+    - podSelector:
+        matchLabels:
+          name: inventory-api
+    ports:
+    - protocol: TCP
+      port: 5432
+  # Allow connections from relations-api
+  - from:
+    - podSelector:
+        matchLabels:
+          app: relations-api
+    ports:
+    - protocol: TCP
+      port: 5432
+  # Allow connections from spicedb (including migration jobs)
+  - from:
+    - podSelector:
+        matchLabels:
+          authzed.com/cluster: spicedb
+    ports:
+    - protocol: TCP
+      port: 5432
+  # Allow Prometheus exporter scraping
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-monitoring
+    ports:
+    - protocol: TCP
+      port: 9187
+  egress:
+  # Allow DNS resolution
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-dns
+    ports:
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+  # Allow access to Kubernetes API for certificate verification
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: default
+    ports:
+    - protocol: TCP
+      port: 443

--- a/operator/pkg/controllers/storage/storage_reconciler.go
+++ b/operator/pkg/controllers/storage/storage_reconciler.go
@@ -15,6 +15,7 @@ import (
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -44,6 +45,7 @@ import (
 // +kubebuilder:rbac:groups="apps",resources=statefulsets,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;create;update;delete;patch
 // +kubebuilder:rbac:groups=postgres-operator.crunchydata.com,resources=postgresclusters,verbs=get;create;list;watch
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;delete
 
 //go:embed database
 var databaseFS embed.FS
@@ -123,6 +125,8 @@ func (r *StorageReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			&handler.EnqueueRequestForObject{}, builder.WithPredicates(config.GeneralPredicate)).
 		Watches(&promv1.ServiceMonitor{},
 			&handler.EnqueueRequestForObject{}, builder.WithPredicates(config.GeneralPredicate)).
+		Watches(&networkingv1.NetworkPolicy{},
+			&handler.EnqueueRequestForObject{}, builder.WithPredicates(networkPolicyPred)).
 		Complete(r)
 }
 
@@ -141,6 +145,21 @@ var configMapPredicate = predicate.Funcs{
 }
 
 var statefulSetPred = predicate.Funcs{
+	CreateFunc: func(e event.CreateEvent) bool {
+		return e.Object.GetNamespace() == commonutils.GetDefaultNamespace() &&
+			e.Object.GetName() == BuiltinPostgresName
+	},
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		return e.ObjectNew.GetNamespace() == commonutils.GetDefaultNamespace() &&
+			e.ObjectNew.GetName() == BuiltinPostgresName
+	},
+	DeleteFunc: func(e event.DeleteEvent) bool {
+		return e.Object.GetNamespace() == commonutils.GetDefaultNamespace() &&
+			e.Object.GetName() == BuiltinPostgresName
+	},
+}
+
+var networkPolicyPred = predicate.Funcs{
 	CreateFunc: func(e event.CreateEvent) bool {
 		return e.Object.GetNamespace() == commonutils.GetDefaultNamespace() &&
 			e.Object.GetName() == BuiltinPostgresName

--- a/operator/pkg/controllers/storage/storage_reconciler_test.go
+++ b/operator/pkg/controllers/storage/storage_reconciler_test.go
@@ -1,0 +1,360 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	commonutils "github.com/stolostron/multicluster-global-hub/pkg/utils"
+)
+
+// Predicate Tests - These test critical watch logic that determines which resources trigger reconciliation
+
+// assertPredicateAllEvents asserts Create, Update, and Delete predicate results for the same expected value.
+func assertPredicateAllEvents(t *testing.T, pred predicate.Funcs, obj client.Object, want bool) {
+	t.Helper()
+	assert.Equal(t, want, pred.Create(event.CreateEvent{Object: obj}), "CreateFunc")
+	assert.Equal(t, want, pred.Update(event.UpdateEvent{ObjectNew: obj}), "UpdateFunc")
+	assert.Equal(t, want, pred.Delete(event.DeleteEvent{Object: obj}), "DeleteFunc")
+}
+
+func TestConfigMapPredicate(t *testing.T) {
+	// configMapPredicate.CreateFunc only checks the watched-name set; owner label is only
+	// evaluated in UpdateFunc/DeleteFunc (operator-created resources don't need Create triggers).
+	tests := []struct {
+		name             string
+		obj              *corev1.ConfigMap
+		wantCreate       bool
+		wantUpdateDelete bool
+	}{
+		{
+			name: "watched configmap should match",
+			obj: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      BuiltinPostgresCAName,
+					Namespace: commonutils.GetDefaultNamespace(),
+				},
+			},
+			wantCreate:       true,
+			wantUpdateDelete: true,
+		},
+		{
+			name: "configmap with owner label should match on update/delete but not create",
+			obj: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "some-configmap",
+					Namespace: commonutils.GetDefaultNamespace(),
+					Labels: map[string]string{
+						constants.GlobalHubOwnerLabelKey: constants.GHOperatorOwnerLabelVal,
+					},
+				},
+			},
+			wantCreate:       false, // CreateFunc only checks name, not owner label
+			wantUpdateDelete: true,  // UpdateFunc/DeleteFunc also check owner label
+		},
+		{
+			name: "other configmap should not match",
+			obj: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "other-configmap",
+					Namespace: commonutils.GetDefaultNamespace(),
+				},
+			},
+			wantCreate:       false,
+			wantUpdateDelete: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantCreate, configMapPredicate.Create(event.CreateEvent{Object: tt.obj}), "CreateFunc")
+			assert.Equal(t, tt.wantUpdateDelete, configMapPredicate.Update(event.UpdateEvent{ObjectNew: tt.obj}), "UpdateFunc")
+			assert.Equal(t, tt.wantUpdateDelete, configMapPredicate.Delete(event.DeleteEvent{Object: tt.obj}), "DeleteFunc")
+		})
+	}
+}
+
+func TestStatefulSetPredicate(t *testing.T) {
+	namespace := commonutils.GetDefaultNamespace()
+
+	tests := []struct {
+		name     string
+		obj      *appsv1.StatefulSet
+		wantBool bool
+	}{
+		{
+			name: "builtin postgres statefulset should match",
+			obj: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      BuiltinPostgresName,
+					Namespace: namespace,
+				},
+			},
+			wantBool: true,
+		},
+		{
+			name: "other statefulset should not match",
+			obj: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "other-sts",
+					Namespace: namespace,
+				},
+			},
+			wantBool: false,
+		},
+		{
+			name: "wrong namespace should not match",
+			obj: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      BuiltinPostgresName,
+					Namespace: "wrong-namespace",
+				},
+			},
+			wantBool: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertPredicateAllEvents(t, statefulSetPred, tt.obj, tt.wantBool)
+		})
+	}
+}
+
+func TestNetworkPolicyPredicate_Storage(t *testing.T) {
+	namespace := commonutils.GetDefaultNamespace()
+
+	tests := []struct {
+		name     string
+		obj      *networkingv1.NetworkPolicy
+		wantBool bool
+	}{
+		{
+			name: "builtin postgres network policy should match",
+			obj: &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      BuiltinPostgresName,
+					Namespace: namespace,
+				},
+			},
+			wantBool: true,
+		},
+		{
+			name: "other network policy should not match",
+			obj: &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "other-policy",
+					Namespace: namespace,
+				},
+			},
+			wantBool: false,
+		},
+		{
+			name: "wrong namespace should not match",
+			obj: &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      BuiltinPostgresName,
+					Namespace: "wrong-namespace",
+				},
+			},
+			wantBool: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertPredicateAllEvents(t, networkPolicyPred, tt.obj, tt.wantBool)
+		})
+	}
+}
+
+func TestSecretPredicate_Storage(t *testing.T) {
+	// secretPred.CreateFunc only checks the watched-name set; owner label is only evaluated in
+	// UpdateFunc/DeleteFunc (operator-created secrets don't need Create triggers).
+	tests := []struct {
+		name             string
+		obj              *corev1.Secret
+		wantCreate       bool
+		wantUpdateDelete bool
+	}{
+		{
+			name: "watched secret should match",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: constants.GHStorageSecretName,
+				},
+			},
+			wantCreate:       true,
+			wantUpdateDelete: true,
+		},
+		{
+			name: "secret with owner label should match on update/delete but not create",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "some-secret",
+					Labels: map[string]string{
+						constants.GlobalHubOwnerLabelKey: constants.GHOperatorOwnerLabelVal,
+					},
+				},
+			},
+			wantCreate:       false, // CreateFunc only checks name, not owner label
+			wantUpdateDelete: true,  // UpdateFunc/DeleteFunc also check owner label
+		},
+		{
+			name: "other secret should not match",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "other-secret",
+				},
+			},
+			wantCreate:       false,
+			wantUpdateDelete: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantCreate, secretPred.Create(event.CreateEvent{Object: tt.obj}), "CreateFunc")
+			assert.Equal(t, tt.wantUpdateDelete, secretPred.Update(event.UpdateEvent{ObjectNew: tt.obj}), "UpdateFunc")
+			assert.Equal(t, tt.wantUpdateDelete, secretPred.Delete(event.DeleteEvent{Object: tt.obj}), "DeleteFunc")
+		})
+	}
+}
+
+// Utility Function Tests - These test pure functions with business logic
+
+func TestGetRetentionConditions(t *testing.T) {
+	tests := []struct {
+		name       string
+		mgh        *v1alpha4.MulticlusterGlobalHub
+		wantType   string
+		wantStatus string
+	}{
+		{
+			name: "valid retention",
+			mgh: &v1alpha4.MulticlusterGlobalHub{
+				Spec: v1alpha4.MulticlusterGlobalHubSpec{
+					DataLayerSpec: v1alpha4.DataLayerSpec{
+						Postgres: v1alpha4.PostgresSpec{
+							Retention: "6m",
+						},
+					},
+				},
+			},
+			wantType:   config.CONDITION_TYPE_DATABASE,
+			wantStatus: config.CONDITION_STATUS_TRUE,
+		},
+		{
+			name: "invalid retention",
+			mgh: &v1alpha4.MulticlusterGlobalHub{
+				Spec: v1alpha4.MulticlusterGlobalHubSpec{
+					DataLayerSpec: v1alpha4.DataLayerSpec{
+						Postgres: v1alpha4.PostgresSpec{
+							Retention: "invalid",
+						},
+					},
+				},
+			},
+			wantType:   config.CONDITION_TYPE_DATABASE,
+			wantStatus: config.CONDITION_STATUS_FALSE,
+		},
+		{
+			name: "empty retention is invalid",
+			mgh: &v1alpha4.MulticlusterGlobalHub{
+				Spec: v1alpha4.MulticlusterGlobalHubSpec{
+					DataLayerSpec: v1alpha4.DataLayerSpec{
+						Postgres: v1alpha4.PostgresSpec{
+							Retention: "",
+						},
+					},
+				},
+			},
+			wantType:   config.CONDITION_TYPE_DATABASE,
+			wantStatus: config.CONDITION_STATUS_FALSE,
+		},
+		{
+			name: "retention with year format",
+			mgh: &v1alpha4.MulticlusterGlobalHub{
+				Spec: v1alpha4.MulticlusterGlobalHubSpec{
+					DataLayerSpec: v1alpha4.DataLayerSpec{
+						Postgres: v1alpha4.PostgresSpec{
+							Retention: "1y",
+						},
+					},
+				},
+			},
+			wantType:   config.CONDITION_TYPE_DATABASE,
+			wantStatus: config.CONDITION_STATUS_TRUE,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			condition := getRetentionConditions(tt.mgh)
+			assert.Equal(t, tt.wantType, condition.Type)
+			assert.Equal(t, tt.wantStatus, string(condition.Status))
+		})
+	}
+}
+
+func TestGeneratePassword(t *testing.T) {
+	tests := []struct {
+		name   string
+		length int
+	}{
+		{
+			name:   "generate 8 char password",
+			length: 8,
+		},
+		{
+			name:   "generate 16 char password",
+			length: 16,
+		},
+		{
+			name:   "generate 32 char password",
+			length: 32,
+		},
+		{
+			name:   "generate 64 char password",
+			length: 64,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			password := generatePassword(tt.length)
+			assert.Equal(t, tt.length, len(password))
+
+			// Verify all characters are alphanumeric
+			for _, char := range password {
+				assert.True(t, (char >= 'A' && char <= 'Z') ||
+					(char >= 'a' && char <= 'z') ||
+					(char >= '0' && char <= '9'),
+					"Password contains non-alphanumeric character: %c", char)
+			}
+
+			// Test that multiple calls generate different passwords (randomness check)
+			password2 := generatePassword(tt.length)
+			// It's extremely unlikely (but not impossible) that two random passwords are identical
+			// This is a heuristic check
+			if tt.length > 8 {
+				assert.NotEqual(t, password, password2, "Generated passwords should be random")
+			}
+		})
+	}
+}
+
+func TestIsResourceRemoved(t *testing.T) {
+	reconciler := &StorageReconciler{}
+	assert.True(t, reconciler.IsResourceRemoved())
+}

--- a/operator/pkg/controllers/transporter/protocol/manifests/kafka-networkpolicy.yaml
+++ b/operator/pkg/controllers/transporter/protocol/manifests/kafka-networkpolicy.yaml
@@ -1,0 +1,71 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{.KafkaCluster}}
+  namespace: {{.Namespace}}
+  labels:
+    strimzi.io/cluster: {{.KafkaCluster}}
+spec:
+  podSelector:
+    matchLabels:
+      strimzi.io/cluster: {{.KafkaCluster}}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow connections from manager
+  - from:
+    - podSelector:
+        matchLabels:
+          name: multicluster-global-hub-manager
+    ports:
+    - protocol: TCP
+      port: 9093
+  # Allow Kafka internal communication (between brokers, controllers)
+  - from:
+    - podSelector:
+        matchLabels:
+          strimzi.io/cluster: {{.KafkaCluster}}
+  # Allow from agents in managed hub namespaces (hosted mode)
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          global-hub.open-cluster-management.io/managed-hub: "true"
+      podSelector:
+        matchLabels:
+          name: multicluster-global-hub-agent
+    ports:
+    - protocol: TCP
+      port: 9093
+  # Allow metrics scraping from Prometheus (JMX exporter tcp-prometheus)
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-monitoring
+    ports:
+    - protocol: TCP
+      port: 9404
+  egress:
+  # Allow DNS resolution
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-dns
+    ports:
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+  # Allow Kafka internal communication
+  - to:
+    - podSelector:
+        matchLabels:
+          strimzi.io/cluster: {{.KafkaCluster}}
+  # Allow Kafka to access Kubernetes API (for Strimzi operator coordination)
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: default
+    ports:
+    - protocol: TCP
+      port: 443

--- a/operator/pkg/controllers/transporter/protocol/manifests/strimzi-cluster-operator-networkpolicy.yaml
+++ b/operator/pkg/controllers/transporter/protocol/manifests/strimzi-cluster-operator-networkpolicy.yaml
@@ -1,0 +1,47 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: strimzi-cluster-operator
+  namespace: {{.Namespace}}
+  labels:
+    global-hub.open-cluster-management.io/managed-by: global-hub-operator
+spec:
+  podSelector:
+    matchLabels:
+      strimzi.io/kind: cluster-operator
+  policyTypes:
+  - Egress
+  egress:
+  # Allow DNS resolution
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-dns
+    ports:
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  # Allow access to Kafka pods for management (KRaft controller, replication, metrics)
+  - to:
+    - podSelector:
+        matchLabels:
+          strimzi.io/cluster: {{.KafkaCluster}}
+    ports:
+    - protocol: TCP
+      port: 9090  # KRaft controller
+    - protocol: TCP
+      port: 9091  # Replication
+    - protocol: TCP
+      port: 8443  # JMX/metrics
+    - protocol: TCP
+      port: 9093  # TLS client listener (admin API)

--- a/operator/pkg/controllers/transporter/transport_reconciler.go
+++ b/operator/pkg/controllers/transporter/transport_reconciler.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -21,6 +22,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
+	commonutils "github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
 // +kubebuilder:rbac:groups=kafka.strimzi.io,resources=kafkas;kafkatopics;kafkausers;kafkanodepools,verbs=get;create;list;watch;update;delete
@@ -28,15 +30,23 @@ import (
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=podmonitors,verbs=get;create;delete;update;list;watch
 // +kubebuilder:rbac:groups=operator.open-cluster-management.io,resources=multiclusterglobalhubs,verbs=get;list;watch;
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;delete;patch
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;delete
 
 var WatchedSecret = sets.NewString(
 	constants.GHTransportSecretName,
 )
 
+const (
+	StrimziClusterLabel = "strimzi.io/cluster"
+	StrimziKindLabel    = "strimzi.io/kind"
+	StrimziKindUser     = "KafkaUser"
+)
+
 var (
-	log                 = logger.DefaultZapLogger()
-	isResourceRemoved   = true
-	transportReconciler *TransportReconciler
+	log                              = logger.DefaultZapLogger()
+	isResourceRemoved                = true
+	transportReconciler              *TransportReconciler
+	kafkaNetworkPolicyWatchNamespace string
 )
 
 type TransportReconciler struct {
@@ -55,6 +65,12 @@ func StartController(controllerOption config.ControllerOption) (config.Controlle
 	}
 	log.Info("start transport controller")
 
+	if controllerOption.MulticlusterGlobalHub != nil {
+		kafkaNetworkPolicyWatchNamespace = controllerOption.MulticlusterGlobalHub.Namespace
+	} else if controllerOption.OperatorConfig != nil && controllerOption.OperatorConfig.PodNamespace != "" {
+		kafkaNetworkPolicyWatchNamespace = controllerOption.OperatorConfig.PodNamespace
+	}
+
 	transportReconciler = NewTransportReconciler(controllerOption.Manager)
 	err := transportReconciler.SetupWithManager(controllerOption.Manager)
 	if err != nil {
@@ -72,6 +88,8 @@ func (r *TransportReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			builder.WithPredicates(config.MGHPred)).
 		Watches(&corev1.Secret{},
 			&handler.EnqueueRequestForObject{}, builder.WithPredicates(secretPred)).
+		Watches(&networkingv1.NetworkPolicy{},
+			&handler.EnqueueRequestForObject{}, builder.WithPredicates(networkPolicyPred)).
 		Complete(r)
 }
 
@@ -87,12 +105,32 @@ var secretPred = predicate.Funcs{
 	},
 }
 
+var networkPolicyPred = predicate.Funcs{
+	CreateFunc: func(e event.CreateEvent) bool {
+		return networkPolicyCond(e.Object)
+	},
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		return networkPolicyCond(e.ObjectNew)
+	},
+	DeleteFunc: func(e event.DeleteEvent) bool {
+		return networkPolicyCond(e.Object)
+	},
+}
+
+func networkPolicyCond(obj client.Object) bool {
+	ns := kafkaNetworkPolicyWatchNamespace
+	if ns == "" {
+		ns = commonutils.GetDefaultNamespace()
+	}
+	return obj.GetNamespace() == ns && obj.GetName() == protocol.KafkaClusterName
+}
+
 func secretCond(obj client.Object) bool {
 	if WatchedSecret.Has(obj.GetName()) {
 		return true
 	}
-	if obj.GetLabels()["strimzi.io/cluster"] == protocol.KafkaClusterName &&
-		obj.GetLabels()["strimzi.io/kind"] == "KafkaUser" {
+	if obj.GetLabels()[StrimziClusterLabel] == protocol.KafkaClusterName &&
+		obj.GetLabels()[StrimziKindLabel] == StrimziKindUser {
 		return true
 	}
 	return false

--- a/operator/pkg/controllers/transporter/transport_reconciler_test.go
+++ b/operator/pkg/controllers/transporter/transport_reconciler_test.go
@@ -1,0 +1,351 @@
+package transporter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/transporter/protocol"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
+)
+
+// Predicate Tests - These test critical watch logic for Kafka-related resources
+
+const testSecretName = "some-secret"
+
+// assertPredicateAllEvents asserts Create, Update, and Delete predicate results for the same expected value.
+func assertPredicateAllEvents(t *testing.T, pred predicate.Funcs, obj client.Object, want bool) {
+	t.Helper()
+	assert.Equal(t, want, pred.Create(event.CreateEvent{Object: obj}), "CreateFunc")
+	assert.Equal(t, want, pred.Update(event.UpdateEvent{ObjectNew: obj}), "UpdateFunc")
+	assert.Equal(t, want, pred.Delete(event.DeleteEvent{Object: obj}), "DeleteFunc")
+}
+
+func TestSecretPredicate(t *testing.T) {
+	tests := []struct {
+		name     string
+		obj      *corev1.Secret
+		wantBool bool
+	}{
+		{
+			name: "transport secret should match",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.GHTransportSecretName,
+					Namespace: utils.GetDefaultNamespace(),
+				},
+			},
+			wantBool: true,
+		},
+		{
+			name: "kafka user secret with strimzi labels should match",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kafka-user-secret",
+					Namespace: utils.GetDefaultNamespace(),
+					Labels: map[string]string{
+						StrimziClusterLabel: protocol.KafkaClusterName,
+						StrimziKindLabel:    StrimziKindUser,
+					},
+				},
+			},
+			wantBool: true,
+		},
+		{
+			name: "kafka secret with wrong cluster name should not match",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kafka-user-secret",
+					Namespace: utils.GetDefaultNamespace(),
+					Labels: map[string]string{
+						StrimziClusterLabel: "wrong-cluster",
+						StrimziKindLabel:    StrimziKindUser,
+					},
+				},
+			},
+			wantBool: false,
+		},
+		{
+			name: "kafka secret with wrong kind should not match",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kafka-secret",
+					Namespace: utils.GetDefaultNamespace(),
+					Labels: map[string]string{
+						StrimziClusterLabel: protocol.KafkaClusterName,
+						StrimziKindLabel:    "Kafka",
+					},
+				},
+			},
+			wantBool: false,
+		},
+		{
+			name: "other secret should not match",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "other-secret",
+					Namespace: utils.GetDefaultNamespace(),
+				},
+			},
+			wantBool: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertPredicateAllEvents(t, secretPred, tt.obj, tt.wantBool)
+		})
+	}
+}
+
+func TestNetworkPolicyPredicate_Transport(t *testing.T) {
+	tests := []struct {
+		name     string
+		obj      *networkingv1.NetworkPolicy
+		wantBool bool
+	}{
+		{
+			name: "kafka network policy should match",
+			obj: &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      protocol.KafkaClusterName,
+					Namespace: utils.GetDefaultNamespace(),
+				},
+			},
+			wantBool: true,
+		},
+		{
+			name: "kafka network policy in wrong namespace should not match",
+			obj: &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      protocol.KafkaClusterName,
+					Namespace: "other-namespace",
+				},
+			},
+			wantBool: false,
+		},
+		{
+			name: "other network policy should not match",
+			obj: &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "other-policy",
+					Namespace: utils.GetDefaultNamespace(),
+				},
+			},
+			wantBool: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertPredicateAllEvents(t, networkPolicyPred, tt.obj, tt.wantBool)
+		})
+	}
+}
+
+// Helper Function Tests - These test the predicate condition logic
+
+func TestNetworkPolicyCond(t *testing.T) {
+	tests := []struct {
+		name     string
+		objName  string
+		expected bool
+	}{
+		{
+			name:     "kafka cluster name matches",
+			objName:  protocol.KafkaClusterName,
+			expected: true,
+		},
+		{
+			name:     "other name does not match",
+			objName:  "other-name",
+			expected: false,
+		},
+		{
+			name:     "empty name does not match",
+			objName:  "",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tt.objName,
+					Namespace: utils.GetDefaultNamespace(),
+				},
+			}
+			result := networkPolicyCond(obj)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSecretCond(t *testing.T) {
+	tests := []struct {
+		name     string
+		obj      *corev1.Secret
+		expected bool
+	}{
+		{
+			name: "transport secret name matches",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: constants.GHTransportSecretName,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "kafka user secret with both labels matches",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: testSecretName,
+					Labels: map[string]string{
+						StrimziClusterLabel: protocol.KafkaClusterName,
+						StrimziKindLabel:    StrimziKindUser,
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "kafka secret with only cluster label does not match",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: testSecretName,
+					Labels: map[string]string{
+						StrimziClusterLabel: protocol.KafkaClusterName,
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "kafka secret with only kind label does not match",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: testSecretName,
+					Labels: map[string]string{
+						StrimziKindLabel: StrimziKindUser,
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "other secret does not match",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "other-secret",
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := secretCond(tt.obj)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// State Management Tests
+
+func TestTransportReconcilerIsResourceRemoved(t *testing.T) {
+	r := &TransportReconciler{}
+
+	// Test with default state (should be true initially)
+	originalState := isResourceRemoved
+	defer func() {
+		isResourceRemoved = originalState
+	}()
+
+	// Test when isResourceRemoved is true
+	isResourceRemoved = true
+	result := r.IsResourceRemoved()
+	assert.True(t, result)
+
+	// Test when isResourceRemoved is false
+	isResourceRemoved = false
+	result = r.IsResourceRemoved()
+	assert.False(t, result)
+}
+
+func TestStartControllerSingleton(t *testing.T) {
+	// Save and restore the singleton so we don't affect other tests.
+	original := transportReconciler
+	t.Cleanup(func() { transportReconciler = original })
+
+	existing := &TransportReconciler{}
+	transportReconciler = existing
+
+	// Second call must return the pre-existing instance without error.
+	controller, err := StartController(config.ControllerOption{})
+	assert.NoError(t, err)
+	assert.Equal(t, existing, controller)
+}
+
+func TestNetworkPolicyCondCustomNamespace(t *testing.T) {
+	// networkPolicyCond uses kafkaNetworkPolicyWatchNamespace when set;
+	// verify it does NOT fall back to the default namespace.
+	originalNS := kafkaNetworkPolicyWatchNamespace
+	t.Cleanup(func() { kafkaNetworkPolicyWatchNamespace = originalNS })
+
+	customNamespace := "custom-kafka-namespace"
+	kafkaNetworkPolicyWatchNamespace = customNamespace
+
+	tests := []struct {
+		name     string
+		obj      *networkingv1.NetworkPolicy
+		expected bool
+	}{
+		{
+			name: "kafka NP in custom namespace should match",
+			obj: &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      protocol.KafkaClusterName,
+					Namespace: customNamespace,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "kafka NP in default namespace should NOT match when custom namespace is set",
+			obj: &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      protocol.KafkaClusterName,
+					Namespace: utils.GetDefaultNamespace(),
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "unknown NP in custom namespace should not match",
+			obj: &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "other-policy",
+					Namespace: customNamespace,
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, networkPolicyCond(tt.obj))
+		})
+	}
+}

--- a/operator/pkg/deployer/hoh_deployer.go
+++ b/operator/pkg/deployer/hoh_deployer.go
@@ -7,6 +7,7 @@ import (
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -43,6 +44,7 @@ func NewHoHDeployer(client client.Client) Deployer {
 		"ClusterRole":        deployer.deployClusterRole,
 		"ClusterRoleBinding": deployer.deployClusterRoleBinding,
 		"PodMonitor":         deployer.deployPodMonitor,
+		"NetworkPolicy":      deployer.deployNetworkPolicy,
 	}
 	return deployer
 }
@@ -50,20 +52,33 @@ func NewHoHDeployer(client client.Client) Deployer {
 func (d *HoHDeployer) Deploy(unsObj *unstructured.Unstructured) error {
 	foundObj := &unstructured.Unstructured{}
 	foundObj.SetGroupVersionKind(unsObj.GetObjectKind().GroupVersionKind())
-	err := d.client.Get(
-		context.TODO(),
-		types.NamespacedName{Name: unsObj.GetName(), Namespace: unsObj.GetNamespace()},
-		foundObj,
-	)
+	namespacedName := types.NamespacedName{Name: unsObj.GetName(), Namespace: unsObj.GetNamespace()}
+	err := d.client.Get(context.TODO(), namespacedName, foundObj)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			return d.client.Create(context.TODO(), unsObj)
+			if createErr := d.client.Create(context.TODO(), unsObj); createErr != nil {
+				if !errors.IsAlreadyExists(createErr) {
+					return createErr
+				}
+				foundObj = &unstructured.Unstructured{}
+				foundObj.SetGroupVersionKind(unsObj.GetObjectKind().GroupVersionKind())
+				if getErr := d.client.Get(context.TODO(), namespacedName, foundObj); getErr != nil {
+					return getErr
+				}
+			} else {
+				return nil
+			}
+		} else {
+			return err
 		}
-		return err
 	}
 
+	return d.deployExisting(unsObj, foundObj)
+}
+
+func (d *HoHDeployer) deployExisting(desiredObj, foundObj *unstructured.Unstructured) error {
 	// if resource has annotation skip-creation-if-exist: true, then it will not be updated
-	metadata, ok := unsObj.Object["metadata"].(map[string]interface{})
+	metadata, ok := desiredObj.Object["metadata"].(map[string]interface{})
 	if ok {
 		annotations, ok := metadata["annotations"].(map[string]interface{})
 		if ok && annotations != nil && annotations["skip-creation-if-exist"] != nil {
@@ -75,13 +90,13 @@ func (d *HoHDeployer) Deploy(unsObj *unstructured.Unstructured) error {
 
 	deployFunction, ok := d.deployFuncs[foundObj.GetKind()]
 	if ok {
-		return deployFunction(unsObj, foundObj)
-	} else {
-		if !apiequality.Semantic.DeepDerivative(unsObj, foundObj) {
-			unsObj.SetGroupVersionKind(unsObj.GetObjectKind().GroupVersionKind())
-			unsObj.SetResourceVersion(foundObj.GetResourceVersion())
-			return d.client.Update(context.TODO(), unsObj)
-		}
+		return deployFunction(desiredObj, foundObj)
+	}
+
+	if !apiequality.Semantic.DeepDerivative(desiredObj, foundObj) {
+		desiredObj.SetGroupVersionKind(desiredObj.GetObjectKind().GroupVersionKind())
+		desiredObj.SetResourceVersion(foundObj.GetResourceVersion())
+		return d.client.Update(context.TODO(), desiredObj)
 	}
 
 	return nil
@@ -322,6 +337,31 @@ func (d *HoHDeployer) deployClusterRoleBinding(desiredObj, existingObj *unstruct
 		!apiequality.Semantic.DeepDerivative(desiredCRB.GetLabels(), existingCRB.GetLabels()) ||
 		!apiequality.Semantic.DeepDerivative(desiredCRB.GetAnnotations(), existingCRB.GetAnnotations()) {
 		return d.client.Update(context.TODO(), desiredCRB)
+	}
+
+	return nil
+}
+
+func (d *HoHDeployer) deployNetworkPolicy(desiredObj, existingObj *unstructured.Unstructured) error {
+	existingJSON, _ := existingObj.MarshalJSON()
+	existingNP := &networkingv1.NetworkPolicy{}
+	err := json.Unmarshal(existingJSON, existingNP)
+	if err != nil {
+		return err
+	}
+
+	desiredJSON, _ := desiredObj.MarshalJSON()
+	desiredNP := &networkingv1.NetworkPolicy{}
+	err = json.Unmarshal(desiredJSON, desiredNP)
+	if err != nil {
+		return err
+	}
+
+	if !apiequality.Semantic.DeepDerivative(desiredNP.Spec, existingNP.Spec) ||
+		!apiequality.Semantic.DeepDerivative(desiredNP.GetLabels(), existingNP.GetLabels()) ||
+		!apiequality.Semantic.DeepDerivative(desiredNP.GetAnnotations(), existingNP.GetAnnotations()) {
+		desiredNP.ResourceVersion = existingNP.ResourceVersion
+		return d.client.Update(context.TODO(), desiredNP)
 	}
 
 	return nil

--- a/operator/pkg/deployer/hoh_deployer_test.go
+++ b/operator/pkg/deployer/hoh_deployer_test.go
@@ -301,6 +301,51 @@ var _ = Describe("Deployer", Ordered, func() {
 		})
 	})
 
+	Context("with NetworkPolicy objects", func() {
+		It("should deploy, update on spec change, and no-op when unchanged", func() {
+			By("load NetworkPolicy object")
+			npObjects, err := loadObjects(manifestsFS, "testdata/networkpolicyv1")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("deploy NetworkPolicy (create path)")
+			for _, obj := range npObjects {
+				Expect(hohdeployer.Deploy(obj)).NotTo(HaveOccurred())
+			}
+
+			By("redeploy with updated spec (update path — ingress port changed)")
+			for _, obj := range npObjects {
+				spec, _, _ := unstructured.NestedMap(obj.Object, "spec")
+				ingress := []interface{}{
+					map[string]interface{}{
+						"ports": []interface{}{
+							map[string]interface{}{"protocol": "TCP", "port": int64(9090)},
+						},
+					},
+				}
+				spec["ingress"] = ingress
+				Expect(unstructured.SetNestedMap(obj.Object, spec, "spec")).To(Succeed())
+				Expect(hohdeployer.Deploy(obj)).NotTo(HaveOccurred())
+			}
+
+			By("verify spec was updated")
+			for _, obj := range npObjects {
+				got := &unstructured.Unstructured{}
+				got.SetGroupVersionKind(obj.GetObjectKind().GroupVersionKind())
+				Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Namespace: obj.GetNamespace(),
+					Name:      obj.GetName(),
+				}, got)).NotTo(HaveOccurred())
+				ports, _, _ := unstructured.NestedSlice(got.Object, "spec", "ingress")
+				Expect(ports).NotTo(BeEmpty())
+			}
+
+			By("redeploy with no changes (no-op path)")
+			for _, obj := range npObjects {
+				Expect(hohdeployer.Deploy(obj)).NotTo(HaveOccurred())
+			}
+		})
+	})
+
 	Context("with untyped objects", func() {
 		It("should be updated when new annotations are added", func() {
 			By("load untyped objects")

--- a/operator/pkg/deployer/testdata/networkpolicyv1/networkpolicy.yaml
+++ b/operator/pkg/deployer/testdata/networkpolicyv1/networkpolicy.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-networkpolicy
+  namespace: default
+  labels:
+    app: test
+spec:
+  podSelector:
+    matchLabels:
+      app: test
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          role: client
+    ports:
+    - protocol: TCP
+      port: 8080

--- a/test/integration/operator/controllers/agent/managedclusteraddon_test.go
+++ b/test/integration/operator/controllers/agent/managedclusteraddon_test.go
@@ -91,7 +91,7 @@ var _ = Describe("deploy default addon", func() {
 			}, work)
 		}, timeout, interval).ShouldNot(HaveOccurred())
 
-		Expect(len(work.Spec.Workload.Manifests)).Should(Equal(8))
+		Expect(len(work.Spec.Workload.Manifests)).Should(Equal(9))
 	})
 
 	It("Should create default addon and ACM with deploy label = Default under brownfield mode", func() {
@@ -135,7 +135,7 @@ var _ = Describe("deploy default addon", func() {
 			}, work)
 		}, timeout, interval).ShouldNot(HaveOccurred())
 
-		// contains both the ACM and the Global Hub manifests
-		Expect(len(work.Spec.Workload.Manifests)).Should(Equal(17))
+		// contains both the ACM and the Global Hub manifests (includes agent NetworkPolicy)
+		Expect(len(work.Spec.Workload.Manifests)).Should(Equal(18))
 	})
 })

--- a/test/integration/operator/controllers/grafana_test.go
+++ b/test/integration/operator/controllers/grafana_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -70,6 +71,15 @@ var _ = Describe("grafana", Ordered, func() {
 				return err
 			}
 			return nil
+		}, 10*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
+
+		// NetworkPolicy is rendered alongside other grafana manifests; verify it is created
+		Eventually(func() error {
+			np := &networkingv1.NetworkPolicy{}
+			return runtimeClient.Get(ctx, types.NamespacedName{
+				Name:      "multicluster-global-hub-grafana",
+				Namespace: mgh.Namespace,
+			}, np)
 		}, 10*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
 	})
 

--- a/test/integration/operator/controllers/manager_test.go
+++ b/test/integration/operator/controllers/manager_test.go
@@ -9,6 +9,7 @@ import (
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -111,6 +112,15 @@ var _ = Describe("manager", Ordered, func() {
 				Name:      operatorconstants.GHServiceMonitorName,
 			}, serviceMonitor)
 			return err
+		}, 10*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
+
+		// NetworkPolicy is rendered alongside other manager manifests; verify it is created
+		Eventually(func() error {
+			np := &networkingv1.NetworkPolicy{}
+			return runtimeClient.Get(ctx, types.NamespacedName{
+				Name:      "multicluster-global-hub-manager",
+				Namespace: mgh.Namespace,
+			}, np)
 		}, 10*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
 	})
 

--- a/test/integration/operator/controllers/networkpolicy_test.go
+++ b/test/integration/operator/controllers/networkpolicy_test.go
@@ -1,0 +1,257 @@
+package controllers
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/networkpolicy"
+	testutils "github.com/stolostron/multicluster-global-hub/test/integration/utils"
+)
+
+// go test ./test/integration/operator/controllers -ginkgo.focus "networkpolicy" -v
+var _ = Describe("networkpolicy", Ordered, func() {
+	var mgh *v1alpha4.MulticlusterGlobalHub
+	var namespace string
+	var reconciler *networkpolicy.NetworkPolicyReconciler
+
+	BeforeAll(func() {
+		namespace = fmt.Sprintf("namespace-%s", rand.String(6))
+		mghName := "test-mgh"
+
+		// Create namespace
+		err := runtimeClient.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		})
+		Expect(err).To(Succeed())
+
+		// Create MGH
+		mgh = &v1alpha4.MulticlusterGlobalHub{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      mghName,
+				Namespace: namespace,
+			},
+			Spec: v1alpha4.MulticlusterGlobalHubSpec{},
+		}
+		Expect(runtimeClient.Create(ctx, mgh)).To(Succeed())
+		Expect(runtimeClient.Get(ctx, client.ObjectKeyFromObject(mgh), mgh)).To(Succeed())
+	})
+
+	It("should start the networkpolicy controller", func() {
+		initOption := config.ControllerOption{
+			Manager:    runtimeManager,
+			KubeClient: kubeClient,
+		}
+
+		controller, err := networkpolicy.StartController(initOption)
+		Expect(err).To(Succeed())
+		Expect(controller).NotTo(BeNil())
+
+		// Cast to get the reconciler for manual reconciliation
+		var ok bool
+		reconciler, ok = controller.(*networkpolicy.NetworkPolicyReconciler)
+		Expect(ok).To(BeTrue())
+	})
+
+	It("should render and deploy networkpolicy manifests", func() {
+		// Trigger reconciliation
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: mgh.Namespace,
+				Name:      mgh.Name,
+			},
+		})
+		Expect(err).To(Succeed())
+
+		// Verify default-deny-all NetworkPolicy is created
+		Eventually(func() error {
+			np := &networkingv1.NetworkPolicy{}
+			return runtimeClient.Get(ctx, types.NamespacedName{
+				Name:      "default-deny-all",
+				Namespace: mgh.Namespace,
+			}, np)
+		}, 10*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
+
+		// Verify allow-dns-and-api NetworkPolicy is created
+		Eventually(func() error {
+			np := &networkingv1.NetworkPolicy{}
+			return runtimeClient.Get(ctx, types.NamespacedName{
+				Name:      "allow-dns-and-api",
+				Namespace: mgh.Namespace,
+			}, np)
+		}, 10*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
+
+		// Verify multicluster-global-hub-operator NetworkPolicy is created
+		Eventually(func() error {
+			np := &networkingv1.NetworkPolicy{}
+			return runtimeClient.Get(ctx, types.NamespacedName{
+				Name:      "multicluster-global-hub-operator",
+				Namespace: mgh.Namespace,
+			}, np)
+		}, 10*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
+	})
+
+	It("should verify networkpolicy content", func() {
+		// Check default-deny-all policy content
+		np := &networkingv1.NetworkPolicy{}
+		err := runtimeClient.Get(ctx, types.NamespacedName{
+			Name:      "default-deny-all",
+			Namespace: mgh.Namespace,
+		}, np)
+		Expect(err).To(Succeed())
+		Expect(np.Spec.PodSelector).NotTo(BeNil())
+		Expect(np.Spec.PolicyTypes).To(ContainElements(
+			networkingv1.PolicyTypeIngress,
+			networkingv1.PolicyTypeEgress,
+		))
+
+		// Check operator NetworkPolicy has correct labels
+		operatorNP := &networkingv1.NetworkPolicy{}
+		err = runtimeClient.Get(ctx, types.NamespacedName{
+			Name:      "multicluster-global-hub-operator",
+			Namespace: mgh.Namespace,
+		}, operatorNP)
+		Expect(err).To(Succeed())
+		Expect(operatorNP.Labels).To(HaveKey("global-hub.open-cluster-management.io/managed-by"))
+		Expect(operatorNP.Spec.PodSelector.MatchLabels).To(HaveKeyWithValue("name", "multicluster-global-hub-operator"))
+		Expect(operatorNP.Spec.PolicyTypes).To(ContainElement(networkingv1.PolicyTypeEgress))
+	})
+
+	It("should recreate networkpolicy when deleted", func() {
+		// Delete one of the NetworkPolicies
+		np := &networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "default-deny-all",
+				Namespace: mgh.Namespace,
+			},
+		}
+		err := runtimeClient.Delete(ctx, np)
+		Expect(err).To(Succeed())
+
+		// Verify it's deleted
+		Eventually(func() bool {
+			err := runtimeClient.Get(ctx, types.NamespacedName{
+				Name:      "default-deny-all",
+				Namespace: mgh.Namespace,
+			}, np)
+			return errors.IsNotFound(err)
+		}, 5*time.Second, 100*time.Millisecond).Should(BeTrue())
+
+		// Trigger reconciliation
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: mgh.Namespace,
+				Name:      mgh.Name,
+			},
+		})
+		Expect(err).To(Succeed())
+
+		// Verify NetworkPolicy is recreated
+		Eventually(func() error {
+			return runtimeClient.Get(ctx, types.NamespacedName{
+				Name:      "default-deny-all",
+				Namespace: mgh.Namespace,
+			}, np)
+		}, 10*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
+	})
+
+	It("should not reconcile when MGH is paused", func() {
+		// Update MGH to be paused
+		mgh.Annotations = map[string]string{
+			"mgh-pause": "true",
+		}
+		err := runtimeClient.Update(ctx, mgh)
+		Expect(err).To(Succeed())
+
+		// Delete a NetworkPolicy
+		np := &networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "allow-dns-and-api",
+				Namespace: mgh.Namespace,
+			},
+		}
+		err = runtimeClient.Delete(ctx, np)
+		Expect(err).To(Succeed())
+
+		// Trigger reconciliation
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: mgh.Namespace,
+				Name:      mgh.Name,
+			},
+		})
+		Expect(err).To(Succeed())
+
+		// Verify NetworkPolicy is NOT recreated (remains deleted)
+		Consistently(func() bool {
+			err := runtimeClient.Get(ctx, types.NamespacedName{
+				Name:      "allow-dns-and-api",
+				Namespace: mgh.Namespace,
+			}, np)
+			return errors.IsNotFound(err)
+		}, 3*time.Second, 100*time.Millisecond).Should(BeTrue())
+
+		// Unpause MGH for cleanup
+		mgh.Annotations = nil
+		err = runtimeClient.Update(ctx, mgh)
+		Expect(err).To(Succeed())
+	})
+
+	It("should not reconcile when MGH is being deleted", func() {
+		// Get the current MGH
+		err := runtimeClient.Get(ctx, client.ObjectKeyFromObject(mgh), mgh)
+		Expect(err).To(Succeed())
+
+		// Add finalizer to prevent immediate deletion
+		mgh.Finalizers = []string{"test-finalizer"}
+		err = runtimeClient.Update(ctx, mgh)
+		Expect(err).To(Succeed())
+
+		// Mark MGH for deletion
+		err = runtimeClient.Delete(ctx, mgh)
+		Expect(err).To(Succeed())
+
+		// Verify MGH has deletion timestamp
+		err = runtimeClient.Get(ctx, client.ObjectKeyFromObject(mgh), mgh)
+		Expect(err).To(Succeed())
+		Expect(mgh.DeletionTimestamp).NotTo(BeNil())
+
+		// Trigger reconciliation
+		result, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: mgh.Namespace,
+				Name:      mgh.Name,
+			},
+		})
+		Expect(err).To(Succeed())
+		Expect(result.Requeue).To(BeFalse())
+
+		// Remove finalizer to allow deletion
+		mgh.Finalizers = nil
+		err = runtimeClient.Update(ctx, mgh)
+		Expect(err).To(Succeed())
+	})
+
+	AfterAll(func() {
+		Eventually(func() error {
+			if err := testutils.DeleteMgh(ctx, runtimeClient, mgh); err != nil {
+				return err
+			}
+			return deleteNamespace(namespace)
+		}, 30*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
+	})
+})

--- a/test/integration/operator/controllers/storage_test.go
+++ b/test/integration/operator/controllers/storage_test.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -328,6 +329,15 @@ var _ = Describe("storage", Ordered, func() {
 				return err
 			}
 			return nil
+		}, 10*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
+
+		// NetworkPolicy is rendered alongside the postgres StatefulSet manifests; verify it is created
+		Eventually(func() error {
+			np := &networkingv1.NetworkPolicy{}
+			return runtimeClient.Get(ctx, types.NamespacedName{
+				Name:      storage.BuiltinPostgresName,
+				Namespace: mgh.Namespace,
+			}, np)
 		}, 10*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
 
 		// verify the customized configuration is merged into the rendered configmap

--- a/test/integration/operator/controllers/transporter_test.go
+++ b/test/integration/operator/controllers/transporter_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -194,6 +195,23 @@ var _ = Describe("transporter", Ordered, func() {
 				return err
 			}
 			return nil
+		}, 10*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
+
+		// NetworkPolicies are rendered alongside the kafka manifests; verify both are created
+		Eventually(func() error {
+			np := &networkingv1.NetworkPolicy{}
+			return runtimeClient.Get(ctx, types.NamespacedName{
+				Name:      protocol.KafkaClusterName,
+				Namespace: mgh.Namespace,
+			}, np)
+		}, 10*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
+
+		Eventually(func() error {
+			np := &networkingv1.NetworkPolicy{}
+			return runtimeClient.Get(ctx, types.NamespacedName{
+				Name:      "strimzi-cluster-operator",
+				Namespace: mgh.Namespace,
+			}, np)
 		}, 10*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
 
 		// update the kafka resource to make it ready

--- a/test/integration/operator/webhook/admission_handler_test.go
+++ b/test/integration/operator/webhook/admission_handler_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Multicluster hub webhook", func() {
 					return false
 				}
 				return true
-			}, 1*time.Second, 5*time.Second).Should(BeTrue())
+			}, 10*time.Second, 100*time.Millisecond).Should(BeTrue())
 		})
 	})
 
@@ -97,7 +97,7 @@ var _ = Describe("Multicluster hub webhook", func() {
 					return false
 				}
 				return true
-			}, 1*time.Second, 5*time.Second).Should(BeTrue())
+			}, 10*time.Second, 100*time.Millisecond).Should(BeTrue())
 		})
 	})
 })


### PR DESCRIPTION
Related Issues
https://redhat.atlassian.net/browse/ACM-31409
Supersedes Add NetworkPolicy support for multicluster-global-hub #2371
https://redhat.atlassian.net/browse/ACM-32313

[ACM-36414](https://redhat.atlassian.net/browse/ACM-36414)

## Summary

Rebased replacement for #2371. Adds NetworkPolicy resources to enforce a default-deny posture with targeted allow rules for Global Hub components in the `multicluster-global-hub` namespace.

Supersedes #2371.

## What this changes

On current `main`, Global Hub deploys manager, grafana, postgres, kafka, inventory, operator, and agent workloads **without** any NetworkPolicy enforcement. All pod-to-pod and egress traffic is unrestricted within the namespace.

This PR introduces operator-managed NetworkPolicies that:

1. **Default deny** — block all ingress/egress unless explicitly allowed
2. **Shared baseline** — permit DNS and Kubernetes API access required by every pod
3. **Component-specific rules** — allow only the ports and peers each component needs

### Architecture

| Layer | Policy | Purpose |
|---|---|---|
| **Baseline** | `default-deny-all` | Deny all ingress/egress by default |
| **Baseline** | `allow-dns-and-api` | DNS (ports 53/5353) + K8s API (443/6443) for all pods |
| **Operator** | `multicluster-global-hub-operator` | Health probes (8081), webhooks (9443) |
| **Manager** | manager networkpolicy | Ingress 8080/8384; egress to postgres, kafka, K8s API |
| **Grafana** | grafana networkpolicy | Ingress from router/Prometheus/HA peers; egress to postgres, OAuth |
| **PostgreSQL** | postgres networkpolicy | Ingress 5432/9187 from manager/grafana; minimal egress |
| **Kafka** | kafka + strimzi-operator policies | Ingress 9093; internal Strimzi communication |
| **Inventory** | inventory-api, relations-api, spicedb policies | Component-specific ingress/egress |
| **Agent** | agent networkpolicy (local + addon) | Egress to DNS, K8s API, kafka (9092–9095), webhooks |

### Operator integration

- **`HoHDeployer`** — new `deployNetworkPolicy()` deploys common policies at install time
- **Dedicated `networkpolicy` controller** — reconciles shared policies (`default-deny-all`, `allow-dns-and-api`, operator policy)
- **Per-component controllers** — manager, grafana, storage, transporter, inventory, and agent controllers each watch and reconcile their own NetworkPolicy
- **RBAC** — ClusterRole and CSV updated with `networkpolicies` create/get/list/watch/update/delete permissions

### Key fixes included from #2371 iteration

- Renamed `allow-dns` → `allow-dns-and-api` so all pods can reach the Kubernetes API service IP (fixes operator/Strimzi crash-loops blocked by default-deny)
- Operator NetworkPolicy ingress for kubelet health checks and API server webhooks
- Flexible postgres egress (port 5432, not tied to a single pod label) for external/cloud DB scenarios
- Agent NetworkPolicy for both addon-based and local agent deployments

## Why this is still needed

**None of this exists on `main` today.** A search for NetworkPolicy manifests, the `networkpolicy` controller, or related RBAC in the current tree returns nothing. The feature was developed in #2371 (April 2026) but never merged — the PR is 21 commits behind `main`, has merge conflicts, and stale failing CI.

NetworkPolicy enforcement is tracked in [ACM-31409](https://redhat.atlassian.net/browse/ACM-31409) as a security hardening requirement for Global Hub.

HoH OpenShift e2e test coverage is tracked in [ACM-32495](https://redhat.atlassian.net/browse/ACM-32495) (separate `acmqe-hoh-e2e` PR, `TEST_TAGS=networkpolicy`).

## Testing

- [x] Unit tests pass locally:
  - `go test ./operator/pkg/controllers/networkpolicy/...`
  - `go test ./operator/pkg/controllers/storage/...`
  - `go test ./operator/pkg/controllers/transporter/...`
- [ ] CI: unit, integration, e2e, Konflux, images
- KinD: policies are **created** but not enforced (kindnet CNI limitation)
- OpenShift (OVN-Kubernetes): policies are created **and** enforced

## Documentation

- `ai-doc/NETWORKPOLICY.md` — rollout phases, testing/monitoring, rollback steps

Made with [Cursor](https://cursor.com)

[ACM-31409]: https://redhat.atlassian.net/browse/ACM-31409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deploys comprehensive NetworkPolicy resources (default-deny baseline plus explicit allow rules) covering operator, manager, Grafana, PostgreSQL, Kafka/Strimzi, inventory/relations/SpiceDB, and agents.

* **Documentation**
  * Added a full NetworkPolicy guide with rollout phases, verification/testing steps, monitoring tips, and rollback instructions.

* **Tests**
  * Added unit and integration tests validating NetworkPolicy controller predicates, reconciliation, and lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


[ACM-36414]: https://redhat.atlassian.net/browse/ACM-36414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ