### PR TITLE
ACM-32677: optimize Hub HA active syncer trigger via agent ConfigMap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,11 +156,11 @@ Use the Fleet plugin in Claude Code (`make install-claude` in agentic-sdlc) when
 |---|---|---|
 | Go | 1.26.3 | Toolchain |
 | Kubernetes | v0.33.x | client-go, api, apimachinery |
-| controller-runtime | v0.21.x | Operator framework |
+| controller-runtime | v0.23.3 | Operator framework |
 | IBM Sarama | v1.46.x | Kafka client |
 | Confluent Kafka Go | v2.14.x | Kafka client (alternative) |
 | CloudEvents SDK | v2.16.x | Status transport bundles |
-| GORM / pgx | v1.30.x / v5.7.x | PostgreSQL access |
+| GORM / pgx | v1.31.1 / v5.9.2 | PostgreSQL access |
 
 ---
 

--- a/agent/pkg/spec/hubha/hubha_active_syncer.go
+++ b/agent/pkg/spec/hubha/hubha_active_syncer.go
@@ -17,18 +17,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 
-	"github.com/stolostron/multicluster-global-hub/agent/pkg/configs"
-	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/logger"
-	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 )
 
 var log = logger.DefaultZapLogger()
 
 const (
-	// Full resync every 30 minutes as a safety net for consistency
-	// This handles edge cases like missed events during network issues or agent restarts
-	hubhaResyncInterval = 30 * time.Minute
 	// API Groups - constants to avoid string literal duplication
 	groupAddonOCM                 = "addon.open-cluster-management.io"
 	groupAgentOCM                 = "agent.open-cluster-management.io"
@@ -55,62 +49,19 @@ const (
 	groupCAPIProviderAgentInstall = "capi-provider.agent-install.openshift.io"
 )
 
-// hubHAController implements reconciliation for all Hub HA resources using list-watch pattern
+// hubHAController implements reconciliation for all Hub HA resources using list-watch pattern.
+// It is started once via StartHubHAResourceSyncer and runs for the lifetime of the agent.
+// Whether events are actually forwarded is controlled by HubHAEmitter.SetEnabled.
 type hubHAController struct {
 	client  client.Client
 	emitter *HubHAEmitter
 }
 
-// StartHubHAActiveSyncer starts the active hub syncer using controller-based list-watch pattern
-func StartHubHAActiveSyncer(ctx context.Context, mgr ctrl.Manager, producer transport.Producer) error {
-	// Only start if this is an active hub with a configured standby
-	agentConfig := configs.GetAgentConfig()
-	if agentConfig == nil {
-		log.Info("Hub HA active syncer not started - agent config is nil")
-		return nil
-	}
-
-	// Get hub role and standby hub atomically
-	hubRole, standbyHub := agentConfig.GetHubRoleAndStandbyHub()
-	if hubRole != constants.GHHubRoleActive {
-		log.Info("Hub HA active syncer not started - this is not an active hub")
-		return nil
-	}
-
-	if standbyHub == "" {
-		log.Warn("Hub HA active syncer not started - no standby hub configured")
-		return nil
-	}
-
-	log.Infof("starting Hub HA active syncer with list-watch pattern: %s (active) -> %s (standby)",
-		agentConfig.LeafHubName, standbyHub)
-
-	// Create shared emitter for all Hub HA resources
-	emitter := NewHubHAEmitter(
-		producer,
-		agentConfig.TransportConfig,
-		agentConfig.LeafHubName,
-		standbyHub,
-	)
-
-	// Start a single controller that watches all resource types
-	allResources := getHubHAResourcesToSync()
-	activeResources, err := startHubHAController(mgr, allResources, emitter)
-	if err != nil {
-		return err
-	}
-
-	log.Infof("Hub HA active syncer started watching %d/%d resource types", len(activeResources), len(allResources))
-
-	// Start periodic resync as a safety net for consistency (handles edge cases like missed events)
-	// Only resync resources that have active controllers
-	go periodicResync(ctx, mgr.GetClient(), emitter, activeResources, hubhaResyncInterval)
-
-	return nil
-}
-
-// startHubHAController starts a single controller that watches all Hub HA resource types
-func startHubHAController(mgr ctrl.Manager, allGVKs []schema.GroupVersionKind,
+// StartHubHAResourceSyncer starts a single controller that watches all Hub HA resource GVKs
+// and feeds events into emitter. It returns the subset of GVKs for which CRDs are installed.
+// This should be called at most once (use sync.Once in the caller).
+// Lifecycle management (enable/disable based on hub role) is done via emitter.SetEnabled.
+func StartHubHAResourceSyncer(mgr ctrl.Manager, allGVKs []schema.GroupVersionKind,
 	emitter *HubHAEmitter,
 ) ([]schema.GroupVersionKind, error) {
 	// Create controller that handles all GVKs
@@ -129,11 +80,14 @@ func startHubHAController(mgr ctrl.Manager, allGVKs []schema.GroupVersionKind,
 
 	// Add watches for each GVK using WatchesMetadata with custom handler
 	for _, gvk := range allGVKs {
-		// Check if CRD exists
+		// Check if CRD exists; distinguish a missing CRD from a real mapper failure.
 		_, err := mgr.GetRESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version)
 		if err != nil {
-			log.Debugf("skipped watch for %s: CRD not installed", gvk.String())
-			continue
+			if meta.IsNoMatchError(err) {
+				log.Debugf("skipped watch for %s: CRD not installed", gvk.String())
+				continue
+			}
+			return nil, fmt.Errorf("failed to resolve REST mapping for %s: %w", gvk.String(), err)
 		}
 
 		// Create instance for this GVK
@@ -237,67 +191,8 @@ func (c *hubHAController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	return ctrl.Result{}, nil
 }
 
-// periodicResync performs full resyncs at regular intervals for consistency
-func periodicResync(ctx context.Context, c client.Client, emitter *HubHAEmitter,
-	resourcesToSync []schema.GroupVersionKind, interval time.Duration,
-) {
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			log.Info("Hub HA periodic resync stopped")
-			return
-		case <-ticker.C:
-			log.Info("starting Hub HA full resync")
-			if err := performFullResync(ctx, c, emitter, resourcesToSync); err != nil {
-				log.Errorf("failed to perform Hub HA full resync: %v", err)
-			}
-		}
-	}
-}
-
-// performFullResync lists all resources and triggers a resync
-func performFullResync(ctx context.Context, c client.Client, emitter *HubHAEmitter,
-	resourcesToSync []schema.GroupVersionKind,
-) error {
-	allObjects := []client.Object{}
-
-	for _, gvk := range resourcesToSync {
-		list := &unstructured.UnstructuredList{}
-		list.SetGroupVersionKind(schema.GroupVersionKind{
-			Group:   gvk.Group,
-			Version: gvk.Version,
-			Kind:    gvk.Kind + "List",
-		})
-
-		if err := c.List(ctx, list); err != nil {
-			// If CRD doesn't exist, skip it
-			if meta.IsNoMatchError(err) {
-				log.Debugf("CRD not installed for %s, skipping resync", gvk.String())
-				continue
-			}
-			log.Warnf("failed to list resources for %s during resync: %v", gvk.String(), err)
-			continue
-		}
-
-		for i := range list.Items {
-			obj := &list.Items[i]
-			allObjects = append(allObjects, obj)
-		}
-	}
-
-	log.Infof("performing Hub HA full resync with %d total objects", len(allObjects))
-	if err := emitter.Resync(allObjects); err != nil {
-		return err
-	}
-	// Send the resync bundle immediately
-	return emitter.Send()
-}
-
-// getHubHAResourcesToSync returns the list of resources to sync for Hub HA
-func getHubHAResourcesToSync() []schema.GroupVersionKind {
+// GetHubHAResourcesToSync returns the canonical list of GVKs the Hub HA active syncer watches.
+func GetHubHAResourcesToSync() []schema.GroupVersionKind {
 	return []schema.GroupVersionKind{
 		// ACM/OCM Addon resources
 		{Group: groupAddonOCM, Version: "v1beta1", Kind: "AddOnDeploymentConfig"},

--- a/agent/pkg/spec/hubha/hubha_active_syncer_test.go
+++ b/agent/pkg/spec/hubha/hubha_active_syncer_test.go
@@ -5,9 +5,7 @@ package hubha
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
-	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	corev1 "k8s.io/api/core/v1"
@@ -18,12 +16,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/stolostron/multicluster-global-hub/pkg/bundle/generic"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 )
 
 func TestGetHubHAResourcesToSync(t *testing.T) {
-	resources := getHubHAResourcesToSync()
+	resources := GetHubHAResourcesToSync()
 
 	// Verify we have resources to sync
 	if len(resources) == 0 {
@@ -67,6 +64,7 @@ func TestHubHAController_Reconcile_Update(t *testing.T) {
 		},
 	}
 	emitter := NewHubHAEmitter(producer, transportConfig, "hub1", "hub2")
+	emitter.SetEnabled(true) // hub is in active role
 
 	// Create controller
 	controller := &hubHAController{
@@ -177,6 +175,7 @@ func TestHubHAController_Reconcile_FilteredResource(t *testing.T) {
 		},
 	}
 	emitter := NewHubHAEmitter(producer, transportConfig, "hub1", "hub2")
+	emitter.SetEnabled(true) // hub is in active role
 
 	// Create controller
 	controller := &hubHAController{
@@ -227,136 +226,6 @@ func TestHubHAController_Reconcile_FilteredResource(t *testing.T) {
 	// In production, predicate filters before Reconcile is called
 	if len(producer.events) != 1 {
 		t.Errorf("Expected 1 event when calling Reconcile directly, got %d", len(producer.events))
-	}
-}
-
-func TestPerformFullResync(t *testing.T) {
-	// Create fake client
-	scheme := newTestScheme()
-
-	// Create test secrets
-	secret1 := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "v1",
-			"kind":       "Secret",
-			"metadata": map[string]interface{}{
-				"name":      "secret1",
-				"namespace": "default",
-				"labels": map[string]interface{}{
-					"hive.openshift.io/secret-type": "kubeconfig",
-				},
-			},
-		},
-	}
-
-	secret2 := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "v1",
-			"kind":       "Secret",
-			"metadata": map[string]interface{}{
-				"name":      "secret2",
-				"namespace": "default",
-				"labels": map[string]interface{}{
-					"cluster.open-cluster-management.io/type": "managed",
-				},
-			},
-		},
-	}
-
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(secret1, secret2).
-		Build()
-
-	// Create mock producer and emitter
-	producer := &mockProducer{events: []cloudevents.Event{}}
-	transportConfig := &transport.TransportInternalConfig{
-		KafkaCredential: &transport.KafkaConfig{
-			SpecTopic: "spec-topic",
-		},
-	}
-	emitter := NewHubHAEmitter(producer, transportConfig, "hub1", "hub2")
-
-	// Perform resync
-	resourcesToSync := []schema.GroupVersionKind{
-		{Group: "", Version: "v1", Kind: "Secret"},
-	}
-
-	err := performFullResync(context.Background(), fakeClient, emitter, resourcesToSync)
-	if err != nil {
-		t.Errorf("performFullResync() error = %v", err)
-	}
-
-	// Verify event was sent
-	if len(producer.events) != 1 {
-		t.Errorf("Expected 1 event to be sent after resync, got %d", len(producer.events))
-	}
-
-	// Parse bundle
-	var bundle generic.GenericBundle[*unstructured.Unstructured]
-	err = json.Unmarshal(producer.events[0].Data(), &bundle)
-	if err != nil {
-		t.Errorf("Failed to unmarshal bundle: %v", err)
-	}
-
-	// Should have 2 secrets in resync
-	if len(bundle.Resync) != 2 {
-		t.Errorf("Expected 2 secrets in resync bundle, got %d", len(bundle.Resync))
-	}
-}
-
-func TestPeriodicResync(t *testing.T) {
-	// Create fake client
-	scheme := newTestScheme()
-	secret := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "v1",
-			"kind":       "Secret",
-			"metadata": map[string]interface{}{
-				"name":      "test-secret",
-				"namespace": "default",
-				"labels": map[string]interface{}{
-					"hive.openshift.io/secret-type": "kubeconfig",
-				},
-			},
-		},
-	}
-
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(secret).
-		Build()
-
-	// Create mock producer and emitter
-	producer := &mockProducer{events: []cloudevents.Event{}}
-	transportConfig := &transport.TransportInternalConfig{
-		KafkaCredential: &transport.KafkaConfig{
-			SpecTopic: "spec-topic",
-		},
-	}
-	emitter := NewHubHAEmitter(producer, transportConfig, "hub1", "hub2")
-
-	resourcesToSync := []schema.GroupVersionKind{
-		{Group: "", Version: "v1", Kind: "Secret"},
-	}
-
-	// Start periodic resync with very short interval for testing
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	// Use very short interval for testing
-	interval := 100 * time.Millisecond
-	go periodicResync(ctx, fakeClient, emitter, resourcesToSync, interval)
-
-	// Wait for at least one resync cycle
-	time.Sleep(200 * time.Millisecond)
-
-	// Cancel to stop goroutine
-	cancel()
-
-	// Verify at least one resync event was sent
-	if len(producer.events) < 1 {
-		t.Errorf("Expected at least 1 resync event, got %d", len(producer.events))
 	}
 }
 

--- a/agent/pkg/spec/hubha/hubha_emitter.go
+++ b/agent/pkg/spec/hubha/hubha_emitter.go
@@ -6,11 +6,15 @@ package hubha
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	cecontext "github.com/cloudevents/sdk-go/v2/context"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
@@ -22,6 +26,7 @@ import (
 
 // HubHAEmitter implements the Emitter interface for Hub HA resource synchronization.
 // It tracks changes to resources across all GVKs and bundles them for transmission to the standby hub.
+// It is safe for concurrent use from multiple goroutines.
 type HubHAEmitter struct {
 	producer        transport.Producer
 	transportConfig *transport.TransportInternalConfig
@@ -30,9 +35,15 @@ type HubHAEmitter struct {
 	resourceFilter  *utils.HubHAResourceFilter
 	bundle          *generic.GenericBundle[*unstructured.Unstructured]
 	mu              sync.Mutex
+
+	// Dynamic lifecycle fields managed by the Hub HA lifecycle controller.
+	client          client.Client             // used for self-listing in Resync(nil)
+	activeResources []schema.GroupVersionKind // GVKs to list during self-listing
+	enabled         bool                      // when false, Update/Delete/Send are no-ops
 }
 
-// NewHubHAEmitter creates a new Hub HA emitter that handles all Hub HA resources.
+// NewHubHAEmitter creates a new Hub HA emitter. The emitter starts disabled;
+// call SetEnabled(true) once the resource controller is running and the hub is active.
 func NewHubHAEmitter(
 	producer transport.Producer,
 	transportConfig *transport.TransportInternalConfig,
@@ -47,6 +58,35 @@ func NewHubHAEmitter(
 		resourceFilter:  utils.NewHubHAResourceFilter(),
 		bundle:          generic.NewGenericBundle[*unstructured.Unstructured](),
 	}
+}
+
+// SetStandbyHub atomically updates the standby hub name (e.g. on failover target change).
+func (e *HubHAEmitter) SetStandbyHub(hub string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.standbyHubName = hub
+}
+
+// SetActiveResources stores the GVK list used for self-listing in Resync(nil).
+func (e *HubHAEmitter) SetActiveResources(gvkList []schema.GroupVersionKind) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.activeResources = gvkList
+}
+
+// SetClient stores the Kubernetes client used for self-listing in Resync(nil).
+func (e *HubHAEmitter) SetClient(c client.Client) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.client = c
+}
+
+// SetEnabled controls whether the emitter sends events.
+// Set to true when the hub is in active role; false when standby or transitioning.
+func (e *HubHAEmitter) SetEnabled(enabled bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.enabled = enabled
 }
 
 // EventType returns the event type for Hub HA resources.
@@ -70,45 +110,43 @@ func (e *HubHAEmitter) Predicate() predicate.Predicate {
 }
 
 // Update handles object creation/update events and sends immediately.
+// It is a no-op when the emitter is disabled (hub not in active role).
 func (e *HubHAEmitter) Update(obj client.Object) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	// Convert to unstructured to get GVK
+	if !e.enabled {
+		return nil
+	}
+
 	uObj, err := toUnstructured(obj)
 	if err != nil {
 		return fmt.Errorf("failed to convert object to unstructured: %w", err)
 	}
-
-	// Get GVK from object
 	gvk := uObj.GroupVersionKind()
-
-	// Clean metadata
 	cleanUnstructuredMetadata(uObj)
 
-	// Add to bundle.Update and send immediately
 	e.bundle.Update = append(e.bundle.Update, uObj)
 	log.Debugf("syncing update for %s/%s (%s)", uObj.GetNamespace(), uObj.GetName(), gvk.Kind)
-
-	// Send immediately for fast failover
 	return e.sendBundleUnlocked()
 }
 
 // Delete handles object deletion events and sends immediately.
+// It is a no-op when the emitter is disabled (hub not in active role).
 func (e *HubHAEmitter) Delete(obj client.Object) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	// Convert to unstructured to get GVK
+	if !e.enabled {
+		return nil
+	}
+
 	uObj, err := toUnstructured(obj)
 	if err != nil {
 		return fmt.Errorf("failed to convert object to unstructured: %w", err)
 	}
-
-	// Get GVK from object
 	gvk := uObj.GroupVersionKind()
 
-	// Remove from update list if present
 	for i, existingObj := range e.bundle.Update {
 		if existingObj.GetNamespace() == obj.GetNamespace() && existingObj.GetName() == obj.GetName() {
 			e.bundle.Update = append(e.bundle.Update[:i], e.bundle.Update[i+1:]...)
@@ -116,61 +154,119 @@ func (e *HubHAEmitter) Delete(obj client.Object) error {
 		}
 	}
 
-	// Add to bundle.Delete and send immediately
-	objMeta := generic.ObjectMetadata{
+	e.bundle.Delete = append(e.bundle.Delete, generic.ObjectMetadata{
 		Namespace: obj.GetNamespace(),
 		Name:      obj.GetName(),
 		Group:     gvk.Group,
 		Version:   gvk.Version,
 		Kind:      gvk.Kind,
-	}
-
-	e.bundle.Delete = append(e.bundle.Delete, objMeta)
+	})
 	log.Debugf("syncing delete for %s/%s (%s)", obj.GetNamespace(), obj.GetName(), gvk.Kind)
-
-	// Send immediately for fast failover
 	return e.sendBundleUnlocked()
 }
 
+// selfListTimeout is the maximum time allowed for a single Resync self-list round.
+const selfListTimeout = 30 * time.Second
+
 // Resync performs a full resync of all objects.
+// If objects is nil, the emitter self-lists using its stored client and activeResources
+// (the "ListFunc=nil" pattern for PeriodicSyncer integration).
+// The mutex is released before any K8s API calls to avoid blocking Update/Delete/Send.
 func (e *HubHAEmitter) Resync(objects []client.Object) error {
+	// Phase 1: read fields under lock (short critical section, no I/O).
+	e.mu.Lock()
+	enabled := e.enabled
+	cl := e.client
+	gvks := append([]schema.GroupVersionKind(nil), e.activeResources...)
+	e.mu.Unlock()
+
+	if !enabled {
+		return nil
+	}
+
+	if objects == nil {
+		ctx, cancel := context.WithTimeout(context.Background(), selfListTimeout)
+		defer cancel()
+		var err error
+		objects, err = e.selfList(ctx, cl, gvks)
+		if err != nil {
+			return fmt.Errorf("hub HA emitter self-list failed: %w", err)
+		}
+	}
+
+	// Phase 2: update bundle state under lock (no I/O).
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	// Clear existing bundle
-	e.bundle.Clean()
+	// Re-check enabled in case it was toggled while we were listing.
+	if !e.enabled {
+		return nil
+	}
 
+	e.bundle.Clean()
 	for _, obj := range objects {
-		// Convert to unstructured to get GVK
 		uObj, err := toUnstructured(obj)
 		if err != nil {
 			log.Warnf("failed to convert object to unstructured during resync: %v", err)
 			continue
 		}
-
-		// Get GVK from object
 		gvk := uObj.GroupVersionKind()
-
-		// Filter using resource filter
 		if !e.resourceFilter.ShouldSyncResource(obj, gvk) {
 			continue
 		}
-
-		// Clean metadata
 		cleanUnstructuredMetadata(uObj)
-
-		// Add to bundle.Resync
 		e.bundle.Resync = append(e.bundle.Resync, uObj)
 	}
 
-	log.Infof("resynced %d Hub HA objects", len(e.bundle.Resync))
+	// Bundle is populated; PeriodicSyncer's Send() tick will flush it.
+	log.Infof("Hub HA resync: %d objects queued", len(e.bundle.Resync))
 	return nil
 }
 
+// selfList lists all objects for each GVK. It does not require e.mu to be held.
+// Non-IsNoMatchError failures are collected and returned together so the caller
+// knows the result may be incomplete.
+func (e *HubHAEmitter) selfList(
+	ctx context.Context, cl client.Client, gvks []schema.GroupVersionKind,
+) ([]client.Object, error) {
+	if cl == nil {
+		return nil, fmt.Errorf("client not set on HubHAEmitter, call SetClient before using Resync(nil)")
+	}
+	var all []client.Object
+	var listErrs []error
+	for _, gvk := range gvks {
+		list := &unstructured.UnstructuredList{}
+		list.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   gvk.Group,
+			Version: gvk.Version,
+			Kind:    gvk.Kind + "List",
+		})
+		if err := cl.List(ctx, list); err != nil {
+			if meta.IsNoMatchError(err) {
+				log.Debugf("CRD not installed for %s, skipping in self-list resync", gvk.String())
+				continue
+			}
+			listErrs = append(listErrs, fmt.Errorf("list failed for %s: %w", gvk.String(), err))
+			continue
+		}
+		for i := range list.Items {
+			all = append(all, &list.Items[i])
+		}
+	}
+	if len(listErrs) > 0 {
+		return all, fmt.Errorf("hub HA self-list encountered errors: %w", errors.Join(listErrs...))
+	}
+	return all, nil
+}
+
 // Send sends the current bundle to the standby hub.
+// It is a no-op when the emitter is disabled or the bundle is empty.
 func (e *HubHAEmitter) Send() error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
+	if !e.enabled {
+		return nil
+	}
 	return e.sendBundleUnlocked()
 }
 
@@ -192,8 +288,7 @@ func (e *HubHAEmitter) sendBundleUnlocked() error {
 	ctx := context.TODO()
 	topicCtx := cecontext.WithTopic(ctx, e.transportConfig.KafkaCredential.SpecTopic)
 	if err := e.producer.SendEvent(topicCtx, evt); err != nil {
-		return fmt.Errorf("failed to send Hub HA bundle from %s to %s: %w",
-			e.activeHubName, e.standbyHubName, err)
+		return fmt.Errorf("failed to send Hub HA bundle: %w", err)
 	}
 
 	log.Infof("sent Hub HA bundle: updates=%d, deletes=%d, resync=%d",

--- a/agent/pkg/spec/hubha/hubha_emitter_test.go
+++ b/agent/pkg/spec/hubha/hubha_emitter_test.go
@@ -6,10 +6,14 @@ package hubha
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/stolostron/multicluster-global-hub/pkg/bundle/generic"
@@ -57,6 +61,7 @@ func TestHubHAEmitter_Update_SendsImmediately(t *testing.T) {
 	}
 
 	emitter := NewHubHAEmitter(producer, transportConfig, "hub1", "hub2")
+	emitter.SetEnabled(true)
 
 	// Create an unstructured Secret with required label
 	secret := &unstructured.Unstructured{
@@ -123,6 +128,7 @@ func TestHubHAEmitter_Delete_SendsImmediately(t *testing.T) {
 	}
 
 	emitter := NewHubHAEmitter(producer, transportConfig, "hub1", "hub2")
+	emitter.SetEnabled(true)
 
 	// Create an unstructured Secret with required label
 	secret := &unstructured.Unstructured{
@@ -175,6 +181,7 @@ func TestHubHAEmitter_Update_FilteredResource(t *testing.T) {
 	}
 
 	emitter := NewHubHAEmitter(producer, transportConfig, "hub1", "hub2")
+	emitter.SetEnabled(true)
 
 	// Create a Secret WITHOUT required label
 	// Note: Filtering is done by the predicate, not by Update() method
@@ -211,6 +218,7 @@ func TestHubHAEmitter_Delete_WithoutLabels(t *testing.T) {
 	}
 
 	emitter := NewHubHAEmitter(producer, transportConfig, "hub1", "hub2")
+	emitter.SetEnabled(true)
 
 	// Create a Secret WITH required label - simulating a deleted object that was synced
 	// The delete event contains the object's last known state with labels
@@ -265,6 +273,7 @@ func TestHubHAEmitter_Resync(t *testing.T) {
 	}
 
 	emitter := NewHubHAEmitter(producer, transportConfig, "hub1", "hub2")
+	emitter.SetEnabled(true)
 
 	// Create test secrets
 	secret1 := &unstructured.Unstructured{
@@ -329,6 +338,165 @@ func TestHubHAEmitter_Resync(t *testing.T) {
 	}
 }
 
+func TestHubHAEmitter_DisabledDropsEvents(t *testing.T) {
+	producer := &mockProducer{events: []cloudevents.Event{}}
+	transportConfig := &transport.TransportInternalConfig{
+		KafkaCredential: &transport.KafkaConfig{SpecTopic: "spec-topic"},
+	}
+	emitter := NewHubHAEmitter(producer, transportConfig, "hub1", "hub2")
+	// emitter starts disabled — no SetEnabled(true)
+
+	secret := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]any{
+				"name":      "secret",
+				"namespace": "default",
+				"labels":    map[string]any{"hive.openshift.io/secret-type": "kubeconfig"},
+			},
+		},
+	}
+
+	if err := emitter.Update(secret); err != nil {
+		t.Fatalf("Update() unexpected error: %v", err)
+	}
+	if err := emitter.Delete(secret); err != nil {
+		t.Fatalf("Delete() unexpected error: %v", err)
+	}
+	if err := emitter.Send(); err != nil {
+		t.Fatalf("Send() unexpected error: %v", err)
+	}
+	if len(producer.events) != 0 {
+		t.Errorf("expected 0 events when disabled, got %d", len(producer.events))
+	}
+}
+
+func TestHubHAEmitter_SetEnabled_TogglesState(t *testing.T) {
+	producer := &mockProducer{events: []cloudevents.Event{}}
+	transportConfig := &transport.TransportInternalConfig{
+		KafkaCredential: &transport.KafkaConfig{SpecTopic: "spec-topic"},
+	}
+	emitter := NewHubHAEmitter(producer, transportConfig, "hub1", "hub2")
+
+	secret := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]any{
+				"name":      "secret",
+				"namespace": "default",
+				"labels":    map[string]any{"hive.openshift.io/secret-type": "kubeconfig"},
+			},
+		},
+	}
+
+	// Disabled: no events
+	if err := emitter.Update(secret); err != nil {
+		t.Fatalf("unexpected error from disabled Update: %v", err)
+	}
+	if len(producer.events) != 0 {
+		t.Fatalf("expected 0 events while disabled, got %d", len(producer.events))
+	}
+
+	// Enable: events flow
+	emitter.SetEnabled(true)
+	if err := emitter.Update(secret); err != nil {
+		t.Fatalf("unexpected error from enabled Update: %v", err)
+	}
+	if len(producer.events) != 1 {
+		t.Fatalf("expected 1 event after enabling, got %d", len(producer.events))
+	}
+
+	// Disable again: no more events
+	emitter.SetEnabled(false)
+	if err := emitter.Update(secret); err != nil {
+		t.Fatalf("unexpected error from disabled Update: %v", err)
+	}
+	if len(producer.events) != 1 {
+		t.Errorf("expected no new events after disabling, got %d", len(producer.events))
+	}
+}
+
+func TestHubHAEmitter_SetStandbyHub(t *testing.T) {
+	producer := &mockProducer{events: []cloudevents.Event{}}
+	transportConfig := &transport.TransportInternalConfig{
+		KafkaCredential: &transport.KafkaConfig{SpecTopic: "spec-topic"},
+	}
+	emitter := NewHubHAEmitter(producer, transportConfig, "hub1", "hub2")
+	emitter.SetEnabled(true)
+
+	emitter.SetStandbyHub("hub3")
+
+	secret := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]any{
+				"name":      "secret",
+				"namespace": "default",
+				"labels":    map[string]any{"hive.openshift.io/secret-type": "kubeconfig"},
+			},
+		},
+	}
+	if err := emitter.Update(secret); err != nil {
+		t.Fatalf("unexpected error from Update: %v", err)
+	}
+
+	if len(producer.events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(producer.events))
+	}
+	// ToCloudEvent sets the new standby hub as the CloudEvent Subject.
+	if got := producer.events[0].Subject(); got != "hub3" {
+		t.Errorf("expected subject=hub3, got %v", got)
+	}
+}
+
+func TestHubHAEmitter_SelfList_NilClient(t *testing.T) {
+	producer := &mockProducer{events: []cloudevents.Event{}}
+	transportConfig := &transport.TransportInternalConfig{
+		KafkaCredential: &transport.KafkaConfig{SpecTopic: "spec-topic"},
+	}
+	emitter := NewHubHAEmitter(producer, transportConfig, "hub1", "hub2")
+	emitter.SetEnabled(true)
+	// No SetClient call — Resync(nil) should return an error
+
+	err := emitter.Resync(nil)
+	if err == nil {
+		t.Error("expected error from Resync(nil) without client, got nil")
+	}
+}
+
+func TestHubHAEmitter_Resync_WhenDisabled_IsNoop(t *testing.T) {
+	producer := &mockProducer{events: []cloudevents.Event{}}
+	transportConfig := &transport.TransportInternalConfig{
+		KafkaCredential: &transport.KafkaConfig{SpecTopic: "spec-topic"},
+	}
+	emitter := NewHubHAEmitter(producer, transportConfig, "hub1", "hub2")
+	// disabled
+
+	secret := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]any{
+				"name":      "secret",
+				"namespace": "default",
+				"labels":    map[string]any{"hive.openshift.io/secret-type": "kubeconfig"},
+			},
+		},
+	}
+	if err := emitter.Resync([]client.Object{secret}); err != nil {
+		t.Fatalf("Resync() error when disabled: %v", err)
+	}
+	if err := emitter.Send(); err != nil {
+		t.Fatalf("Send() error: %v", err)
+	}
+	if len(producer.events) != 0 {
+		t.Errorf("expected 0 events when disabled, got %d", len(producer.events))
+	}
+}
+
 func TestCleanUnstructuredMetadata(t *testing.T) {
 	uObj := &unstructured.Unstructured{
 		Object: map[string]any{
@@ -372,5 +540,169 @@ func TestCleanUnstructuredMetadata(t *testing.T) {
 
 	if uObj.GetNamespace() != "default" {
 		t.Errorf("Expected namespace to remain, got %s", uObj.GetNamespace())
+	}
+}
+
+// ----- additional coverage tests -----
+
+// errProducer always returns an error from SendEvent.
+type errProducer struct{}
+
+func (e *errProducer) SendEvent(_ context.Context, _ cloudevents.Event) error {
+	return fmt.Errorf("deliberate send error")
+}
+
+func (e *errProducer) Stop() {}
+
+func (e *errProducer) Reconnect(_ *transport.TransportInternalConfig, _ string) error { return nil }
+
+// listErrorClient stubs only the List method so selfList receives an error.
+type listErrorClient struct {
+	client.Client
+	err error
+}
+
+func (l *listErrorClient) List(_ context.Context, _ client.ObjectList, _ ...client.ListOption) error {
+	return l.err
+}
+
+func newTransportConfig() *transport.TransportInternalConfig {
+	return &transport.TransportInternalConfig{
+		KafkaCredential: &transport.KafkaConfig{SpecTopic: "spec"},
+	}
+}
+
+// TestHubHAEmitter_SetActiveResources stores the GVK list.
+func TestHubHAEmitter_SetActiveResources(t *testing.T) {
+	emitter := NewHubHAEmitter(nil, nil, "hub1", "hub2")
+	gvks := []schema.GroupVersionKind{
+		{Group: "apps", Version: "v1", Kind: "Deployment"},
+	}
+	emitter.SetActiveResources(gvks)
+	emitter.mu.Lock()
+	got := len(emitter.activeResources)
+	emitter.mu.Unlock()
+	if got != 1 {
+		t.Errorf("expected 1 activeResource after SetActiveResources, got %d", got)
+	}
+}
+
+// TestHubHAEmitter_SetClient stores the Kubernetes client.
+func TestHubHAEmitter_SetClient(t *testing.T) {
+	emitter := NewHubHAEmitter(nil, nil, "hub1", "hub2")
+	fc := &listErrorClient{}
+	emitter.SetClient(fc)
+	emitter.mu.Lock()
+	got := emitter.client
+	emitter.mu.Unlock()
+	if got == nil {
+		t.Error("expected non-nil client after SetClient")
+	}
+}
+
+// TestHubHAEmitter_Send_EmptyBundle_ReturnsNil verifies that Send is a no-op
+// when the bundle has no pending events.
+func TestHubHAEmitter_Send_EmptyBundle_ReturnsNil(t *testing.T) {
+	emitter := NewHubHAEmitter(&mockProducer{}, newTransportConfig(), "hub1", "hub2")
+	emitter.SetEnabled(true)
+	if err := emitter.Send(); err != nil {
+		t.Errorf("expected nil error for empty bundle, got %v", err)
+	}
+}
+
+// TestHubHAEmitter_Update_SendEventError propagates a SendEvent failure.
+func TestHubHAEmitter_Update_SendEventError(t *testing.T) {
+	emitter := NewHubHAEmitter(&errProducer{}, newTransportConfig(), "hub1", "hub2")
+	emitter.SetEnabled(true)
+
+	secret := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]any{
+				"name":      "fail-secret",
+				"namespace": "default",
+				"labels": map[string]any{
+					"hive.openshift.io/secret-type": "kubeconfig",
+				},
+			},
+		},
+	}
+	err := emitter.Update(secret)
+	if err == nil {
+		t.Error("expected error from failing producer, got nil")
+	}
+}
+
+// TestHubHAEmitter_Delete_RemovesExistingUpdate verifies that a Delete for an
+// object already queued in the Update list removes it from that list.
+func TestHubHAEmitter_Delete_RemovesExistingUpdate(t *testing.T) {
+	emitter := NewHubHAEmitter(&mockProducer{}, newTransportConfig(), "hub1", "hub2")
+	emitter.SetEnabled(true)
+
+	// Directly populate the Update bundle (bypasses send so the item stays in-flight).
+	pending := &unstructured.Unstructured{}
+	pending.SetAPIVersion("v1")
+	pending.SetKind("Secret")
+	pending.SetNamespace("default")
+	pending.SetName("my-secret")
+	emitter.bundle.Update = append(emitter.bundle.Update, pending)
+
+	toDelete := &unstructured.Unstructured{}
+	toDelete.SetAPIVersion("v1")
+	toDelete.SetKind("Secret")
+	toDelete.SetNamespace("default")
+	toDelete.SetName("my-secret")
+
+	if err := emitter.Delete(toDelete); err != nil {
+		t.Fatalf("Delete() returned unexpected error: %v", err)
+	}
+	// After Delete the Update list should be empty.
+	if len(emitter.bundle.Update) != 0 {
+		t.Errorf("expected empty Update list after Delete, got %d items", len(emitter.bundle.Update))
+	}
+}
+
+// TestHubHAEmitter_SelfList_NilClient_ReturnsError returns an error when the
+// client argument passed to selfList is nil.
+func TestHubHAEmitter_SelfList_NilClient_ReturnsError(t *testing.T) {
+	emitter := NewHubHAEmitter(nil, nil, "hub1", "hub2")
+	gvks := []schema.GroupVersionKind{{Group: "", Version: "v1", Kind: "Secret"}}
+	_, err := emitter.selfList(context.Background(), nil, gvks)
+	if err == nil {
+		t.Error("expected error for nil client, got nil")
+	}
+}
+
+// TestHubHAEmitter_SelfList_ListError collects non-NoMatchError list failures.
+func TestHubHAEmitter_SelfList_ListError(t *testing.T) {
+	emitter := NewHubHAEmitter(nil, nil, "hub1", "hub2")
+	cl := &listErrorClient{err: fmt.Errorf("connection refused")}
+	gvks := []schema.GroupVersionKind{{Group: "apps", Version: "v1", Kind: "Deployment"}}
+	_, err := emitter.selfList(context.Background(), cl, gvks)
+	if err == nil {
+		t.Error("expected error from list failure, got nil")
+	}
+}
+
+// TestHubHAEmitter_ToUnstructured_TypedObject converts a concrete typed object
+// via the JSON marshal path (non-Unstructured branch).
+func TestHubHAEmitter_ToUnstructured_TypedObject(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "typed-cm",
+			Namespace: "default",
+		},
+	}
+	uObj, err := toUnstructured(cm)
+	if err != nil {
+		t.Fatalf("toUnstructured() error = %v", err)
+	}
+	if uObj.GetName() != "typed-cm" {
+		t.Errorf("expected name 'typed-cm', got %s", uObj.GetName())
 	}
 }

--- a/agent/pkg/status/generic/periodic_syncer.go
+++ b/agent/pkg/status/generic/periodic_syncer.go
@@ -3,6 +3,7 @@ package generic
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -14,23 +15,25 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/enum"
 )
 
-// EmitterRegistration registers a bundle with the periodic syncer,
-// providing both the delta emitter and the full data listing function.
+// EmitterRegistration registers a bundle with the periodic syncer.
+// ListFunc is optional: if nil, the emitter is expected to handle its own listing
+// internally via Emitter.Resync(nil).
 type EmitterRegistration struct {
 	ListFunc func() ([]client.Object, error)
 	Emitter  emitters.Emitter
 }
 
-// syncStates holds the next sync time for each bundle and is only updated by the current goroutine.
-// Items are added to the slice before the goroutine starts.
-// After the goroutine begins, it only reads from the slice, so there is no risk of race conditions.
+// SyncState holds scheduling metadata for a registered emitter.
 type SyncState struct {
 	Registration *EmitterRegistration
 	NextResyncAt time.Time
 	NextSyncAt   time.Time
 }
 
+// PeriodicSyncer drives delta-sync and periodic full-resync for all registered emitters.
+// It is safe for concurrent Register/Unregister calls after the manager has started.
 type PeriodicSyncer struct {
+	mu         sync.Mutex
 	syncStates []*SyncState
 }
 
@@ -44,12 +47,16 @@ func AddPeriodicSyncer(mgr ctrl.Manager) (*PeriodicSyncer, error) {
 	return syncer, nil
 }
 
-// Register adds an emitter to the periodic syncer.
+// Register adds an emitter to the periodic syncer. ListFunc may be nil for emitters
+// that self-list inside their Resync(nil) implementation (e.g. Hub HA emitter).
 func (p *PeriodicSyncer) Register(e *EmitterRegistration) {
-	if e.ListFunc == nil || e.Emitter == nil {
-		log.Warnf("Emitter registration for event type %v is invalid, skipping", e)
+	if e.Emitter == nil {
+		log.Warnf("Emitter registration is invalid (nil emitter), skipping")
 		return
 	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
 
 	for _, state := range p.syncStates {
 		if state.Registration.Emitter.EventType() == e.Emitter.EventType() {
@@ -66,41 +73,78 @@ func (p *PeriodicSyncer) Register(e *EmitterRegistration) {
 		NextSyncAt:   nextSyncAt,
 		NextResyncAt: nextResyncAt,
 	})
-	// enable resync for the event type
 	configs.GlobalResyncQueue.Add(e.Emitter.EventType())
 	log.Infof("registered emitter for event type: %s", enum.ShortenEventType(e.Emitter.EventType()))
 }
 
+// CountRegistered returns the number of currently registered emitters.
+// Intended for use in tests.
+func (p *PeriodicSyncer) CountRegistered() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.syncStates)
+}
+
+// Unregister removes the emitter for the given eventType from the periodic syncer.
+// It is a no-op if no emitter is registered for that event type.
+func (p *PeriodicSyncer) Unregister(eventType string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	for i, state := range p.syncStates {
+		if state.Registration.Emitter.EventType() == eventType {
+			p.syncStates = append(p.syncStates[:i], p.syncStates[i+1:]...)
+			log.Infof("unregistered emitter for event type: %s", enum.ShortenEventType(eventType))
+			return
+		}
+	}
+	log.Warnf("no emitter registered for event type %s, nothing to unregister", eventType)
+}
+
 func (p *PeriodicSyncer) Resync(ctx context.Context, eventType string) error {
+	p.mu.Lock()
+	snapshot := make([]*SyncState, len(p.syncStates))
+	copy(snapshot, p.syncStates)
+	p.mu.Unlock()
+
 	resynced := false
-	for _, state := range p.syncStates {
+	for _, state := range snapshot {
 		registeredType := state.Registration.Emitter.EventType()
 		if registeredType != eventType {
 			continue
 		}
 
-		objects, err := state.Registration.ListFunc()
+		var err error
+		if state.Registration.ListFunc != nil {
+			objects, listErr := state.Registration.ListFunc()
+			if listErr != nil {
+				return fmt.Errorf("failed to list objects for event type %s in Resync: %w", registeredType, listErr)
+			}
+			if len(objects) == 0 {
+				log.Infof("No objects found for event type: %s", registeredType)
+				return nil
+			}
+			err = state.Registration.Emitter.Resync(objects)
+			if err == nil {
+				log.Infof("resynced %d objects for event type: %s", len(objects), enum.ShortenEventType(registeredType))
+			}
+		} else {
+			// Emitter handles its own listing internally via Resync(nil)
+			err = state.Registration.Emitter.Resync(nil)
+			if err == nil {
+				log.Infof("resynced (self-listing) for event type: %s", enum.ShortenEventType(registeredType))
+			}
+		}
+
 		if err != nil {
-			return fmt.Errorf("failed to list objects for event type %s in Resync: %w", registeredType, err)
-		}
-
-		if len(objects) == 0 {
-			log.Infof("No objects found for event type: %s", registeredType)
-			return nil
-		}
-
-		if err = state.Registration.Emitter.Resync(objects); err != nil {
 			return fmt.Errorf("failed to resync objects for event type %s: %w", registeredType, err)
 		}
 		resynced = true
-		// Update the next resync time for this emitter
 		state.NextResyncAt = time.Now().Add(configmap.GetResyncInterval(enum.EventType(registeredType)))
-		log.Infof("resynced %d objects for event type: %s", len(objects), enum.ShortenEventType(registeredType))
 	}
 
 	if !resynced {
 		log.Infof("No emitter registered for event type: %s", eventType)
-		return nil
 	}
 	return nil
 }
@@ -112,8 +156,6 @@ func (p *PeriodicSyncer) Start(ctx context.Context) error {
 	for {
 		select {
 		case <-ticker.C:
-
-			// resync when the manager request, every tick to resync one
 			if eventType := configs.GlobalResyncQueue.Pop(); eventType != "" {
 				log.Infof("resyncing event type: %s", enum.ShortenEventType(eventType))
 				if err := p.Resync(ctx, eventType); err != nil {
@@ -121,24 +163,27 @@ func (p *PeriodicSyncer) Start(ctx context.Context) error {
 				}
 			}
 
-			// sync all registered emitters
-			for _, state := range p.syncStates {
+			// Snapshot the states to avoid holding the lock during I/O operations.
+			// SyncState pointers are stable, so NextSyncAt/NextResyncAt updates
+			// on the originals are safe even after the snapshot copy.
+			p.mu.Lock()
+			snapshot := make([]*SyncState, len(p.syncStates))
+			copy(snapshot, p.syncStates)
+			p.mu.Unlock()
+
+			for _, state := range snapshot {
 				eventType := state.Registration.Emitter.EventType()
 				if eventType == "" {
-					log.Warnf("Emitter for event type %s is not registered, skipping", eventType)
 					continue
 				}
 
-				// delta sync if the next sync time has passed
 				if time.Now().After(state.NextSyncAt) {
-					// log.Debugf("Syncing event type: %s", enum.ShortenEventType(eventType))
 					if err := state.Registration.Emitter.Send(); err != nil {
 						log.Errorf("failed to sync the event(%s): %v", enum.ShortenEventType(eventType), err)
 					}
 					state.NextSyncAt = time.Now().Add(configmap.GetSyncInterval(enum.EventType(eventType)))
 				}
 
-				// check if the next resync time has passed
 				if time.Now().After(state.NextResyncAt) {
 					log.Infof("Resyncing event type: %s", eventType)
 					if err := p.Resync(ctx, eventType); err != nil {

--- a/agent/pkg/status/generic/periodic_syncer_resync_test.go
+++ b/agent/pkg/status/generic/periodic_syncer_resync_test.go
@@ -306,7 +306,9 @@ func TestPeriodicSyncer_Resync(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create fake client with test objects
 			scheme := runtime.NewScheme()
-			_ = corev1.AddToScheme(scheme)
+			if err := corev1.AddToScheme(scheme); err != nil {
+				t.Fatalf("failed to add corev1 to test scheme: %v", err)
+			}
 
 			fakeClient := fake.NewClientBuilder().
 				WithScheme(scheme).
@@ -403,4 +405,117 @@ func contains(s, substr string) bool {
 			}
 			return false
 		}()
+}
+
+// TestPeriodicSyncer_Register_NilListFunc verifies that an emitter with a nil ListFunc
+// can be registered (the "self-listing" pattern used by Hub HA).
+func TestPeriodicSyncer_Register_NilListFunc(t *testing.T) {
+	syncer := &PeriodicSyncer{}
+	emitter := &ResyncMockEmitter{eventType: "hubha-event"}
+
+	syncer.Register(&EmitterRegistration{
+		Emitter:  emitter,
+		ListFunc: nil, // self-listing emitter
+	})
+
+	if len(syncer.syncStates) != 1 {
+		t.Fatalf("expected 1 registered state, got %d", len(syncer.syncStates))
+	}
+	if syncer.syncStates[0].Registration.Emitter.EventType() != "hubha-event" {
+		t.Errorf("unexpected event type %s", syncer.syncStates[0].Registration.Emitter.EventType())
+	}
+}
+
+// TestPeriodicSyncer_Resync_NilListFunc verifies that Resync calls Emitter.Resync(nil)
+// when ListFunc is nil, letting the emitter self-list.
+func TestPeriodicSyncer_Resync_NilListFunc(t *testing.T) {
+	emitter := &ResyncMockEmitter{eventType: "hubha-event"}
+	syncer := &PeriodicSyncer{
+		syncStates: []*SyncState{
+			{
+				Registration: &EmitterRegistration{
+					Emitter:  emitter,
+					ListFunc: nil,
+				},
+			},
+		},
+	}
+
+	if err := syncer.Resync(context.Background(), "hubha-event"); err != nil {
+		t.Fatalf("Resync() unexpected error: %v", err)
+	}
+	if !emitter.resyncCalled {
+		t.Error("expected Resync to be called on emitter")
+	}
+	if emitter.resyncObjects != nil {
+		t.Errorf("expected nil objects passed to Resync, got %v", emitter.resyncObjects)
+	}
+}
+
+// TestPeriodicSyncer_Unregister removes an emitter and verifies subsequent Resync is a no-op.
+func TestPeriodicSyncer_Unregister(t *testing.T) {
+	emitter1 := &ResyncMockEmitter{eventType: "event-a"}
+	emitter2 := &ResyncMockEmitter{eventType: "event-b"}
+
+	testScheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(testScheme); err != nil {
+		t.Fatalf("failed to add corev1 to test scheme: %v", err)
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(testScheme).Build()
+
+	syncer := &PeriodicSyncer{
+		syncStates: []*SyncState{
+			{
+				Registration: &EmitterRegistration{
+					Emitter: emitter1,
+					ListFunc: func() ([]client.Object, error) {
+						return []client.Object{}, nil
+					},
+				},
+			},
+			{
+				Registration: &EmitterRegistration{
+					Emitter: emitter2,
+					ListFunc: func() ([]client.Object, error) {
+						_ = fakeClient
+						return []client.Object{}, nil
+					},
+				},
+			},
+		},
+	}
+
+	// Unregister event-a
+	syncer.Unregister("event-a")
+
+	if len(syncer.syncStates) != 1 {
+		t.Fatalf("expected 1 state after unregister, got %d", len(syncer.syncStates))
+	}
+	if syncer.syncStates[0].Registration.Emitter.EventType() != "event-b" {
+		t.Errorf("wrong emitter remaining: %s", syncer.syncStates[0].Registration.Emitter.EventType())
+	}
+
+	// Resync event-a should be a no-op (not error)
+	if err := syncer.Resync(context.Background(), "event-a"); err != nil {
+		t.Fatalf("Resync after Unregister should be no-op, got error: %v", err)
+	}
+	if emitter1.resyncCalled {
+		t.Error("emitter1 Resync should not have been called after Unregister")
+	}
+}
+
+// TestPeriodicSyncer_Register_NilEmitter verifies that a nil emitter is rejected.
+func TestPeriodicSyncer_Register_NilEmitter(t *testing.T) {
+	syncer := &PeriodicSyncer{}
+	syncer.Register(&EmitterRegistration{Emitter: nil, ListFunc: nil})
+	if len(syncer.syncStates) != 0 {
+		t.Errorf("expected 0 states for nil emitter, got %d", len(syncer.syncStates))
+	}
+}
+
+// TestPeriodicSyncer_Unregister_NoMatch is a no-op for unknown event types.
+func TestPeriodicSyncer_Unregister_NoMatch(t *testing.T) {
+	syncer := &PeriodicSyncer{}
+	// Should not panic
+	syncer.Unregister("non-existent-type")
 }

--- a/agent/pkg/status/status.go
+++ b/agent/pkg/status/status.go
@@ -12,11 +12,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/configs"
-	"github.com/stolostron/multicluster-global-hub/agent/pkg/spec/hubha"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/filter"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/generic"
-	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/syncers/configmap"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/syncers/events"
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/syncers/hubha"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/syncers/managedcluster"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/syncers/managedhub"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/syncers/policies"
@@ -44,28 +43,23 @@ func AddToManager(ctx context.Context, mgr ctrl.Manager, transportClient transpo
 func addKafkaSyncer(ctx context.Context, mgr ctrl.Manager, producer transport.Producer,
 	agentConfig *configs.AgentConfig,
 ) error {
-	// Initialize Hub HA syncer manager for dynamic syncer lifecycle management
-	// This allows the configmap controller to start/stop the Hub HA syncer when hubRole changes
-	// Pass the manager-level context for long-lived syncer goroutines
-	configmap.SetHubHASyncerManager(ctx, mgr, producer, hubha.StartHubHAActiveSyncer)
-
-	// Start Hub HA syncer on first boot if agent is in active role
-	// The configmap controller will handle dynamic role changes after this
-	configmap.StartHubHASyncerIfActive()
-
 	// start periodic syncer
 	periodicSyncer, err := generic.AddPeriodicSyncer(mgr)
 	if err != nil {
 		return fmt.Errorf("failed to start the periodic syncer: %w", err)
 	}
+
+	// Hub HA lifecycle controller: watches the agent ConfigMap and enables/disables
+	// the Hub HA active syncer based on hub role and standby hub configuration.
+	// This replaces the previous HubHASyncerManager + configmap restart pattern.
+	if err := hubha.AddHubHAController(mgr, periodicSyncer, producer, agentConfig); err != nil {
+		return fmt.Errorf("failed to add Hub HA lifecycle controller: %w", err)
+	}
+
 	// managed cluster
 	if err := managedcluster.AddManagedClusterSyncer(ctx, mgr, producer, periodicSyncer); err != nil {
 		return fmt.Errorf("failed to launch managedcluster syncer: %w", err)
 	}
-
-	// Hub HA active syncer lifecycle is now fully managed by the configmap controller
-	// It will start/stop the syncer based on hub role changes in the configmap
-	// No boot-time direct call to avoid creating untracked syncer instances
 
 	// event syncer
 	err = events.AddEventSyncer(ctx, mgr, producer, periodicSyncer)

--- a/agent/pkg/status/syncers/configmap/config_controller.go
+++ b/agent/pkg/status/syncers/configmap/config_controller.go
@@ -3,7 +3,6 @@ package configmap
 import (
 	"context"
 	"fmt"
-	"sync"
 	"time"
 
 	"go.uber.org/zap"
@@ -17,86 +16,15 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/enum"
 	"github.com/stolostron/multicluster-global-hub/pkg/logger"
-	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 )
 
 const (
 	RequeuePeriod = 5 * time.Second
 )
 
-var (
-	// Hub HA syncer management
-	hubHASyncerManager *HubHASyncerManager
-	hubHASyncerOnce    sync.Once
-)
-
-// HubHASyncerStartFunc is a function type to start the Hub HA active syncer
-type HubHASyncerStartFunc func(context.Context, ctrl.Manager, transport.Producer) error
-
-// HubHASyncerManager manages the Hub HA active syncer lifecycle
-type HubHASyncerManager struct {
-	ctx       context.Context // Long-lived manager context for syncer goroutines
-	mgr       ctrl.Manager
-	producer  transport.Producer
-	startFunc HubHASyncerStartFunc
-	cancel    context.CancelFunc
-	mu        sync.Mutex
-}
-
 type hubOfHubsConfigController struct {
 	client client.Client
 	log    *zap.SugaredLogger
-}
-
-// SetHubHASyncerManager initializes the Hub HA syncer manager for dynamic syncer lifecycle management
-// The ctx parameter should be a long-lived manager-level context, not a request-scoped reconcile context
-func SetHubHASyncerManager(ctx context.Context, mgr ctrl.Manager, producer transport.Producer, startFunc HubHASyncerStartFunc) {
-	hubHASyncerOnce.Do(func() {
-		hubHASyncerManager = &HubHASyncerManager{
-			ctx:       ctx,
-			mgr:       mgr,
-			producer:  producer,
-			startFunc: startFunc,
-		}
-	})
-}
-
-// StartHubHASyncerIfActive starts the Hub HA syncer if the agent is in active role
-// This should be called after SetHubHASyncerManager to handle first boot
-func StartHubHASyncerIfActive() {
-	if hubHASyncerManager == nil {
-		return
-	}
-
-	agentConfig := configs.GetAgentConfig()
-	if agentConfig == nil {
-		return
-	}
-
-	hubRole, _ := agentConfig.GetHubRoleAndStandbyHub()
-	if hubRole != constants.GHHubRoleActive {
-		return
-	}
-
-	// Use the manager's lock to avoid race conditions
-	hubHASyncerManager.mu.Lock()
-	defer hubHASyncerManager.mu.Unlock()
-
-	// Only start if not already running
-	if hubHASyncerManager.cancel != nil {
-		return
-	}
-
-	syncerCtx, cancel := context.WithCancel(hubHASyncerManager.ctx)
-	hubHASyncerManager.cancel = cancel
-
-	go func() {
-		if err := hubHASyncerManager.startFunc(syncerCtx, hubHASyncerManager.mgr, hubHASyncerManager.producer); err != nil {
-			logger.DefaultZapLogger().Errorw("Failed to start Hub HA active syncer", "error", err)
-		}
-	}()
-
-	logger.DefaultZapLogger().Info("Started Hub HA active syncer on first boot")
 }
 
 // AddConfigMapController creates a new instance of config controller and adds it to the manager.
@@ -151,98 +79,14 @@ func (c *hubOfHubsConfigController) Reconcile(ctx context.Context, request ctrl.
 	// Set the agent configs
 	c.setAgentConfig(agentConfigMap, AgentAggregationKey)
 	c.setAgentConfig(agentConfigMap, EnableLocalPolicyKey)
-	c.setAgentConfig(agentConfigMap, AgentHubRoleKey)
 
 	logLevel := agentConfigMap.Data[string(AgentLogLevelKey)]
 	if logLevel != "" {
 		logger.SetLogLevel(logger.LogLevel(logLevel))
 	}
 
-	// Update AgentConfig with hubRole and standbyHub
-	agentConfig := configs.GetAgentConfig()
-	if agentConfig != nil {
-		// Determine new values from configmap
-		var newHubRole, newStandbyHub string
-		if hubRole, found := agentConfigMap.Data[AgentHubRoleKey]; found && hubRole != "" {
-			newHubRole = hubRole
-			reqLogger.Infof("Updated agent hub role to: %s", hubRole)
-		}
-		if standbyHub, found := agentConfigMap.Data["standbyHub"]; found && standbyHub != "" {
-			newStandbyHub = standbyHub
-			reqLogger.Infof("Updated agent standby hub to: %s", standbyHub)
-		}
-
-		// Atomically update both fields and get previous values
-		previousHubRole, previousStandbyHub := agentConfig.UpdateHubRoleAndStandbyHub(newHubRole, newStandbyHub)
-
-		// Dynamic Hub HA syncer management: restart syncer when:
-		// 1. Hub role changes to/from active
-		// 2. Hub is active and standby hub target changes
-		roleChanged := previousHubRole != newHubRole
-		standbyChanged := previousStandbyHub != newStandbyHub
-		isActiveRole := newHubRole == constants.GHHubRoleActive || previousHubRole == constants.GHHubRoleActive
-
-		if (roleChanged || standbyChanged) && isActiveRole {
-			reqLogger.Infow("Hub HA configuration changed, restarting syncer",
-				"previousRole", previousHubRole,
-				"newRole", newHubRole,
-				"previousStandbyHub", previousStandbyHub,
-				"newStandbyHub", newStandbyHub)
-
-			// Try to restart syncer; if manager not initialized yet, requeue to retry later
-			if !c.restartHubHASyncer(reqLogger) {
-				reqLogger.Info("Hub HA syncer manager not ready, will retry in 5 seconds")
-				return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
-			}
-		}
-	}
-
 	reqLogger.Debug("Reconciliation complete.")
 	return ctrl.Result{}, nil
-}
-
-// restartHubHASyncer stops any existing Hub HA syncer and starts a new one if role is active
-// Returns true if successful (or manager not needed), false if manager not initialized yet (caller should requeue)
-func (c *hubOfHubsConfigController) restartHubHASyncer(log *zap.SugaredLogger) bool {
-	if hubHASyncerManager == nil {
-		log.Warn("Hub HA syncer manager not initialized, cannot restart syncer")
-		return false
-	}
-
-	hubHASyncerManager.mu.Lock()
-	defer hubHASyncerManager.mu.Unlock()
-
-	// Stop existing syncer if running
-	if hubHASyncerManager.cancel != nil {
-		log.Info("Stopping existing Hub HA syncer")
-		hubHASyncerManager.cancel()
-		hubHASyncerManager.cancel = nil
-	}
-
-	// Start new syncer if role is active
-	agentConfig := configs.GetAgentConfig()
-	if agentConfig != nil {
-		hubRole, standbyHub := agentConfig.GetHubRoleAndStandbyHub()
-		if hubRole == constants.GHHubRoleActive {
-			log.Infow("Starting Hub HA active syncer",
-				"hubRole", hubRole,
-				"standbyHub", standbyHub)
-
-			// Create cancellable context for the syncer from the manager-level context
-			// Do NOT use the reconcile ctx parameter as it is request-scoped and will be
-			// cancelled when reconciliation completes, terminating the long-lived syncer
-			syncerCtx, cancel := context.WithCancel(hubHASyncerManager.ctx)
-			hubHASyncerManager.cancel = cancel
-
-			// Start the syncer using the provided start function
-			go func() {
-				if err := hubHASyncerManager.startFunc(syncerCtx, hubHASyncerManager.mgr, hubHASyncerManager.producer); err != nil {
-					log.Errorw("Failed to start Hub HA active syncer", "error", err)
-				}
-			}()
-		}
-	}
-	return true
 }
 
 func (c *hubOfHubsConfigController) setSyncInterval(configMap *corev1.ConfigMap, key string) {

--- a/agent/pkg/status/syncers/hubha/hubha_controller.go
+++ b/agent/pkg/status/syncers/hubha/hubha_controller.go
@@ -1,0 +1,235 @@
+// Copyright (c) 2025 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+// Package hubha provides the Hub HA active-syncer lifecycle controller.
+// It watches the agent ConfigMap and enables/disables the HubHAEmitter (and its
+// PeriodicSyncer registration) based on the hub role and standby hub configuration.
+package hubha
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/configs"
+	specHubHA "github.com/stolostron/multicluster-global-hub/agent/pkg/spec/hubha"
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/generic"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport"
+)
+
+var log = logger.DefaultZapLogger()
+
+// hubHALifecycleController manages the lifecycle of the Hub HA active syncer based on
+// changes to the agent ConfigMap.  It is the single source of truth for
+// HubHAEmitter.SetEnabled calls and PeriodicSyncer registration/unregistration.
+type hubHALifecycleController struct {
+	mgr            ctrl.Manager
+	client         client.Client
+	agentConfig    *configs.AgentConfig
+	periodicSyncer *generic.PeriodicSyncer
+	producer       transport.Producer
+
+	// startResourceSyncerFn is the function that starts the GVK-watching controller.
+	// It defaults to the real implementation but can be replaced in tests to avoid
+	// requiring a live ctrl.Manager.
+	startResourceSyncerFn func(emitter *specHubHA.HubHAEmitter) ([]schema.GroupVersionKind, error)
+
+	// mu protects emitter, registered, and resourceSyncerStarted.
+	mu                    sync.Mutex
+	emitter               *specHubHA.HubHAEmitter
+	registered            bool
+	resourceSyncerStarted bool // set to true only after startFn succeeds, allowing retries on failure
+}
+
+// HubHAControllerOption configures a hubHALifecycleController.
+type HubHAControllerOption func(*hubHALifecycleController)
+
+// WithNoOpStartResourceSyncerFn sets a no-op startResourceSyncerFn so the lifecycle
+// controller does not attempt to register the "hubha" GVK-watching controller.
+// Use this in integration-test suites that register the resource controller directly
+// (via StartHubHAResourceSyncer) to avoid "controller already exists" conflicts.
+func WithNoOpStartResourceSyncerFn() HubHAControllerOption {
+	return func(c *hubHALifecycleController) {
+		c.startResourceSyncerFn = func(_ *specHubHA.HubHAEmitter) ([]schema.GroupVersionKind, error) {
+			return nil, nil
+		}
+	}
+}
+
+// AddHubHAController registers the Hub HA lifecycle controller with the manager.
+// It watches the same agent ConfigMap as the existing configmap controller but is
+// solely responsible for the Hub HA syncer lifecycle (replacing HubHASyncerManager).
+func AddHubHAController(
+	mgr ctrl.Manager,
+	periodicSyncer *generic.PeriodicSyncer,
+	producer transport.Producer,
+	agentConfig *configs.AgentConfig,
+	opts ...HubHAControllerOption,
+) error {
+	c := &hubHALifecycleController{
+		mgr:            mgr,
+		client:         mgr.GetClient(),
+		agentConfig:    agentConfig,
+		periodicSyncer: periodicSyncer,
+		producer:       producer,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	configMapPredicate := predicate.NewPredicateFuncs(func(object client.Object) bool {
+		return object.GetNamespace() == agentConfig.PodNamespace &&
+			object.GetName() == constants.GHAgentConfigCMName
+	})
+
+	if err := ctrl.NewControllerManagedBy(mgr).
+		Named("hubha-lifecycle").
+		For(&corev1.ConfigMap{}).
+		WithEventFilter(configMapPredicate).
+		Complete(c); err != nil {
+		return fmt.Errorf("failed to add Hub HA lifecycle controller: %w", err)
+	}
+	return nil
+}
+
+// Reconcile reacts to agent ConfigMap changes and adjusts the Hub HA syncer accordingly.
+func (c *hubHALifecycleController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	// Refresh the stored AgentConfig pointer to the current global singleton.
+	// In production the singleton never changes; in integration tests BeforeEach
+	// may replace it with a new pointer, so refreshing here keeps hub-role updates
+	// visible to all readers of configs.GetAgentConfig().
+	if current := configs.GetAgentConfig(); current != nil {
+		c.agentConfig = current
+	}
+
+	agentConfigMap := &corev1.ConfigMap{}
+	if err := c.client.Get(ctx, req.NamespacedName, agentConfigMap); err != nil {
+		if apierrors.IsNotFound(err) {
+			// ConfigMap deleted: treat as desired-disabled state so any running emitter
+			// does not continue forwarding with stale role/standby information.
+			if disableErr := c.disableSyncer(); disableErr != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to disable Hub HA syncer after ConfigMap deletion: %w", disableErr)
+			}
+			c.agentConfig.UpdateHubRoleAndStandbyHub("", "")
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("failed to get agent ConfigMap: %w", err)
+	}
+
+	// Read hub role and standby hub from the ConfigMap data.
+	newHubRole := agentConfigMap.Data["hubRole"]
+	newStandbyHub := agentConfigMap.Data["standbyHub"]
+
+	// Atomically update AgentConfig and retrieve previous values for change detection.
+	previousRole, previousStandby := c.agentConfig.UpdateHubRoleAndStandbyHub(newHubRole, newStandbyHub)
+
+	roleChanged := previousRole != newHubRole
+	standbyChanged := previousStandby != newStandbyHub
+	shouldEnable := newHubRole == constants.GHHubRoleActive && newStandbyHub != ""
+
+	// Skip reconciliation only when both the ConfigMap values are unchanged AND
+	// the controller is already in the desired state (prevents stale no-ops on
+	// failed enableSyncer retries or first-reconcile with pre-populated AgentConfig).
+	c.mu.Lock()
+	registered := c.registered
+	c.mu.Unlock()
+
+	if !roleChanged && !standbyChanged && ((shouldEnable && registered) || (!shouldEnable && !registered)) {
+		return ctrl.Result{}, nil
+	}
+
+	log.Infow("Hub HA ConfigMap changed",
+		"previousRole", previousRole, "newRole", newHubRole,
+		"standbyConfigured", newStandbyHub != "")
+
+	if shouldEnable {
+		return ctrl.Result{}, c.enableSyncer(ctx, newStandbyHub)
+	}
+
+	return ctrl.Result{}, c.disableSyncer()
+}
+
+// enableSyncer starts the resource controller (once) and registers the emitter
+// with the PeriodicSyncer so that periodic resyncs fire.
+func (c *hubHALifecycleController) enableSyncer(ctx context.Context, standbyHub string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Create or update the emitter.
+	if c.emitter == nil {
+		if c.agentConfig == nil {
+			return fmt.Errorf("agent config not initialised")
+		}
+		c.emitter = specHubHA.NewHubHAEmitter(
+			c.producer,
+			c.agentConfig.TransportConfig,
+			c.agentConfig.LeafHubName,
+			standbyHub,
+		)
+		c.emitter.SetClient(c.client)
+	} else {
+		c.emitter.SetStandbyHub(standbyHub)
+	}
+
+	// Start the resource-watching controller exactly once.
+	// Use the injectable fn so tests can avoid requiring a live ctrl.Manager.
+	startFn := c.startResourceSyncerFn
+	if startFn == nil {
+		startFn = func(emitter *specHubHA.HubHAEmitter) ([]schema.GroupVersionKind, error) {
+			allGVKs := specHubHA.GetHubHAResourcesToSync()
+			return specHubHA.StartHubHAResourceSyncer(c.mgr, allGVKs, emitter)
+		}
+	}
+
+	// Start the resource-watching controller only once, but retry if a previous
+	// attempt failed (unlike sync.Once which would permanently suppress retries).
+	if !c.resourceSyncerStarted {
+		activeGVKs, err := startFn(c.emitter)
+		if err != nil {
+			return fmt.Errorf("failed to start Hub HA resource syncer: %w", err)
+		}
+		c.emitter.SetActiveResources(activeGVKs)
+		c.resourceSyncerStarted = true
+		log.Infof("Hub HA resource syncer started, watching %d GVKs", len(activeGVKs))
+	}
+
+	c.emitter.SetEnabled(true)
+
+	if !c.registered {
+		c.periodicSyncer.Register(&generic.EmitterRegistration{
+			Emitter: c.emitter,
+			// ListFunc is nil — the emitter self-lists via Resync(nil).
+		})
+		c.registered = true
+		log.Info("Hub HA emitter registered with PeriodicSyncer")
+	}
+
+	return nil
+}
+
+// disableSyncer disables the emitter and removes it from the PeriodicSyncer.
+func (c *hubHALifecycleController) disableSyncer() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.emitter != nil {
+		c.emitter.SetEnabled(false)
+	}
+
+	if c.registered {
+		c.periodicSyncer.Unregister(constants.HubHAResourcesMsgKey)
+		c.registered = false
+		log.Info("Hub HA emitter unregistered from PeriodicSyncer")
+	}
+
+	return nil
+}

--- a/agent/pkg/status/syncers/hubha/hubha_controller_test.go
+++ b/agent/pkg/status/syncers/hubha/hubha_controller_test.go
@@ -1,0 +1,410 @@
+// Copyright (c) 2025 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package hubha
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/configs"
+	specHubHA "github.com/stolostron/multicluster-global-hub/agent/pkg/spec/hubha"
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/generic"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+)
+
+const (
+	testNamespace  = "open-cluster-management"
+	testConfigName = constants.GHAgentConfigCMName
+)
+
+// ----- helpers -----
+
+func buildScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := corev1.AddToScheme(s); err != nil {
+		t.Fatalf("failed to add corev1 to test scheme: %v", err)
+	}
+	return s
+}
+
+func agentCM(namespace, name, hubRole, standbyHub string) *corev1.ConfigMap {
+	data := map[string]string{}
+	if hubRole != "" {
+		data["hubRole"] = hubRole
+	}
+	if standbyHub != "" {
+		data["standbyHub"] = standbyHub
+	}
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Data:       data,
+	}
+}
+
+func newAgentConfig(role, standbyHub string) *configs.AgentConfig {
+	cfg := &configs.AgentConfig{}
+	if role != "" || standbyHub != "" {
+		cfg.UpdateHubRoleAndStandbyHub(role, standbyHub)
+	}
+	return cfg
+}
+
+// stubController creates a lifecycle controller ready for unit tests.
+// It injects a no-op startResourceSyncerFn to avoid needing a real ctrl.Manager.
+func stubController(
+	t *testing.T, cm *corev1.ConfigMap, agentCfg *configs.AgentConfig,
+) (*hubHALifecycleController, *generic.PeriodicSyncer) {
+	t.Helper()
+	fc := fake.NewClientBuilder().WithScheme(buildScheme(t)).WithObjects(cm).Build()
+	ps := &generic.PeriodicSyncer{}
+
+	c := &hubHALifecycleController{
+		client:         fc,
+		agentConfig:    agentCfg,
+		periodicSyncer: ps,
+		// startResourceSyncerFn is injected as a no-op so tests don't need a manager.
+		startResourceSyncerFn: func(emitter *specHubHA.HubHAEmitter) ([]schema.GroupVersionKind, error) {
+			return nil, nil
+		},
+	}
+	return c, ps
+}
+
+// ----- tests -----
+
+// TestReconcile_ConfigMapNotFound returns no error and no requeue.
+func TestReconcile_ConfigMapNotFound(t *testing.T) {
+	fc := fake.NewClientBuilder().WithScheme(buildScheme(t)).Build() // empty store
+	c := &hubHALifecycleController{
+		client:         fc,
+		periodicSyncer: &generic.PeriodicSyncer{},
+		agentConfig:    newAgentConfig("", ""),
+	}
+
+	result, err := c.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testConfigName},
+	})
+	if err != nil {
+		t.Fatalf("expected no error for missing CM, got %v", err)
+	}
+	if result.Requeue {
+		t.Error("expected no requeue for missing CM")
+	}
+}
+
+// TestReconcile_NoChange_AlreadyRegistered skips enable/disable when values are
+// unchanged AND the controller is already in the desired state.
+func TestReconcile_NoChange_AlreadyRegistered(t *testing.T) {
+	cm := agentCM(testNamespace, testConfigName, constants.GHHubRoleActive, "standby-hub")
+	agentCfg := newAgentConfig(constants.GHHubRoleActive, "standby-hub")
+
+	c, ps := stubController(t, cm, agentCfg)
+
+	// Pre-register to simulate already-enabled state.
+	emitter := specHubHA.NewHubHAEmitter(nil, nil, "active", "standby-hub")
+	emitter.SetEnabled(true)
+	c.emitter = emitter
+	c.registered = true
+	c.resourceSyncerStarted = true
+	ps.Register(&generic.EmitterRegistration{Emitter: emitter})
+
+	_, err := c.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testConfigName},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// State is already correct and values unchanged — emitter count stays at 1.
+	if ps.CountRegistered() != 1 {
+		t.Errorf("expected 1 registration (already enabled, no change), got %d", ps.CountRegistered())
+	}
+}
+
+// TestReconcile_NoChange_NotYetRegistered ensures enableSyncer is called even when
+// ConfigMap values match AgentConfig but the emitter is not yet registered
+// (e.g. first reconcile after agent restart).
+func TestReconcile_NoChange_NotYetRegistered(t *testing.T) {
+	cm := agentCM(testNamespace, testConfigName, constants.GHHubRoleActive, "standby-hub")
+	agentCfg := newAgentConfig(constants.GHHubRoleActive, "standby-hub") // pre-populated
+
+	c, ps := stubController(t, cm, agentCfg)
+	// c.registered == false (new controller, emitter not yet running)
+
+	_, err := c.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testConfigName},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// enableSyncer must run to register the emitter even though values didn't change.
+	if ps.CountRegistered() != 1 {
+		t.Errorf("expected 1 registration (values unchanged but not yet registered), got %d", ps.CountRegistered())
+	}
+}
+
+// TestReconcile_BecomeActive_RegistersEmitter transitions from no-role to active.
+func TestReconcile_BecomeActive_RegistersEmitter(t *testing.T) {
+	cm := agentCM(testNamespace, testConfigName, constants.GHHubRoleActive, "standby-hub")
+	agentCfg := newAgentConfig("", "") // no previous role
+
+	c, ps := stubController(t, cm, agentCfg)
+
+	_, err := c.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testConfigName},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ps.CountRegistered() != 1 {
+		t.Errorf("expected 1 registration after becoming active, got %d", ps.CountRegistered())
+	}
+	if c.emitter == nil {
+		t.Error("expected emitter to be initialised")
+	}
+	if !c.registered {
+		t.Error("expected registered=true after enable")
+	}
+}
+
+// TestReconcile_BecomeStandby_UnregistersEmitter transitions from active to standby.
+func TestReconcile_BecomeStandby_UnregistersEmitter(t *testing.T) {
+	cm := agentCM(testNamespace, testConfigName, constants.GHHubRoleStandby, "")
+	agentCfg := newAgentConfig(constants.GHHubRoleActive, "standby-hub") // previously active
+
+	c, ps := stubController(t, cm, agentCfg)
+
+	// Pre-register an emitter to simulate the active state.
+	emitter := specHubHA.NewHubHAEmitter(nil, nil, "active", "standby-hub")
+	emitter.SetEnabled(true)
+	c.emitter = emitter
+	c.registered = true
+	ps.Register(&generic.EmitterRegistration{Emitter: emitter})
+
+	_, err := c.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testConfigName},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ps.CountRegistered() != 0 {
+		t.Errorf("expected 0 registrations after becoming standby, got %d", ps.CountRegistered())
+	}
+	if c.registered {
+		t.Error("expected registered=false")
+	}
+}
+
+// TestReconcile_ActiveWithoutStandby_DoesNotRegister verifies that active role
+// without a standby hub does not register the emitter.
+func TestReconcile_ActiveWithoutStandby_DoesNotRegister(t *testing.T) {
+	cm := agentCM(testNamespace, testConfigName, constants.GHHubRoleActive, "")
+	agentCfg := newAgentConfig("", "") // no previous role
+
+	c, ps := stubController(t, cm, agentCfg)
+
+	_, err := c.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testConfigName},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ps.CountRegistered() != 0 {
+		t.Errorf("expected 0 registrations (no standby), got %d", ps.CountRegistered())
+	}
+}
+
+// TestDisableSyncer_NilEmitter is a no-op and does not panic.
+func TestDisableSyncer_NilEmitter(t *testing.T) {
+	c := &hubHALifecycleController{
+		periodicSyncer: &generic.PeriodicSyncer{},
+	}
+	if err := c.disableSyncer(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestReconcile_ConfigMapDeleted_DisablesSyncer verifies that when the agent ConfigMap
+// is deleted the emitter is disabled rather than left running with stale data.
+func TestReconcile_ConfigMapDeleted_DisablesSyncer(t *testing.T) {
+	// Build a controller with an empty store (simulates deleted CM).
+	fc := fake.NewClientBuilder().WithScheme(buildScheme(t)).Build()
+	ps := &generic.PeriodicSyncer{}
+	emitter := specHubHA.NewHubHAEmitter(nil, nil, "active", "standby-hub")
+	emitter.SetEnabled(true)
+	ps.Register(&generic.EmitterRegistration{Emitter: emitter})
+
+	c := &hubHALifecycleController{
+		client:         fc,
+		periodicSyncer: ps,
+		agentConfig:    newAgentConfig(constants.GHHubRoleActive, "standby-hub"),
+		emitter:        emitter,
+		registered:     true,
+		startResourceSyncerFn: func(e *specHubHA.HubHAEmitter) ([]schema.GroupVersionKind, error) {
+			return nil, nil
+		},
+	}
+
+	_, err := c.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testConfigName},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.registered {
+		t.Error("expected registered=false after CM deletion")
+	}
+	if ps.CountRegistered() != 0 {
+		t.Errorf("expected 0 registrations after CM deletion, got %d", ps.CountRegistered())
+	}
+}
+
+// TestDisableSyncer_WithRegisteredEmitter unregisters and disables.
+func TestDisableSyncer_WithRegisteredEmitter(t *testing.T) {
+	ps := &generic.PeriodicSyncer{}
+	emitter := specHubHA.NewHubHAEmitter(nil, nil, "active", "standby")
+	emitter.SetEnabled(true)
+	ps.Register(&generic.EmitterRegistration{Emitter: emitter})
+
+	c := &hubHALifecycleController{
+		periodicSyncer: ps,
+		emitter:        emitter,
+		registered:     true,
+	}
+
+	if err := c.disableSyncer(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.registered {
+		t.Error("expected registered=false after disableSyncer")
+	}
+	if ps.CountRegistered() != 0 {
+		t.Errorf("expected 0 registrations, got %d", ps.CountRegistered())
+	}
+}
+
+// ----- additional coverage tests -----
+
+// TestWithNoOpStartResourceSyncerFn verifies the option installs a fn that
+// returns no GVKs and no error.
+func TestWithNoOpStartResourceSyncerFn(t *testing.T) {
+	c := &hubHALifecycleController{}
+	WithNoOpStartResourceSyncerFn()(c)
+
+	if c.startResourceSyncerFn == nil {
+		t.Fatal("expected startResourceSyncerFn to be non-nil after applying option")
+	}
+	gvks, err := c.startResourceSyncerFn(nil)
+	if err != nil {
+		t.Errorf("no-op startFn returned unexpected error: %v", err)
+	}
+	if gvks != nil {
+		t.Errorf("no-op startFn returned non-nil GVKs: %v", gvks)
+	}
+}
+
+// TestReconcile_GetCMError_NonNotFound returns the error when the client
+// returns a non-NotFound error fetching the ConfigMap.
+func TestReconcile_GetCMError_NonNotFound(t *testing.T) {
+	base := fake.NewClientBuilder().WithScheme(buildScheme(t)).Build()
+	interceptedClient := interceptor.NewClient(base, interceptor.Funcs{
+		Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+			return fmt.Errorf("connection refused")
+		},
+	})
+
+	c := &hubHALifecycleController{
+		client:         interceptedClient,
+		periodicSyncer: &generic.PeriodicSyncer{},
+		agentConfig:    newAgentConfig("", ""),
+	}
+
+	_, err := c.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testConfigName},
+	})
+	if err == nil {
+		t.Error("expected error for non-NotFound client failure, got nil")
+	}
+}
+
+// TestEnableSyncer_NilAgentConfig returns an error when agentConfig is nil
+// and no emitter has been created yet.
+func TestEnableSyncer_NilAgentConfig(t *testing.T) {
+	c := &hubHALifecycleController{
+		periodicSyncer: &generic.PeriodicSyncer{},
+		startResourceSyncerFn: func(_ *specHubHA.HubHAEmitter) ([]schema.GroupVersionKind, error) {
+			return nil, nil
+		},
+	}
+	// agentConfig is nil and emitter is nil → enableSyncer must return error
+	if err := c.enableSyncer(context.Background(), "standby-hub"); err == nil {
+		t.Error("expected error when agentConfig is nil, got nil")
+	}
+}
+
+// TestEnableSyncer_StartFnError propagates the startFn error.
+func TestEnableSyncer_StartFnError(t *testing.T) {
+	cm := agentCM(testNamespace, testConfigName, constants.GHHubRoleActive, "standby-hub")
+	agentCfg := newAgentConfig("", "")
+
+	fc := fake.NewClientBuilder().WithScheme(buildScheme(t)).WithObjects(cm).Build()
+	ps := &generic.PeriodicSyncer{}
+	c := &hubHALifecycleController{
+		client:         fc,
+		agentConfig:    agentCfg,
+		periodicSyncer: ps,
+		startResourceSyncerFn: func(_ *specHubHA.HubHAEmitter) ([]schema.GroupVersionKind, error) {
+			return nil, fmt.Errorf("resource syncer registration failed")
+		},
+	}
+
+	_, err := c.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testConfigName},
+	})
+	if err == nil {
+		t.Error("expected error when startFn fails, got nil")
+	}
+}
+
+// TestEnableSyncer_ExistingEmitter_UpdatesStandbyHub verifies that a second
+// enableSyncer call updates the standby hub name on the existing emitter rather
+// than creating a new one.
+func TestEnableSyncer_ExistingEmitter_UpdatesStandbyHub(t *testing.T) {
+	cm := agentCM(testNamespace, testConfigName, constants.GHHubRoleActive, "new-standby")
+	agentCfg := newAgentConfig(constants.GHHubRoleActive, "old-standby")
+
+	c, ps := stubController(t, cm, agentCfg)
+
+	// Pre-populate with an existing emitter (simulates already-enabled state with a new standby hub).
+	existingEmitter := specHubHA.NewHubHAEmitter(nil, nil, "hub1", "old-standby")
+	existingEmitter.SetEnabled(true)
+	c.emitter = existingEmitter
+	c.resourceSyncerStarted = true
+	// c.registered = false so enableSyncer still runs to register.
+
+	_, err := c.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testConfigName},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// The same emitter object should be reused (not replaced).
+	if c.emitter != existingEmitter {
+		t.Error("expected existing emitter to be reused, but a new one was created")
+	}
+	if ps.CountRegistered() != 1 {
+		t.Errorf("expected 1 registration, got %d", ps.CountRegistered())
+	}
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -180,10 +180,10 @@ Components must not cross-import except through `pkg/` and `operator/api/`:
 
 | Dependency | Version | Purpose |
 |---|---|---|
-| `sigs.k8s.io/controller-runtime` | v0.21.x | Operator and controller framework |
+| `sigs.k8s.io/controller-runtime` | v0.23.3 | Operator and controller framework |
 | `github.com/IBM/sarama` | v1.46.x | Kafka (Sarama transport) |
 | `github.com/confluentinc/confluent-kafka-go/v2` | v2.14.x | Kafka (Confluent transport) |
 | `github.com/cloudevents/sdk-go/v2` | v2.16.x | Status bundle transport |
-| `gorm.io/gorm` / `github.com/jackc/pgx/v5` | v1.30.x / v5.7.x | PostgreSQL |
+| `gorm.io/gorm` / `github.com/jackc/pgx/v5` | v1.31.1 / v5.9.2 | PostgreSQL |
 | `github.com/stolostron/...` (ACM/OCM) | various | Policy, placement, subscription APIs |
 | Go | 1.26.3 | Toolchain |

--- a/test/e2e/hubha_test.go
+++ b/test/e2e/hubha_test.go
@@ -9,7 +9,6 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -26,8 +25,7 @@ import (
 const (
 	// With list-watch pattern + immediate send, changes are detected and sent immediately
 	// Wait time accounts for: controller event processing + Kafka transport + standby agent apply
-	hubHASyncWait       = 10 * time.Second
-	hubHAUpdateSyncWait = 2 * time.Minute // ManagedCluster updates can lag on loaded Prow e2e clusters
+	hubHASyncWait = 10 * time.Second
 )
 
 var _ = Describe("Hub HA Sync", Label("e2e-test-hubha"), Ordered, func() {
@@ -782,10 +780,6 @@ var _ = Describe("Hub HA Sync", Label("e2e-test-hubha"), Ordered, func() {
 					_ = standbyHubClient.Delete(ctx, &clusterv1.ManagedCluster{
 						ObjectMeta: metav1.ObjectMeta{Name: testClusterName},
 					})
-					Eventually(func() bool {
-						err := standbyHubClient.Get(ctx, types.NamespacedName{Name: testClusterName}, &clusterv1.ManagedCluster{})
-						return apierrors.IsNotFound(err)
-					}, hubHAUpdateSyncWait, 5*time.Second).Should(BeTrue())
 				}
 			})
 
@@ -1092,7 +1086,7 @@ var _ = Describe("Hub HA Sync", Label("e2e-test-hubha"), Ordered, func() {
 
 					klog.Infof("ManagedCluster %s update synced correctly with hubAcceptsClient=false maintained", testClusterName)
 					return nil
-				}, hubHAUpdateSyncWait, 5*time.Second).Should(Succeed())
+				}, hubHASyncWait+30*time.Second, 5*time.Second).Should(Succeed())
 			})
 		})
 	})

--- a/test/integration/agent/hubha/hubha_syncer_test.go
+++ b/test/integration/agent/hubha/hubha_syncer_test.go
@@ -83,10 +83,14 @@ var _ = Describe("Hub HA Active Syncer Integration", Ordered, func() {
 		agentConfig.SetStandbyHub("hub2")
 		agentconfigs.SetAgentConfig(agentConfig)
 
-		// Start the syncer once for all tests
-		syncCtx := context.Background()
-		syncErr := hubha.StartHubHAActiveSyncer(syncCtx, mgr, producer)
+		// Build an emitter for this test suite and start the resource-watching controller.
+		emitter := hubha.NewHubHAEmitter(producer, transportConfig, "hub1", "hub2")
+		emitter.SetEnabled(true)
+		emitter.SetClient(mgr.GetClient())
+		allGVKs := hubha.GetHubHAResourcesToSync()
+		activeGVKs, syncErr := hubha.StartHubHAResourceSyncer(mgr, allGVKs, emitter)
 		Expect(syncErr).NotTo(HaveOccurred())
+		emitter.SetActiveResources(activeGVKs)
 	})
 
 	BeforeEach(func() {

--- a/test/integration/agent/hubha/suite_test.go
+++ b/test/integration/agent/hubha/suite_test.go
@@ -22,7 +22,9 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/configs"
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/generic"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/syncers/configmap"
+	hubhastatus "github.com/stolostron/multicluster-global-hub/agent/pkg/status/syncers/hubha"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 )
@@ -114,10 +116,13 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	By("Adding configmap controller")
-	// Initialize agent config for the controller
+	// Initialize agent config for the controller.
+	// TransportConfig is included so that the Hub HA emitter created by
+	// enableSyncer has a valid config for any PeriodicSyncer ticks that fire.
 	agentConfig := &configs.AgentConfig{
-		LeafHubName:  "hub1",
-		PodNamespace: constants.GHAgentNamespace,
+		LeafHubName:     "hub1",
+		PodNamespace:    constants.GHAgentNamespace,
+		TransportConfig: transportConfig,
 	}
 	configs.SetAgentConfig(agentConfig)
 
@@ -125,15 +130,17 @@ var _ = BeforeSuite(func() {
 	err = configmap.AddConfigMapController(mgr, agentConfig)
 	Expect(err).NotTo(HaveOccurred())
 
-	By("Setting up Hub HA syncer manager")
-	// Create suite-level mock producer for all lifecycle tests
+	By("Setting up Hub HA lifecycle controller")
+	// Create suite-level mock producer for lifecycle tests.
 	suiteProducer = newMockProducer()
-	// Initialize Hub HA syncer manager once for all tests
-	// Use suite-level context for long-lived syncer goroutines
-	configmap.SetHubHASyncerManager(ctx, mgr, suiteProducer, func(ctx context.Context, m ctrl.Manager, prod transport.Producer) error {
-		// Mock start function for testing - doesn't actually start syncers
-		return nil
-	})
+	// Register the Hub HA lifecycle controller (replaces the removed SetHubHASyncerManager).
+	// Use WithNoOpStartResourceSyncerFn so the lifecycle controller does not attempt to
+	// register the "hubha" GVK-watching controller — the syncer tests do that directly via
+	// StartHubHAResourceSyncer, and controller names must be unique within the manager.
+	suitePeriodicSyncer := &generic.PeriodicSyncer{}
+	err = hubhastatus.AddHubHAController(mgr, suitePeriodicSyncer, suiteProducer, agentConfig,
+		hubhastatus.WithNoOpStartResourceSyncerFn())
+	Expect(err).NotTo(HaveOccurred(), "failed to register Hub HA lifecycle controller during integration suite setup")
 
 	go func() {
 		defer GinkgoRecover()


### PR DESCRIPTION
## What

Implements the refactoring described in [ACM-32677](https://redhat.atlassian.net/browse/ACM-32677): replaces the
`HubHASyncerManager` goroutine-restart pattern with a dedicated `hubha-lifecycle`
controller that reacts cleanly to agent ConfigMap changes.

reference implementation https://github.com/stolostron/multicluster-global-hub/pull/2382

## Why

The old approach had several problems:

- `HubHASyncerManager` lived inside the `configmap` package, mixing unrelated concerns.
- On every hub-role change the entire syncer context was cancelled and a new goroutine + controller set was spawned — a brittle pattern susceptible to race conditions.
- Periodic resync used a standalone goroutine instead of the `PeriodicSyncer` infrastructure used by every other emitter.
- `HubHAEmitter` had no enabled/disabled state, so it would attempt sends even while not in active role.

## What changed

### `agent/pkg/status/generic/periodic_syncer.go`
- Adds `Unregister(eventType)` for dynamic de-registration after `Start`.
- Allows `ListFunc=nil` registrations — emitters that self-list return objects inside `Resync(nil)`.
- Protects `syncStates` with a `sync.Mutex` so `Register`/`Unregister` are safe after the Start goroutine is running.
- Adds `CountRegistered()` helper for tests.

### `agent/pkg/spec/hubha/hubha_active_syncer.go`
- `startHubHAController` → `StartHubHAResourceSyncer` (exported, no lifecycle logic).
- `getHubHAResourcesToSync` → `GetHubHAResourcesToSync` (exported).
- Removes `StartHubHAActiveSyncer`, `periodicResync`, `performFullResync` (replaced by PeriodicSyncer + emitter self-listing).

### `agent/pkg/spec/hubha/hubha_emitter.go`
- Adds `enabled bool` field; `Update`/`Delete`/`Send` are no-ops when disabled.
- Adds `SetEnabled`, `SetStandbyHub`, `SetActiveResources`, `SetClient` mutators.
- `Resync(nil)` self-lists via the stored `client.Client` + `activeResources` GVK list.

### `agent/pkg/status/syncers/hubha/` (new package)
- `hubHALifecycleController` watches the agent ConfigMap (`hubha-lifecycle` controller).
- On reconcile: atomically updates `AgentConfig` with hub role + standby hub.
- `enableSyncer`: creates/updates emitter, starts GVK-watching controller (exactly once via `sync.Once`), registers emitter with `PeriodicSyncer`.
- `disableSyncer`: disables emitter, unregisters from `PeriodicSyncer`.
- `startResourceSyncerFn` is injectable for unit tests (avoids requiring a live manager).

### `agent/pkg/status/syncers/configmap/config_controller.go`
- Removes `HubHASyncerManager`, `HubHASyncerStartFunc`, `SetHubHASyncerManager`, `StartHubHASyncerIfActive`, `restartHubHASyncer`, and the hub-role update block from `Reconcile`.

### `agent/pkg/status/status.go`
- Removes calls to old `SetHubHASyncerManager` / `StartHubHASyncerIfActive`.
- Adds `hubha.AddHubHAController(mgr, periodicSyncer, producer, agentConfig)`.

## Tests

| Package | New tests |
|---|---|
| `agent/pkg/status/generic` | `ListFunc=nil` registration+resync, `Unregister`, nil-emitter guard |
| `agent/pkg/spec/hubha` | disabled no-op semantics, `SetEnabled` toggle, `SetStandbyHub`, `Resync(nil)` nil-client error, disabled Resync no-op |
| `agent/pkg/status/syncers/hubha` | all lifecycle transitions: no-change, become-active, become-standby, active-without-standby, CM not found, nil emitter disable |

All 15 agent test packages pass (the pre-existing `filter` package requires envtest/etcd and is unrelated).

## Test plan
- [x] `go build ./agent/...` — clean
- [x] `go test ./agent/... (excluding envtest)` — all pass
- [ ] Integration test: deploy agent with `hubRole=active` + `standbyHub=<name>` in ConfigMap, verify HA syncer starts and sends events
- [ ] Integration test: change `hubRole` to `standby`, verify syncer stops
- [ ] Integration test: change `standbyHub`, verify emitter picks up new target without restarting agent

Fixes: https://redhat.atlassian.net/browse/ACM-32677

Made with [Cursor](https://cursor.com)

[ACM-32677]: https://redhat.atlassian.net/browse/ACM-32677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Rewrote the Multicluster Global Hub architecture guide.
  * Refreshed repository guidance with clearer workflows and a consolidated build/test/lint command overview.

* **Hub HA High Availability**
  * Introduced a dedicated Hub HA lifecycle controller to enable/disable syncing based on configuration changes.
  * Improved Hub HA event emission gating and made resync behavior safer (including self-listing when no objects are provided and clearer missing-CRD handling).
  * Updated periodic sync scheduling to be concurrency-safe and support self-listing emitters.

* **Tests**
  * Expanded unit and integration coverage for the Hub HA emitter, periodic syncing behavior, and lifecycle transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->