### PR TITLE
ACM-31409: Allow unrestricted external Kafka ingress on TCP 9093

### DIFF
--- a/ai-doc/NETWORKPOLICY.md
+++ b/ai-doc/NETWORKPOLICY.md
@@ -353,9 +353,10 @@ spec:
 ### 7. Kafka NetworkPolicy
 
 Allows in-cluster clients (manager, Strimzi, managed-hub agents) and **external**
-TLS bootstrap access via the OpenShift router on TCP 9093. The latter is required
-for Jenkins `globalhub-e2e` kafka tests, which connect to `kafka-kafka-tls-bootstrap`
-Route (`transport-config` bootstrap.server) from outside the cluster.
+TLS bootstrap access on TCP 9093 (OpenShift router and unrestricted external clients).
+Jenkins `globalhub-e2e` connects to `kafka-kafka-tls-bootstrap` Route
+(`transport-config` bootstrap.server on `:443` passthrough) from outside the cluster;
+router-scoped ingress alone (#2562) was insufficient on vbirsan--gh-777 / globalhub-e2e #1838.
 
 ```yaml
 apiVersion: networking.k8s.io/v1
@@ -403,6 +404,10 @@ spec:
         matchLabels:
           network.openshift.io/policy-group: ingress
     ports:
+    - protocol: TCP
+      port: 9093
+  # Allow external connections via Route/LoadBalancer/NodePort (e2e CI)
+  - ports:
     - protocol: TCP
       port: 9093
   # Allow metrics scraping from Prometheus (JMX exporter tcp-prometheus)
@@ -567,13 +572,13 @@ For agents in managed hub clusters:
   ```
   global-hub.open-cluster-management.io/managed-hub: "true"
   ```
-- If agents are in remote clusters, Kafka bootstrap Routes need external exposure via the OpenShift router (see Kafka NetworkPolicy ingress on TCP 9093)
+- If agents are in remote clusters, Kafka bootstrap Routes need external exposure on TCP 9093 (router + unrestricted ingress; see Kafka NetworkPolicy)
 
 ### 4. External Kafka Access
 If using external Kafka bootstrap servers:
 - Add egress rules to allow manager to connect to external Kafka
 - Configure appropriate authentication/TLS
-- Built-in Strimzi Kafka TLS bootstrap Routes are allowed via `network.openshift.io/policy-group: ingress` on TCP 9093
+- Built-in Strimzi Kafka TLS bootstrap Routes require unrestricted TCP 9093 ingress on the GH `kafka` NetworkPolicy for Jenkins e2e and other external clients (router-only ingress from #2562 is not sufficient)
 
 ### 5. Backup Considerations
 If using backup solutions (Velero, OADP):

--- a/operator/pkg/controllers/transporter/protocol/manifests/kafka-networkpolicy.yaml
+++ b/operator/pkg/controllers/transporter/protocol/manifests/kafka-networkpolicy.yaml
@@ -45,6 +45,10 @@ spec:
     ports:
     - protocol: TCP
       port: 9093
+  # Allow external connections via Route/LoadBalancer/NodePort (e2e CI, remote agents)
+  - ports:
+    - protocol: TCP
+      port: 9093
   # Allow metrics scraping from Prometheus (JMX exporter tcp-prometheus)
   - from:
     - namespaceSelector:


### PR DESCRIPTION
Fixes: [ACM-31409](https://redhat.atlassian.net/browse/ACM-31409)

Follow-up to #2562 (merged).

## Summary
- Add Kafka NetworkPolicy ingress on TCP **9093** without source selectors (external Route/LB/NodePort clients)
- Keep the OpenShift router-scoped rule from #2562
- Document that router-only ingress was insufficient for Jenkins globalhub-e2e external kafka admin tests

## Problem
#2562 added `network.openshift.io/policy-group: ingress` on TCP 9093. Manual cluster patch matched the merged manifest, but `globalhub-e2e #1838` still failed kafka admin tests:

```
ssl://kafka-kafka-tls-bootstrap-<openshift-route-host>:443/bootstrap: Connection setup timed out
```

In-cluster kafka tests (RHACM4K-53967) passed; only external `CreateKafkaAdminClientFromSecret` tests (RHACM4K-59007, 58986) failed — same pattern as postgres BeforeSuite, which required unrestricted 5432 ingress (#2561) rather than a scoped rule.

## Files
- `operator/pkg/controllers/transporter/protocol/manifests/kafka-networkpolicy.yaml`
- `ai-doc/NETWORKPOLICY.md`

## Related
- #2562 — router ingress (merged)
- #2561 — postgres external LB ingress (open)
- #2560 — agent API egress 6443 (merged)

## Test plan
- [ ] CI unit/integration
- [ ] Cluster patch + `globalhub-e2e` — RHACM4K-59007 / 58986 connect via bootstrap Route
- [ ] After ffwd to `release-5.0` and operator rebuild, fresh GH 5.0 install e2e

Made with [Cursor](https://cursor.com)

[ACM-31409]: https://redhat.atlassian.net/browse/ACM-31409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ