### PR TITLE
ACM-32313: NetworkPolicy ipBlock hardening (API server + Kafka bootstrap) (#2493)

### DIFF
--- a/ai-doc/NETWORKPOLICY.md
+++ b/ai-doc/NETWORKPOLICY.md
@@ -672,11 +672,12 @@ kubectl delete networkpolicy -n multicluster-global-hub <policy-name>
 
 ## Known Limitations and Follow-ups
 
-Remaining items are tracked in [ACM-32313](https://redhat.atlassian.net/browse/ACM-32313) (child story of epic [ACM-31409](https://redhat.atlassian.net/browse/ACM-31409)).
+Remaining items are tracked under [ACM-32313](https://redhat.atlassian.net/browse/ACM-32313) (child story of epic [ACM-31409](https://redhat.atlassian.net/browse/ACM-31409)).
 
 - **OVN-Kubernetes enforcement:** Policies are created on KinD (used in product CI) but are only enforced on clusters running OVN-Kubernetes (e.g. OpenShift). Manual soak testing on OVN is tracked in [ACM-32494](https://redhat.atlassian.net/browse/ACM-32494); HoH automation in [ACM-32495](https://redhat.atlassian.net/browse/ACM-32495).
-- **Kafka `ipBlock` egress:** Agent egress to external Kafka bootstrap currently uses a broad `namespaceSelector`. Tightening to a specific CIDR `ipBlock` requires the operator to resolve the broker address at runtime — follow-up in [ACM-32313](https://redhat.atlassian.net/browse/ACM-32313).
-- **API server `ipBlock`:** The `allow-dns-and-api` policy allows egress to the `default` namespace broadly. Narrowing to the exact API server IP requires runtime address resolution — follow-up in [ACM-32313](https://redhat.atlassian.net/browse/ACM-32313).
+- **Kafka `ipBlock` egress:** The operator resolves Kafka bootstrap broker hostnames/IPs at reconcile time and templates `ipBlock` rules for agent external Kafka egress (local agent and addon agent). When bootstrap resolution fails, the prior broad `namespaceSelector` fallback is retained.
+- **API server `ipBlock`:** The operator resolves the `kubernetes` Service and endpoint addresses at reconcile time and templates `ipBlock` rules in `allow-dns-and-api` and the local agent NetworkPolicy. When resolution fails, ports-only egress (443/6443) is used as fallback. Addon agent manifests are rendered on the hub; managed-hub API server CIDRs are not available at render time, so addon agent API egress keeps the ports-only fallback until spoke-side resolution exists.
+- **Webhook egress (8443):** When the OpenShift cluster `Network` CR exposes `spec.serviceNetwork`, agent policies use that CIDR for TCP 8443; otherwise the broad in-cluster fallback remains.
 
 ## References
 - **Jira Ticket**: [ACM-19479](https://redhat.atlassian.net/browse/ACM-19479)

--- a/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -978,6 +978,7 @@ spec:
           resources:
           - clusterversions
           - infrastructures
+          - networks
           verbs:
           - get
           - list
@@ -993,6 +994,14 @@ spec:
           - list
           - patch
           - update
+          - watch
+        - apiGroups:
+          - discovery.k8s.io
+          resources:
+          - endpointslices
+          verbs:
+          - get
+          - list
           - watch
         - apiGroups:
           - extensions.hive.openshift.io

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -331,6 +331,7 @@ rules:
   resources:
   - clusterversions
   - infrastructures
+  - networks
   verbs:
   - get
   - list
@@ -346,6 +347,14 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - extensions.hive.openshift.io

--- a/operator/pkg/config/addon_config.go
+++ b/operator/pkg/config/addon_config.go
@@ -130,6 +130,11 @@ type ManifestsConfig struct {
 	HubRole string
 	// StandbyHub is the standby hub name (only populated for active hubs)
 	StandbyHub string
+
+	// NetworkPolicy ipBlock CIDRs (addon agent manifests; managed-hub API/webhook use template fallback when empty)
+	APIServerCIDRs     []string
+	ExternalKafkaCIDRs []string
+	WebhookEgressCIDRs []string
 }
 
 type Resources struct {

--- a/operator/pkg/controllers/agent/addon/addon_agent_manifest_transport.go
+++ b/operator/pkg/controllers/agent/addon/addon_agent_manifest_transport.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/certificates"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	nputils "github.com/stolostron/multicluster-global-hub/operator/pkg/networkpolicy"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 )
@@ -47,6 +48,18 @@ func setTransportConfigs(manifestsConfig *config.ManifestsConfig,
 	// render the cluster ca whether under the BYO cases
 	manifestsConfig.KafkaClusterCASecret = kafkaConnection.CASecretName
 	manifestsConfig.KafkaClusterCACert = kafkaConnection.CACert
+
+	mgh, err := config.GetMulticlusterGlobalHub(context.Background(), c)
+	if err != nil {
+		return err
+	}
+	hubNamespace := config.GetMGHNamespacedName().Namespace
+	if mgh != nil && mgh.Namespace != "" {
+		hubNamespace = mgh.Namespace
+	}
+	externalKafkaCIDRs := nputils.BuildAddonAgentValues(context.Background(), c,
+		kafkaConnection.BootstrapServer, hubNamespace)
+	manifestsConfig.ExternalKafkaCIDRs = externalKafkaCIDRs
 	return nil
 }
 

--- a/operator/pkg/controllers/agent/addon/manifests/templates/agent/multicluster-global-hub-agent-networkpolicy.yaml
+++ b/operator/pkg/controllers/agent/addon/manifests/templates/agent/multicluster-global-hub-agent-networkpolicy.yaml
@@ -33,12 +33,25 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
-  # Allow access to Kubernetes API server service IP
+  # Allow access to Kubernetes API server (managed hub cluster; ipBlock when resolved on hub)
+  {{- if .APIServerCIDRs }}
+  - to:
+    {{- range .APIServerCIDRs }}
+    - ipBlock:
+        cidr: {{ . }}
+    {{- end }}
+    ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
+  {{- else }}
   - ports:
     - protocol: TCP
       port: 443
     - protocol: TCP
       port: 6443
+  {{- end }}
   # Allow connections to Kafka (Strimzi)
   - to:
     - namespaceSelector: {}
@@ -52,7 +65,19 @@ spec:
       port: 9094
     - protocol: TCP
       port: 9095
-  # Allow connections to external Kafka via LoadBalancer/NodePort
+  # Allow connections to external Global Hub Kafka bootstrap brokers
+  {{- if .ExternalKafkaCIDRs }}
+  - to:
+    {{- range .ExternalKafkaCIDRs }}
+    - ipBlock:
+        cidr: {{ . }}
+    {{- end }}
+    ports:
+    - protocol: TCP
+      port: 9092
+    - protocol: TCP
+      port: 9093
+  {{- else }}
   - to:
     - namespaceSelector: {}
     ports:
@@ -60,9 +85,21 @@ spec:
       port: 9092
     - protocol: TCP
       port: 9093
+  {{- end }}
   # Allow HTTPS egress for internal Kubernetes services (webhooks, admission controllers)
+  {{- if .WebhookEgressCIDRs }}
+  - to:
+    {{- range .WebhookEgressCIDRs }}
+    - ipBlock:
+        cidr: {{ . }}
+    {{- end }}
+    ports:
+    - protocol: TCP
+      port: 8443
+  {{- else }}
   - to:
     - namespaceSelector: {}
     ports:
     - protocol: TCP
       port: 8443
+  {{- end }}

--- a/operator/pkg/controllers/agent/local_agent_controller.go
+++ b/operator/pkg/controllers/agent/local_agent_controller.go
@@ -186,6 +186,7 @@ func (s *LocalAgentController) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	log.Debugf("render agent resources")
 	return renderAgentManifests(
+		ctx,
 		s.Manager,
 		clusterName,
 		getTransportSecretName(),

--- a/operator/pkg/controllers/agent/manifests/networkpolicy.yaml
+++ b/operator/pkg/controllers/agent/manifests/networkpolicy.yaml
@@ -33,12 +33,25 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
-  # Allow access to Kubernetes API server service IP
+  # Allow access to Kubernetes API server
+  {{- if .APIServerCIDRs }}
+  - to:
+    {{- range .APIServerCIDRs }}
+    - ipBlock:
+        cidr: {{ . }}
+    {{- end }}
+    ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
+  {{- else }}
   - ports:
     - protocol: TCP
       port: 443
     - protocol: TCP
       port: 6443
+  {{- end }}
   # Allow connections to Kafka (Strimzi)
   - to:
     - namespaceSelector: {}
@@ -53,6 +66,18 @@ spec:
     - protocol: TCP
       port: 9095
   # Allow connections to external Kafka via LoadBalancer/NodePort
+  {{- if .ExternalKafkaCIDRs }}
+  - to:
+    {{- range .ExternalKafkaCIDRs }}
+    - ipBlock:
+        cidr: {{ . }}
+    {{- end }}
+    ports:
+    - protocol: TCP
+      port: 9092
+    - protocol: TCP
+      port: 9093
+  {{- else }}
   - to:
     - namespaceSelector: {}
     ports:
@@ -60,9 +85,21 @@ spec:
       port: 9092
     - protocol: TCP
       port: 9093
+  {{- end }}
   # Allow HTTPS egress for internal Kubernetes services (webhooks, admission controllers)
+  {{- if .WebhookEgressCIDRs }}
+  - to:
+    {{- range .WebhookEgressCIDRs }}
+    - ipBlock:
+        cidr: {{ . }}
+    {{- end }}
+    ports:
+    - protocol: TCP
+      port: 8443
+  {{- else }}
   - to:
     - namespaceSelector: {}
     ports:
     - protocol: TCP
       port: 8443
+  {{- end }}

--- a/operator/pkg/controllers/agent/standalone_agent_controller.go
+++ b/operator/pkg/controllers/agent/standalone_agent_controller.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
 	operatorconstants "github.com/stolostron/multicluster-global-hub/operator/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/deployer"
+	nputils "github.com/stolostron/multicluster-global-hub/operator/pkg/networkpolicy"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/renderer"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/utils"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
@@ -153,6 +154,7 @@ func (s *StandaloneAgentController) Reconcile(ctx context.Context, req ctrl.Requ
 	clusterName := string(infra.GetUID())
 
 	return renderAgentManifests(
+		ctx,
 		s.Manager,
 		clusterName,
 		constants.GHTransportConfigSecret,
@@ -162,6 +164,7 @@ func (s *StandaloneAgentController) Reconcile(ctx context.Context, req ctrl.Requ
 }
 
 func renderAgentManifests(
+	ctx context.Context,
 	mgr ctrl.Manager,
 	clusterName string,
 	transportConfigSecretName string,
@@ -244,6 +247,17 @@ func renderAgentManifests(
 		log.Errorw("failed to get log level", "error", err)
 		return ctrl.Result{}, err
 	}
+
+	bootstrapServer := ""
+	if trans := config.GetTransporter(); trans != nil {
+		if conn, connErr := trans.GetConnCredential(clusterName); connErr == nil {
+			bootstrapServer = conn.BootstrapServer
+		} else {
+			log.Warnw("failed to resolve kafka bootstrap for agent NetworkPolicy", "error", connErr)
+		}
+	}
+	npValues := nputils.BuildAgentValues(ctx, mgr.GetClient(), namespace, bootstrapServer)
+
 	// create the agent objects
 	agentObjects, err := hohRenderer.Render("manifests", "", func(profile string) (interface{}, error) {
 		return struct {
@@ -268,6 +282,9 @@ func renderAgentManifests(
 			EventSendMode             string
 			HubRole                   string
 			StandbyHub                string
+			APIServerCIDRs            []string
+			ExternalKafkaCIDRs        []string
+			WebhookEgressCIDRs        []string
 		}{
 			Image:                     config.GetImage(config.GlobalHubAgentImageKey),
 			ImagePullSecret:           imagePullSecret,
@@ -290,6 +307,9 @@ func renderAgentManifests(
 			EventSendMode:             eventSendMode,
 			HubRole:                   constants.GHHubRoleStandby, // Local agent is always standby
 			StandbyHub:                clusterName,                // Standby hub is itself
+			APIServerCIDRs:            npValues.APIServerCIDRs,
+			ExternalKafkaCIDRs:        npValues.ExternalKafkaCIDRs,
+			WebhookEgressCIDRs:        npValues.WebhookEgressCIDRs,
 		}, nil
 	})
 	if err != nil {

--- a/operator/pkg/controllers/agent/standalone_agent_controller.go
+++ b/operator/pkg/controllers/agent/standalone_agent_controller.go
@@ -172,65 +172,27 @@ func renderAgentManifests(
 	mgh *v1alpha4.MulticlusterGlobalHub,
 	deployMode string,
 ) (ctrl.Result, error) {
-	var namespace string
-	var agentImagePullPolicy corev1.PullPolicy
-	var resources *shared.ResourceRequirements
-	var imagePullSecret string
-	var nodeSelector map[string]string
-	var tolerations []corev1.Toleration
-	var owner metav1.Object
-	var enableStackroxIntegration bool
-	var stackroxPollInterval time.Duration
-	var eventSendMode string
+	src := agentManifestSourceFromCR(mgha, mgh)
 
-	if mgh != nil {
-		namespace = mgh.Namespace
-		agentImagePullPolicy = mgh.Spec.ImagePullPolicy
-		if mgh.Spec.AdvancedSpec != nil &&
-			mgh.Spec.AdvancedSpec.Agent != nil &&
-			mgh.Spec.AdvancedSpec.Agent.Resources != nil {
-			resources = mgh.Spec.AdvancedSpec.Agent.Resources
-		}
-		imagePullSecret = mgh.Spec.ImagePullSecret
-		nodeSelector = mgh.Spec.NodeSelector
-		tolerations = mgh.Spec.Tolerations
-		owner = mgh
-		enableStackroxIntegration = config.WithStackroxIntegration(mgh)
-		stackroxPollInterval = config.GetStackroxPollInterval(mgh)
-		eventSendMode = config.GetEventSendMode(mgh)
-	}
-	if mgha != nil {
-		namespace = mgha.Namespace
-		agentImagePullPolicy = mgha.Spec.ImagePullPolicy
-		resources = mgha.Spec.Resources
-		imagePullSecret = mgha.Spec.ImagePullSecret
-		nodeSelector = mgha.Spec.NodeSelector
-		tolerations = mgha.Spec.Tolerations
-		owner = mgha
-		eventSendMode = config.GetEventSendMode(mgha)
-	}
-	// create new HoHRenderer and HoHDeployer
 	hohRenderer, hohDeployer := renderer.NewHoHRenderer(fs), deployer.NewHoHDeployer(mgr.GetClient())
 
-	// create discovery client
 	dc, err := discovery.NewDiscoveryClientForConfig(mgr.GetConfig())
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
 	imagePullPolicy := corev1.PullAlways
-	if agentImagePullPolicy != "" {
-		imagePullPolicy = agentImagePullPolicy
+	if src.agentImagePullPolicy != "" {
+		imagePullPolicy = src.agentImagePullPolicy
 	}
 	agentQPS, agentBurst := config.GetAgentRestConfig()
 
-	// set resource requirements
 	resourceReq := corev1.ResourceRequirements{}
 	requests := corev1.ResourceList{
 		corev1.ResourceName(corev1.ResourceMemory): resource.MustParse(operatorconstants.AgentMemoryRequest),
 		corev1.ResourceName(corev1.ResourceCPU):    resource.MustParse(operatorconstants.AgentCPURequest),
 	}
-	utils.SetResourcesFromCR(resources, requests)
+	utils.SetResourcesFromCR(src.resources, requests)
 	resourceReq.Requests = requests
 
 	electionConfig, err := config.GetElectionConfig()
@@ -239,7 +201,6 @@ func renderAgentManifests(
 		return ctrl.Result{}, err
 	}
 
-	// create restmapper for deployer to find GVR
 	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(dc))
 
 	logLevel, err := getLogLevel(mgr.GetClient())
@@ -248,77 +209,152 @@ func renderAgentManifests(
 		return ctrl.Result{}, err
 	}
 
-	bootstrapServer := ""
-	if trans := config.GetTransporter(); trans != nil {
-		if conn, connErr := trans.GetConnCredential(clusterName); connErr == nil {
-			bootstrapServer = conn.BootstrapServer
-		} else {
-			log.Warnw("failed to resolve kafka bootstrap for agent NetworkPolicy", "error", connErr)
-		}
-	}
-	npValues := nputils.BuildAgentValues(ctx, mgr.GetClient(), namespace, bootstrapServer)
+	bootstrapServer := standaloneAgentBootstrapServer(clusterName)
+	npValues := nputils.BuildAgentValues(ctx, mgr.GetClient(), src.namespace, bootstrapServer)
 
-	// create the agent objects
 	agentObjects, err := hohRenderer.Render("manifests", "", func(profile string) (interface{}, error) {
-		return struct {
-			Image                     string
-			ImagePullSecret           string
-			ImagePullPolicy           string
-			Namespace                 string
-			NodeSelector              map[string]string
-			Tolerations               []corev1.Toleration
-			LeaseDuration             string
-			RenewDeadline             string
-			RetryPeriod               string
-			AgentQPS                  float32
-			AgentBurst                int
-			LogLevel                  string
-			ClusterId                 string
-			Resources                 *corev1.ResourceRequirements
-			TransportConfigSecretName string
-			EnableStackroxIntegration bool
-			StackroxPollInterval      time.Duration
-			DeployMode                string
-			EventSendMode             string
-			HubRole                   string
-			StandbyHub                string
-			APIServerCIDRs            []string
-			ExternalKafkaCIDRs        []string
-			WebhookEgressCIDRs        []string
-		}{
-			Image:                     config.GetImage(config.GlobalHubAgentImageKey),
-			ImagePullSecret:           imagePullSecret,
-			ImagePullPolicy:           string(imagePullPolicy),
-			Namespace:                 namespace,
-			NodeSelector:              nodeSelector,
-			Tolerations:               tolerations,
-			LeaseDuration:             strconv.Itoa(electionConfig.LeaseDuration),
-			RenewDeadline:             strconv.Itoa(electionConfig.RenewDeadline),
-			RetryPeriod:               strconv.Itoa(electionConfig.RetryPeriod),
-			AgentQPS:                  agentQPS,
-			AgentBurst:                agentBurst,
-			LogLevel:                  logLevel,
-			ClusterId:                 clusterName,
-			Resources:                 &resourceReq,
-			TransportConfigSecretName: transportConfigSecretName,
-			EnableStackroxIntegration: enableStackroxIntegration,
-			StackroxPollInterval:      stackroxPollInterval,
-			DeployMode:                deployMode,
-			EventSendMode:             eventSendMode,
-			HubRole:                   constants.GHHubRoleStandby, // Local agent is always standby
-			StandbyHub:                clusterName,                // Standby hub is itself
-			APIServerCIDRs:            npValues.APIServerCIDRs,
-			ExternalKafkaCIDRs:        npValues.ExternalKafkaCIDRs,
-			WebhookEgressCIDRs:        npValues.WebhookEgressCIDRs,
-		}, nil
+		return buildStandaloneAgentManifestTemplate(
+			src, clusterName, transportConfigSecretName, deployMode,
+			imagePullPolicy, resourceReq,
+			electionConfig.LeaseDuration, electionConfig.RenewDeadline, electionConfig.RetryPeriod,
+			agentQPS, agentBurst, logLevel, npValues,
+		), nil
 	})
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to render standalone agent objects: %v", err)
 	}
-	if err = utils.ManipulateGlobalHubObjects(agentObjects, owner, hohDeployer, mapper, mgr.GetScheme()); err != nil {
+	if err = utils.ManipulateGlobalHubObjects(agentObjects, src.owner, hohDeployer, mapper, mgr.GetScheme()); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to create/update standalone agent objects: %v", err)
 	}
 	return ctrl.Result{}, nil
+}
+
+type agentManifestSource struct {
+	namespace                 string
+	agentImagePullPolicy      corev1.PullPolicy
+	resources                 *shared.ResourceRequirements
+	imagePullSecret           string
+	nodeSelector              map[string]string
+	tolerations               []corev1.Toleration
+	owner                     metav1.Object
+	enableStackroxIntegration bool
+	stackroxPollInterval      time.Duration
+	eventSendMode             string
+}
+
+func agentManifestSourceFromCR(
+	mgha *v1alpha1.MulticlusterGlobalHubAgent,
+	mgh *v1alpha4.MulticlusterGlobalHub,
+) agentManifestSource {
+	var src agentManifestSource
+	if mgh != nil {
+		src.namespace = mgh.Namespace
+		src.agentImagePullPolicy = mgh.Spec.ImagePullPolicy
+		if mgh.Spec.AdvancedSpec != nil &&
+			mgh.Spec.AdvancedSpec.Agent != nil &&
+			mgh.Spec.AdvancedSpec.Agent.Resources != nil {
+			src.resources = mgh.Spec.AdvancedSpec.Agent.Resources
+		}
+		src.imagePullSecret = mgh.Spec.ImagePullSecret
+		src.nodeSelector = mgh.Spec.NodeSelector
+		src.tolerations = mgh.Spec.Tolerations
+		src.owner = mgh
+		src.enableStackroxIntegration = config.WithStackroxIntegration(mgh)
+		src.stackroxPollInterval = config.GetStackroxPollInterval(mgh)
+		src.eventSendMode = config.GetEventSendMode(mgh)
+	}
+	if mgha != nil {
+		src.namespace = mgha.Namespace
+		src.agentImagePullPolicy = mgha.Spec.ImagePullPolicy
+		src.resources = mgha.Spec.Resources
+		src.imagePullSecret = mgha.Spec.ImagePullSecret
+		src.nodeSelector = mgha.Spec.NodeSelector
+		src.tolerations = mgha.Spec.Tolerations
+		src.owner = mgha
+		src.eventSendMode = config.GetEventSendMode(mgha)
+	}
+	return src
+}
+
+func standaloneAgentBootstrapServer(clusterName string) string {
+	trans := config.GetTransporter()
+	if trans == nil {
+		return ""
+	}
+	conn, err := trans.GetConnCredential(clusterName)
+	if err != nil {
+		log.Warnw("failed to resolve kafka bootstrap for agent NetworkPolicy", "error", err)
+		return ""
+	}
+	return conn.BootstrapServer
+}
+
+func buildStandaloneAgentManifestTemplate(
+	src agentManifestSource,
+	clusterName string,
+	transportConfigSecretName string,
+	deployMode string,
+	imagePullPolicy corev1.PullPolicy,
+	resourceReq corev1.ResourceRequirements,
+	leaseDuration int,
+	renewDeadline int,
+	retryPeriod int,
+	agentQPS float32,
+	agentBurst int,
+	logLevel string,
+	npValues nputils.AgentManifestValues,
+) interface{} {
+	return struct {
+		Image                     string
+		ImagePullSecret           string
+		ImagePullPolicy           string
+		Namespace                 string
+		NodeSelector              map[string]string
+		Tolerations               []corev1.Toleration
+		LeaseDuration             string
+		RenewDeadline             string
+		RetryPeriod               string
+		AgentQPS                  float32
+		AgentBurst                int
+		LogLevel                  string
+		ClusterId                 string
+		Resources                 *corev1.ResourceRequirements
+		TransportConfigSecretName string
+		EnableStackroxIntegration bool
+		StackroxPollInterval      time.Duration
+		DeployMode                string
+		EventSendMode             string
+		HubRole                   string
+		StandbyHub                string
+		APIServerCIDRs            []string
+		ExternalKafkaCIDRs        []string
+		WebhookEgressCIDRs        []string
+	}{
+		Image:                     config.GetImage(config.GlobalHubAgentImageKey),
+		ImagePullSecret:           src.imagePullSecret,
+		ImagePullPolicy:           string(imagePullPolicy),
+		Namespace:                 src.namespace,
+		NodeSelector:              src.nodeSelector,
+		Tolerations:               src.tolerations,
+		LeaseDuration:             strconv.Itoa(leaseDuration),
+		RenewDeadline:             strconv.Itoa(renewDeadline),
+		RetryPeriod:               strconv.Itoa(retryPeriod),
+		AgentQPS:                  agentQPS,
+		AgentBurst:                agentBurst,
+		LogLevel:                  logLevel,
+		ClusterId:                 clusterName,
+		Resources:                 &resourceReq,
+		TransportConfigSecretName: transportConfigSecretName,
+		EnableStackroxIntegration: src.enableStackroxIntegration,
+		StackroxPollInterval:      src.stackroxPollInterval,
+		DeployMode:                deployMode,
+		EventSendMode:             src.eventSendMode,
+		HubRole:                   constants.GHHubRoleStandby,
+		StandbyHub:                clusterName,
+		APIServerCIDRs:            npValues.APIServerCIDRs,
+		ExternalKafkaCIDRs:        npValues.ExternalKafkaCIDRs,
+		WebhookEgressCIDRs:        npValues.WebhookEgressCIDRs,
+	}
 }
 
 func getLogLevel(c client.Client) (string, error) {

--- a/operator/pkg/controllers/agent/standalone_agent_controller.go
+++ b/operator/pkg/controllers/agent/standalone_agent_controller.go
@@ -213,12 +213,21 @@ func renderAgentManifests(
 	npValues := nputils.BuildAgentValues(ctx, mgr.GetClient(), src.namespace, bootstrapServer)
 
 	agentObjects, err := hohRenderer.Render("manifests", "", func(profile string) (interface{}, error) {
-		return buildStandaloneAgentManifestTemplate(
-			src, clusterName, transportConfigSecretName, deployMode,
-			imagePullPolicy, resourceReq,
-			electionConfig.LeaseDuration, electionConfig.RenewDeadline, electionConfig.RetryPeriod,
-			agentQPS, agentBurst, logLevel, npValues,
-		), nil
+		return buildStandaloneAgentManifestTemplate(standaloneAgentRenderInput{
+			src:                       src,
+			clusterName:               clusterName,
+			transportConfigSecretName: transportConfigSecretName,
+			deployMode:                deployMode,
+			imagePullPolicy:           imagePullPolicy,
+			resourceReq:               resourceReq,
+			leaseDuration:             electionConfig.LeaseDuration,
+			renewDeadline:             electionConfig.RenewDeadline,
+			retryPeriod:               electionConfig.RetryPeriod,
+			agentQPS:                  agentQPS,
+			agentBurst:                agentBurst,
+			logLevel:                  logLevel,
+			npValues:                  npValues,
+		}), nil
 	})
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to render standalone agent objects: %v", err)
@@ -289,21 +298,23 @@ func standaloneAgentBootstrapServer(clusterName string) string {
 	return conn.BootstrapServer
 }
 
-func buildStandaloneAgentManifestTemplate(
-	src agentManifestSource,
-	clusterName string,
-	transportConfigSecretName string,
-	deployMode string,
-	imagePullPolicy corev1.PullPolicy,
-	resourceReq corev1.ResourceRequirements,
-	leaseDuration int,
-	renewDeadline int,
-	retryPeriod int,
-	agentQPS float32,
-	agentBurst int,
-	logLevel string,
-	npValues nputils.AgentManifestValues,
-) interface{} {
+type standaloneAgentRenderInput struct {
+	src                       agentManifestSource
+	clusterName               string
+	transportConfigSecretName string
+	deployMode                string
+	imagePullPolicy           corev1.PullPolicy
+	resourceReq               corev1.ResourceRequirements
+	leaseDuration             int
+	renewDeadline             int
+	retryPeriod               int
+	agentQPS                  float32
+	agentBurst                int
+	logLevel                  string
+	npValues                  nputils.AgentManifestValues
+}
+
+func buildStandaloneAgentManifestTemplate(in standaloneAgentRenderInput) interface{} {
 	return struct {
 		Image                     string
 		ImagePullSecret           string
@@ -331,29 +342,29 @@ func buildStandaloneAgentManifestTemplate(
 		WebhookEgressCIDRs        []string
 	}{
 		Image:                     config.GetImage(config.GlobalHubAgentImageKey),
-		ImagePullSecret:           src.imagePullSecret,
-		ImagePullPolicy:           string(imagePullPolicy),
-		Namespace:                 src.namespace,
-		NodeSelector:              src.nodeSelector,
-		Tolerations:               src.tolerations,
-		LeaseDuration:             strconv.Itoa(leaseDuration),
-		RenewDeadline:             strconv.Itoa(renewDeadline),
-		RetryPeriod:               strconv.Itoa(retryPeriod),
-		AgentQPS:                  agentQPS,
-		AgentBurst:                agentBurst,
-		LogLevel:                  logLevel,
-		ClusterId:                 clusterName,
-		Resources:                 &resourceReq,
-		TransportConfigSecretName: transportConfigSecretName,
-		EnableStackroxIntegration: src.enableStackroxIntegration,
-		StackroxPollInterval:      src.stackroxPollInterval,
-		DeployMode:                deployMode,
-		EventSendMode:             src.eventSendMode,
+		ImagePullSecret:           in.src.imagePullSecret,
+		ImagePullPolicy:           string(in.imagePullPolicy),
+		Namespace:                 in.src.namespace,
+		NodeSelector:              in.src.nodeSelector,
+		Tolerations:               in.src.tolerations,
+		LeaseDuration:             strconv.Itoa(in.leaseDuration),
+		RenewDeadline:             strconv.Itoa(in.renewDeadline),
+		RetryPeriod:               strconv.Itoa(in.retryPeriod),
+		AgentQPS:                  in.agentQPS,
+		AgentBurst:                in.agentBurst,
+		LogLevel:                  in.logLevel,
+		ClusterId:                 in.clusterName,
+		Resources:                 &in.resourceReq,
+		TransportConfigSecretName: in.transportConfigSecretName,
+		EnableStackroxIntegration: in.src.enableStackroxIntegration,
+		StackroxPollInterval:      in.src.stackroxPollInterval,
+		DeployMode:                in.deployMode,
+		EventSendMode:             in.src.eventSendMode,
 		HubRole:                   constants.GHHubRoleStandby,
-		StandbyHub:                clusterName,
-		APIServerCIDRs:            npValues.APIServerCIDRs,
-		ExternalKafkaCIDRs:        npValues.ExternalKafkaCIDRs,
-		WebhookEgressCIDRs:        npValues.WebhookEgressCIDRs,
+		StandbyHub:                in.clusterName,
+		APIServerCIDRs:            in.npValues.APIServerCIDRs,
+		ExternalKafkaCIDRs:        in.npValues.ExternalKafkaCIDRs,
+		WebhookEgressCIDRs:        in.npValues.WebhookEgressCIDRs,
 	}
 }
 

--- a/operator/pkg/controllers/networkpolicy/manifests/allow-dns-and-api.yaml
+++ b/operator/pkg/controllers/networkpolicy/manifests/allow-dns-and-api.yaml
@@ -33,9 +33,22 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
-  # Allow access to Kubernetes API server service IP
+  # Allow access to Kubernetes API server
+  {{- if .APIServerCIDRs }}
+  - to:
+    {{- range .APIServerCIDRs }}
+    - ipBlock:
+        cidr: {{ . }}
+    {{- end }}
+    ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
+  {{- else }}
   - ports:
     - protocol: TCP
       port: 443
     - protocol: TCP
       port: 6443
+  {{- end }}

--- a/operator/pkg/controllers/networkpolicy/networkpolicy_controller.go
+++ b/operator/pkg/controllers/networkpolicy/networkpolicy_controller.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/deployer"
+	nputils "github.com/stolostron/multicluster-global-hub/operator/pkg/networkpolicy"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/renderer"
 	operatorutils "github.com/stolostron/multicluster-global-hub/operator/pkg/utils"
 	"github.com/stolostron/multicluster-global-hub/pkg/logger"
@@ -28,6 +29,9 @@ import (
 
 // +kubebuilder:rbac:groups=operator.open-cluster-management.io,resources=multiclusterglobalhubs,verbs=get;list;watch;
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;delete
+// +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch
+// +kubebuilder:rbac:groups=discovery.k8s.io,resources=endpointslices,verbs=get;list;watch
+// +kubebuilder:rbac:groups=config.openshift.io,resources=networks,verbs=get;list;watch
 
 //go:embed manifests
 var fs embed.FS
@@ -128,14 +132,9 @@ func (r *NetworkPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	npRenderer := renderer.NewHoHRenderer(fs)
 	npDeployer := deployer.NewHoHDeployer(r.GetClient())
 
+	npValues := nputils.BuildBaselineValues(ctx, r.GetClient(), mgh.Namespace, config.COMPONENTS_POSTGRES_NAME)
 	networkPolicyObjects, err := npRenderer.Render("manifests", "", func(profile string) (interface{}, error) {
-		return struct {
-			Namespace    string
-			PostgresName string
-		}{
-			Namespace:    mgh.Namespace,
-			PostgresName: config.COMPONENTS_POSTGRES_NAME,
-		}, nil
+		return npValues, nil
 	})
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to render networkpolicy manifests: %w", err)

--- a/operator/pkg/networkpolicy/resolve.go
+++ b/operator/pkg/networkpolicy/resolve.go
@@ -1,0 +1,231 @@
+/*
+Copyright 2023
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package networkpolicy
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sort"
+	"strings"
+
+	configv1 "github.com/openshift/api/config/v1"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	kubernetesServiceName      = "kubernetes"
+	kubernetesDefaultNamespace = "default"
+	clusterNetworkName         = "cluster"
+)
+
+// ResolveAPIServerCIDRs discovers Kubernetes API server endpoint addresses for NetworkPolicy ipBlock rules.
+func ResolveAPIServerCIDRs(ctx context.Context, c client.Client) ([]string, error) {
+	cidrs, err := resolveServiceCIDRs(ctx, c, kubernetesDefaultNamespace, kubernetesServiceName)
+	if err != nil {
+		return nil, fmt.Errorf("no kubernetes API server addresses found: %w", err)
+	}
+	return cidrs, nil
+}
+
+// ResolveBootstrapServerCIDRs resolves Kafka bootstrap broker hostnames/IPs to ipBlock CIDR strings.
+// clusterNamespace is used to resolve unqualified in-cluster service names.
+func ResolveBootstrapServerCIDRs(ctx context.Context, c client.Client, bootstrapServer, clusterNamespace string) ([]string, error) {
+	bootstrapServer = strings.TrimSpace(bootstrapServer)
+	if bootstrapServer == "" {
+		return nil, fmt.Errorf("empty bootstrap server")
+	}
+
+	cidrs := map[string]struct{}{}
+	var resolveErrs []string
+	for _, broker := range strings.Split(bootstrapServer, ",") {
+		broker = strings.TrimSpace(broker)
+		if broker == "" {
+			continue
+		}
+		host := brokerHost(broker)
+		if host == "" {
+			continue
+		}
+		if err := resolveHostToCIDRs(ctx, c, host, clusterNamespace, cidrs); err != nil {
+			resolveErrs = append(resolveErrs, fmt.Sprintf("%s: %v", host, err))
+		}
+	}
+
+	if len(cidrs) == 0 {
+		if len(resolveErrs) > 0 {
+			return nil, fmt.Errorf("no bootstrap broker addresses resolved: %s",
+				strings.Join(resolveErrs, "; "))
+		}
+		return nil, fmt.Errorf("no bootstrap broker addresses resolved")
+	}
+	return sortedCIDRs(cidrs), nil
+}
+
+// ResolveServiceNetworkCIDRs returns cluster service network CIDRs when available (OpenShift Network CR).
+func ResolveServiceNetworkCIDRs(ctx context.Context, c client.Client) ([]string, error) {
+	network := &configv1.Network{}
+	err := c.Get(ctx, types.NamespacedName{Name: clusterNetworkName}, network)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get cluster Network config: %w", err)
+	}
+	if len(network.Spec.ServiceNetwork) == 0 {
+		return nil, nil
+	}
+	cidrs := make([]string, 0, len(network.Spec.ServiceNetwork))
+	for _, serviceNetwork := range network.Spec.ServiceNetwork {
+		if _, _, err := net.ParseCIDR(serviceNetwork); err != nil {
+			return nil, fmt.Errorf("invalid service network CIDR %q: %w", serviceNetwork, err)
+		}
+		cidrs = append(cidrs, serviceNetwork)
+	}
+	return cidrs, nil
+}
+
+func resolveHostToCIDRs(ctx context.Context, c client.Client, host, defaultNamespace string, cidrs map[string]struct{}) error {
+	host = strings.Trim(host, "[]")
+	if ip := net.ParseIP(host); ip != nil {
+		addHostCIDR(cidrs, ip)
+		return nil
+	}
+
+	if !strings.Contains(host, ".") {
+		if svcCIDRs, err := resolveServiceCIDRs(ctx, c, defaultNamespace, host); err == nil && len(svcCIDRs) > 0 {
+			for _, cidr := range svcCIDRs {
+				cidrs[cidr] = struct{}{}
+			}
+			return nil
+		}
+	}
+
+	svcNamespace, svcName := parseServiceHost(host, defaultNamespace)
+	if svcName != "" {
+		svcCIDRs, err := resolveServiceCIDRs(ctx, c, svcNamespace, svcName)
+		if err == nil && len(svcCIDRs) > 0 {
+			for _, cidr := range svcCIDRs {
+				cidrs[cidr] = struct{}{}
+			}
+			return nil
+		}
+	}
+
+	ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return err
+	}
+	if len(ips) == 0 {
+		return fmt.Errorf("no addresses returned for %q", host)
+	}
+	for _, ipAddr := range ips {
+		addHostCIDR(cidrs, ipAddr.IP)
+	}
+	return nil
+}
+
+func resolveServiceCIDRs(ctx context.Context, c client.Client, namespace, name string) ([]string, error) {
+	cidrs := map[string]struct{}{}
+
+	svc := &corev1.Service{}
+	if err := c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, svc); err != nil {
+		return nil, err
+	}
+	if ip := net.ParseIP(svc.Spec.ClusterIP); ip != nil && svc.Spec.ClusterIP != "" && svc.Spec.ClusterIP != "None" {
+		addHostCIDR(cidrs, ip)
+	}
+
+	sliceList := &discoveryv1.EndpointSliceList{}
+	if err := c.List(
+		ctx, sliceList,
+		client.InNamespace(namespace),
+		client.MatchingLabels{discoveryv1.LabelServiceName: name},
+	); err != nil {
+		log.Warnw("failed to list EndpointSlices for service",
+			"namespace", namespace, "name", name, "error", err)
+	} else {
+		for i := range sliceList.Items {
+			for _, endpoint := range sliceList.Items[i].Endpoints {
+				for _, addr := range endpoint.Addresses {
+					if ip := net.ParseIP(addr); ip != nil {
+						addHostCIDR(cidrs, ip)
+					}
+				}
+			}
+		}
+	}
+
+	if len(cidrs) == 0 {
+		return nil, fmt.Errorf("no addresses found for service %s/%s", namespace, name)
+	}
+	return sortedCIDRs(cidrs), nil
+}
+
+func brokerHost(broker string) string {
+	host, _, err := net.SplitHostPort(broker)
+	if err != nil {
+		return strings.TrimSpace(broker)
+	}
+	return strings.TrimSpace(host)
+}
+
+func parseServiceHost(host, defaultNamespace string) (namespace, name string) {
+	host = strings.TrimSuffix(host, ".")
+	switch {
+	case strings.HasSuffix(host, ".svc.cluster.local"):
+		host = strings.TrimSuffix(host, ".svc.cluster.local")
+	case strings.HasSuffix(host, ".svc"):
+		host = strings.TrimSuffix(host, ".svc")
+	default:
+		return "", ""
+	}
+
+	parts := strings.Split(host, ".")
+	switch len(parts) {
+	case 1:
+		return defaultNamespace, parts[0]
+	case 2:
+		return parts[1], parts[0]
+	default:
+		return "", ""
+	}
+}
+
+func addHostCIDR(cidrs map[string]struct{}, ip net.IP) {
+	if ip == nil {
+		return
+	}
+	if v4 := ip.To4(); v4 != nil {
+		cidrs[v4.String()+"/32"] = struct{}{}
+		return
+	}
+	cidrs[ip.String()+"/128"] = struct{}{}
+}
+
+func sortedCIDRs(cidrs map[string]struct{}) []string {
+	out := make([]string, 0, len(cidrs))
+	for cidr := range cidrs {
+		out = append(out, cidr)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/operator/pkg/networkpolicy/resolve.go
+++ b/operator/pkg/networkpolicy/resolve.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023
+Copyright 2023 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/operator/pkg/networkpolicy/resolve.go
+++ b/operator/pkg/networkpolicy/resolve.go
@@ -48,7 +48,12 @@ func ResolveAPIServerCIDRs(ctx context.Context, c client.Client) ([]string, erro
 
 // ResolveBootstrapServerCIDRs resolves Kafka bootstrap broker hostnames/IPs to ipBlock CIDR strings.
 // clusterNamespace is used to resolve unqualified in-cluster service names.
-func ResolveBootstrapServerCIDRs(ctx context.Context, c client.Client, bootstrapServer, clusterNamespace string) ([]string, error) {
+func ResolveBootstrapServerCIDRs(
+	ctx context.Context,
+	c client.Client,
+	bootstrapServer string,
+	clusterNamespace string,
+) ([]string, error) {
 	bootstrapServer = strings.TrimSpace(bootstrapServer)
 	if bootstrapServer == "" {
 		return nil, fmt.Errorf("empty bootstrap server")
@@ -103,7 +108,13 @@ func ResolveServiceNetworkCIDRs(ctx context.Context, c client.Client) ([]string,
 	return cidrs, nil
 }
 
-func resolveHostToCIDRs(ctx context.Context, c client.Client, host, defaultNamespace string, cidrs map[string]struct{}) error {
+func resolveHostToCIDRs(
+	ctx context.Context,
+	c client.Client,
+	host string,
+	defaultNamespace string,
+	cidrs map[string]struct{},
+) error {
 	host = strings.Trim(host, "[]")
 	if ip := net.ParseIP(host); ip != nil {
 		addHostCIDR(cidrs, ip)
@@ -163,21 +174,25 @@ func resolveServiceCIDRs(ctx context.Context, c client.Client, namespace, name s
 		log.Warnw("failed to list EndpointSlices for service",
 			"namespace", namespace, "name", name, "error", err)
 	} else {
-		for i := range sliceList.Items {
-			for _, endpoint := range sliceList.Items[i].Endpoints {
-				for _, addr := range endpoint.Addresses {
-					if ip := net.ParseIP(addr); ip != nil {
-						addHostCIDR(cidrs, ip)
-					}
-				}
-			}
-		}
+		addEndpointSliceCIDRs(sliceList, cidrs)
 	}
 
 	if len(cidrs) == 0 {
 		return nil, fmt.Errorf("no addresses found for service %s/%s", namespace, name)
 	}
 	return sortedCIDRs(cidrs), nil
+}
+
+func addEndpointSliceCIDRs(sliceList *discoveryv1.EndpointSliceList, cidrs map[string]struct{}) {
+	for i := range sliceList.Items {
+		for _, endpoint := range sliceList.Items[i].Endpoints {
+			for _, addr := range endpoint.Addresses {
+				if ip := net.ParseIP(addr); ip != nil {
+					addHostCIDR(cidrs, ip)
+				}
+			}
+		}
+	}
 }
 
 func brokerHost(broker string) string {

--- a/operator/pkg/networkpolicy/resolve_test.go
+++ b/operator/pkg/networkpolicy/resolve_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023
+Copyright 2023 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -41,32 +41,7 @@ func newTestScheme(t *testing.T) *runtime.Scheme {
 
 func TestResolveAPIServerCIDRs(t *testing.T) {
 	scheme := newTestScheme(t)
-	objs := []runtime.Object{
-		&corev1.Service{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      kubernetesServiceName,
-				Namespace: kubernetesDefaultNamespace,
-			},
-			Spec: corev1.ServiceSpec{
-				ClusterIP: "10.96.0.1",
-			},
-		},
-		&discoveryv1.EndpointSlice{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "kubernetes-endpoints",
-				Namespace: kubernetesDefaultNamespace,
-				Labels: map[string]string{
-					discoveryv1.LabelServiceName: kubernetesServiceName,
-				},
-			},
-			AddressType: discoveryv1.AddressTypeIPv4,
-			Endpoints: []discoveryv1.Endpoint{
-				{Addresses: []string{"192.168.1.10"}},
-			},
-		},
-	}
-
-	c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
+	c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(kubernetesServiceObjects()...).Build()
 	cidrs, err := ResolveAPIServerCIDRs(t.Context(), c)
 	require.NoError(t, err, "resolve kubernetes API server CIDRs")
 	assert.ElementsMatch(t, []string{"10.96.0.1/32", "192.168.1.10/32"}, cidrs, "unexpected API server CIDRs")
@@ -109,6 +84,7 @@ func TestParseServiceHost(t *testing.T) {
 	}{
 		{"kafka-kafka-bootstrap.gh-ns.svc", "gh-ns", "kafka-kafka-bootstrap"},
 		{"kafka-kafka-bootstrap.gh-ns.svc.cluster.local", "gh-ns", "kafka-kafka-bootstrap"},
+		{"kafka-kafka-bootstrap.svc", "gh-ns", "kafka-kafka-bootstrap"},
 		{"example.com", "", ""},
 	}
 

--- a/operator/pkg/networkpolicy/resolve_test.go
+++ b/operator/pkg/networkpolicy/resolve_test.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2023
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package networkpolicy
+
+import (
+	"net"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme), "register corev1 scheme")
+	require.NoError(t, discoveryv1.AddToScheme(scheme), "register discoveryv1 scheme")
+	require.NoError(t, configv1.AddToScheme(scheme), "register configv1 scheme")
+	return scheme
+}
+
+func TestResolveAPIServerCIDRs(t *testing.T) {
+	scheme := newTestScheme(t)
+	objs := []runtime.Object{
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      kubernetesServiceName,
+				Namespace: kubernetesDefaultNamespace,
+			},
+			Spec: corev1.ServiceSpec{
+				ClusterIP: "10.96.0.1",
+			},
+		},
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "kubernetes-endpoints",
+				Namespace: kubernetesDefaultNamespace,
+				Labels: map[string]string{
+					discoveryv1.LabelServiceName: kubernetesServiceName,
+				},
+			},
+			AddressType: discoveryv1.AddressTypeIPv4,
+			Endpoints: []discoveryv1.Endpoint{
+				{Addresses: []string{"192.168.1.10"}},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
+	cidrs, err := ResolveAPIServerCIDRs(t.Context(), c)
+	require.NoError(t, err, "resolve kubernetes API server CIDRs")
+	assert.ElementsMatch(t, []string{"10.96.0.1/32", "192.168.1.10/32"}, cidrs, "unexpected API server CIDRs")
+}
+
+func TestResolveBootstrapServerCIDRs_IPAndService(t *testing.T) {
+	scheme := newTestScheme(t)
+	objs := []runtime.Object{
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "kafka-kafka-bootstrap",
+				Namespace: "multicluster-global-hub",
+			},
+			Spec: corev1.ServiceSpec{
+				ClusterIP: "172.30.10.5",
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
+	cidrs, err := ResolveBootstrapServerCIDRs(t.Context(), c,
+		"203.0.113.10:9092,kafka-kafka-bootstrap.multicluster-global-hub.svc:9092",
+		"multicluster-global-hub")
+	require.NoError(t, err, "resolve bootstrap server CIDRs")
+	assert.ElementsMatch(t, []string{"172.30.10.5/32", "203.0.113.10/32"}, cidrs, "unexpected bootstrap CIDRs")
+}
+
+func TestResolveBootstrapServerCIDRs_Empty(t *testing.T) {
+	scheme := newTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	_, err := ResolveBootstrapServerCIDRs(t.Context(), c, "  ", "ns")
+	require.Error(t, err, "expected error for empty bootstrap server")
+}
+
+func TestParseServiceHost(t *testing.T) {
+	tests := []struct {
+		host     string
+		wantNS   string
+		wantName string
+	}{
+		{"kafka-kafka-bootstrap.gh-ns.svc", "gh-ns", "kafka-kafka-bootstrap"},
+		{"kafka-kafka-bootstrap.gh-ns.svc.cluster.local", "gh-ns", "kafka-kafka-bootstrap"},
+		{"example.com", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.host, func(t *testing.T) {
+			ns, name := parseServiceHost(tt.host, "gh-ns")
+			assert.Equal(t, tt.wantNS, ns, "unexpected namespace")
+			assert.Equal(t, tt.wantName, name, "unexpected service name")
+		})
+	}
+}
+
+func TestBrokerHost(t *testing.T) {
+	assert.Equal(t, "broker.example.com", brokerHost("broker.example.com:9092"), "broker host with port")
+	assert.Equal(t, "203.0.113.1", brokerHost("203.0.113.1:9093"), "IP broker host")
+	assert.Equal(t, "broker", brokerHost("broker"), "broker host without port")
+}
+
+func TestResolveAPIServerCIDRs_NotFound(t *testing.T) {
+	scheme := newTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	_, err := ResolveAPIServerCIDRs(t.Context(), c)
+	require.Error(t, err, "expected error when kubernetes service is missing")
+}
+
+func TestResolveServiceNetworkCIDRs(t *testing.T) {
+	scheme := newTestScheme(t)
+	objs := []runtime.Object{
+		&configv1.Network{
+			ObjectMeta: metav1.ObjectMeta{Name: clusterNetworkName},
+			Spec: configv1.NetworkSpec{
+				ServiceNetwork: []string{"172.30.0.0/16"},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
+
+	cidrs, err := ResolveServiceNetworkCIDRs(t.Context(), c)
+	require.NoError(t, err, "resolve service network CIDRs")
+	assert.Equal(t, []string{"172.30.0.0/16"}, cidrs, "unexpected service network CIDRs")
+}
+
+func TestResolveServiceNetworkCIDRs_NotFound(t *testing.T) {
+	scheme := newTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	cidrs, err := ResolveServiceNetworkCIDRs(t.Context(), c)
+	require.NoError(t, err, "missing Network CR should not error")
+	assert.Nil(t, cidrs, "expected nil CIDRs when Network CR is absent")
+}
+
+func TestResolveServiceNetworkCIDRs_InvalidCIDR(t *testing.T) {
+	scheme := newTestScheme(t)
+	objs := []runtime.Object{
+		&configv1.Network{
+			ObjectMeta: metav1.ObjectMeta{Name: clusterNetworkName},
+			Spec: configv1.NetworkSpec{
+				ServiceNetwork: []string{"not-a-cidr"},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
+
+	_, err := ResolveServiceNetworkCIDRs(t.Context(), c)
+	require.Error(t, err, "expected error for invalid service network CIDR")
+}
+
+func TestResolveServiceCIDRs_ServiceOnly(t *testing.T) {
+	scheme := newTestScheme(t)
+	objs := []runtime.Object{
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "kafka-kafka-bootstrap",
+				Namespace: "multicluster-global-hub",
+			},
+			Spec: corev1.ServiceSpec{
+				ClusterIP: "172.30.10.5",
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
+
+	cidrs, err := resolveServiceCIDRs(t.Context(), c, "multicluster-global-hub", "kafka-kafka-bootstrap")
+	require.NoError(t, err, "resolve service CIDRs from ClusterIP")
+	assert.Equal(t, []string{"172.30.10.5/32"}, cidrs, "unexpected service CIDRs")
+}
+
+func TestAddHostCIDRAndSortedCIDRs(t *testing.T) {
+	cidrs := map[string]struct{}{}
+	addHostCIDR(cidrs, nil)
+	addHostCIDR(cidrs, parseTestIP(t, "10.0.0.1"))
+	addHostCIDR(cidrs, parseTestIP(t, "2001:db8::1"))
+
+	assert.Equal(t, []string{"10.0.0.1/32", "2001:db8::1/128"}, sortedCIDRs(cidrs), "unexpected sorted CIDRs")
+}
+
+func parseTestIP(t *testing.T, raw string) net.IP {
+	t.Helper()
+	ip := net.ParseIP(raw)
+	require.NotNil(t, ip, "parse test IP %q", raw)
+	return ip
+}

--- a/operator/pkg/networkpolicy/values.go
+++ b/operator/pkg/networkpolicy/values.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023
+Copyright 2023 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/operator/pkg/networkpolicy/values.go
+++ b/operator/pkg/networkpolicy/values.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2023
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package networkpolicy
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
+)
+
+var log = logger.DefaultZapLogger()
+
+// BaselineManifestValues is passed to baseline NetworkPolicy templates (allow-dns-and-api, operator NP).
+type BaselineManifestValues struct {
+	Namespace      string
+	PostgresName   string
+	APIServerCIDRs []string
+}
+
+// AgentManifestValues is passed to agent NetworkPolicy templates.
+type AgentManifestValues struct {
+	Namespace          string
+	APIServerCIDRs     []string
+	ExternalKafkaCIDRs []string
+	WebhookEgressCIDRs []string
+}
+
+// BuildBaselineValues resolves API server CIDRs for hub-namespace baseline policies.
+func BuildBaselineValues(ctx context.Context, c client.Client, namespace, postgresName string) BaselineManifestValues {
+	values := BaselineManifestValues{
+		Namespace:    namespace,
+		PostgresName: postgresName,
+	}
+	cidrs, err := ResolveAPIServerCIDRs(ctx, c)
+	if err != nil {
+		log.Infow("using ports-only API egress fallback for baseline NetworkPolicy",
+			"namespace", namespace, "error", err)
+		return values
+	}
+	values.APIServerCIDRs = cidrs
+	return values
+}
+
+// BuildAgentValues resolves egress CIDRs for a Global Hub agent NetworkPolicy on the local hub cluster.
+func BuildAgentValues(ctx context.Context, c client.Client, namespace, bootstrapServer string) AgentManifestValues {
+	values := AgentManifestValues{Namespace: namespace}
+
+	cidrs, err := ResolveAPIServerCIDRs(ctx, c)
+	if err != nil {
+		log.Infow("using ports-only API egress fallback for agent NetworkPolicy",
+			"namespace", namespace, "error", err)
+	} else {
+		values.APIServerCIDRs = cidrs
+	}
+
+	if bootstrapServer != "" {
+		kafkaCIDRs, err := ResolveBootstrapServerCIDRs(ctx, c, bootstrapServer, namespace)
+		if err != nil {
+			log.Infow("using broad external Kafka egress fallback for agent NetworkPolicy",
+				"namespace", namespace, "error", err)
+		} else {
+			values.ExternalKafkaCIDRs = kafkaCIDRs
+		}
+	}
+
+	serviceNetworks, err := ResolveServiceNetworkCIDRs(ctx, c)
+	if err != nil {
+		log.Warnw("failed to resolve service network CIDR for webhook egress", "error", err)
+	} else {
+		values.WebhookEgressCIDRs = serviceNetworks
+	}
+
+	return values
+}
+
+// BuildAddonAgentValues resolves Kafka bootstrap CIDRs for addon agent manifests rendered on the hub.
+// API server and webhook CIDRs are resolved on the managed hub at runtime and remain as fallback rules in the template.
+func BuildAddonAgentValues(ctx context.Context, c client.Client, bootstrapServer, hubNamespace string) []string {
+	if bootstrapServer == "" {
+		return nil
+	}
+	kafkaCIDRs, err := ResolveBootstrapServerCIDRs(ctx, c, bootstrapServer, hubNamespace)
+	if err != nil {
+		log.Infow("using broad external Kafka egress fallback for addon agent NetworkPolicy", "error", err)
+		return nil
+	}
+	return kafkaCIDRs
+}

--- a/operator/pkg/networkpolicy/values_test.go
+++ b/operator/pkg/networkpolicy/values_test.go
@@ -75,7 +75,8 @@ func TestBuildBaselineValues_Fallback(t *testing.T) {
 
 func TestBuildAgentValues(t *testing.T) {
 	scheme := newTestScheme(t)
-	objs := append(kubernetesServiceObjects(),
+	objs := append(
+		kubernetesServiceObjects(),
 		&corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "kafka-kafka-bootstrap",

--- a/operator/pkg/networkpolicy/values_test.go
+++ b/operator/pkg/networkpolicy/values_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023
+Copyright 2023 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/operator/pkg/networkpolicy/values_test.go
+++ b/operator/pkg/networkpolicy/values_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2023
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package networkpolicy
+
+import (
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func kubernetesServiceObjects() []runtime.Object {
+	return []runtime.Object{
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      kubernetesServiceName,
+				Namespace: kubernetesDefaultNamespace,
+			},
+			Spec: corev1.ServiceSpec{
+				ClusterIP: "10.96.0.1",
+			},
+		},
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "kubernetes-endpoints",
+				Namespace: kubernetesDefaultNamespace,
+				Labels: map[string]string{
+					discoveryv1.LabelServiceName: kubernetesServiceName,
+				},
+			},
+			AddressType: discoveryv1.AddressTypeIPv4,
+			Endpoints: []discoveryv1.Endpoint{
+				{Addresses: []string{"192.168.1.10"}},
+			},
+		},
+	}
+}
+
+func TestBuildBaselineValues(t *testing.T) {
+	scheme := newTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(kubernetesServiceObjects()...).Build()
+
+	values := BuildBaselineValues(t.Context(), c, "gh-ns", "postgres")
+	assert.Equal(t, "gh-ns", values.Namespace, "namespace")
+	assert.Equal(t, "postgres", values.PostgresName, "postgres name")
+	assert.ElementsMatch(t, []string{"10.96.0.1/32", "192.168.1.10/32"}, values.APIServerCIDRs, "API server CIDRs")
+}
+
+func TestBuildBaselineValues_Fallback(t *testing.T) {
+	scheme := newTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	values := BuildBaselineValues(t.Context(), c, "gh-ns", "postgres")
+	assert.Empty(t, values.APIServerCIDRs, "expected empty API server CIDR fallback")
+}
+
+func TestBuildAgentValues(t *testing.T) {
+	scheme := newTestScheme(t)
+	objs := append(kubernetesServiceObjects(),
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "kafka-kafka-bootstrap",
+				Namespace: "gh-ns",
+			},
+			Spec: corev1.ServiceSpec{ClusterIP: "172.30.10.5"},
+		},
+		&configv1.Network{
+			ObjectMeta: metav1.ObjectMeta{Name: clusterNetworkName},
+			Spec:       configv1.NetworkSpec{ServiceNetwork: []string{"172.30.0.0/16"}},
+		},
+	)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
+
+	values := BuildAgentValues(t.Context(), c, "gh-ns", "203.0.113.10:9092")
+	assert.ElementsMatch(t, []string{"10.96.0.1/32", "192.168.1.10/32"}, values.APIServerCIDRs, "API server CIDRs")
+	assert.ElementsMatch(t, []string{"203.0.113.10/32"}, values.ExternalKafkaCIDRs, "Kafka CIDRs")
+	assert.Equal(t, []string{"172.30.0.0/16"}, values.WebhookEgressCIDRs, "webhook CIDRs")
+}
+
+func TestBuildAddonAgentValues(t *testing.T) {
+	scheme := newTestScheme(t)
+	objs := []runtime.Object{
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "kafka-kafka-bootstrap",
+				Namespace: "gh-ns",
+			},
+			Spec: corev1.ServiceSpec{ClusterIP: "172.30.10.5"},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
+
+	cidrs := BuildAddonAgentValues(t.Context(), c,
+		"kafka-kafka-bootstrap.gh-ns.svc:9092", "gh-ns")
+	assert.Equal(t, []string{"172.30.10.5/32"}, cidrs, "addon Kafka CIDRs")
+}
+
+func TestBuildAddonAgentValues_EmptyBootstrap(t *testing.T) {
+	scheme := newTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	cidrs := BuildAddonAgentValues(t.Context(), c, "", "gh-ns")
+	assert.Nil(t, cidrs, "expected nil CIDRs for empty bootstrap server")
+}
+
+func TestBuildAddonAgentValues_Fallback(t *testing.T) {
+	scheme := newTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	cidrs := BuildAddonAgentValues(t.Context(), c, ":9092", "gh-ns")
+	assert.Nil(t, cidrs, "expected nil CIDRs when bootstrap resolution fails")
+}


### PR DESCRIPTION
Fixes: [ACM-32313](https://redhat.atlassian.net/browse/ACM-32313)

## Summary

- Add operator runtime resolution for Kubernetes API server and Kafka bootstrap broker addresses, templated as `ipBlock` rules in `allow-dns-and-api` and agent NetworkPolicies (local + addon).
- Resolve API server from the `kubernetes` Service plus Endpoints/EndpointSlices; resolve external Kafka from transport bootstrap servers (IP, in-cluster Service, or DNS).
- Use OpenShift `Network.spec.serviceNetwork` for agent webhook egress (TCP 8443) when available.
- Retain prior broad egress fallbacks when resolution fails (KinD CI / addon manifests rendered on hub without managed-hub API visibility).

## Context

Follow-up to [#2493](https://github.com/stolostron/multicluster-global-hub/pull/2493) (NetworkPolicy support). Implements ACM-32313 follow-up items 1–2:

- Agent external Kafka bootstrap `ipBlock` (local + addon templates)
- API server `ipBlock` in `allow-dns-and-api` and local agent NP

**Bundle-repo CSV sync required for GH 5.0 stage** (same pattern as [operator-bundle#1289](https://github.com/stolostron/multicluster-global-hub-operator-bundle/pull/1289) and [operator-bundle#1323](https://github.com/stolostron/multicluster-global-hub-operator-bundle/pull/1323)):

- Companion PR: [operator-bundle#1460](https://github.com/stolostron/multicluster-global-hub-operator-bundle/pull/1460) — adds `endpointslices` and `networks` to the CSV-installed operator ClusterRole
- Without #1460, OLM may ship an operator SA missing permissions to resolve addresses for `ipBlock` templating

Related:

- [ACM-31409](https://redhat.atlassian.net/browse/ACM-31409) — NetworkPolicy epic
- [ACM-32494](https://redhat.atlassian.net/browse/ACM-32494) / [ACM-32495](https://redhat.atlassian.net/browse/ACM-32495) — OVN soak / HoH automation (item 3, out of scope here)

## Test plan

- [x] `go test ./operator/pkg/networkpolicy/...`
- [ ] Operator integration test (`networkpolicy` focus) on CI
- [ ] Merge [operator-bundle#1460](https://github.com/stolostron/multicluster-global-hub-operator-bundle/pull/1460) and cut stage bundle before OVN soak
- [ ] Manual OVN soak tracked in ACM-32494 after merge


[ACM-32313]: https://redhat.atlassian.net/browse/ACM-32313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-31409]: https://redhat.atlassian.net/browse/ACM-31409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NetworkPolicy egress rules can now optionally restrict destinations using reconcile-time CIDR resolution for API server (443/6443), external Kafka bootstrap (9092/9093), and internal webhook/admission HTTPS (8443).
  * Add-on agent manifests can use resolved CIDR inputs to further limit external Kafka and API/webhook egress.
  * Expanded operator RBAC read access to support required service and endpoint-slice lookups.
* **Bug Fixes**
  * If CIDR resolution fails or inputs are unavailable, egress rules retain the prior broader allow behavior to prevent regressions.
* **Documentation**
  * Updated “Known Limitations and Follow-ups” to clarify resolution timing and fallback behavior.
* **Tests**
  * Added unit tests covering CIDR resolution, parsing, and fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->