### PR TITLE
Security: Fix ACM-35899 / ACM-36289 / ACM-36634 / ACM-36655 / ACM-36636 / ACM-36967 / ACM-36969 / ACM-36970 - Go 1.26.3 z-stream [multicluster-globalhub-1.7]

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 env:
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
   GO_REQUIRED_MIN_VERSION: ''
 
 permissions:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
 
       - name: Setup gci
         run: go install github.com/daixiang0/gci@latest
@@ -34,6 +34,7 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         with:
           version: v2.7.2
+          install-mode: goinstall
 
       - name: format
         run: make strict-fmt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,7 +223,7 @@ This maintains clean separation between components. Only shared code should live
 - **Database**: GORM v1.30.x, pgx v5.7.x
 - **CloudEvents**: v2.16.x
 - **ACM/OCM**: Multiple stolostron and open-cluster-management.io dependencies
-- **Go Version**: 1.25.7
+- **Go Version**: 1.26.3
 
 ## Environment Variables
 

--- a/agent/Containerfile.agent
+++ b/agent/Containerfile.agent
@@ -2,7 +2,7 @@
 # Copyright Contributors to the Open Cluster Management project
 
 # Stage 1: build the target binaries
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /workspace
 

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Open Cluster Management project
 
 # Stage 1: build the target binaries
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/multicluster-global-hub
 
-go 1.25.7
+go 1.26.3
 
 require (
 	github.com/IBM/sarama v1.46.3

--- a/manager/Containerfile.manager
+++ b/manager/Containerfile.manager
@@ -2,7 +2,7 @@
 # Copyright Contributors to the Open Cluster Management project
 
 # Stage 1: build the target binaries
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /workspace
 

--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Open Cluster Management project
 
 # Stage 1: build the target binaries
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 

--- a/operator/Containerfile.operator
+++ b/operator/Containerfile.operator
@@ -2,7 +2,7 @@
 # Copyright Contributors to the Open Cluster Management project
 
 # Stage 1: build the target binaries
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /workspace
 COPY go.sum go.mod ./

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -2,7 +2,7 @@
 # Copyright Contributors to the Open Cluster Management project
 
 # Stage 1: build the target binaries
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 COPY go.sum go.mod ./

--- a/test/script/util.sh
+++ b/test/script/util.sh
@@ -8,7 +8,7 @@ export KUBECTL_VERSION=v1.28.1
 export CLUSTERADM_VERSION=1.1.1
 export KIND_VERSION=v0.19.0
 export ROUTE_VERSION=release-4.12
-export GO_VERSION=go1.25.7
+export GO_VERSION=go1.26.3
 export GINKGO_VERSION=v2.17.2
 
 # Environment Variables
@@ -714,8 +714,11 @@ check_golang() {
     sudo tar -C /usr/local/ -xvf $GO_VERSION.linux-amd64.tar.gz >/dev/null 2>&1
     sudo rm $GO_VERSION.linux-amd64.tar.gz
   fi
-  if [[ $(go version) < "go version go1.24" ]]; then
-    echo "go version is less than 1.24, update to $GO_VERSION"
+  installed_version=$(go version | awk '{print $3}' | sed 's/^go//')
+  required_version=${GO_VERSION#go}
+  version_compare "$installed_version" "$required_version"
+  if [[ $? -eq 2 ]]; then
+    echo "go version is less than ${required_version}, update to $GO_VERSION"
     sudo rm -rf /usr/local/go
     wget https://dl.google.com/go/$GO_VERSION.linux-amd64.tar.gz >/dev/null 2>&1
     sudo tar -C /usr/local/ -xvf $GO_VERSION.linux-amd64.tar.gz >/dev/null 2>&1


### PR DESCRIPTION
## Summary

Fixes: [ACM-35899](https://redhat.atlassian.net/browse/ACM-35899), [ACM-36289](https://redhat.atlassian.net/browse/ACM-36289), [ACM-36634](https://redhat.atlassian.net/browse/ACM-36634), [ACM-36655](https://redhat.atlassian.net/browse/ACM-36655), [ACM-36636](https://redhat.atlassian.net/browse/ACM-36636), [ACM-36967](https://redhat.atlassian.net/browse/ACM-36967), [ACM-36969](https://redhat.atlassian.net/browse/ACM-36969), [ACM-36970](https://redhat.atlassian.net/browse/ACM-36970)

### ACM-35899 / ACM-36289 — CVE-2026-33811 (Go net LookupCNAME)

CVE-2026-33811 (GO-2026-4981, CVSS 7.5 HIGH): When using `LookupCNAME` with the cgo DNS resolver, a very long CNAME response can trigger a double-free of C memory and crash the process. The Go vuln DB patches this in **Go 1.25.10+**. GA Global Hub 1.7.1 shipped with Go 1.25.7; this PR bumps the toolchain to **Go 1.26.3** for the 1.7.2 z-stream ([ACM-36312](https://redhat.atlassian.net/browse/ACM-36312)).

### ACM-36634 / ACM-36655 / ACM-36636 — CVE-2026-53488 (containerd)

CVE-2026-53488 (GO-2026-5758, CVSS 8.8 HIGH): GA Global Hub **1.7.1** shipped with `github.com/containerd/containerd v1.7.29` (Go 1.25.7). After this PR, `release-2.16` uses Go **1.26.3** and no longer pulls in `containerd` — the vulnerable module is absent from the agent/manager/operator dependency graph for the **1.7.2** z-stream build. No separate containerd v1.7.33 bump is required on 1.7.

### ACM-36967 / ACM-36969 / ACM-36970 — CVE-2026-53492 (containerd CDI checkpoint restore)

CVE-2026-53492 (GO-2026-5064, CVSS 8.2 Important): containerd CRI checkpoint-restore CDI annotation smuggling. GA Global Hub **1.7.1** shipped with `containerd v1.7.29` as an indirect dependency (operator [ACM-36967](https://redhat.atlassian.net/browse/ACM-36967), manager [ACM-36969](https://redhat.atlassian.net/browse/ACM-36969), agent [ACM-36970](https://redhat.atlassian.net/browse/ACM-36970)). The Go **1.26.3** z-stream bump removes `containerd` from the dependency graph — same remediation as CVE-2026-53488 above. No additional code change required.

## Changes

- Bump `go` directive from **1.25.7** to **1.26.3** in `go.mod` to fix CVE-2026-33811
- Switch Konflux builder images to `openshift-golang-builder:rhel_9_1.26` (operator, manager, agent Containerfiles)
- Align OpenShift CI Dockerfiles to `go1.26-linux`, GitHub Actions, and E2E `util.sh`

Companion OpenShift CI PR: openshift/release (release-2.16 `go1.26-linux` builder). Same rationale as [#2574](https://github.com/stolostron/multicluster-global-hub/pull/2574) for GH 5.0.

## Test plan

- [x] CI / Konflux build-images passes (operator, manager, agent)
- [ ] `/test all` on release-2.16 after merge
- OSV [GO-2026-4981](https://osv.dev/vulnerability/GO-2026-4981) confirms fix in Go ≥ 1.25.10; merged `go.mod` specifies 1.26.3

[ACM-35899]: https://redhat.atlassian.net/browse/ACM-35899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-36289]: https://redhat.atlassian.net/browse/ACM-36289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-36634]: https://redhat.atlassian.net/browse/ACM-36634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-36655]: https://redhat.atlassian.net/browse/ACM-36655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-36636]: https://redhat.atlassian.net/browse/ACM-36636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-36967]: https://redhat.atlassian.net/browse/ACM-36967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-36969]: https://redhat.atlassian.net/browse/ACM-36969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-36970]: https://redhat.atlassian.net/browse/ACM-36970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-36312]: https://redhat.atlassian.net/browse/ACM-36312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-36967]: https://redhat.atlassian.net/browse/ACM-36967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ