### PR TITLE
Security: Fix ACM-35903 - CVE-2026-33811 Go net LookupCNAME DoS [multicluster-globalhub-1.4]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/multicluster-global-hub
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/IBM/sarama v1.44.0

--- a/test/script/util.sh
+++ b/test/script/util.sh
@@ -8,7 +8,7 @@ export KUBECTL_VERSION=v1.28.1
 export CLUSTERADM_VERSION=0.8.2
 export KIND_VERSION=v0.19.0
 export ROUTE_VERSION=release-4.12
-export GO_VERSION=go1.25.7
+export GO_VERSION=go1.25.10
 export GINKGO_VERSION=v2.17.2
 
 # Environment Variables


### PR DESCRIPTION
## Summary

Fixes: [ACM-35903](https://redhat.atlassian.net/browse/ACM-35903)

### ACM-35903 — CVE-2026-33811 Go net package: Denial of Service via long CNAME response in LookupCNAME [multicluster-globalhub-1.4]

When using `LookupCNAME` with the cgo DNS resolver, a very long CNAME response can trigger a double-free of C memory and crash the process. Go vuln DB [GO-2026-4981](https://pkg.go.dev/vuln/GO-2026-4981) — fixed in Go **1.25.10**.

## Changes
- Bump `go` directive from `1.25.9` to `1.25.10` in `go.mod`
- Update `test/script/util.sh` `GO_VERSION` to `go1.25.10` for E2E script alignment

## Test plan
- [ ] CI / Konflux build passes on `release-2.13`
- [ ] Delivered via GH 1.4.7 z-stream ([ACM-35805](https://redhat.atlassian.net/browse/ACM-35805))

Made with [Cursor](https://cursor.com)

[ACM-35903]: https://redhat.atlassian.net/browse/ACM-35903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-35805]: https://redhat.atlassian.net/browse/ACM-35805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ