### PR TITLE
Security: Fix ACM-36523 / ACM-36776 / ACM-36778 / ACM-36779 - Go 1.26.3 z-stream [multicluster-globalhub-1.4]

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 env:
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
   GO_REQUIRED_MIN_VERSION: ''
 
 permissions:
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: install ginkgo

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,18 +17,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
 
-      - name: Setup gci
-        run: go install github.com/daixiang0/gci@v0.13.7
-
-      - name: Setup gofumpt
-        run: go install mvdan.cc/gofumpt@v0.8.0
+      - name: Setup format tools
+        run: go install tool
 
       - name: format
         run: make strict-fmt
@@ -37,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: bundle
         run: cd operator && make bundle
@@ -47,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1

--- a/agent/Containerfile.agent
+++ b/agent/Containerfile.agent
@@ -2,7 +2,7 @@
 # Copyright Contributors to the Open Cluster Management project
 
 # Stage 1: build the target binaries
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /workspace
 

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Open Cluster Management project
 
 # Stage 1: build the target binaries
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,11 @@
 module github.com/stolostron/multicluster-global-hub
 
-go 1.25.9
+go 1.26.3
+
+tool (
+	github.com/daixiang0/gci
+	mvdan.cc/gofumpt
+)
 
 require (
 	github.com/IBM/sarama v1.44.0
@@ -68,11 +73,14 @@ require (
 
 require (
 	github.com/containerd/containerd v1.7.29 // indirect
+	github.com/daixiang0/gci v0.14.0 // indirect
 	github.com/gonvenience/idem v0.0.3 // indirect
+	github.com/hexops/gotextdiff v1.0.3 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/mod v0.35.0 // indirect
+	mvdan.cc/gofumpt v0.7.0 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -165,6 +165,8 @@ github.com/crunchydata/postgres-operator v1.3.3-0.20230629151007-94ebcf2df74d h1
 github.com/crunchydata/postgres-operator v1.3.3-0.20230629151007-94ebcf2df74d/go.mod h1:rofwFoq0O85c9lyj3xC2Hl7SG9jo63c/NwXX85JjVVA=
 github.com/cyphar/filepath-securejoin v0.3.6 h1:4d9N5ykBnSp5Xn2JkhocYDkOpURL/18CYMpo6xB9uWM=
 github.com/cyphar/filepath-securejoin v0.3.6/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
+github.com/daixiang0/gci v0.14.0 h1:h6AcLqmjIOBgojhtzY2CvBnA6RawPTkBHgtMvYD5YZ8=
+github.com/daixiang0/gci v0.14.0/go.mod h1:w9E+SWQ4aPQ+xYPUdqitGDoXpT4mayqOfk7Szz2U6wQ=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -468,6 +470,8 @@ github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
+github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/homeport/dyff v1.10.4 h1:l1Y7TF5+bvmZ4sZbo/78RnjrPGoUj5q6O8Qoxxsx/Xs=
 github.com/homeport/dyff v1.10.4/go.mod h1:i5C9VJj2SDS7m8Z3ULwk1Araou05Dg+5mb0WsYVmxhY=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
@@ -1308,6 +1312,8 @@ modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=
 modernc.org/strutil v1.0.0/go.mod h1:lstksw84oURvj9y3tn8lGvRxyRC1S2+g5uuIzNfIOBs=
 modernc.org/xc v1.0.0/go.mod h1:mRNCo0bvLjGhHO9WsyuKVU4q0ceiDDDoEeWDJHrNx8I=
+mvdan.cc/gofumpt v0.7.0 h1:bg91ttqXmi9y2xawvkuMXyvAA/1ZGJqYAEGjXuP0JXU=
+mvdan.cc/gofumpt v0.7.0/go.mod h1:txVFJy/Sc/mvaycET54pV8SW8gWxTlUuGHVEcncmNUo=
 nullprogram.com/x/optparse v1.0.0/go.mod h1:KdyPE+Igbe0jQUrVfMqDMeJQIJZEuyV7pjYmp6pbG50=
 open-cluster-management.io/addon-framework v0.11.0 h1:ZJxphgHQ36VUJF0RIag+nzcEn5PNyep2rsEPdz6wT7o=
 open-cluster-management.io/addon-framework v0.11.0/go.mod h1:ruMU8i/dciz3qCv2CQ46Cu1b7rkK7TpvB+W4bRwHf+I=

--- a/manager/Containerfile.manager
+++ b/manager/Containerfile.manager
@@ -2,7 +2,7 @@
 # Copyright Contributors to the Open Cluster Management project
 
 # Stage 1: build the target binaries
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /workspace
 

--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Open Cluster Management project
 
 # Stage 1: build the target binaries
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 

--- a/operator/Containerfile.operator
+++ b/operator/Containerfile.operator
@@ -2,7 +2,7 @@
 # Copyright Contributors to the Open Cluster Management project
 
 # Stage 1: build the target binaries
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /workspace
 COPY go.sum go.mod ./

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -2,7 +2,7 @@
 # Copyright Contributors to the Open Cluster Management project
 
 # Stage 1: build the target binaries
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 COPY go.sum go.mod ./

--- a/test/script/util.sh
+++ b/test/script/util.sh
@@ -8,7 +8,7 @@ export KUBECTL_VERSION=v1.28.1
 export CLUSTERADM_VERSION=0.8.2
 export KIND_VERSION=v0.19.0
 export ROUTE_VERSION=release-4.12
-export GO_VERSION=go1.25.7
+export GO_VERSION=go1.26.3
 export GINKGO_VERSION=v2.17.2
 
 # Environment Variables


### PR DESCRIPTION
## Summary

Fixes: [ACM-36523](https://redhat.atlassian.net/browse/ACM-36523), [ACM-36776](https://redhat.atlassian.net/browse/ACM-36776), [ACM-36778](https://redhat.atlassian.net/browse/ACM-36778), [ACM-36779](https://redhat.atlassian.net/browse/ACM-36779)

- Bump `go.mod` to **1.26.3** and Konflux/Prow builder images to `rhel_9_1.26` / `go1.26-linux` on `release-2.13`
- Pin GitHub Actions to full SHAs and install `gci`/`gofumpt` via `go tool` directive (SonarCloud S8545)
- Update `go.yml` / `e2e.yml` to Go 1.26

### ACM-36523 / ACM-36776 / ACM-36778 / ACM-36779 — CVE-2026-25681 / CVE-2026-27136 (golang.org/x/net/html)

CVE-2026-25681 (GO-2026-5029) and CVE-2026-27136 (GO-2026-5030): HTML parsing/render XSS in `golang.org/x/net/html`. Fixed in `golang.org/x/net` **v0.55.0**. GA Global Hub **1.4.6** shipped **v0.49.0**; this PR updates the dependency graph to **v0.55.0** (agent/manager/operator share one `go.mod`).

## Why

Follows the GH 1.7.2 pattern ([#2581](https://github.com/stolostron/multicluster-global-hub/pull/2581), [#2589](https://github.com/stolostron/multicluster-global-hub/pull/2589), [openshift/release#81274](https://github.com/openshift/release/pull/81274)) for the **1.4** z-stream line. Resolves Go stdlib CVEs requiring ≥ 1.25.10 / 1.26.3 and unblocks Prow `sonarcloud` after the companion openshift/release builder bump.

> **Note:** `containerd v1.7.29` remains in the dependency graph on 1.4 after this PR — unlike GH 1.7, containerd CVEs (ACM-36641/36650/36651) still need a separate v1.7.33 bump.

## Test plan

- [ ] GitHub Actions `Go` workflow `format` job passes
- [ ] SonarCloud quality gate passes
- [ ] Merge with or after companion PRs: postgres_exporter, glo-grafana, openshift/release

[ACM-36523]: https://redhat.atlassian.net/browse/ACM-36523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-36776]: https://redhat.atlassian.net/browse/ACM-36776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-36778]: https://redhat.atlassian.net/browse/ACM-36778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-36779]: https://redhat.atlassian.net/browse/ACM-36779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ