### PR TITLE
Update GH 5.0 CPE and version labels in Containerfiles

### DIFF
--- a/agent/Containerfile.agent
+++ b/agent/Containerfile.agent
@@ -24,11 +24,11 @@ LABEL com.redhat.component="multicluster-globalhub-agent-rhel9"
 LABEL org.label-schema.vendor="Red Hat"
 LABEL org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA"
 LABEL org.label-schema.schema-version="1.0"
-LABEL cpe="cpe:/a:redhat:multicluster_globalhub:1.8::el9"
+LABEL cpe="cpe:/a:redhat:multicluster_globalhub:5.0::el9"
 
 # Bundle metadata
 LABEL name="multicluster-globalhub/multicluster-globalhub-agent-rhel9"
-LABEL version="release-1.8"
+LABEL version="release-5.0"
 LABEL summary="multicluster global hub agent"
 LABEL io.openshift.expose-services=""
 LABEL io.openshift.tags="data,images"

--- a/manager/Containerfile.manager
+++ b/manager/Containerfile.manager
@@ -25,11 +25,11 @@ LABEL com.redhat.component="multicluster-globalhub-manager-rhel9"
 LABEL org.label-schema.vendor="Red Hat"
 LABEL org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA"
 LABEL org.label-schema.schema-version="1.0"
-LABEL cpe="cpe:/a:redhat:multicluster_globalhub:1.8::el9"
+LABEL cpe="cpe:/a:redhat:multicluster_globalhub:5.0::el9"
 
 # Bundle metadata
 LABEL name="multicluster-globalhub/multicluster-globalhub-manager-rhel9"
-LABEL version="release-1.8"
+LABEL version="release-5.0"
 LABEL summary="multicluster global hub manager"
 LABEL io.openshift.expose-services=""
 LABEL io.openshift.tags="data,images"

--- a/operator/Containerfile.operator
+++ b/operator/Containerfile.operator
@@ -20,11 +20,11 @@ LABEL com.redhat.component="multicluster-globalhub-rhel9-operator"
 LABEL org.label-schema.vendor="Red Hat"
 LABEL org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA"
 LABEL org.label-schema.schema-version="1.0"
-LABEL cpe="cpe:/a:redhat:multicluster_globalhub:1.8::el9"
+LABEL cpe="cpe:/a:redhat:multicluster_globalhub:5.0::el9"
 
 # Bundle metadata
 LABEL name="multicluster-globalhub/multicluster-globalhub-rhel9-operator"
-LABEL version="release-1.8"
+LABEL version="release-5.0"
 LABEL summary="multicluster global hub operator"
 LABEL io.openshift.expose-services=""
 LABEL io.openshift.tags="data,images"


### PR DESCRIPTION
## Summary
Update image `cpe` and `version` labels from GH 1.8 to GH 5.0 on `release-5.0`.

## Why
Konflux stage publish (`stage-publish-globalhub-5-0`) failed `check-labels` / `enforce-cpe-label`:
built images had `cpe:/a:redhat:multicluster_globalhub:1.8::el9` but the 5.0 stage RPA requires `cpe:/a:redhat:multicluster_globalhub:5.0::el9`.

## Test plan
- [ ] Merge to `release-5.0` and wait for Konflux rebuild
- [ ] New snapshot passes stage publish `check-labels`