### PR TITLE
ACM-31409: Allow external Kafka TLS bootstrap ingress via OpenShift router

### DIFF
--- a/ai-doc/NETWORKPOLICY.md
+++ b/ai-doc/NETWORKPOLICY.md
@@ -352,6 +352,11 @@ spec:
 
 ### 7. Kafka NetworkPolicy
 
+Allows in-cluster clients (manager, Strimzi, managed-hub agents) and **external**
+TLS bootstrap access via the OpenShift router on TCP 9093. The latter is required
+for Jenkins `globalhub-e2e` kafka tests, which connect to `kafka-kafka-tls-bootstrap`
+Route (`transport-config` bootstrap.server) from outside the cluster.
+
 ```yaml
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -543,12 +548,13 @@ For agents in managed hub clusters:
   ```
   global-hub.open-cluster-management.io/managed-hub: "true"
   ```
-- If agents are in remote clusters, Kafka needs external exposure (not covered by these policies)
+- If agents are in remote clusters, Kafka bootstrap Routes need external exposure via the OpenShift router (see Kafka NetworkPolicy ingress on TCP 9093)
 
 ### 4. External Kafka Access
 If using external Kafka bootstrap servers:
 - Add egress rules to allow manager to connect to external Kafka
 - Configure appropriate authentication/TLS
+- Built-in Strimzi Kafka TLS bootstrap Routes are allowed via `network.openshift.io/policy-group: ingress` on TCP 9093
 
 ### 5. Backup Considerations
 If using backup solutions (Velero, OADP):

--- a/ai-doc/NETWORKPOLICY.md
+++ b/ai-doc/NETWORKPOLICY.md
@@ -363,6 +363,8 @@ kind: NetworkPolicy
 metadata:
   name: kafka
   namespace: multicluster-global-hub
+  labels:
+    strimzi.io/cluster: kafka
 spec:
   podSelector:
     matchLabels:
@@ -378,33 +380,50 @@ spec:
           name: multicluster-global-hub-manager
     ports:
     - protocol: TCP
-      port: 9092
-    - protocol: TCP
       port: 9093
-    - protocol: TCP
-      port: 9094
-  # Allow Kafka internal communication (between brokers, ZooKeeper, etc.)
+  # Allow Kafka internal communication (between brokers, controllers)
   - from:
     - podSelector:
         matchLabels:
           strimzi.io/cluster: kafka
-  # Allow from agents in managed hub namespaces
+  # Allow from agents in managed hub namespaces (hosted mode)
   - from:
     - namespaceSelector:
         matchLabels:
           global-hub.open-cluster-management.io/managed-hub: "true"
-    podSelector:
-      matchLabels:
-        name: multicluster-global-hub-agent
+      podSelector:
+        matchLabels:
+          name: multicluster-global-hub-agent
     ports:
     - protocol: TCP
       port: 9093
-  # Allow metrics scraping
+  # Allow external access via OpenShift router (Kafka TLS bootstrap Route)
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: ingress
+    ports:
+    - protocol: TCP
+      port: 9093
+  # Allow metrics scraping from Prometheus (JMX exporter tcp-prometheus)
   - from:
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: openshift-monitoring
+    ports:
+    - protocol: TCP
+      port: 9404
   egress:
+  # Allow DNS resolution
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-dns
+    ports:
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
   # Allow Kafka internal communication
   - to:
     - podSelector:

--- a/operator/pkg/controllers/transporter/protocol/manifests/kafka-networkpolicy.yaml
+++ b/operator/pkg/controllers/transporter/protocol/manifests/kafka-networkpolicy.yaml
@@ -37,6 +37,14 @@ spec:
     ports:
     - protocol: TCP
       port: 9093
+  # Allow external access via OpenShift router (Kafka TLS bootstrap Route)
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: ingress
+    ports:
+    - protocol: TCP
+      port: 9093
   # Allow metrics scraping from Prometheus (JMX exporter tcp-prometheus)
   - from:
     - namespaceSelector:


### PR DESCRIPTION
Fixes: [ACM-31409](https://redhat.atlassian.net/browse/ACM-31409)

## Summary
- Add Kafka NetworkPolicy ingress on TCP **9093** from `network.openshift.io/policy-group: ingress`
- Match the grafana external Route pattern so TLS bootstrap Routes work when NetworkPolicies are deployed
- Document in `ai-doc/NETWORKPOLICY.md`

## Problem
After operator NetworkPolicies deploy (ACM-31409 / operator-bundle #1323), Jenkins `globalhub-e2e` kafka tests fail connecting to the external bootstrap Route:

```
ssl://kafka-kafka-tls-bootstrap-multicluster-global-hub.apps...:443/bootstrap: Connection setup timed out
no consumer group found with prefix: custom_qe_global_hub
```

`transport-config` uses the passthrough Route hostname (`bootstrap.server: ...apps...:443`). The `kafka` NetworkPolicy only allowed 9093 from manager, Strimzi internals, and managed-hub agents — not from the OpenShift router.

Observed on `globalhub-e2e #1837` (after postgres BeforeSuite fix in #2561).

## Related PRs
- #2560 — agent API egress 6443 (import / regional sync)
- #2561 — postgres external LB ingress (BeforeSuite)

## Files
- `operator/pkg/controllers/transporter/protocol/manifests/kafka-networkpolicy.yaml`
- `ai-doc/NETWORKPOLICY.md`

## Test plan
- [ ] CI unit/integration
- [ ] After ffwd to `release-5.0` and operator rebuild, re-run `globalhub-e2e` — RHACM4K-59007 / RHACM4K-58986 kafka tests connect via bootstrap Route

[ACM-31409]: https://redhat.atlassian.net/browse/ACM-31409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Kafka NetworkPolicy to allow TLS bootstrap traffic on TCP 9093 via the OpenShift router for external clients, while also supporting in-cluster and managed hub agent access on the same port.

* **Documentation**
  * Updated Kafka network policy guidance and “Important Considerations” to reflect the required router-based TCP 9093 exposure for remote-cluster agents.
  * Adjusted external Kafka access notes to confirm Strimzi TLS bootstrap routes are covered via the ingress policy-group on TCP 9093.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->