### PR TITLE
Backport Agentic SDLC onboarding and GH 5.0 CPE labels to main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,198 +1,116 @@
+# CLAUDE.md — multicluster-global-hub
 
-# CLAUDE.md
+AI assistant context for **Multicluster Global Hub** — a Kubernetes operator-based system for managing ACM/OCM at very high scale across multiple regional hub clusters.
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Onboarded per [Fleet Engineering Agentic SDLC — repo onboarding](https://github.com/OpenShift-Fleet/agentic-sdlc/blob/main/practices/repo-onboarding.md). Day-to-day workflow: [ai-dev-workflow.md](https://github.com/OpenShift-Fleet/agentic-sdlc/blob/main/practices/ai-dev-workflow.md).
 
-## Overview
+---
 
-Multicluster Global Hub is a Kubernetes operator-based system for managing ACM/OCM at very high scale. The repository contains three main components:
-
-- **operator**: Deploys and manages the Global Hub infrastructure
-- **manager**: Runs on the global hub cluster to sync data to/from PostgreSQL and Kafka
-- **agent**: Runs on managed hub clusters to sync data between global hub and managed hubs
-
-Shared code lives in `pkg/`.
-
-## Architecture
-
-### Component Responsibilities
-
-**Operator** (`operator/`):
-
-- Deploys manager (global hub cluster) and agent (managed hub clusters)
-- Manages CRD lifecycle and custom resources
-- API definitions in `operator/api/`
-
-**Manager** (`manager/`):
-
-- `pkg/spec/`: Syncs resources FROM database TO managed hubs via Kafka
-  - `specdb/`: Database operations for spec resources
-  - `controllers/`: Watches and persists resources to database
-  - `syncers/`: Retrieves from database and sends via transport
-- `pkg/status/`: Syncs resource status FROM managed hubs TO database
-  - `conflator/`: Merges bundles from transport before database insertion
-  - `dispatcher/`: Routes bundles between transport, conflator, and database
-  - `handlers/`: Persists transferred bundles to database
-- `pkg/controllers/`: Common controllers (migration, backup)
-- `pkg/processes/`: Periodic jobs (policy compliance cronjob, managed hub management)
-- `pkg/restapis/`: REST APIs for managed clusters, policies, subscriptions
-- `pkg/webhook/`: Webhooks for global resources
-
-**Agent** (`agent/`):
-
-- `pkg/spec/`: Applies resources FROM global hub TO managed hub cluster
-  - `rbac/`: Role-based access control
-  - `syncers/`: Syncs resources and signals from manager
-  - `workers/`: Backend goroutines executing spec syncer tasks
-- `pkg/status/`: Reports resource status FROM managed hub TO manager via Kafka/Inventory API
-  - `filter/`: Deduplicates events
-  - `generic/`: Templates for status syncers
-    - `controller/`: Specifies resource types to sync
-    - `handler/`: Updates bundles for watched resources
-    - `emitter/`: Sends bundles via transport (CloudEvents)
-    - `multi-event syncer`: Template for multiple events per object (policy syncer)
-    - `multi-object syncer`: Template for one event per multiple objects (managedhub info syncer)
-  - `syncers/`: Specific resource syncers using generic templates
-- `pkg/controllers/inventory/`: Controllers reporting via Inventory API
-
-**Shared** (`pkg/`):
-
-- `transport/`: Kafka integration (Sarama and Confluent)
-- `database/`: PostgreSQL operations (GORM and pgx)
-- `bundle/`: Data bundling and compression
-- `constants/`, `enum/`, `utils/`: Common utilities
-
-## Build and Development Commands
-
-### Building Images
+## Build, Test, and Lint Commands
 
 ```bash
-
-# Build and push all component images
+# Vendor dependencies (required before image builds)
 make vendor
-make build-operator-image push-operator-image IMG=<registry>/multicluster-global-hub-operator:<tag>
-make build-manager-image push-manager-image IMG=<registry>/multicluster-global-hub-manager:<tag>
-make build-agent-image push-agent-image IMG=<registry>/multicluster-global-hub-agent:<tag>
 
-# Individual component builds
-cd operator && make docker-build docker-push IMG=<registry>/multicluster-global-hub-operator:<tag>
-cd manager && make
-cd agent && make
-```
-
-### Deploying
-
-```bash
-
-# Deploy operator to cluster
-make deploy-operator  # or: cd operator && make deploy IMG=<registry>/...:tag
-
-# Install Global Hub instance
-kubectl apply -k operator/config/samples/
-
-# Undeploy
-make undeploy-operator  # or: cd operator && make undeploy
-```
-
-### Code Quality
-
-```bash
-
-# Format code (standard Go formatting)
+# Format and lint
 make fmt
-
-# Strict formatting (gci + gofumpt)
-make strict-fmt
+make strict-fmt          # gci + gofumpt (CI format job)
 
 # Update dependencies
 make tidy
 make vendor
-```
 
-### Testing
+# Build component binaries
+cd operator && make
+cd manager && make
+cd agent && make
 
-**Unit Tests:**
+# Build and push container images
+make build-operator-image push-operator-image REGISTRY=<registry> IMAGE_TAG=<tag>
+make build-manager-image push-manager-image REGISTRY=<registry> IMAGE_TAG=<tag>
+make build-agent-image push-agent-image REGISTRY=<registry> IMAGE_TAG=<tag>
 
-```bash
+# Deploy operator and install a Global Hub instance
+make deploy-operator
+kubectl apply -k operator/config/samples/
+make undeploy-operator
 
-# Run all unit tests (requires setup-envtest)
+# Unit tests (downloads envtest binaries to /tmp/cr-tests-bin on first run)
 make unit-tests
-
-# Run component-specific unit tests
 make unit-tests-operator
 make unit-tests-manager
 make unit-tests-agent
 make unit-tests-pkg
-```
 
-**Integration Tests:**
-
-```bash
-
-make integration-test                # All integration tests
+# Integration tests
+make integration-test
 make integration-test/operator
 make integration-test/manager
 make integration-test/agent
-```
 
-**E2E Tests:**
-
-```bash
-
-# Setup E2E environment (creates KinD clusters)
+# E2E tests (creates KinD clusters)
 make e2e-setup
-
-# Run specific E2E test suites
 make e2e-test-cluster
 make e2e-test-local-agent
 make e2e-test-localpolicy
 make e2e-test-grafana
-
-# Run all E2E tests
 make e2e-test-all
-
-# Cleanup E2E environment
 make e2e-cleanup
+make e2e-test-localpolicy VERBOSE=9   # verbose E2E output
 
-# E2E test with verbose output
-make e2e-test-localpolicy VERBOSE=9
-```
-
-**Running Single Tests:**
-
-To run a single test file or function:
-
-```bash
-# Unit test - single package
-cd operator && KUBEBUILDER_ASSETS="$(setup-envtest use --use-env -p path)" go test -v ./pkg/path/to/package -run TestFunctionName
-
-# Integration test - single test
-KUBEBUILDER_ASSETS="$(setup-envtest use --use-env -p path)" go test -v ./test/integration/operator/... -run TestSpecificFunction
-```
-
-### Operator-Specific Commands
-
-When modifying operator API definitions:
-
-
-```bash
+# Operator API / bundle generation
 cd operator
-make generate    # Generate code (DeepCopy, etc.)
-make manifests   # Generate CRDs, RBAC, etc.
-make bundle      # Generate operator bundle
-```
+make generate    # DeepCopy, etc.
+make manifests   # CRDs, RBAC
+make bundle      # OLM bundle
 
-### Logs
-
-Fetch logs from E2E test environment:
-
-
-```bash
+# E2E log collection
 make e2e-log/operator
 make e2e-log/manager
 make e2e-log/grafana
 make e2e-log/agent
 ```
+
+> Unit and integration tests use controller-runtime's envtest harness. `KUBEBUILDER_ASSETS` is set automatically by the Makefile via `setup-envtest`.
+>
+> `make fmt` enforces import boundaries between `pkg/`, `operator/`, `manager/`, and `agent/` — see [Code Formatting Rules](#code-formatting-rules) below.
+
+---
+
+## Repo Layout
+
+```text
+operator/             OLM operator — deploys manager, agent, Kafka, Postgres, Grafana
+  api/                CRD type definitions (MulticlusterGlobalHub, Agent, Migration)
+  pkg/controllers/    Operator reconcilers (storage, kafka, grafana, agent, migration)
+  config/             Kustomize manifests (CRDs, RBAC, manager, samples)
+manager/              Runs on global hub — syncs spec/status via PostgreSQL and Kafka
+  pkg/spec/           Spec sync: controllers → DB → Kafka → managed hubs
+  pkg/status/         Status sync: Kafka → conflator → DB
+  pkg/controllers/    Migration, backup controllers
+  pkg/processes/      Cronjobs (compliance summarization, managed hub management)
+  pkg/restapis/       REST APIs (clusters, policies, subscriptions)
+agent/                Runs on managed hub clusters — applies spec, reports status
+  pkg/spec/           Applies resources from global hub to managed hub
+  pkg/status/         Reports managed-hub status to global hub via Kafka/Inventory API
+  pkg/controllers/    Inventory API controllers
+pkg/                  Shared code (transport, database, bundle, constants, utils)
+test/                 Integration and E2E test scripts and configs
+  script/             KinD E2E setup/run/cleanup scripts
+doc/                  Human-facing product documentation and architecture diagrams
+samples/              Example CRs and deployment manifests
+tools/                Helper scripts (kafka config generation, etc.)
+```
+
+---
+
+## Architecture
+
+See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for CRDs, spec/status data flow, PostgreSQL schema layout, Kafka topics, controller reconciliation, namespace layout, and migration/DR patterns.
+
+Additional product docs: [doc/README.md](doc/README.md), [doc/how_global_hub_works.md](doc/how_global_hub_works.md).
+
+---
 
 ## Code Formatting Rules
 
@@ -203,40 +121,64 @@ The `make fmt` target enforces import dependency rules:
 - `agent/` must NOT import from `manager/` or `operator/` (except `operator/api`)
 - `manager/` must NOT import from `agent/` or `operator/` (except `operator/api`)
 
-This maintains clean separation between components. Only shared code should live in `pkg/`.
+Only shared code should live in `pkg/`.
 
-## Testing Guidelines
+---
 
-- Integration tests use envtest and require KUBEBUILDER_ASSETS
+## Personal Config
 
-- E2E tests create real KinD clusters (configured via MH_NUM, MC_NUM environment variables)
-- Test scripts are in `test/script/`
-- E2E test configuration is stored in a temporary `CONFIG_DIR`
-- When debugging test failures, run tests individually with verbose flags (`-v` for go test, `VERBOSE=9` for E2E scripts)
+Read `.claude/user.local.md` at the start of any task that needs an assignee, email, or project key. If the file does not exist, fall back to Claude memory (`user-config`), then placeholders. Run `make personalize` in [OpenShift-Fleet/agentic-sdlc](https://github.com/OpenShift-Fleet/agentic-sdlc) to generate it.
+
+Repo-local skills live under `.claude/skills/` (e.g. `new-release` for z-stream cut workflows).
+
+---
+
+## Fleet Engineering Skills
+
+Use the Fleet plugin in Claude Code (`make install-claude` in agentic-sdlc) when available. In Cursor or other agents without the plugin, fetch and apply the relevant skill URL when the task matches its domain.
+
+| Skill | When to use |
+|---|---|
+| [start-work](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/start-work/SKILL.md) | Begin work on a Jira ticket — creates sub-task, transitions status |
+| [finish-work](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/finish-work/SKILL.md) | Commit, push, open PR, update Jira |
+| [pr-review](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/pr-review/SKILL.md) | Review a GitHub PR with worktree isolation and inline comments |
+| [pr-fix](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/pr-fix/SKILL.md) | Fix blocked PRs: merge conflicts, CI failures, review comments |
+| [jira-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/jira-specialist/SKILL.md) | Triage, search, link, or transition Jira issues |
+| [bug-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/bug-specialist/SKILL.md) | Create a well-structured bug report with reproduction steps |
+| [story-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/story-specialist/SKILL.md) | Create a user story with acceptance criteria |
+| [spike-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/spike-specialist/SKILL.md) | Time-boxed research and PoC tickets |
+
+---
 
 ## Key Dependencies
 
-- **Kubernetes**: v0.33.x (client-go, api, apimachinery)
+| Dependency | Version | Purpose |
+|---|---|---|
+| Go | 1.25.7 | Toolchain |
+| Kubernetes | v0.33.x | client-go, api, apimachinery |
+| controller-runtime | v0.21.x | Operator framework |
+| IBM Sarama | v1.46.x | Kafka client |
+| Confluent Kafka Go | v2.14.x | Kafka client (alternative) |
+| CloudEvents SDK | v2.16.x | Status transport bundles |
+| GORM / pgx | v1.30.x / v5.7.x | PostgreSQL access |
 
-- **Controller Runtime**: v0.21.x
-- **Kafka**: IBM Sarama v1.45.x, Confluent Kafka v2.12.x
-- **Database**: GORM v1.30.x, pgx v5.7.x
-- **CloudEvents**: v2.16.x
-- **ACM/OCM**: Multiple stolostron and open-cluster-management.io dependencies
-- **Go Version**: 1.25.7
+---
 
 ## Environment Variables
 
-E2E testing:
+**E2E testing:**
 
+| Variable | Default | Purpose |
+|---|---|---|
+| `MH_NUM` | 2 | Managed hub KinD clusters |
+| `MC_NUM` | 1 | Managed clusters per hub |
+| `GH_NAMESPACE` | `multicluster-global-hub` | Global hub namespace |
+| `VERBOSE` | 5 | E2E script log level |
 
-- `MH_NUM`: Number of managed hub clusters (default: 2)
-- `MC_NUM`: Number of managed clusters (default: 1)
-- `GH_NAMESPACE`: Global hub namespace (default: multicluster-global-hub)
-- `VERBOSE`: Log verbosity level for E2E tests (default: 5)
+**Build:**
 
-Build:
-
-- `REGISTRY`: Container registry (default: quay.io/stolostron)
-- `IMAGE_TAG`: Image tag (default: latest)
-- `GO_TEST`: Go test command override
+| Variable | Default | Purpose |
+|---|---|---|
+| `REGISTRY` | `quay.io/stolostron` | Container registry |
+| `IMAGE_TAG` | `latest` | Image tag |
+| `GO_TEST` | `go test -v` | Go test command override |

--- a/agent/Containerfile.agent
+++ b/agent/Containerfile.agent
@@ -24,11 +24,11 @@ LABEL com.redhat.component="multicluster-globalhub-agent-rhel9"
 LABEL org.label-schema.vendor="Red Hat"
 LABEL org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA"
 LABEL org.label-schema.schema-version="1.0"
-LABEL cpe="cpe:/a:redhat:multicluster_globalhub:1.8::el9"
+LABEL cpe="cpe:/a:redhat:multicluster_globalhub:5.0::el9"
 
 # Bundle metadata
 LABEL name="multicluster-globalhub/multicluster-globalhub-agent-rhel9"
-LABEL version="release-1.8"
+LABEL version="release-5.0"
 LABEL summary="multicluster global hub agent"
 LABEL io.openshift.expose-services=""
 LABEL io.openshift.tags="data,images"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,189 @@
+# Architecture — Multicluster Global Hub
+
+**Multicluster Global Hub** enables ACM/OCM management at very high scale by aggregating multiple regional (managed) hub clusters under a single global hub. The global hub stores fleet-wide state in PostgreSQL and distributes workloads to managed hubs via Kafka.
+
+Conceptual diagram: [doc/architecture/multicluster-global-hub-arch.png](../doc/architecture/multicluster-global-hub-arch.png)
+
+---
+
+## Components
+
+| Component | Runs on | Role |
+|---|---|---|
+| **Operator** | Global hub cluster | Deploys manager, agent (via ManifestWork), Kafka, Postgres, Grafana; manages CRDs |
+| **Manager** | Global hub cluster | Persists spec/status to PostgreSQL; publishes spec to Kafka; consumes status from Kafka |
+| **Agent** | Managed hub clusters | Applies spec from Kafka to managed hub; reports status back via Kafka or Inventory API |
+| **Grafana** | Global hub cluster | Observability dashboards backed by PostgreSQL |
+
+---
+
+## CRDs
+
+### `MulticlusterGlobalHub` (`operator.open-cluster-management.io/v1alpha4`)
+
+Short names: `mgh`, `mcgh`
+
+| Field | Purpose |
+|---|---|
+| `spec.availabilityConfig` | `Basic` or `High` (default) — replica counts for HA |
+| `spec.dataLayer.kafka.topics` | `specTopic` (default `gh-spec`), `statusTopic` (default `gh-status.*`) |
+| `spec.dataLayer.kafka.consumerGroupPrefix` | Prefix for Kafka consumer group IDs |
+| `spec.dataLayer.postgres.retention` | DB retention duration (default `18m`) |
+| `spec.advanced` | Per-component resource overrides (manager, agent, kafka, postgres, grafana) |
+| `spec.installAgentOnLocal` | Deploy agent on the local/global hub cluster (default `true`) |
+| `spec.enableMetrics` | Enable metrics for built-in Kafka and Postgres |
+
+Status tracks `phase`, `conditions`, and per-component readiness.
+
+### `MulticlusterGlobalHubAgent` (`operator.open-cluster-management.io/v1alpha1`)
+
+Short names: `mgha`, `mcgha`
+
+Deployed on each managed hub cluster. Key field:
+
+| Field | Purpose |
+|---|---|
+| `spec.transportConfigSecretName` | Secret containing `kafka.yaml` for connecting to global hub Kafka (default `transport-config`) |
+
+### `ManagedClusterMigration` (`global-hub.open-cluster-management.io/v1alpha1`)
+
+Short name: `mcm`
+
+Migrates managed clusters from one regional hub to another. Specify clusters via `includedManagedClusters` or `includedManagedClustersPlacementRef` (mutually exclusive).
+
+Phases: `Pending` → `Validating` → `Initializing` → `Deploying` → `Registering` → `Completed` (or `Failed` / `Rollbacking` / `Cleaning`).
+
+---
+
+## Data Flow
+
+### Spec path (global hub → managed hubs)
+
+1. ACM policies, placements, subscriptions, and other global resources are watched by **manager spec controllers**.
+2. Controllers persist resource payloads to PostgreSQL (`local_spec.*` schemas).
+3. **Spec syncers** read from the database and publish bundles to the `gh-spec` Kafka topic.
+4. **Agent spec syncers** on each managed hub consume from Kafka and apply resources to the managed hub cluster.
+5. **Agent workers** execute sync tasks with RBAC enforcement.
+
+### Status path (managed hubs → global hub)
+
+1. **Agent status controllers** watch managed-hub resources (policies, managed clusters, addons, etc.).
+2. Status changes are bundled and emitted as CloudEvents to per-hub Kafka topics (`gh-status.<hub-name>`).
+3. **Manager status dispatcher** routes bundles to the **conflator** (dedup/merge).
+4. **Status handlers** persist to PostgreSQL (`local_status.*`, `status.*`, `event.*`, `history.*` schemas).
+5. Nightly **compliance cronjob** summarizes policy compliance into `history.local_compliance`.
+
+Dataflow diagram: [doc/architecture/mcgh-data-flow.png](../doc/architecture/mcgh-data-flow.png)
+
+---
+
+## PostgreSQL Schema
+
+The operator applies SQL from `operator/pkg/controllers/storage/database/` on startup. Key schemas:
+
+| Schema | Purpose | Example tables |
+|---|---|---|
+| `local_spec` | Desired-state resources from managed hubs | `policies`, placements, subscriptions |
+| `local_status` | Current compliance/status per policy × cluster | `compliance` |
+| `status` | Fleet inventory and hub health | `managed_clusters`, `leaf_hubs`, `leaf_hub_heartbeats` |
+| `event` | Raw policy/cluster events (partitioned by date) | `local_policies`, `managed_clusters` |
+| `history` | Time-series compliance summaries | `local_compliance`, `local_compliance_job_log` |
+
+Retention is controlled by `spec.dataLayer.postgres.retention` on the `MulticlusterGlobalHub` CR. Built-in Postgres runs as `multicluster-global-hub-postgresql` in the global hub namespace.
+
+---
+
+## Kafka Topics
+
+| Topic | Direction | Contents |
+|---|---|---|
+| `gh-spec` | Manager → all agents | Policy/placement/subscription spec bundles |
+| `gh-status.*` | Agents → manager | Per-hub status CloudEvents (`gh-status.hub1`, etc.) |
+| `gh-status` | Agents → manager (BYO Kafka) | Single shared status topic when not using built-in per-hub topics |
+
+Consumer group IDs:
+
+- Global hub manager: `<prefix>global_hub`
+- Managed hub agent: `<prefix><hub-name>` (hyphens → underscores)
+
+Generate transport config for agents: `tools/generate-kafka-config.sh`.
+
+---
+
+## Controller Flow
+
+### Operator reconciler
+
+1. Watches `MulticlusterGlobalHub` CR.
+2. Deploys Postgres, Kafka (Strimzi), manager, Grafana on the global hub.
+3. Creates `MulticlusterGlobalHubAgent` ManifestWorks for each managed hub (or local hub if `installAgentOnLocal`).
+4. Applies database schema and upgrade SQL.
+5. Updates CR status with component readiness.
+
+### Manager spec controllers
+
+1. Watch ACM/OCM resources on the global hub (policies, placements, etc.).
+2. Upsert resource JSON into `local_spec.*` tables.
+3. Spec syncers poll/notify on DB changes and publish to `gh-spec`.
+
+### Manager status pipeline
+
+1. Kafka consumer receives status bundles from `gh-status.*` topics.
+2. Conflator merges partial bundles for the same resource.
+3. Dispatcher routes to typed handlers (policies, managed clusters, addons, etc.).
+4. Handlers upsert into `local_status.*`, `status.*`, and `event.*` tables.
+
+### Agent spec syncers
+
+1. Consume `gh-spec` topic.
+2. Decode bundles and apply/create/update/delete resources on the managed hub.
+3. RBAC module enforces least-privilege access.
+
+### Agent status syncers
+
+1. Watch managed-hub resources via controller-runtime.
+2. Filter duplicate events.
+3. Emit CloudEvents to the hub's status topic.
+
+---
+
+## Namespace Layout
+
+| Namespace | Cluster | Contents |
+|---|---|---|
+| `multicluster-global-hub` | Global hub | Operator, manager, Postgres, Kafka, Grafana |
+| `multicluster-global-hub-agent` | Managed hub | Agent deployment |
+| `open-cluster-management` | Both | ACM hub components |
+| `open-cluster-management-backup` | ACM hub | Backup operator resources (separate component) |
+
+---
+
+## Active/Passive and Migration
+
+Global Hub supports hub-level migration via `ManagedClusterMigration` CR and integrates with ACM backup/restore for DR scenarios. For backup operator specifics (Velero schedules, passive vs activation data), see [cluster-backup-operator docs](https://github.com/stolostron/cluster-backup-operator/blob/main/docs/ARCHITECTURE.md).
+
+Global Hub backup controllers live in `operator/pkg/controllers/backup` (operator-side) and `manager/pkg/controllers/backup_controller.go` (manager-side).
+
+---
+
+## Import Boundaries
+
+Components must not cross-import except through `pkg/` and `operator/api/`:
+
+- `pkg/` — shared transport, database, bundle utilities
+- `operator/api/` — CRD types readable by manager and agent
+- `manager/`, `agent/`, `operator/` — isolated; communicate via Kafka and Kubernetes APIs only
+
+---
+
+## Dependencies
+
+| Dependency | Version | Purpose |
+|---|---|---|
+| `sigs.k8s.io/controller-runtime` | v0.21.x | Operator and controller framework |
+| `github.com/IBM/sarama` | v1.46.x | Kafka (Sarama transport) |
+| `github.com/confluentinc/confluent-kafka-go/v2` | v2.14.x | Kafka (Confluent transport) |
+| `github.com/cloudevents/sdk-go/v2` | v2.16.x | Status bundle transport |
+| `gorm.io/gorm` / `github.com/jackc/pgx/v5` | v1.30.x / v5.7.x | PostgreSQL |
+| `github.com/stolostron/...` (ACM/OCM) | various | Policy, placement, subscription APIs |
+| Go | 1.25.7 | Toolchain |

--- a/manager/Containerfile.manager
+++ b/manager/Containerfile.manager
@@ -25,11 +25,11 @@ LABEL com.redhat.component="multicluster-globalhub-manager-rhel9"
 LABEL org.label-schema.vendor="Red Hat"
 LABEL org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA"
 LABEL org.label-schema.schema-version="1.0"
-LABEL cpe="cpe:/a:redhat:multicluster_globalhub:1.8::el9"
+LABEL cpe="cpe:/a:redhat:multicluster_globalhub:5.0::el9"
 
 # Bundle metadata
 LABEL name="multicluster-globalhub/multicluster-globalhub-manager-rhel9"
-LABEL version="release-1.8"
+LABEL version="release-5.0"
 LABEL summary="multicluster global hub manager"
 LABEL io.openshift.expose-services=""
 LABEL io.openshift.tags="data,images"

--- a/operator/Containerfile.operator
+++ b/operator/Containerfile.operator
@@ -20,11 +20,11 @@ LABEL com.redhat.component="multicluster-globalhub-rhel9-operator"
 LABEL org.label-schema.vendor="Red Hat"
 LABEL org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA"
 LABEL org.label-schema.schema-version="1.0"
-LABEL cpe="cpe:/a:redhat:multicluster_globalhub:1.8::el9"
+LABEL cpe="cpe:/a:redhat:multicluster_globalhub:5.0::el9"
 
 # Bundle metadata
 LABEL name="multicluster-globalhub/multicluster-globalhub-rhel9-operator"
-LABEL version="release-1.8"
+LABEL version="release-5.0"
 LABEL summary="multicluster global hub operator"
 LABEL io.openshift.expose-services=""
 LABEL io.openshift.tags="data,images"


### PR DESCRIPTION
## Summary

Backport release-5.0-only commits to `main` so `release-5.0` can align with `main` and restore fast-forward (currently **7 commits ahead** after merge PR #2533).

## Changes

1. **Agentic SDLC onboarding** (from #2512 on release-5.0) — `CLAUDE.md`, `docs/ARCHITECTURE.md`
2. **GH 5.0 CPE/version labels** (from #2516 on release-5.0) — `agent/manager/operator` Containerfiles

After this merges, `release-5.0` will be reset to match `main` exactly (0 ahead / 0 behind).

## Test plan

- [ ] CI passes (format, bundle verify, scorecard)
- [ ] After merge: reset `release-5.0` to `main` (force-push with lease)
- [ ] Verify compare shows 0 ahead / 0 behind


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured developer guide with clearer build, test, and deployment command instructions
  * Added comprehensive architecture documentation for the Multicluster Global Hub system

* **Chores**
  * Updated container image versions from 1.8 to 5.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->