### PR TITLE
Pin workflows for SonarCloud branch quality gate (release-2.15)

### DIFF
--- a/.github/workflows/auto_code_review.yml
+++ b/.github/workflows/auto_code_review.yml
@@ -136,7 +136,7 @@ jobs:
           } >> "${GITHUB_OUTPUT}"
 
       - name: 'Run Gemini PR Review'
-        uses: 'google-github-actions/run-gemini-cli@v0'
+        uses: 'google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489' # v0
         id: 'gemini_pr_review'
         env:
           GITHUB_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,8 +31,8 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: ${{ env.GO_VERSION }}
-      - name: install ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo
+      - name: Setup test tools
+        run: go install tool
       - name: SET E2E
         run: |
           make kessel-e2e-setup

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.3
 
 tool (
 	github.com/daixiang0/gci
+	github.com/onsi/ginkgo/v2/ginkgo
 	mvdan.cc/gofumpt
 )
 


### PR DESCRIPTION
## Summary

- Add `github.com/onsi/ginkgo/v2/ginkgo` to the `go.mod` `tool` block; switch e2e.yml to `go install tool` (clears S8545)
- Pin `google-github-actions/run-gemini-cli` to full commit SHA in `auto_code_review.yml` (clears S7637)

## Why

`release-2.15` has branch post-submit SonarCloud risk from unpinned ginkgo (same as [#2608](https://github.com/stolostron/multicluster-global-hub/pull/2608) for 2.13) plus a floating `@v0` action tag unique to this line. Hub is already on `go 1.26.3`; merge before or with the companion openshift/release `go1.26-linux` bump for `release-2.15`.

Follows [#2588](https://github.com/stolostron/multicluster-global-hub/pull/2588) / [#2602](https://github.com/stolostron/multicluster-global-hub/pull/2602) patterns.

## Test plan

- [ ] SonarCloud Code Analysis passes on this PR
- [ ] GitHub Actions `Go` workflow still passes
- [ ] After merge, openshift/release pj-rehearse sonarcloud for `release-2.15` should pass when the go1.26-linux builder PR lands

Made with [Cursor](https://cursor.com)