### PR TITLE
Fix SonarCloud quality gate GitHub Actions findings

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: install ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.15.0
+        run: go install github.com/onsi/ginkgo/v2/ginkgo
       - name: SET E2E
         run: |
           make kessel-e2e-setup

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,13 +25,13 @@ jobs:
           go-version: '1.25'
 
       - name: Setup gci
-        run: go install github.com/daixiang0/gci@latest
+        run: go install github.com/daixiang0/gci@v0.13.7
 
       - name: Setup gofumpt
-        run: go install mvdan.cc/gofumpt@latest
-        
+        run: go install mvdan.cc/gofumpt@v0.10.0
+
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
           version: v2.7.2
 
@@ -66,10 +66,10 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Create k8s Kind Cluster
-        uses: helm/kind-action@v1
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1
 
       - name: Download operator-sdk
-        uses: drmendes/setup-k8s-operator-sdk@v1.1.5
+        uses: drmendes/setup-k8s-operator-sdk@576d2bf133e6b89a808063375f56c892475627aa # v1.1.5
         with:
           version: "^1.34.1"
       


### PR DESCRIPTION
## Summary
- Pin third-party GitHub Actions to full commit SHAs in `go.yml` (golangci-lint, kind-action, setup-k8s-operator-sdk)
- Replace `go install ...@latest` with pinned versions for `gci` and `gofumpt`
- Install ginkgo from `go.mod`/`go.sum` in `e2e.yml`

## Why
SonarCloud quality gate fails on `release-2.16` with **security_rating C** (6 open workflow vulnerabilities: S7637 unpinned actions, S8545 unpredictable `go install`). This blocks the `sonarcloud` Prow job (e.g. openshift/release#81274 rehearse).

## Test plan
- [ ] SonarCloud Code Analysis passes on this PR
- [ ] GitHub Actions `Go` workflow still passes (format, bundle verify, scorecard)
- [ ] Re-run openshift/release#81274 `sonarcloud` rehearse after merge


Made with [Cursor](https://cursor.com)