### PR TITLE
Pin ginkgo install for SonarCloud branch quality gate (release-2.13)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,8 +23,8 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: ${{ env.GO_VERSION }}
-      - name: install ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo
+      - name: Setup test tools
+        run: go install tool
       - name: SET E2E
         run: |
           make kessel-e2e-setup

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.3
 
 tool (
 	github.com/daixiang0/gci
+	github.com/onsi/ginkgo/v2/ginkgo
 	mvdan.cc/gofumpt
 )
 


### PR DESCRIPTION
## Summary

- Add `github.com/onsi/ginkgo/v2/ginkgo` to the `go.mod` `tool` block
- Switch `.github/workflows/e2e.yml` from unpinned `go install github.com/onsi/ginkgo/v2/ginkgo` to `go install tool`

## Why

Branch post-submit SonarCloud scans (including openshift/release pj-rehearse sonarcloud on [#81354](https://github.com/openshift/release/pull/81354)) fail the quality gate with **Security Rating C** due to S8545 from the unpinned ginkgo install. Follows the same pattern as [#2602](https://github.com/stolostron/multicluster-global-hub/pull/2602) for `go.yml` format tools.

## Test plan

- [ ] SonarCloud Code Analysis passes on this PR
- [ ] GitHub Actions `Go` workflow still passes
- [ ] After merge, re-run `/pj-rehearse pull-ci-stolostron-multicluster-global-hub-release-2.13-sonarcloud` on openshift/release#81354

Made with [Cursor](https://cursor.com)