### PR TITLE
Security: Fix ACM-35889 - Bump Go to 1.26.3 / CVE-2026-33811 LookupCNAME DoS [multicluster-globalhub-1.5]

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 env:
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
   GO_REQUIRED_MIN_VERSION: ''
 
 permissions:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,11 +24,8 @@ jobs:
         with:
           go-version: '1.26'
 
-      - name: Setup gci
-        run: go install github.com/daixiang0/gci@v0.13.7
-
-      - name: Setup gofumpt
-        run: go install mvdan.cc/gofumpt@v0.8.0
+      - name: Setup format tools
+        run: go install tool
 
       - name: format
         run: make strict-fmt

--- a/agent/Containerfile.agent
+++ b/agent/Containerfile.agent
@@ -2,7 +2,7 @@
 # Copyright Contributors to the Open Cluster Management project
 
 # Stage 1: build the target binaries
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /workspace
 

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Open Cluster Management project
 
 # Stage 1: build the target binaries
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 

--- a/doc/simulation/setup/local-policies/policy.sh
+++ b/doc/simulation/setup/local-policies/policy.sh
@@ -1,4 +1,4 @@
-
+#!/bin/bash
 
 function limit_range_policy() {
 plicy_name=$1
@@ -123,7 +123,7 @@ kubectl patch policy $root_policy_namespace.$root_plicy_name -n $cluster_name --
 function generate_placement() {
 placement_namespace="$1"
 placement_name="$2"
-decsion="$3"
+decision="$3"
 
 cat <<EOF | kubectl apply -f -
 apiVersion: cluster.open-cluster-management.io/v1beta1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,11 @@
 module github.com/stolostron/multicluster-global-hub
 
-go 1.25.9
+go 1.26.3
+
+tool (
+	github.com/daixiang0/gci
+	mvdan.cc/gofumpt
+)
 
 require (
 	github.com/IBM/sarama v1.45.2
@@ -69,12 +74,15 @@ require (
 
 require (
 	github.com/containerd/containerd v1.7.29 // indirect
+	github.com/daixiang0/gci v0.14.0 // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/gonvenience/idem v0.0.3 // indirect
+	github.com/hexops/gotextdiff v1.0.3 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	helm.sh/helm/v3 v3.17.3 // indirect
+	mvdan.cc/gofumpt v0.7.0 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1571,6 +1571,8 @@ github.com/crunchydata/postgres-operator v1.3.3-0.20230629151007-94ebcf2df74d h1
 github.com/crunchydata/postgres-operator v1.3.3-0.20230629151007-94ebcf2df74d/go.mod h1:rofwFoq0O85c9lyj3xC2Hl7SG9jo63c/NwXX85JjVVA=
 github.com/cyphar/filepath-securejoin v0.3.6 h1:4d9N5ykBnSp5Xn2JkhocYDkOpURL/18CYMpo6xB9uWM=
 github.com/cyphar/filepath-securejoin v0.3.6/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
+github.com/daixiang0/gci v0.14.0 h1:h6AcLqmjIOBgojhtzY2CvBnA6RawPTkBHgtMvYD5YZ8=
+github.com/daixiang0/gci v0.14.0/go.mod h1:w9E+SWQ4aPQ+xYPUdqitGDoXpT4mayqOfk7Szz2U6wQ=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -2079,6 +2081,7 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
+github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/homeport/dyff v1.10.5 h1:19PgFJoR4rseGUkUXcU8uaRCycHa1ziL7CgydmjZCzU=
 github.com/homeport/dyff v1.10.5/go.mod h1:pB/DNp7qT6yv/9rUgB+aQzySAwos0EsQkBY9NbPtX18=
@@ -4008,6 +4011,8 @@ modernc.org/token v1.1.0/go.mod h1:UGzOrNV1mAFSEB63lOFHIpNRUVMvYTc6yu1SMY/XTDM=
 modernc.org/xc v1.0.0/go.mod h1:mRNCo0bvLjGhHO9WsyuKVU4q0ceiDDDoEeWDJHrNx8I=
 modernc.org/z v1.5.1/go.mod h1:eWFB510QWW5Th9YGZT81s+LwvaAs3Q2yr4sP0rmLkv8=
 modernc.org/z v1.7.0/go.mod h1:hVdgNMh8ggTuRG1rGU8x+xGRFfiQUIAw0ZqlPy8+HyQ=
+mvdan.cc/gofumpt v0.7.0 h1:bg91ttqXmi9y2xawvkuMXyvAA/1ZGJqYAEGjXuP0JXU=
+mvdan.cc/gofumpt v0.7.0/go.mod h1:txVFJy/Sc/mvaycET54pV8SW8gWxTlUuGHVEcncmNUo=
 nullprogram.com/x/optparse v1.0.0/go.mod h1:KdyPE+Igbe0jQUrVfMqDMeJQIJZEuyV7pjYmp6pbG50=
 open-cluster-management.io/addon-framework v0.12.1-0.20250422083707-fb6b4ebb66b5 h1:Hc3bZ6pITNHM+lhvdBoYhIvyuMnL8YGojlZ/Lb2f6Vc=
 open-cluster-management.io/addon-framework v0.12.1-0.20250422083707-fb6b4ebb66b5/go.mod h1:ZQlrPweYXqG14bzk2oBOyRcNpoI4x//9XvTS1L+hCu0=

--- a/manager/Containerfile.manager
+++ b/manager/Containerfile.manager
@@ -2,7 +2,7 @@
 # Copyright Contributors to the Open Cluster Management project
 
 # Stage 1: build the target binaries
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /workspace
 

--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Open Cluster Management project
 
 # Stage 1: build the target binaries
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 

--- a/manager/pkg/status/conflator/workerpool/worker.go
+++ b/manager/pkg/status/conflator/workerpool/worker.go
@@ -42,11 +42,23 @@ func (worker *Worker) RunAsync(job *conflator.ConflationJob) {
 func (worker *Worker) start(ctx context.Context) {
 	log.Infow("started worker", "WorkerID", worker.workerID)
 	for {
+		select {
+		case <-ctx.Done():
+			close(worker.jobsQueue)
+			return
+		default:
+		}
+
 		// add worker into the dbWorkerPool to mark this worker as available.
 		// this is done in each iteration after the worker finished handling a job (or at startup),
 		// for receiving a new job to handle.
-		worker.workers <- worker
-		worker.statistics.SetNumberOfAvailableDBWorkers(len(worker.workers))
+		select {
+		case worker.workers <- worker:
+			worker.statistics.SetNumberOfAvailableDBWorkers(len(worker.workers))
+		case <-ctx.Done():
+			close(worker.jobsQueue)
+			return
+		}
 
 		select {
 		case <-ctx.Done(): // we have received a signal to stop

--- a/manager/pkg/status/conflator/workerpool/worker_test.go
+++ b/manager/pkg/status/conflator/workerpool/worker_test.go
@@ -1,0 +1,384 @@
+package workerpool
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stolostron/multicluster-global-hub/manager/pkg/status/conflator"
+	"github.com/stolostron/multicluster-global-hub/pkg/bundle/version"
+	"github.com/stolostron/multicluster-global-hub/pkg/statistics"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport"
+)
+
+// Mock implementations for testing
+type mockConflationMetadata struct {
+	processed         bool
+	version           *version.Version
+	dependencyVersion *version.Version
+	eventType         string
+	position          *transport.EventPosition
+}
+
+func (m *mockConflationMetadata) MarkAsProcessed() {
+	m.processed = true
+}
+
+func (m *mockConflationMetadata) Processed() bool {
+	return m.processed
+}
+
+func (m *mockConflationMetadata) MarkAsUnprocessed() {
+	m.processed = false
+}
+
+func (m *mockConflationMetadata) Version() *version.Version {
+	return m.version
+}
+
+func (m *mockConflationMetadata) DependencyVersion() *version.Version {
+	return m.dependencyVersion
+}
+
+func (m *mockConflationMetadata) EventType() string {
+	return m.eventType
+}
+
+func (m *mockConflationMetadata) TransportPosition() *transport.EventPosition {
+	return m.position
+}
+
+type mockResultReporter struct {
+	results []reportResult
+	mu      sync.Mutex
+}
+
+type reportResult struct {
+	metadata conflator.ConflationMetadata
+	err      error
+}
+
+func (m *mockResultReporter) ReportResult(metadata conflator.ConflationMetadata, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.results = append(m.results, reportResult{metadata: metadata, err: err})
+}
+
+func (m *mockResultReporter) GetResults() []reportResult {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]reportResult{}, m.results...)
+}
+
+func TestNewWorker(t *testing.T) {
+	t.Run("NewWorker creates worker correctly", func(t *testing.T) {
+		workerID := int32(1)
+		dbWorkersPool := make(chan *Worker, 10)
+		stats := &statistics.Statistics{}
+
+		worker := NewWorker(workerID, dbWorkersPool, stats)
+
+		assert.NotNil(t, worker)
+		assert.Equal(t, workerID, worker.workerID)
+		assert.Equal(t, dbWorkersPool, worker.workers)
+		assert.Equal(t, stats, worker.statistics)
+		assert.NotNil(t, worker.jobsQueue)
+		assert.Equal(t, 1, cap(worker.jobsQueue))
+	})
+
+	t.Run("NewWorker with different worker ID", func(t *testing.T) {
+		workerID := int32(42)
+		dbWorkersPool := make(chan *Worker, 5)
+		stats := &statistics.Statistics{}
+
+		worker := NewWorker(workerID, dbWorkersPool, stats)
+
+		assert.Equal(t, workerID, worker.workerID)
+		assert.Equal(t, dbWorkersPool, worker.workers)
+	})
+
+	t.Run("NewWorker with nil statistics", func(t *testing.T) {
+		workerID := int32(1)
+		dbWorkersPool := make(chan *Worker, 10)
+
+		worker := NewWorker(workerID, dbWorkersPool, nil)
+
+		assert.NotNil(t, worker)
+		assert.Nil(t, worker.statistics)
+	})
+}
+
+func TestWorker_RunAsync(t *testing.T) {
+	t.Run("RunAsync adds job to queue", func(t *testing.T) {
+		worker := NewWorker(1, make(chan *Worker, 10), &statistics.Statistics{})
+
+		event := cloudevents.NewEvent()
+		event.SetType("test.event")
+		event.SetSource("test-source")
+
+		job := &conflator.ConflationJob{
+			Event: &event,
+		}
+
+		worker.RunAsync(job)
+
+		select {
+		case receivedJob := <-worker.jobsQueue:
+			assert.Equal(t, job, receivedJob)
+		case <-time.After(100 * time.Millisecond):
+			t.Error("Job was not added to queue")
+		}
+	})
+
+	t.Run("RunAsync with multiple jobs", func(t *testing.T) {
+		worker := NewWorker(1, make(chan *Worker, 10), &statistics.Statistics{})
+
+		event1 := cloudevents.NewEvent()
+		event1.SetType("test.event1")
+		event1.SetSource("test-source1")
+
+		event2 := cloudevents.NewEvent()
+		event2.SetType("test.event2")
+		event2.SetSource("test-source2")
+
+		job1 := &conflator.ConflationJob{Event: &event1}
+		job2 := &conflator.ConflationJob{Event: &event2}
+
+		worker.RunAsync(job1)
+
+		go worker.RunAsync(job2)
+
+		select {
+		case receivedJob := <-worker.jobsQueue:
+			assert.Equal(t, job1, receivedJob)
+		case <-time.After(100 * time.Millisecond):
+			t.Error("First job was not added to queue")
+		}
+
+		select {
+		case receivedJob := <-worker.jobsQueue:
+			assert.Equal(t, job2, receivedJob)
+		case <-time.After(100 * time.Millisecond):
+			t.Error("Second job was not added to queue")
+		}
+	})
+}
+
+func TestWorker_start(t *testing.T) {
+	t.Run("start makes worker available in pool", func(t *testing.T) {
+		dbWorkersPool := make(chan *Worker, 2)
+		worker := NewWorker(1, dbWorkersPool, &statistics.Statistics{})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		go worker.start(ctx)
+
+		select {
+		case availableWorker := <-dbWorkersPool:
+			assert.Equal(t, worker, availableWorker)
+		case <-time.After(1 * time.Second):
+			t.Error("Worker did not become available")
+		}
+
+		cancel()
+		time.Sleep(100 * time.Millisecond)
+	})
+
+	t.Run("start handles context cancellation", func(t *testing.T) {
+		dbWorkersPool := make(chan *Worker, 2)
+		worker := NewWorker(1, dbWorkersPool, &statistics.Statistics{})
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		done := make(chan bool)
+		go func() {
+			worker.start(ctx)
+			done <- true
+		}()
+
+		select {
+		case <-dbWorkersPool:
+		case <-time.After(1 * time.Second):
+			t.Error("Worker did not become available")
+		}
+
+		cancel()
+
+		select {
+		case <-done:
+		case <-time.After(1 * time.Second):
+			t.Error("Worker did not stop after context cancellation")
+		}
+	})
+
+	t.Run("start stops when context already cancelled", func(t *testing.T) {
+		dbWorkersPool := make(chan *Worker, 2)
+		worker := NewWorker(1, dbWorkersPool, &statistics.Statistics{})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		done := make(chan struct{})
+		go func() {
+			worker.start(ctx)
+			close(done)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(1 * time.Second):
+			t.Error("Worker did not stop when context was already cancelled")
+		}
+
+		_, ok := <-worker.jobsQueue
+		assert.False(t, ok, "jobs queue should be closed on shutdown")
+	})
+
+	t.Run("start stops during blocked pool registration", func(t *testing.T) {
+		dbWorkersPool := make(chan *Worker, 1)
+		occupant := NewWorker(99, dbWorkersPool, &statistics.Statistics{})
+		dbWorkersPool <- occupant
+
+		worker := NewWorker(1, dbWorkersPool, &statistics.Statistics{})
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		done := make(chan struct{})
+		go func() {
+			worker.start(ctx)
+			close(done)
+		}()
+
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+
+		select {
+		case <-done:
+		case <-time.After(1 * time.Second):
+			t.Error("Worker did not stop during blocked pool registration")
+		}
+
+		_, ok := <-worker.jobsQueue
+		assert.False(t, ok, "jobs queue should be closed on shutdown")
+	})
+}
+
+func TestWorker_EdgeCases(t *testing.T) {
+	t.Run("worker with nil statistics", func(t *testing.T) {
+		worker := NewWorker(1, make(chan *Worker, 10), nil)
+
+		event := cloudevents.NewEvent()
+		event.SetType("test.event")
+		event.SetSource("test-source")
+
+		job := &conflator.ConflationJob{
+			Event: &event,
+		}
+
+		assert.NotPanics(t, func() {
+			worker.RunAsync(job)
+		})
+	})
+
+	t.Run("worker with closed workers channel", func(t *testing.T) {
+		dbWorkersPool := make(chan *Worker, 1)
+		close(dbWorkersPool)
+
+		worker := NewWorker(1, dbWorkersPool, &statistics.Statistics{})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		assert.Panics(t, func() {
+			worker.start(ctx)
+		})
+	})
+
+	t.Run("worker queue capacity", func(t *testing.T) {
+		worker := NewWorker(1, make(chan *Worker, 10), &statistics.Statistics{})
+
+		assert.Equal(t, 1, cap(worker.jobsQueue))
+
+		event := cloudevents.NewEvent()
+		event.SetType("test.event")
+		event.SetSource("test-source")
+
+		job1 := &conflator.ConflationJob{Event: &event}
+		job2 := &conflator.ConflationJob{Event: &event}
+
+		worker.RunAsync(job1)
+
+		jobAdded := make(chan bool)
+		go func() {
+			worker.RunAsync(job2)
+			jobAdded <- true
+		}()
+
+		<-worker.jobsQueue
+
+		select {
+		case <-jobAdded:
+		case <-time.After(100 * time.Millisecond):
+			t.Error("Second job was not added")
+		}
+
+		<-worker.jobsQueue
+	})
+}
+
+func TestWorker_WorkflowIntegration(t *testing.T) {
+	t.Run("complete worker workflow", func(t *testing.T) {
+		dbWorkersPool := make(chan *Worker, 2)
+		worker := NewWorker(1, dbWorkersPool, &statistics.Statistics{})
+
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+
+		go worker.start(ctx)
+
+		select {
+		case availableWorker := <-dbWorkersPool:
+			assert.Equal(t, worker, availableWorker)
+		case <-time.After(500 * time.Millisecond):
+			t.Error("Worker did not become available")
+		}
+
+		event := cloudevents.NewEvent()
+		event.SetType("test.event")
+		event.SetSource("test-source")
+
+		metadata := &mockConflationMetadata{
+			version:   version.NewVersion(),
+			eventType: "test.event",
+		}
+
+		reporter := &mockResultReporter{}
+
+		handler := func(ctx context.Context, event *cloudevents.Event) error {
+			return nil
+		}
+
+		job := &conflator.ConflationJob{
+			Event:    &event,
+			Handle:   handler,
+			Metadata: metadata,
+			Reporter: reporter,
+		}
+
+		worker.RunAsync(job)
+
+		time.Sleep(100 * time.Millisecond)
+
+		assert.True(t, metadata.Processed())
+
+		results := reporter.GetResults()
+		assert.Len(t, results, 1)
+		assert.Equal(t, metadata, results[0].metadata)
+		assert.Nil(t, results[0].err)
+	})
+}

--- a/operator/Containerfile.operator
+++ b/operator/Containerfile.operator
@@ -2,7 +2,7 @@
 # Copyright Contributors to the Open Cluster Management project
 
 # Stage 1: build the target binaries
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /workspace
 COPY go.sum go.mod ./

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -2,7 +2,7 @@
 # Copyright Contributors to the Open Cluster Management project
 
 # Stage 1: build the target binaries
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 COPY go.sum go.mod ./

--- a/test/script/util.sh
+++ b/test/script/util.sh
@@ -8,7 +8,7 @@ export KUBECTL_VERSION=v1.28.1
 export CLUSTERADM_VERSION=0.10.1
 export KIND_VERSION=v0.19.0
 export ROUTE_VERSION=release-4.12
-export GO_VERSION=go1.25.7
+export GO_VERSION=go1.26.3
 export GINKGO_VERSION=v2.17.2
 
 # Environment Variables


### PR DESCRIPTION
## Summary

Fixes: [ACM-35889](https://redhat.atlassian.net/browse/ACM-35889)

CVE-2026-33811 (GO-2026-4981): when using `LookupCNAME` with the cgo DNS resolver, a very long CNAME response can trigger a double-free of C memory and crash the process. GA Global Hub 1.5.5 shipped with Go **1.25.9** (vulnerable). Bumping the toolchain to **1.26.3** clears this CVE on the 1.26 line (patched in Go 1.26.3 per GO-2026-4981).

- Bump `go.mod` to **1.26.3** and Konflux/Prow builder images to `rhel_9_1.26` / `go1.26-linux` on `release-2.14`
- Replace separate `gci`/`gofumpt` install with `go tool` directive (SonarCloud S8545)
- Update `e2e.yml` to Go 1.26 (workflows already use pinned checkout/setup-go SHAs)

## Why

Follows the GH 1.7.2 / 1.4 z-stream pattern ([#2581](https://github.com/stolostron/multicluster-global-hub/pull/2581), [#2602](https://github.com/stolostron/multicluster-global-hub/pull/2602)) for **1.5** on `release-2.14`.

### ACM-35889 — CVE-2026-33811 (multicluster-globalhub-agent-rhel9)

Agent/manager/operator share one `go.mod`; the Go 1.26.3 toolchain bump fixes CVE-2026-33811 for all components on this branch. Delivers with **Global Hub 1.5.6** z-stream.

## Test plan

- [x] GitHub Actions `Go` workflow `format` job passes
- [x] SonarCloud quality gate passes
- [x] Merge with companion PRs: postgres_exporter, glo-grafana, openshift/release

Made with Cursor

Made with [Cursor](https://cursor.com)

[ACM-35889]: https://redhat.atlassian.net/browse/ACM-35889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ