### PR TITLE
ACM-31409: Fix agent NetworkPolicy to allow Kubernetes API on port 6443

### DIFF
--- a/operator/pkg/controllers/agent/addon/manifests/templates/agent/multicluster-global-hub-agent-networkpolicy.yaml
+++ b/operator/pkg/controllers/agent/addon/manifests/templates/agent/multicluster-global-hub-agent-networkpolicy.yaml
@@ -33,14 +33,12 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
-  # Allow access to Kubernetes API server
-  - to:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: default
-    ports:
+  # Allow access to Kubernetes API server service IP
+  - ports:
     - protocol: TCP
       port: 443
+    - protocol: TCP
+      port: 6443
   # Allow connections to Kafka (Strimzi)
   - to:
     - namespaceSelector: {}

--- a/operator/pkg/controllers/agent/manifests/networkpolicy.yaml
+++ b/operator/pkg/controllers/agent/manifests/networkpolicy.yaml
@@ -33,14 +33,12 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
-  # Allow access to Kubernetes API server
-  - to:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: default
-    ports:
+  # Allow access to Kubernetes API server service IP
+  - ports:
     - protocol: TCP
       port: 443
+    - protocol: TCP
+      port: 6443
   # Allow connections to Kafka (Strimzi)
   - to:
     - namespaceSelector: {}


### PR DESCRIPTION
Fixes: [ACM-31409](https://redhat.atlassian.net/browse/ACM-31409)

## Summary
- Allow TCP **6443** egress for the Kubernetes API in agent NetworkPolicies (addon + standalone manifests)
- Match the hub `allow-dns-and-api` rule: ports 443/6443 without a `default`-namespace selector

## Problem
On managed/regional hubs (e.g. Jenkins `regionalhub-import #581` / rh-807), the GH agent addon deploys `multicluster-global-hub-agent` NetworkPolicy with API egress limited to **443 → default namespace only**. On OpenShift, `kubernetes` endpoints use **6443** on node IPs, so the agent cannot reach `apiextensions.k8s.io` and crashes:

```
dial tcp 172.30.0.1:443: i/o timeout
```

That leaves `multicluster-global-hub-controller` addon **Available=Unknown** (`ManagedClusterAddOnLeaseNotFound`) and fails import test RHACM4K-22296.

Observed after GH hub install was already **Running** (separate from operator-bundle networkpolicies RBAC fix in stolostron/multicluster-global-hub-operator-bundle#1323).

## Files
- `operator/pkg/controllers/agent/manifests/networkpolicy.yaml`
- `operator/pkg/controllers/agent/addon/manifests/templates/agent/multicluster-global-hub-agent-networkpolicy.yaml`

## Test plan
- [ ] CI unit/integration
- [ ] Fresh import on test env: agent pod Ready, addon Available=True, no API timeout in logs
- [ ] After ffwd to `release-5.0`, re-run `regionalhub-import` / `globalhub_e2e_test_pipeline`


[ACM-31409]: https://redhat.atlassian.net/browse/ACM-31409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ