### PR TITLE
ACM-36289: Bump Go toolchain to 1.26.3 for GH 5.0

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 env:
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
   GO_REQUIRED_MIN_VERSION: ''
 
 permissions:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,6 +37,7 @@ jobs:
         uses: golangci/golangci-lint-action@63c23d5020da8f97005b6de340504130bdbe42c7 # v9
         with:
           version: v2.7.2
+          install-mode: goinstall
 
       - name: format
         run: make strict-fmt

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: false
 
       - name: Setup gci

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,7 +154,7 @@ Use the Fleet plugin in Claude Code (`make install-claude` in agentic-sdlc) when
 
 | Dependency | Version | Purpose |
 |---|---|---|
-| Go | 1.25.7 | Toolchain |
+| Go | 1.26.3 | Toolchain |
 | Kubernetes | v0.33.x | client-go, api, apimachinery |
 | controller-runtime | v0.21.x | Operator framework |
 | IBM Sarama | v1.46.x | Kafka client |

--- a/agent/Containerfile.agent
+++ b/agent/Containerfile.agent
@@ -2,7 +2,7 @@
 # Copyright Contributors to the Open Cluster Management project
 
 # Stage 1: build the target binaries
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /workspace
 

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Open Cluster Management project
 
 # Stage 1: build the target binaries
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -186,4 +186,4 @@ Components must not cross-import except through `pkg/` and `operator/api/`:
 | `github.com/cloudevents/sdk-go/v2` | v2.16.x | Status bundle transport |
 | `gorm.io/gorm` / `github.com/jackc/pgx/v5` | v1.30.x / v5.7.x | PostgreSQL |
 | `github.com/stolostron/...` (ACM/OCM) | various | Policy, placement, subscription APIs |
-| Go | 1.25.7 | Toolchain |
+| Go | 1.26.3 | Toolchain |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/multicluster-global-hub
 
-go 1.25.7
+go 1.26.3
 
 require (
 	github.com/IBM/sarama v1.46.3

--- a/manager/Containerfile.manager
+++ b/manager/Containerfile.manager
@@ -2,7 +2,7 @@
 # Copyright Contributors to the Open Cluster Management project
 
 # Stage 1: build the target binaries
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /workspace
 

--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Open Cluster Management project
 
 # Stage 1: build the target binaries
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 

--- a/operator/Containerfile.operator
+++ b/operator/Containerfile.operator
@@ -2,7 +2,7 @@
 # Copyright Contributors to the Open Cluster Management project
 
 # Stage 1: build the target binaries
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /workspace
 COPY go.sum go.mod ./

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -2,7 +2,7 @@
 # Copyright Contributors to the Open Cluster Management project
 
 # Stage 1: build the target binaries
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 COPY go.sum go.mod ./

--- a/test/script/util.sh
+++ b/test/script/util.sh
@@ -714,8 +714,11 @@ check_golang() {
     sudo tar -C /usr/local/ -xvf $GO_VERSION.linux-amd64.tar.gz >/dev/null 2>&1
     sudo rm $GO_VERSION.linux-amd64.tar.gz
   fi
-  if [[ $(go version) < "go version go1.24" ]]; then
-    echo "go version is less than 1.24, update to $GO_VERSION"
+  installed_version=$(go version | awk '{print $3}' | sed 's/^go//')
+  required_version=${GO_VERSION#go}
+  version_compare "$installed_version" "$required_version"
+  if [[ $? -eq 2 ]]; then
+    echo "go version is less than ${required_version}, update to $GO_VERSION"
     sudo rm -rf /usr/local/go
     wget https://dl.google.com/go/$GO_VERSION.linux-amd64.tar.gz >/dev/null 2>&1
     sudo tar -C /usr/local/ -xvf $GO_VERSION.linux-amd64.tar.gz >/dev/null 2>&1

--- a/test/script/util.sh
+++ b/test/script/util.sh
@@ -8,7 +8,7 @@ export KUBECTL_VERSION=v1.28.1
 export CLUSTERADM_VERSION=1.1.1
 export KIND_VERSION=v0.19.0
 export ROUTE_VERSION=release-4.12
-export GO_VERSION=go1.25.7
+export GO_VERSION=go1.26.3
 export GINKGO_VERSION=v2.31.0
 
 # Environment Variables


### PR DESCRIPTION
Fixes: [ACM-36289](https://redhat.atlassian.net/browse/ACM-36289)

## Summary
- Bump `go` directive to **1.26.3** in `go.mod`
- Switch Konflux builder images to `openshift-golang-builder:rhel_9_1.26` (operator, manager, agent Containerfiles)
- Align OpenShift CI Dockerfiles to `go1.26-linux`, GitHub Actions, and E2E `util.sh`

## Why
GH 5.0 needs Go 1.26+ for security fixes (e.g. GO-2026-4981 / CVE-2026-33811 requires 1.25.10; builder `rhel_9_1.25` is still on 1.25.9). The `rhel_9_1.26` builder ships **Go 1.26.3** today.

After merge to `main`, OpenShift CI will ffwd to `release-5.0`.

## Test plan
- [ ] CI / Konflux build-images passes on PR (operator, manager, agent)
- [ ] `/test all` on release-5.0 after ffwd

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded the Go toolchain to **1.26** across CI workflows and Docker/Container build images.
  * Updated the documented Go version to **1.26.3** in project references.
  * Adjusted CI Go tooling setup for linting to use `goinstall`.
  * Updated test tooling to target **go1.26.3** and improved Go version gating logic.
* **Bug Fixes**
  * Ensured build/test/toolchain checks remain aligned with the **1.26** toolchain version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[ACM-36289]: https://redhat.atlassian.net/browse/ACM-36289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ