### PR TITLE
Pin GitHub Actions to full SHAs for SonarCloud quality gate (release-2.13)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,17 +18,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: install ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.15.0
+        run: go install github.com/onsi/ginkgo/v2/ginkgo
       - name: SET E2E
         run: |
           make kessel-e2e-setup
       - name: RUN E2E
         run: |
           make kessel-e2e-run
-  

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,15 +17,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '1.25'
 
       - name: Setup gci
-        run: go install github.com/daixiang0/gci@latest
+        run: go install github.com/daixiang0/gci@v0.13.7
 
       - name: Setup gofumpt
         run: go install mvdan.cc/gofumpt@v0.8.0
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: bundle
         run: cd operator && make bundle
@@ -47,15 +47,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Create k8s Kind Cluster
-        uses: helm/kind-action@v1
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1
 
       - name: Download operator-sdk
-        uses: drmendes/setup-k8s-operator-sdk@v1.1.5
+        uses: drmendes/setup-k8s-operator-sdk@576d2bf133e6b89a808063375f56c892475627aa # v1.1.5
         with:
           version: "^1.34.1"
-      
+
       - name: scorecard
         run: cd operator && operator-sdk scorecard ./bundle/


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions `uses:` references to full commit SHAs in `go.yml` and `e2e.yml`
- Replace `@latest` / floating-tag `go install` with pinned versions

## Why
SonarCloud branch post-submit fails with **Quality Gate FAILED** (security rating C) due to unpinned workflow actions (S7637) and unpredictable `go install` (S8545). Needed for GA z-stream releases on this line.

## Test plan
- [ ] SonarCloud Code Analysis passes on this PR
- [ ] GitHub Actions `Go` workflow still passes
- [ ] Post-submit sonarcloud on target branch goes green after merge

Made with [Cursor](https://cursor.com)