### PR TITLE
Pin ginkgo install for SonarCloud branch quality gate (release-2.14)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: install ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.28.1
       - name: SET E2E
         run: |
           make kessel-e2e-setup


### PR DESCRIPTION
## Summary

- Pin `.github/workflows/e2e.yml` ginkgo install to `@v2.28.1` (matching `go.mod`)

## Why

Branch post-submit SonarCloud scans (including openshift/release pj-rehearse sonarcloud on [#81355](https://github.com/openshift/release/pull/81355)) fail the quality gate with **Security Rating C** due to S8545 from the unpinned ginkgo install. Uses the same pinned `go install` pattern as gci/gofumpt in `go.yml` on this branch.

## Test plan

- [ ] SonarCloud Code Analysis passes on this PR
- [ ] GitHub Actions `Go` workflow still passes
- [ ] After merge, re-run `/pj-rehearse pull-ci-stolostron-multicluster-global-hub-release-2.14-sonarcloud` on openshift/release#81355

Made with [Cursor](https://cursor.com)