### PR TITLE
Bump gopkg.in/ini.v1 to v1.67.3 for GH 1.4.7 z-stream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/stolostron/multiclusterhub-operator v0.0.0-20230829141355-4ad378ab367f
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/zap v1.27.1
-	gopkg.in/ini.v1 v1.67.1
+	gopkg.in/ini.v1 v1.67.3
 	gopkg.in/yaml.v2 v2.4.0
 	gorm.io/datatypes v1.2.7
 	gorm.io/driver/postgres v1.5.11

--- a/go.sum
+++ b/go.sum
@@ -1215,8 +1215,8 @@ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMy
 gopkg.in/inf.v0 v0.9.0/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
-gopkg.in/ini.v1 v1.67.1 h1:tVBILHy0R6e4wkYOn3XmiITt/hEVH4TFMYvAX2Ytz6k=
-gopkg.in/ini.v1 v1.67.1/go.mod h1:x/cyOwCgZqOkJoDIJ3c1KNHMo10+nLGAhh+kn3Zizss=
+gopkg.in/ini.v1 v1.67.3 h1:iM9Lhz5MRSGhHVGGwCuzG9KO8PoirCXj/m/qTmOJJQw=
+gopkg.in/ini.v1 v1.67.3/go.mod h1:x/cyOwCgZqOkJoDIJ3c1KNHMo10+nLGAhh+kn3Zizss=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=


### PR DESCRIPTION
## Summary

- Bumps `gopkg.in/ini.v1` v1.67.1 → v1.67.3 on `release-2.13` for GH **1.4.7** z-stream
- Fixes **CVE-2024-45339** (DoS via unbounded key/value allocation in ini parser)
- Completes the ini.v1 security fix set alongside [#2590](https://github.com/stolostron/multicluster-global-hub/pull/2590), [#2591](https://github.com/stolostron/multicluster-global-hub/pull/2591), [#2592](https://github.com/stolostron/multicluster-global-hub/pull/2592), [#2593](https://github.com/stolostron/multicluster-global-hub/pull/2593)

Version bump **#2555** and prior CVE fixes are already merged on this branch.

## Test plan

- [ ] Konflux `globalhub-1-4` pipelines pass (agent, manager, operator)
- [ ] `ci/prow/test-integration` on `release-2.13`


Made with [Cursor](https://cursor.com)