### PR TITLE
ACM-34834: preserve inactive heartbeat status on upsert

### DIFF
--- a/manager/pkg/status/handlers/managedhub/hub_cluster_heartbeat_handler.go
+++ b/manager/pkg/status/handlers/managedhub/hub_cluster_heartbeat_handler.go
@@ -6,9 +6,9 @@ import (
 	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"gorm.io/gorm/clause"
 
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/status/conflator"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/database"
 	"github.com/stolostron/multicluster-global-hub/pkg/database/models"
 	"github.com/stolostron/multicluster-global-hub/pkg/enum"
@@ -27,12 +27,11 @@ func handleHeartbeatEvent(ctx context.Context, evt *cloudevents.Event) error {
 	db := database.GetGorm()
 	heartbeat := models.LeafHubHeartbeat{
 		Name:         evt.Source(),
-		Status:       "active",
+		Status:       constants.HubStatusActive,
 		LastUpdateAt: time.Now(),
 	}
-	err := db.Clauses(clause.OnConflict{UpdateAll: true}).Create(&heartbeat).Error
-	if err != nil {
-		return fmt.Errorf("failed to update heartbeat %v", err)
+	if err := heartbeat.UpInsertHeartBeat(db); err != nil {
+		return fmt.Errorf("failed to update heartbeat %w", err)
 	}
 	return nil
 }

--- a/test/integration/manager/status/hub_cluster_heartbeat_handler_test.go
+++ b/test/integration/manager/status/hub_cluster_heartbeat_handler_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stolostron/multicluster-global-hub/pkg/bundle/generic"
 	eventversion "github.com/stolostron/multicluster-global-hub/pkg/bundle/version"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/database"
 	"github.com/stolostron/multicluster-global-hub/pkg/database/models"
 	"github.com/stolostron/multicluster-global-hub/pkg/enum"
@@ -47,6 +48,35 @@ var _ = Describe("HubClusterHeartbeatHandler", Ordered, func() {
 			}
 			return fmt.Errorf("not found heartbeat record on the table")
 		}, 30*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
+	})
+
+	It("preserves inactive status when updating heartbeat timestamp", func() {
+		leafHubName := "hub-inactive-preserve"
+		db := database.GetGorm()
+		inactiveAt := time.Now().Add(-10 * time.Minute)
+		Expect(db.Exec(
+			`INSERT INTO status.leaf_hub_heartbeats (leaf_hub_name, status, last_timestamp) VALUES ($1, $2, $3)`,
+			leafHubName, constants.HubStatusInactive, inactiveAt,
+		).Error).To(Succeed())
+
+		version := eventversion.NewVersion()
+		version.Incr()
+		evt := ToCloudEvent(leafHubName, string(enum.HubClusterHeartbeatType), version, generic.GenericObjectBundle{})
+		Expect(producer.SendEvent(ctx, *evt)).To(Succeed())
+
+		Eventually(func() error {
+			var heartbeat models.LeafHubHeartbeat
+			if err := db.Where("leaf_hub_name = ?", leafHubName).First(&heartbeat).Error; err != nil {
+				return err
+			}
+			if heartbeat.Status != constants.HubStatusInactive {
+				return fmt.Errorf("expected status %q, got %q", constants.HubStatusInactive, heartbeat.Status)
+			}
+			if !heartbeat.LastUpdateAt.After(inactiveAt) {
+				return fmt.Errorf("expected last_timestamp after %v, got %v", inactiveAt, heartbeat.LastUpdateAt)
+			}
+			return nil
+		}, 30*time.Second, 100*time.Millisecond).Should(Succeed())
 	})
 })
 


### PR DESCRIPTION
Fixes: [ACM-34834](https://redhat.atlassian.net/browse/ACM-34834)

Related: [ACM-34827](https://redhat.atlassian.net/browse/ACM-34827)

## Summary

- Route heartbeat upserts through `LeafHubHeartbeat.UpInsertHeartBeat()` so `ON CONFLICT` updates **only** `last_timestamp`.
- Set `status = active` on **insert** only; preserve `inactive` when hub management disables the agent.
- Fixes RHACM4K-43020 / `disableAgent()` timing where late agent pings flipped `status.leaf_hub_heartbeats` back to `active` (`OnConflict{UpdateAll: true}` after #2260).

## Test plan

- [ ] CI integration: `HubClusterHeartbeatHandler` (new case: inactive preserved on heartbeat)
- [ ] CI integration: `hub management` (existing)
- [ ] Re-run Jenkins `globalhub-e2e` with `status` label or full `e2e` (RHACM4K-43020)


[ACM-34834]: https://redhat.atlassian.net/browse/ACM-34834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-34827]: https://redhat.atlassian.net/browse/ACM-34827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ