### PR TITLE
Pin checkout and setup-go to full SHAs for SonarCloud quality gate

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,9 +26,9 @@ jobs:
           docker system prune -af
           df -h /
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: install ginkgo

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: '1.26'
 
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: bundle
         run: cd operator && make bundle
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1


### PR DESCRIPTION
## Summary
- Pin `actions/checkout@v7` and `actions/setup-go@v6` to full commit SHAs in `go.yml` and `e2e.yml`
- Completes the workflow hardening started in #2582

## Why
Post-submit `branch-ci-stolostron-multicluster-global-hub-release-2.16-sonarcloud-post-submit` fails with **Quality Gate FAILED** because six floating-tag action references remain (S7637), keeping branch security rating at C. #2582 pinned other actions but left `checkout@v7` (×4) and `setup-go@v6` (×2) unpinned.

## Test plan
- [ ] SonarCloud Code Analysis passes on this PR
- [ ] GitHub Actions `Go` workflow still passes
- [ ] Post-submit sonarcloud on `release-2.16` goes green after merge
- [ ] Re-run openshift/release#81274 sonarcloud rehearse after merge


Made with [Cursor](https://cursor.com)