### PR TITLE
Pin GitHub Actions to full SHAs for SonarCloud quality gate (release-2.17)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,17 +26,16 @@ jobs:
           docker system prune -af
           df -h /
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: install ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.15.0
+        run: go install github.com/onsi/ginkgo/v2/ginkgo
       - name: SET E2E
         run: |
           make kessel-e2e-setup
       - name: RUN E2E
         run: |
           make kessel-e2e-run
-  

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,23 +17,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: '1.25'
 
       - name: Setup gci
-        run: go install github.com/daixiang0/gci@latest
+        run: go install github.com/daixiang0/gci@v0.13.7
 
       - name: Setup gofumpt
-        run: go install mvdan.cc/gofumpt@latest
-        
+        run: go install mvdan.cc/gofumpt@v0.10.0
+
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
           version: v2.7.2
+          install-mode: goinstall
 
       - name: format
         run: make strict-fmt
@@ -42,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: bundle
         run: cd operator && make bundle
@@ -63,15 +64,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Create k8s Kind Cluster
-        uses: helm/kind-action@v1
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1
 
       - name: Download operator-sdk
-        uses: drmendes/setup-k8s-operator-sdk@v1.1.5
+        uses: drmendes/setup-k8s-operator-sdk@576d2bf133e6b89a808063375f56c892475627aa # v1.1.5
         with:
           version: "^1.34.1"
-      
+
       - name: scorecard
         run: cd operator && operator-sdk scorecard ./bundle/


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions `uses:` references to full commit SHAs in `go.yml` and `e2e.yml`
- Replace `@latest` / floating-tag `go install` with pinned versions

## Why
SonarCloud branch post-submit fails with **Quality Gate FAILED** (security rating C) due to unpinned workflow actions (S7637) and unpredictable `go install` (S8545). Needed for GA z-stream releases on this line.

## Test plan
- [ ] SonarCloud Code Analysis passes on this PR
- [ ] GitHub Actions `Go` workflow still passes
- [ ] Post-submit sonarcloud on target branch goes green after merge

Made with [Cursor](https://cursor.com)