### PR TITLE
fix(ci): skip bundle repo sync check on release-5.0

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -47,8 +47,9 @@ jobs:
       - name: bundle
         run: cd operator && make bundle
 
-      # main uses dev bundle versions (e.g. 1.8.0-dev) while release-* bundle
-      # repos carry GA z-stream versions — skip external sync on main.
+      # main and release-5.0 use dev bundle versions (e.g. 1.8.0-dev) while the
+      # matching release-* branches in multicluster-global-hub-operator-bundle
+      # carry GA z-stream versions — skip external sync on those branches.
       - name: resolve bundle comparison branch
         id: bundle-branch
         run: |
@@ -58,11 +59,14 @@ jobs:
             TARGET="${GITHUB_REF#refs/heads/}"
           fi
           echo "target=${TARGET}" >> "$GITHUB_OUTPUT"
-          if [ "${TARGET}" = "main" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
+          case "${TARGET}" in
+            main|release-5.0)
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "skip=false" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
 
       - name: compare bundle with stolostron/multicluster-global-hub-operator-bundle
         if: steps.bundle-branch.outputs.skip != 'true'


### PR DESCRIPTION
## Summary

Extends the #2470 bundle-repo sync skip to **`release-5.0`**.

- `main` and `release-5.0` still generate dev bundle versions (`1.8.0-dev`)
- `multicluster-global-hub-operator-bundle` `release-5.0` carries GA `1.8.0` (since [operator-bundle#1053](https://github.com/stolostron/multicluster-global-hub-operator-bundle/pull/1053))
- The external diff fails on version only — unrelated to the actual code change (e.g. #2409 librdkafka)

`make bundle` still runs on all branches (validates committed bundle matches generated tree).

## Root cause

| Branch | global-hub bundle | operator-bundle branch | verify bundle |
|--------|-------------------|------------------------|---------------|
| `main` | `1.8.0-dev` | skipped (#2470) | ✅ |
| `release-5.0` | `1.8.0-dev` | `1.8.0` GA | ❌ |

Fixes [verify bundle failure on release-5.0 push](https://github.com/stolostron/multicluster-global-hub/actions/runs/26521331833/job/78112908748).

## Test plan

- [ ] Merge to `main` — verify bundle passes on this PR
- [ ] Fast-forward/cherry-pick to `release-5.0` (same fix needed there for push CI)
- [ ] Confirm `release-2.15` / `release-2.16` PRs still run the bundle repo diff


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

No user-facing changes in this release. This PR contains internal CI/CD workflow updates that do not impact end-user functionality or experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->