### PR TITLE
ACM-31409: Allow external postgres ingress for e2e LoadBalancer

### DIFF
--- a/ai-doc/NETWORKPOLICY.md
+++ b/ai-doc/NETWORKPOLICY.md
@@ -299,6 +299,11 @@ spec:
 
 ### 6. PostgreSQL NetworkPolicy
 
+Allows in-cluster clients (manager, grafana, inventory-api, spicedb, etc.) and **external**
+LoadBalancer/NodePort clients on TCP 5432. The latter is required for Jenkins `globalhub-e2e`
+BeforeSuite, which creates a temporary `multicluster-global-hub-postgres-lb` Service and connects
+from outside the cluster over TLS.
+
 ```yaml
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -578,7 +583,7 @@ If using external Kafka bootstrap servers:
 ### 5. Backup Considerations
 If using backup solutions (Velero, OADP):
 - Add egress rules for manager/postgres to access backup namespace
-- Allow backup namespace ingress to postgres for data backup
+- Postgres ingress on TCP 5432 already allows external LoadBalancer/NodePort clients (see PostgreSQL NetworkPolicy)
 
 ## Testing Commands
 

--- a/ai-doc/NETWORKPOLICY.md
+++ b/ai-doc/NETWORKPOLICY.md
@@ -299,10 +299,17 @@ spec:
 
 ### 6. PostgreSQL NetworkPolicy
 
-Allows in-cluster clients (manager, grafana, inventory-api, spicedb, etc.) and **external**
-LoadBalancer/NodePort clients on TCP 5432. The latter is required for Jenkins `globalhub-e2e`
-BeforeSuite, which creates a temporary `multicluster-global-hub-postgres-lb` Service and connects
-from outside the cluster over TLS.
+Allows in-cluster clients (manager, grafana, inventory-api, spicedb, etc.) on TCP 5432 via
+pod selectors. A separate **ports-only** ingress rule (no `from` selector) also allows TCP 5432
+from any source that can reach the pod — including out-of-cluster clients via NodePort.
+
+The ports-only rule is required for Jenkins `globalhub-e2e` BeforeSuite, which creates a
+temporary NodePort Service `multicluster-global-hub-postgresql-external` (fixed NodePort
+**32433**) and connects from outside the cluster to the hub node IP over TLS
+(`test/e2e/suite_test.go`).
+
+> **Follow-up (ACM-31409):** tighten external access with `ipBlock` CIDRs — tracked from
+> [PR #2561](https://github.com/stolostron/multicluster-global-hub/pull/2561).
 
 ```yaml
 apiVersion: networking.k8s.io/v1
@@ -332,6 +339,12 @@ spec:
         matchLabels:
           name: multicluster-global-hub-grafana
     ports:
+    - protocol: TCP
+      port: 5432
+  # Allow TCP 5432 from any source (no `from` selector). Required for globalhub-e2e
+  # NodePort access (multicluster-global-hub-postgresql-external:32433) and backup tools.
+  # Follow-up: scope with ipBlock CIDRs (ACM-31409).
+  - ports:
     - protocol: TCP
       port: 5432
   # Allow Prometheus exporter scraping
@@ -583,7 +596,10 @@ If using external Kafka bootstrap servers:
 ### 5. Backup Considerations
 If using backup solutions (Velero, OADP):
 - Add egress rules for manager/postgres to access backup namespace
-- Postgres ingress on TCP 5432 already allows external LoadBalancer/NodePort clients (see PostgreSQL NetworkPolicy)
+- The ports-only postgres ingress rule (no `from` selector) allows TCP 5432 from any source;
+  backup or restore tools connecting via NodePort or from outside the cluster rely on this rule.
+  Prefer explicit namespace selectors for in-cluster backup workloads where possible (see
+  PostgreSQL NetworkPolicy; follow-up hardening tracked in ACM-31409).
 
 ## Testing Commands
 

--- a/operator/pkg/controllers/storage/manifests.sts/postgres-networkpolicy.yaml
+++ b/operator/pkg/controllers/storage/manifests.sts/postgres-networkpolicy.yaml
@@ -61,7 +61,11 @@ spec:
     ports:
     - protocol: TCP
       port: 5432
-  # Allow external connections via LoadBalancer/NodePort (e2e CI, backup tools)
+  # Allow TCP 5432 from any source (no `from` selector). Required for Jenkins globalhub-e2e
+  # BeforeSuite, which exposes postgres via NodePort Service
+  # multicluster-global-hub-postgresql-external (port 32433) and connects from outside the
+  # cluster. Also used by backup tools on NodePort. Cannot scope with pod/namespace selectors
+  # for external clients. Follow-up: ipBlock CIDR hardening (ACM-31409, PR #2561).
   - ports:
     - protocol: TCP
       port: 5432

--- a/operator/pkg/controllers/storage/manifests.sts/postgres-networkpolicy.yaml
+++ b/operator/pkg/controllers/storage/manifests.sts/postgres-networkpolicy.yaml
@@ -61,6 +61,10 @@ spec:
     ports:
     - protocol: TCP
       port: 5432
+  # Allow external connections via LoadBalancer/NodePort (e2e CI, backup tools)
+  - ports:
+    - protocol: TCP
+      port: 5432
   # Allow Prometheus exporter scraping
   - from:
     - namespaceSelector:


### PR DESCRIPTION
Fixes: [ACM-31409](https://redhat.atlassian.net/browse/ACM-31409)

## Summary
- Add postgres NetworkPolicy ingress on TCP **5432** without source selectors so external LoadBalancer/NodePort clients can connect
- Document the rule in `ai-doc/NETWORKPOLICY.md` (e2e BeforeSuite + backup tools)

## Problem
After operator networkpolicies RBAC shipped ([operator-bundle #1323](https://github.com/stolostron/multicluster-global-hub-operator-bundle/pull/1323)), fresh GH 5.0 installs deploy `multicluster-global-hub-postgresql` NetworkPolicy with ingress limited to in-cluster pods only.

Jenkins `globalhub-e2e` BeforeSuite creates a temporary `multicluster-global-hub-postgres-lb` LoadBalancer Service and connects from outside the cluster (via SOCKS proxy) with TLS. With the restrictive NP in place, the handshake fails and **0 of 52 specs** run:

```
failed to connect to user=postgres database=hoh:
  <elb-ip>:5432 (...elb.amazonaws.com): tls error: EOF
```

Observed on `globalhub-e2e #1836` / cluster `vbirsan--gh-777` after hub install and import were already healthy.

This is **not** the agent ManifestWork revert issue ([#2560](https://github.com/stolostron/multicluster-global-hub/pull/2560)); it fails before any test specs execute.

## Files
- `operator/pkg/controllers/storage/manifests.sts/postgres-networkpolicy.yaml`
- `ai-doc/NETWORKPOLICY.md`

## Test plan
- [ ] CI unit/integration
- [ ] After ffwd to `release-5.0` and operator image rebuild, re-run `globalhub-e2e` on a fresh GH 5.0 install — BeforeSuite postgres ping succeeds
- [ ] Confirm in-cluster manager/grafana postgres connectivity unchanged

## Follow-up
Tightening external ingress to `ipBlock` CIDRs (similar to agent Kafka hardening in ACM-31409) can be a separate task if security review requires it.

[ACM-31409]: https://redhat.atlassian.net/browse/ACM-31409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded PostgreSQL NetworkPolicy to allow TCP port **5432** via a ports-only ingress rule, enabling external **NodePort/LoadBalancer** connectivity when required.
  * Preserved existing restricted in-cluster access paths to port **5432**.
  * Updated backup/restore guidance to reflect that the ports-only rule already supports external backup tooling, while recommending explicit namespace selectors for in-cluster backup workloads where possible.
* **Documentation**
  * Clarified PostgreSQL NetworkPolicy behavior, including external access hardening notes and follow-up restriction guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->