### PR TITLE
Use go.mod tool directive for e2e ginkgo install (release-2.14)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,8 +23,8 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: ${{ env.GO_VERSION }}
-      - name: install ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.28.1
+      - name: Setup test tools
+        run: go install tool
       - name: SET E2E
         run: |
           make kessel-e2e-setup

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.3
 
 tool (
 	github.com/daixiang0/gci
+	github.com/onsi/ginkgo/v2/ginkgo
 	mvdan.cc/gofumpt
 )
 


### PR DESCRIPTION
## Summary

- Add `github.com/onsi/ginkgo/v2/ginkgo` to the `go.mod` `tool` block
- Switch `.github/workflows/e2e.yml` from pinned `go install github.com/onsi/ginkgo/v2/ginkgo@v2.28.1` to `go install tool`

## Why

Branch post-submit SonarCloud scans (including openshift/release pj-rehearse sonarcloud on [#81355](https://github.com/openshift/release/pull/81355)) still fail the quality gate with **Security Rating C** (S8545) after [#2609](https://github.com/stolostron/multicluster-global-hub/pull/2609). SonarCloud clears S8545 with the `go install tool` pattern, not a version suffix on the workflow line — same fix as [#2608](https://github.com/stolostron/multicluster-global-hub/pull/2608) on release-2.13.

## Test plan

- [ ] SonarCloud Code Analysis passes on this PR
- [ ] GitHub Actions `Go` workflow still passes
- [ ] After merge, re-run `/pj-rehearse pull-ci-stolostron-multicluster-global-hub-release-2.14-sonarcloud` on [openshift/release#81355](https://github.com/openshift/release/pull/81355)

Made with [Cursor](https://cursor.com)