### PR TITLE
Bump operator version to 5.0.0 for GH 5.0 GA

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -47,7 +47,7 @@ jobs:
       - name: bundle
         run: cd operator && make bundle
 
-      # main and release-5.0 use dev bundle versions (e.g. 1.8.0-dev) while the
+      # main and release-5.0 use dev bundle versions (e.g. 5.0.0-dev) while the
       # matching release-* branches in multicluster-global-hub-operator-bundle
       # carry GA z-stream versions — skip external sync on those branches.
       - name: resolve bundle comparison branch

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -3,14 +3,14 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.8.0-dev
+VERSION ?= 5.0.0-dev
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
 # To re-generate a bundle for other specific channels without changing the standard setup, you can:
 # - use the CHANNELS as arg of the bundle target (e.g make bundle CHANNELS=candidate,fast,stable)
 # - use environment variables to overwrite this value (e.g export CHANNELS="candidate,fast,stable")
-CHANNELS = "release-1.8"
+CHANNELS = "release-5.0"
 ifneq ($(origin CHANNELS), undefined)
 BUNDLE_CHANNELS := --channels=$(CHANNELS)
 endif
@@ -20,7 +20,7 @@ endif
 # To re-generate a bundle for any other default channel without changing the default setup, you can:
 # - use the DEFAULT_CHANNEL as arg of the bundle target (e.g make bundle DEFAULT_CHANNEL=stable)
 # - use environment variables to overwrite this value (e.g export DEFAULT_CHANNEL="stable")
-DEFAULT_CHANNEL = "release-1.8"
+DEFAULT_CHANNEL = "release-5.0"
 ifneq ($(origin DEFAULT_CHANNEL), undefined)
 BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
 endif

--- a/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -53,7 +53,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=1.7.0 <1.8.0'
+    olm.skipRange: '>=1.8.0 <5.0.0'
     operatorframework.io/initialization-resource: '{"apiVersion":"operator.open-cluster-management.io/v1alpha4",
       "kind":"MulticlusterGlobalHub","metadata":{"name":"multiclusterglobalhub","namespace":"multicluster-global-hub"},
       "spec": {}}'
@@ -71,7 +71,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: multicluster-global-hub-operator.v1.8.0-dev
+  name: multicluster-global-hub-operator.v5.0.0-dev
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1444,8 +1444,8 @@ spec:
   maintainers:
   - email: acm-contact@redhat.com
     name: acm-contact
-  maturity: release-1.8
+  maturity: release-5.0
   provider:
     name: Red Hat, Inc
     url: https://github.com/stolostron/multicluster-global-hub
-  version: 1.8.0-dev
+  version: 5.0.0-dev

--- a/operator/bundle/metadata/annotations.yaml
+++ b/operator/bundle/metadata/annotations.yaml
@@ -4,8 +4,8 @@ annotations:
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: multicluster-global-hub-operator
-  operators.operatorframework.io.bundle.channels.v1: release-1.8
-  operators.operatorframework.io.bundle.channel.default.v1: release-1.8
+  operators.operatorframework.io.bundle.channels.v1: release-5.0
+  operators.operatorframework.io.bundle.channel.default.v1: release-5.0
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.34.1
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4

--- a/operator/config/manifests/bases/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -18,7 +18,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=1.7.0 <1.8.0'
+    olm.skipRange: '>=1.8.0 <5.0.0'
     operatorframework.io/initialization-resource: '{"apiVersion":"operator.open-cluster-management.io/v1alpha4",
       "kind":"MulticlusterGlobalHub","metadata":{"name":"multiclusterglobalhub","namespace":"multicluster-global-hub"},
       "spec": {}}'
@@ -253,7 +253,7 @@ spec:
   maintainers:
   - email: acm-contact@redhat.com
     name: acm-contact
-  maturity: release-1.8
+  maturity: release-5.0
   provider:
     name: Red Hat, Inc
     url: https://github.com/stolostron/multicluster-global-hub


### PR DESCRIPTION
## Summary
- Bump operator bundle version from `1.8.0-dev` → `5.0.0-dev` on `release-5.0` channel
- Update `olm.skipRange` to `>=1.8.0 <5.0.0` and maturity to `release-5.0`
- Targets `main` for ffwd to `release-5.0` after merge

## Why
Jenkins operator-install (#1094) installed CSV `multicluster-global-hub-operator-rh.v1.8.0` from the GH 5.0 stage catalog because bundle/catalog still carry 1.8.0 metadata.

## Test plan
- [ ] CI `bundle` job passes on PR
- [ ] After merge + ffwd, Konflux rebuilds operator/bundle images
- [ ] Companion PRs: operator-bundle + operator-catalog version bump


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated operator build configurations and metadata to reflect version 5.0.0-dev release track.
  * Updated operator release channel from `release-1.8` to `release-5.0`.
  * Updated operator upgrade skip logic to handle transitions from 1.8 to 5.0 versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->