### PR TITLE
ACM-34834: preserve inactive heartbeat status on upsert (main)

### DIFF
--- a/manager/pkg/status/handlers/managedhub/hub_cluster_heartbeat_handler.go
+++ b/manager/pkg/status/handlers/managedhub/hub_cluster_heartbeat_handler.go
@@ -6,9 +6,9 @@ import (
 	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"gorm.io/gorm/clause"
 
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/status/conflator"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/database"
 	"github.com/stolostron/multicluster-global-hub/pkg/database/models"
 	"github.com/stolostron/multicluster-global-hub/pkg/enum"
@@ -27,12 +27,11 @@ func handleHeartbeatEvent(ctx context.Context, evt *cloudevents.Event) error {
 	db := database.GetGorm()
 	heartbeat := models.LeafHubHeartbeat{
 		Name:         evt.Source(),
-		Status:       "active",
+		Status:       constants.HubStatusActive,
 		LastUpdateAt: time.Now(),
 	}
-	err := db.Clauses(clause.OnConflict{UpdateAll: true}).Create(&heartbeat).Error
-	if err != nil {
-		return fmt.Errorf("failed to update heartbeat %v", err)
+	if err := heartbeat.UpInsertHeartBeat(db); err != nil {
+		return fmt.Errorf("failed to update heartbeat %w", err)
 	}
 	return nil
 }

--- a/test/integration/manager/status/hub_cluster_heartbeat_handler_test.go
+++ b/test/integration/manager/status/hub_cluster_heartbeat_handler_test.go
@@ -57,12 +57,18 @@ var _ = Describe("HubClusterHeartbeatHandler", Ordered, func() {
 		Expect(db.Exec(
 			`INSERT INTO status.leaf_hub_heartbeats (leaf_hub_name, status, last_timestamp) VALUES ($1, $2, $3)`,
 			leafHubName, constants.HubStatusInactive, inactiveAt,
-		).Error).To(Succeed())
+		).Error).To(Succeed(), "failed to seed inactive heartbeat row for preservation test")
+		DeferCleanup(func() {
+			Expect(db.Exec(
+				`DELETE FROM status.leaf_hub_heartbeats WHERE leaf_hub_name = $1`,
+				leafHubName,
+			).Error).To(Succeed(), "failed to clean up seeded heartbeat row")
+		})
 
 		version := eventversion.NewVersion()
 		version.Incr()
 		evt := ToCloudEvent(leafHubName, string(enum.HubClusterHeartbeatType), version, generic.GenericObjectBundle{})
-		Expect(producer.SendEvent(ctx, *evt)).To(Succeed())
+		Expect(producer.SendEvent(ctx, *evt)).To(Succeed(), "failed to send heartbeat event for inactive-status preservation")
 
 		Eventually(func() error {
 			var heartbeat models.LeafHubHeartbeat

--- a/test/integration/manager/status/hub_cluster_heartbeat_handler_test.go
+++ b/test/integration/manager/status/hub_cluster_heartbeat_handler_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stolostron/multicluster-global-hub/pkg/bundle/generic"
 	eventversion "github.com/stolostron/multicluster-global-hub/pkg/bundle/version"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/database"
 	"github.com/stolostron/multicluster-global-hub/pkg/database/models"
 	"github.com/stolostron/multicluster-global-hub/pkg/enum"
@@ -47,6 +48,35 @@ var _ = Describe("HubClusterHeartbeatHandler", Ordered, func() {
 			}
 			return fmt.Errorf("not found heartbeat record on the table")
 		}, 30*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
+	})
+
+	It("preserves inactive status when updating heartbeat timestamp", func() {
+		leafHubName := "hub-inactive-preserve"
+		db := database.GetGorm()
+		inactiveAt := time.Now().Add(-10 * time.Minute)
+		Expect(db.Exec(
+			`INSERT INTO status.leaf_hub_heartbeats (leaf_hub_name, status, last_timestamp) VALUES ($1, $2, $3)`,
+			leafHubName, constants.HubStatusInactive, inactiveAt,
+		).Error).To(Succeed())
+
+		version := eventversion.NewVersion()
+		version.Incr()
+		evt := ToCloudEvent(leafHubName, string(enum.HubClusterHeartbeatType), version, generic.GenericObjectBundle{})
+		Expect(producer.SendEvent(ctx, *evt)).To(Succeed())
+
+		Eventually(func() error {
+			var heartbeat models.LeafHubHeartbeat
+			if err := db.Where("leaf_hub_name = ?", leafHubName).First(&heartbeat).Error; err != nil {
+				return err
+			}
+			if heartbeat.Status != constants.HubStatusInactive {
+				return fmt.Errorf("expected status %q, got %q", constants.HubStatusInactive, heartbeat.Status)
+			}
+			if !heartbeat.LastUpdateAt.After(inactiveAt) {
+				return fmt.Errorf("expected last_timestamp after %v, got %v", inactiveAt, heartbeat.LastUpdateAt)
+			}
+			return nil
+		}, 30*time.Second, 100*time.Millisecond).Should(Succeed())
 	})
 })
 


### PR DESCRIPTION
Fixes: [ACM-34834](https://redhat.atlassian.net/browse/ACM-34834)

Related: [ACM-28978](https://redhat.atlassian.net/browse/ACM-28978), [ACM-34827](https://redhat.atlassian.net/browse/ACM-34827)

## Summary

Backport the heartbeat upsert fix to **`main`** (same change as merged #2509 on `release-2.17` and #2510 on `release-2.16`).

- Route heartbeat upserts through `LeafHubHeartbeat.UpInsertHeartBeat()` so `ON CONFLICT` updates **only** `last_timestamp`.
- Set `status = active` on **insert** only; preserve `inactive` when hub management has marked the leaf hub inactive (addon removed).
- Add integration test: inactive row stays inactive after a late heartbeat event.

Completes the intent of #2260 on `main`.

## Test plan

- [ ] `make unit-tests-manager` (handler path)
- [ ] Integration: `hub_cluster_heartbeat_handler_test` — new "preserves inactive status" case
- [ ] CI format / sonarcloud on `main`

Made with [Cursor](https://cursor.com)

[ACM-34834]: https://redhat.atlassian.net/browse/ACM-34834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-28978]: https://redhat.atlassian.net/browse/ACM-28978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-34827]: https://redhat.atlassian.net/browse/ACM-34827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented active overwrite of an inactive leaf hub status during heartbeat sync, ensuring preserved status and updated last-update timestamps.

* **Tests**
  * Added integration test verifying inactive leaf hub status remains unchanged and its last-update time is advanced when processing cluster heartbeat events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->