### PR TITLE
ACM-37165: allow BYO Postgres/Kafka egress in operator NetworkPolicy

### DIFF
--- a/ai-doc/NETWORKPOLICY.md
+++ b/ai-doc/NETWORKPOLICY.md
@@ -611,14 +611,18 @@ When Postgres (CNPG/Crunchy) or Kafka (Strimzi) run in separate namespaces from 
 operator namespace, the operator must reach them during database initialization and transport
 configuration.
 
-- **Operator:** `multicluster-global-hub-operator` NetworkPolicy includes ports-only egress on
-  TCP 5432 (Postgres) and TCP 9091/9093 (Kafka) for external/BYO endpoints, in addition to
-  in-namespace pod selectors for built-in deployments. This mirrors the Grafana policy pattern.
+- **Operator:** When the BYO storage or transport secret is present, the operator NetworkPolicy
+  adds scoped BYO egress rules:
+  - **Postgres:** `ipBlock` CIDRs resolved from the `database_uri` host when available; otherwise
+    cross-namespace pod selectors for CNPG (`cnpg.io/cluster`) and Crunchy
+    (`postgres-operator.crunchydata.com/cluster`) pods on TCP 5432.
+  - **Kafka:** Cross-namespace Strimzi pod selector (`strimzi.io/cluster: kafka`) on TCP 9091/9093,
+    plus optional `ipBlock` CIDRs resolved from the BYO `bootstrap_server` when available.
 - **Grafana:** Already allows ports-only TCP 5432 egress for in-cluster or external Postgres.
 - **Manager:** Includes a broad `namespaceSelector: {}` egress rule (all ports) for cross-namespace
   operations; BYO Postgres/Kafka connectivity is covered once the manager deploys.
-- **Follow-up hardening:** Prefer `ipBlock` or namespace-scoped selectors for BYO endpoints where
-  bootstrap/service CIDRs can be resolved at reconcile time (see ACM-32313).
+- **Follow-up hardening:** Prefer namespace-scoped selectors or tighter `ipBlock` rules when BYO
+  bootstrap/service CIDRs cannot be resolved (see ACM-32313).
 
 ## Testing Commands
 
@@ -692,7 +696,10 @@ Remaining items are tracked under [ACM-32313](https://redhat.atlassian.net/brows
 - **Kafka `ipBlock` egress:** The operator resolves Kafka bootstrap broker hostnames/IPs at reconcile time and templates `ipBlock` rules for agent external Kafka egress (local agent and addon agent). When bootstrap resolution fails, the prior broad `namespaceSelector` fallback is retained.
 - **API server `ipBlock`:** The operator resolves the `kubernetes` Service and endpoint addresses at reconcile time and templates `ipBlock` rules in `allow-dns-and-api` and the local agent NetworkPolicy. When resolution fails, ports-only egress (443/6443) is used as fallback. Addon agent manifests are rendered on the hub; managed-hub API server CIDRs are not available at render time, so addon agent API egress keeps the ports-only fallback until spoke-side resolution exists.
 - **Webhook egress (8443):** When the OpenShift cluster `Network` CR exposes `spec.serviceNetwork`, agent policies use that CIDR for TCP 8443; otherwise the broad in-cluster fallback remains.
-- **BYO Postgres/Kafka egress (ACM-37165):** Operator NP now includes ports-only egress for external Postgres (5432) and Kafka (9091/9093). Prior to this fix, BYO installs blocked at database init because operator egress only targeted in-namespace pod selectors. Follow-up: tighten with `ipBlock`/namespace selectors when BYO bootstrap CIDRs are resolvable.
+- **BYO Postgres/Kafka egress (ACM-37165):** Operator NP adds BYO egress only when the storage or
+  transport secret is present. Postgres uses resolved `ipBlock` CIDRs from `database_uri` when
+  available, otherwise CNPG/Crunchy pod selectors. Kafka uses cross-namespace Strimzi pod selectors
+  plus optional `ipBlock` CIDRs from `bootstrap_server`.
 
 ## References
 - **Jira Ticket**: [ACM-19479](https://redhat.atlassian.net/browse/ACM-19479)

--- a/ai-doc/NETWORKPOLICY.md
+++ b/ai-doc/NETWORKPOLICY.md
@@ -606,6 +606,20 @@ If using backup solutions (Velero, OADP):
   Prefer explicit namespace selectors for in-cluster backup workloads where possible (see
   PostgreSQL NetworkPolicy; follow-up hardening tracked in ACM-31409).
 
+### 6. Bring Your Own (BYO) Postgres and Kafka
+When Postgres (CNPG/Crunchy) or Kafka (Strimzi) run in separate namespaces from the Global Hub
+operator namespace, the operator must reach them during database initialization and transport
+configuration.
+
+- **Operator:** `multicluster-global-hub-operator` NetworkPolicy includes ports-only egress on
+  TCP 5432 (Postgres) and TCP 9091/9093 (Kafka) for external/BYO endpoints, in addition to
+  in-namespace pod selectors for built-in deployments. This mirrors the Grafana policy pattern.
+- **Grafana:** Already allows ports-only TCP 5432 egress for in-cluster or external Postgres.
+- **Manager:** Includes a broad `namespaceSelector: {}` egress rule (all ports) for cross-namespace
+  operations; BYO Postgres/Kafka connectivity is covered once the manager deploys.
+- **Follow-up hardening:** Prefer `ipBlock` or namespace-scoped selectors for BYO endpoints where
+  bootstrap/service CIDRs can be resolved at reconcile time (see ACM-32313).
+
 ## Testing Commands
 
 ```bash
@@ -678,6 +692,7 @@ Remaining items are tracked under [ACM-32313](https://redhat.atlassian.net/brows
 - **Kafka `ipBlock` egress:** The operator resolves Kafka bootstrap broker hostnames/IPs at reconcile time and templates `ipBlock` rules for agent external Kafka egress (local agent and addon agent). When bootstrap resolution fails, the prior broad `namespaceSelector` fallback is retained.
 - **API server `ipBlock`:** The operator resolves the `kubernetes` Service and endpoint addresses at reconcile time and templates `ipBlock` rules in `allow-dns-and-api` and the local agent NetworkPolicy. When resolution fails, ports-only egress (443/6443) is used as fallback. Addon agent manifests are rendered on the hub; managed-hub API server CIDRs are not available at render time, so addon agent API egress keeps the ports-only fallback until spoke-side resolution exists.
 - **Webhook egress (8443):** When the OpenShift cluster `Network` CR exposes `spec.serviceNetwork`, agent policies use that CIDR for TCP 8443; otherwise the broad in-cluster fallback remains.
+- **BYO Postgres/Kafka egress (ACM-37165):** Operator NP now includes ports-only egress for external Postgres (5432) and Kafka (9091/9093). Prior to this fix, BYO installs blocked at database init because operator egress only targeted in-namespace pod selectors. Follow-up: tighten with `ipBlock`/namespace selectors when BYO bootstrap CIDRs are resolvable.
 
 ## References
 - **Jira Ticket**: [ACM-19479](https://redhat.atlassian.net/browse/ACM-19479)

--- a/operator/pkg/controllers/networkpolicy/manifests/operator-networkpolicy.yaml
+++ b/operator/pkg/controllers/networkpolicy/manifests/operator-networkpolicy.yaml
@@ -41,7 +41,7 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
-  # Allow connections to PostgreSQL
+  # Allow connections to PostgreSQL in the hub namespace
   - to:
     - podSelector:
         matchLabels:
@@ -49,12 +49,22 @@ spec:
     ports:
     - protocol: TCP
       port: 5432
-  # Allow connections to Kafka
+  # Allow connections to PostgreSQL in external namespaces (BYO)
+  - ports:
+    - protocol: TCP
+      port: 5432
+  # Allow connections to Kafka in the hub namespace
   - to:
     - podSelector:
         matchLabels:
           strimzi.io/cluster: kafka
     ports:
+    - protocol: TCP
+      port: 9093
+    - protocol: TCP
+      port: 9091
+  # Allow connections to Kafka in external namespaces (BYO)
+  - ports:
     - protocol: TCP
       port: 9093
     - protocol: TCP

--- a/operator/pkg/controllers/networkpolicy/manifests/operator-networkpolicy.yaml
+++ b/operator/pkg/controllers/networkpolicy/manifests/operator-networkpolicy.yaml
@@ -83,22 +83,23 @@ spec:
   {{- end }}
   {{- if .BYOKafka }}
   # Allow connections to Kafka in external namespaces (BYO Strimzi)
-  - to:
-    - namespaceSelector: {}
-      podSelector:
-        matchLabels:
-          strimzi.io/cluster: kafka
-    ports:
-    - protocol: TCP
-      port: 9093
-    - protocol: TCP
-      port: 9091
   {{- if .ExternalKafkaCIDRs }}
   - to:
     {{- range .ExternalKafkaCIDRs }}
     - ipBlock:
         cidr: {{ . }}
     {{- end }}
+    ports:
+    - protocol: TCP
+      port: 9093
+    - protocol: TCP
+      port: 9091
+  {{- else }}
+  - to:
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          strimzi.io/cluster: kafka
     ports:
     - protocol: TCP
       port: 9093

--- a/operator/pkg/controllers/networkpolicy/manifests/operator-networkpolicy.yaml
+++ b/operator/pkg/controllers/networkpolicy/manifests/operator-networkpolicy.yaml
@@ -49,10 +49,63 @@ spec:
     ports:
     - protocol: TCP
       port: 5432
+  {{- if .BYOPostgres }}
   # Allow connections to PostgreSQL in external namespaces (BYO)
-  - ports:
+  {{- if .ExternalPostgresCIDRs }}
+  - to:
+    {{- range .ExternalPostgresCIDRs }}
+    - ipBlock:
+        cidr: {{ . }}
+    {{- end }}
+    ports:
     - protocol: TCP
       port: 5432
+  {{- else }}
+  - to:
+    - namespaceSelector: {}
+      podSelector:
+        matchExpressions:
+        - key: cnpg.io/cluster
+          operator: Exists
+    ports:
+    - protocol: TCP
+      port: 5432
+  - to:
+    - namespaceSelector: {}
+      podSelector:
+        matchExpressions:
+        - key: postgres-operator.crunchydata.com/cluster
+          operator: Exists
+    ports:
+    - protocol: TCP
+      port: 5432
+  {{- end }}
+  {{- end }}
+  {{- if .BYOKafka }}
+  # Allow connections to Kafka in external namespaces (BYO Strimzi)
+  - to:
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          strimzi.io/cluster: kafka
+    ports:
+    - protocol: TCP
+      port: 9093
+    - protocol: TCP
+      port: 9091
+  {{- if .ExternalKafkaCIDRs }}
+  - to:
+    {{- range .ExternalKafkaCIDRs }}
+    - ipBlock:
+        cidr: {{ . }}
+    {{- end }}
+    ports:
+    - protocol: TCP
+      port: 9093
+    - protocol: TCP
+      port: 9091
+  {{- end }}
+  {{- else }}
   # Allow connections to Kafka in the hub namespace
   - to:
     - podSelector:
@@ -63,12 +116,7 @@ spec:
       port: 9093
     - protocol: TCP
       port: 9091
-  # Allow connections to Kafka in external namespaces (BYO)
-  - ports:
-    - protocol: TCP
-      port: 9093
-    - protocol: TCP
-      port: 9091
+  {{- end }}
   # Allow connections to SpiceDB
   - to:
     - podSelector:

--- a/operator/pkg/controllers/networkpolicy/operator_networkpolicy_template_test.go
+++ b/operator/pkg/controllers/networkpolicy/operator_networkpolicy_template_test.go
@@ -1,0 +1,88 @@
+package networkpolicy
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+
+	nputils "github.com/stolostron/multicluster-global-hub/operator/pkg/networkpolicy"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/renderer"
+)
+
+func TestRenderOperatorNetworkPolicy_BYOWithCIDRs(t *testing.T) {
+	npRenderer := renderer.NewHoHRenderer(fs)
+	values := nputils.BaselineManifestValues{
+		Namespace:           "multicluster-global-hub",
+		PostgresName:        "multicluster-global-hub-postgresql",
+		BYOPostgres:         true,
+		ExternalPostgresCIDRs: []string{"172.30.5.56/32", "10.131.1.85/32"},
+		BYOKafka:            true,
+		ExternalKafkaCIDRs:  []string{"172.30.85.220/32"},
+		APIServerCIDRs:      []string{"10.96.0.1/32"},
+	}
+	objects, err := npRenderer.Render("manifests", "", func(profile string) (interface{}, error) {
+		return values, nil
+	})
+	require.NoError(t, err, "render operator networkpolicy manifests")
+
+	yamlText := renderedOperatorNetworkPolicyYAML(t, objects)
+	assert.Contains(t, yamlText, "cidr: 172.30.5.56/32", "expected BYO postgres ipBlock")
+	assert.Contains(t, yamlText, "cidr: 172.30.85.220/32", "expected BYO kafka ipBlock")
+	assert.NotContains(t, yamlText, "cnpg.io/cluster", "CNPG fallback should not render when postgres CIDRs resolve")
+	assert.NotContains(t, yamlText, "namespaceSelector: {}", "Strimzi fallback should not render when kafka CIDRs resolve")
+}
+
+func TestRenderOperatorNetworkPolicy_BYOFallbackSelectors(t *testing.T) {
+	npRenderer := renderer.NewHoHRenderer(fs)
+	values := nputils.BaselineManifestValues{
+		Namespace:    "multicluster-global-hub",
+		PostgresName: "multicluster-global-hub-postgresql",
+		BYOPostgres:  true,
+		BYOKafka:     true,
+	}
+	objects, err := npRenderer.Render("manifests", "", func(profile string) (interface{}, error) {
+		return values, nil
+	})
+	require.NoError(t, err, "render operator networkpolicy manifests")
+
+	yamlText := renderedOperatorNetworkPolicyYAML(t, objects)
+	assert.Contains(t, yamlText, "cnpg.io/cluster", "expected CNPG pod selector fallback")
+	assert.Contains(t, yamlText, "postgres-operator.crunchydata.com/cluster", "expected Crunchy pod selector fallback")
+	assert.Contains(t, yamlText, "strimzi.io/cluster: kafka", "expected Strimzi pod selector fallback")
+	assert.NotContains(t, yamlText, "ipBlock:", "ipBlock rules should not render without resolved CIDRs")
+}
+
+func TestRenderOperatorNetworkPolicy_BuiltInOnly(t *testing.T) {
+	npRenderer := renderer.NewHoHRenderer(fs)
+	values := nputils.BaselineManifestValues{
+		Namespace:    "multicluster-global-hub",
+		PostgresName: "multicluster-global-hub-postgresql",
+	}
+	objects, err := npRenderer.Render("manifests", "", func(profile string) (interface{}, error) {
+		return values, nil
+	})
+	require.NoError(t, err, "render operator networkpolicy manifests")
+
+	yamlText := renderedOperatorNetworkPolicyYAML(t, objects)
+	assert.Contains(t, yamlText, "name: multicluster-global-hub-postgresql", "expected in-hub postgres selector")
+	assert.NotContains(t, yamlText, "cnpg.io/cluster", "BYO postgres rules should not render")
+	assert.NotContains(t, yamlText, "namespaceSelector: {}", "BYO kafka rules should not render")
+}
+
+func renderedOperatorNetworkPolicyYAML(t *testing.T, objects []*unstructured.Unstructured) string {
+	t.Helper()
+	var b strings.Builder
+	for _, obj := range objects {
+		if obj.GetKind() != "NetworkPolicy" || obj.GetName() != NetworkPolicyOperator {
+			continue
+		}
+		data, err := yaml.Marshal(obj.Object)
+		require.NoError(t, err, "marshal rendered networkpolicy")
+		b.Write(data)
+	}
+	return b.String()
+}

--- a/operator/pkg/controllers/networkpolicy/operator_networkpolicy_template_test.go
+++ b/operator/pkg/controllers/networkpolicy/operator_networkpolicy_template_test.go
@@ -16,13 +16,13 @@ import (
 func TestRenderOperatorNetworkPolicy_BYOWithCIDRs(t *testing.T) {
 	npRenderer := renderer.NewHoHRenderer(fs)
 	values := nputils.BaselineManifestValues{
-		Namespace:           "multicluster-global-hub",
-		PostgresName:        "multicluster-global-hub-postgresql",
-		BYOPostgres:         true,
+		Namespace:             "multicluster-global-hub",
+		PostgresName:          "multicluster-global-hub-postgresql",
+		BYOPostgres:           true,
 		ExternalPostgresCIDRs: []string{"172.30.5.56/32", "10.131.1.85/32"},
-		BYOKafka:            true,
-		ExternalKafkaCIDRs:  []string{"172.30.85.220/32"},
-		APIServerCIDRs:      []string{"10.96.0.1/32"},
+		BYOKafka:              true,
+		ExternalKafkaCIDRs:    []string{"172.30.85.220/32"},
+		APIServerCIDRs:        []string{"10.96.0.1/32"},
 	}
 	objects, err := npRenderer.Render("manifests", "", func(profile string) (interface{}, error) {
 		return values, nil

--- a/operator/pkg/networkpolicy/resolve.go
+++ b/operator/pkg/networkpolicy/resolve.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/url"
 	"sort"
 	"strings"
 
@@ -44,6 +45,32 @@ func ResolveAPIServerCIDRs(ctx context.Context, c client.Client) ([]string, erro
 		return nil, fmt.Errorf("no kubernetes API server addresses found: %w", err)
 	}
 	return cidrs, nil
+}
+
+// ResolvePostgresCIDRs resolves a BYO Postgres database URI host to ipBlock CIDR strings.
+func ResolvePostgresCIDRs(ctx context.Context, c client.Client, namespace, databaseURI string) ([]string, error) {
+	databaseURI = strings.TrimSpace(databaseURI)
+	if databaseURI == "" {
+		return nil, fmt.Errorf("empty postgres database URI")
+	}
+
+	objURI, err := url.Parse(databaseURI)
+	if err != nil {
+		return nil, fmt.Errorf("parse postgres database URI: %w", err)
+	}
+	host := strings.TrimSpace(objURI.Hostname())
+	if host == "" {
+		return nil, fmt.Errorf("empty postgres host in database URI")
+	}
+
+	cidrs := map[string]struct{}{}
+	if err := resolveHostToCIDRs(ctx, c, host, namespace, cidrs); err != nil {
+		return nil, err
+	}
+	if len(cidrs) == 0 {
+		return nil, fmt.Errorf("no postgres addresses resolved for %q", host)
+	}
+	return sortedCIDRs(cidrs), nil
 }
 
 // ResolveBootstrapServerCIDRs resolves Kafka bootstrap broker hostnames/IPs to ipBlock CIDR strings.

--- a/operator/pkg/networkpolicy/resolve.go
+++ b/operator/pkg/networkpolicy/resolve.go
@@ -56,7 +56,7 @@ func ResolvePostgresCIDRs(ctx context.Context, c client.Client, namespace, datab
 
 	objURI, err := url.Parse(databaseURI)
 	if err != nil {
-		return nil, fmt.Errorf("parse postgres database URI: %w", err)
+		return nil, fmt.Errorf("invalid postgres database URI host")
 	}
 	host := strings.TrimSpace(objURI.Hostname())
 	if host == "" {
@@ -65,7 +65,7 @@ func ResolvePostgresCIDRs(ctx context.Context, c client.Client, namespace, datab
 
 	cidrs := map[string]struct{}{}
 	if err := resolveHostToCIDRs(ctx, c, host, namespace, cidrs); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("resolve postgres host %q: %w", host, err)
 	}
 	if len(cidrs) == 0 {
 		return nil, fmt.Errorf("no postgres addresses resolved for %q", host)

--- a/operator/pkg/networkpolicy/resolve.go
+++ b/operator/pkg/networkpolicy/resolve.go
@@ -160,12 +160,13 @@ func resolveHostToCIDRs(
 	svcNamespace, svcName := parseServiceHost(host, defaultNamespace)
 	if svcName != "" {
 		svcCIDRs, err := resolveServiceCIDRs(ctx, c, svcNamespace, svcName)
-		if err == nil && len(svcCIDRs) > 0 {
-			for _, cidr := range svcCIDRs {
-				cidrs[cidr] = struct{}{}
-			}
-			return nil
+		if err != nil {
+			return err
 		}
+		for _, cidr := range svcCIDRs {
+			cidrs[cidr] = struct{}{}
+		}
+		return nil
 	}
 
 	ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)

--- a/operator/pkg/networkpolicy/resolve_test.go
+++ b/operator/pkg/networkpolicy/resolve_test.go
@@ -157,6 +157,7 @@ func TestResolvePostgresCIDRs_UnresolvableHost(t *testing.T) {
 		"postgresql://postgres:secret@ghost-service.ghost-ns.svc:5432/hoh")
 	require.Error(t, err, "expected error for unresolvable postgres host")
 	assert.Contains(t, err.Error(), "resolve postgres host", "unexpected error message")
+	assert.Contains(t, err.Error(), "ghost-service", "expected in-cluster service lookup error")
 }
 
 func TestParseServiceHost(t *testing.T) {

--- a/operator/pkg/networkpolicy/resolve_test.go
+++ b/operator/pkg/networkpolicy/resolve_test.go
@@ -76,6 +76,32 @@ func TestResolveBootstrapServerCIDRs_Empty(t *testing.T) {
 	require.Error(t, err, "expected error for empty bootstrap server")
 }
 
+func TestResolvePostgresCIDRs_Service(t *testing.T) {
+	scheme := newTestScheme(t)
+	objs := []runtime.Object{
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "hoh-rw",
+				Namespace: "multicluster-global-hub-postgres",
+			},
+			Spec: corev1.ServiceSpec{ClusterIP: "172.30.5.56"},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
+
+	cidrs, err := ResolvePostgresCIDRs(t.Context(), c, "gh-ns",
+		"postgresql://postgres:secret@hoh-rw.multicluster-global-hub-postgres.svc:5432/hoh")
+	require.NoError(t, err, "resolve postgres CIDRs")
+	assert.Equal(t, []string{"172.30.5.56/32"}, cidrs, "unexpected postgres CIDRs")
+}
+
+func TestResolvePostgresCIDRs_EmptyURI(t *testing.T) {
+	scheme := newTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	_, err := ResolvePostgresCIDRs(t.Context(), c, "gh-ns", "  ")
+	require.Error(t, err, "expected error for empty postgres URI")
+}
+
 func TestParseServiceHost(t *testing.T) {
 	tests := []struct {
 		host     string

--- a/operator/pkg/networkpolicy/resolve_test.go
+++ b/operator/pkg/networkpolicy/resolve_test.go
@@ -110,6 +110,49 @@ func TestResolvePostgresCIDRs_InvalidURIDoesNotLeakCredentials(t *testing.T) {
 	assert.NotContains(t, err.Error(), "supersecret", "error must not contain database credentials")
 }
 
+func TestResolvePostgresCIDRs_EmptyHost(t *testing.T) {
+	scheme := newTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	_, err := ResolvePostgresCIDRs(t.Context(), c, "gh-ns", "postgresql:///hoh")
+	require.Error(t, err, "expected error for empty postgres host")
+	assert.Contains(t, err.Error(), "empty postgres host in database URI", "unexpected error message")
+}
+
+func TestResolvePostgresCIDRs_WithEndpointSlice(t *testing.T) {
+	scheme := newTestScheme(t)
+	objs := []runtime.Object{
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "hoh-rw", Namespace: "multicluster-global-hub-postgres",
+			},
+			Spec: corev1.ServiceSpec{ClusterIP: "172.30.5.56"},
+		},
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "hoh-rw-endpoints", Namespace: "multicluster-global-hub-postgres",
+				Labels: map[string]string{discoveryv1.LabelServiceName: "hoh-rw"},
+			},
+			AddressType: discoveryv1.AddressTypeIPv4,
+			Endpoints:   []discoveryv1.Endpoint{{Addresses: []string{"10.131.1.85"}}},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
+
+	cidrs, err := ResolvePostgresCIDRs(t.Context(), c, "gh-ns",
+		"postgresql://postgres:secret@hoh-rw.multicluster-global-hub-postgres.svc:5432/hoh")
+	require.NoError(t, err, "resolve postgres CIDRs with endpoint slice")
+	assert.ElementsMatch(t, []string{"10.131.1.85/32", "172.30.5.56/32"}, cidrs, "unexpected postgres CIDRs")
+}
+
+func TestResolvePostgresCIDRs_UnresolvableHost(t *testing.T) {
+	scheme := newTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	_, err := ResolvePostgresCIDRs(t.Context(), c, "gh-ns",
+		"postgresql://postgres:secret@ghost-service.ghost-ns.svc:5432/hoh")
+	require.Error(t, err, "expected error for unresolvable postgres host")
+	assert.Contains(t, err.Error(), "resolve postgres host", "unexpected error message")
+}
+
 func TestParseServiceHost(t *testing.T) {
 	tests := []struct {
 		host     string

--- a/operator/pkg/networkpolicy/resolve_test.go
+++ b/operator/pkg/networkpolicy/resolve_test.go
@@ -105,9 +105,15 @@ func TestResolvePostgresCIDRs_EmptyURI(t *testing.T) {
 func TestResolvePostgresCIDRs_InvalidURIDoesNotLeakCredentials(t *testing.T) {
 	scheme := newTestScheme(t)
 	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
 	_, err := ResolvePostgresCIDRs(t.Context(), c, "gh-ns", "://postgres:supersecret@bad-uri")
 	require.Error(t, err, "expected error for invalid postgres URI")
-	assert.NotContains(t, err.Error(), "supersecret", "error must not contain database credentials")
+	assert.NotContains(t, err.Error(), "supersecret", "parse error must not contain database credentials")
+
+	_, err = ResolvePostgresCIDRs(t.Context(), c, "gh-ns",
+		"postgresql://postgres:supersecret@missing-postgres.ghost-ns.svc:5432/hoh")
+	require.Error(t, err, "expected error for unresolvable postgres host")
+	assert.NotContains(t, err.Error(), "supersecret", "host resolution error must not contain database credentials")
 }
 
 func TestResolvePostgresCIDRs_EmptyHost(t *testing.T) {

--- a/operator/pkg/networkpolicy/resolve_test.go
+++ b/operator/pkg/networkpolicy/resolve_test.go
@@ -102,6 +102,14 @@ func TestResolvePostgresCIDRs_EmptyURI(t *testing.T) {
 	require.Error(t, err, "expected error for empty postgres URI")
 }
 
+func TestResolvePostgresCIDRs_InvalidURIDoesNotLeakCredentials(t *testing.T) {
+	scheme := newTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	_, err := ResolvePostgresCIDRs(t.Context(), c, "gh-ns", "://postgres:supersecret@bad-uri")
+	require.Error(t, err, "expected error for invalid postgres URI")
+	assert.NotContains(t, err.Error(), "supersecret", "error must not contain database credentials")
+}
+
 func TestParseServiceHost(t *testing.T) {
 	tests := []struct {
 		host     string

--- a/operator/pkg/networkpolicy/values.go
+++ b/operator/pkg/networkpolicy/values.go
@@ -72,7 +72,7 @@ func BuildBaselineValues(ctx context.Context, c client.Client, namespace, postgr
 			postgresCIDRs, resolveErr := ResolvePostgresCIDRs(ctx, c, namespace, uri)
 			if resolveErr != nil {
 				log.Infow("using CNPG/Crunchy pod selector fallback for BYO Postgres egress",
-					"namespace", namespace, "error", resolveErr)
+					"namespace", namespace, "error", resolveErr.Error())
 			} else {
 				values.ExternalPostgresCIDRs = postgresCIDRs
 			}

--- a/operator/pkg/networkpolicy/values.go
+++ b/operator/pkg/networkpolicy/values.go
@@ -72,7 +72,7 @@ func BuildBaselineValues(ctx context.Context, c client.Client, namespace, postgr
 			postgresCIDRs, resolveErr := ResolvePostgresCIDRs(ctx, c, namespace, uri)
 			if resolveErr != nil {
 				log.Infow("using CNPG/Crunchy pod selector fallback for BYO Postgres egress",
-					"namespace", namespace, "error", resolveErr.Error())
+					"namespace", namespace)
 			} else {
 				values.ExternalPostgresCIDRs = postgresCIDRs
 			}
@@ -90,7 +90,7 @@ func BuildBaselineValues(ctx context.Context, c client.Client, namespace, postgr
 			kafkaCIDRs, resolveErr := ResolveBootstrapServerCIDRs(ctx, c, bootstrap, namespace)
 			if resolveErr != nil {
 				log.Infow("using cross-namespace Strimzi pod selector fallback for BYO Kafka egress",
-					"namespace", namespace, "error", resolveErr)
+					"namespace", namespace)
 			} else {
 				values.ExternalKafkaCIDRs = kafkaCIDRs
 			}

--- a/operator/pkg/networkpolicy/values.go
+++ b/operator/pkg/networkpolicy/values.go
@@ -19,8 +19,12 @@ package networkpolicy
 import (
 	"context"
 
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 )
 
@@ -28,9 +32,13 @@ var log = logger.DefaultZapLogger()
 
 // BaselineManifestValues is passed to baseline NetworkPolicy templates (allow-dns-and-api, operator NP).
 type BaselineManifestValues struct {
-	Namespace      string
-	PostgresName   string
-	APIServerCIDRs []string
+	Namespace             string
+	PostgresName          string
+	APIServerCIDRs        []string
+	BYOPostgres           bool
+	ExternalPostgresCIDRs []string
+	BYOKafka              bool
+	ExternalKafkaCIDRs    []string
 }
 
 // AgentManifestValues is passed to agent NetworkPolicy templates.
@@ -41,7 +49,7 @@ type AgentManifestValues struct {
 	WebhookEgressCIDRs []string
 }
 
-// BuildBaselineValues resolves API server CIDRs for hub-namespace baseline policies.
+// BuildBaselineValues resolves API server and BYO Postgres/Kafka CIDRs for hub-namespace baseline policies.
 func BuildBaselineValues(ctx context.Context, c client.Client, namespace, postgresName string) BaselineManifestValues {
 	values := BaselineManifestValues{
 		Namespace:    namespace,
@@ -51,9 +59,46 @@ func BuildBaselineValues(ctx context.Context, c client.Client, namespace, postgr
 	if err != nil {
 		log.Infow("using ports-only API egress fallback for baseline NetworkPolicy",
 			"namespace", namespace, "error", err)
-		return values
+	} else {
+		values.APIServerCIDRs = cidrs
 	}
-	values.APIServerCIDRs = cidrs
+
+	pgSecret := &corev1.Secret{}
+	if err := c.Get(ctx, types.NamespacedName{
+		Name: constants.GHStorageSecretName, Namespace: namespace,
+	}, pgSecret); err == nil {
+		values.BYOPostgres = true
+		if uri := string(pgSecret.Data["database_uri"]); uri != "" {
+			postgresCIDRs, resolveErr := ResolvePostgresCIDRs(ctx, c, namespace, uri)
+			if resolveErr != nil {
+				log.Infow("using CNPG/Crunchy pod selector fallback for BYO Postgres egress",
+					"namespace", namespace, "error", resolveErr)
+			} else {
+				values.ExternalPostgresCIDRs = postgresCIDRs
+			}
+		}
+	} else if !apierrors.IsNotFound(err) {
+		log.Warnw("failed to read BYO postgres secret for NetworkPolicy egress", "namespace", namespace, "error", err)
+	}
+
+	kafkaSecret := &corev1.Secret{}
+	if err := c.Get(ctx, types.NamespacedName{
+		Name: constants.GHTransportSecretName, Namespace: namespace,
+	}, kafkaSecret); err == nil {
+		values.BYOKafka = true
+		if bootstrap := string(kafkaSecret.Data["bootstrap_server"]); bootstrap != "" {
+			kafkaCIDRs, resolveErr := ResolveBootstrapServerCIDRs(ctx, c, bootstrap, namespace)
+			if resolveErr != nil {
+				log.Infow("using cross-namespace Strimzi pod selector fallback for BYO Kafka egress",
+					"namespace", namespace, "error", resolveErr)
+			} else {
+				values.ExternalKafkaCIDRs = kafkaCIDRs
+			}
+		}
+	} else if !apierrors.IsNotFound(err) {
+		log.Warnw("failed to read BYO kafka secret for NetworkPolicy egress", "namespace", namespace, "error", err)
+	}
+
 	return values
 }
 

--- a/operator/pkg/networkpolicy/values_test.go
+++ b/operator/pkg/networkpolicy/values_test.go
@@ -71,6 +71,47 @@ func TestBuildBaselineValues_Fallback(t *testing.T) {
 
 	values := BuildBaselineValues(t.Context(), c, "gh-ns", "postgres")
 	assert.Empty(t, values.APIServerCIDRs, "expected empty API server CIDR fallback")
+	assert.False(t, values.BYOPostgres, "expected built-in postgres mode")
+	assert.False(t, values.BYOKafka, "expected built-in kafka mode")
+}
+
+func TestBuildBaselineValues_BYO(t *testing.T) {
+	scheme := newTestScheme(t)
+	objs := append(
+		kubernetesServiceObjects(),
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "hoh-rw",
+				Namespace: "multicluster-global-hub-postgres",
+			},
+			Spec: corev1.ServiceSpec{ClusterIP: "172.30.5.56"},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "multicluster-global-hub-storage",
+				Namespace: "gh-ns",
+			},
+			Data: map[string][]byte{
+				"database_uri": []byte("postgresql://postgres:secret@hoh-rw.multicluster-global-hub-postgres.svc:5432/hoh"),
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "multicluster-global-hub-transport",
+				Namespace: "gh-ns",
+			},
+			Data: map[string][]byte{
+				"bootstrap_server": []byte("203.0.113.10:9093"),
+			},
+		},
+	)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
+
+	values := BuildBaselineValues(t.Context(), c, "gh-ns", "postgres")
+	assert.True(t, values.BYOPostgres, "expected BYO postgres mode")
+	assert.True(t, values.BYOKafka, "expected BYO kafka mode")
+	assert.Equal(t, []string{"172.30.5.56/32"}, values.ExternalPostgresCIDRs, "BYO postgres CIDRs")
+	assert.Equal(t, []string{"203.0.113.10/32"}, values.ExternalKafkaCIDRs, "BYO kafka CIDRs")
 }
 
 func TestBuildAgentValues(t *testing.T) {

--- a/operator/pkg/networkpolicy/values_test.go
+++ b/operator/pkg/networkpolicy/values_test.go
@@ -114,6 +114,95 @@ func TestBuildBaselineValues_BYO(t *testing.T) {
 	assert.Equal(t, []string{"203.0.113.10/32"}, values.ExternalKafkaCIDRs, "BYO kafka CIDRs")
 }
 
+func TestBuildBaselineValues_BYOPostgresFallback(t *testing.T) {
+	scheme := newTestScheme(t)
+	objs := append(kubernetesServiceObjects(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "multicluster-global-hub-storage",
+			Namespace: "gh-ns",
+		},
+		Data: map[string][]byte{
+			"database_uri": []byte("postgresql://postgres:secret@missing-postgres.example.com:5432/hoh"),
+		},
+	})
+	c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
+
+	values := BuildBaselineValues(t.Context(), c, "gh-ns", "postgres")
+	assert.True(t, values.BYOPostgres, "expected BYO postgres mode")
+	assert.Empty(t, values.ExternalPostgresCIDRs, "expected postgres CIDR fallback")
+	assert.False(t, values.BYOKafka, "expected built-in kafka mode")
+}
+
+func TestBuildBaselineValues_BYOKafkaFallback(t *testing.T) {
+	scheme := newTestScheme(t)
+	objs := append(kubernetesServiceObjects(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "multicluster-global-hub-transport",
+			Namespace: "gh-ns",
+		},
+		Data: map[string][]byte{
+			"bootstrap_server": []byte("missing-kafka.example.com:9093"),
+		},
+	})
+	c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
+
+	values := BuildBaselineValues(t.Context(), c, "gh-ns", "postgres")
+	assert.False(t, values.BYOPostgres, "expected built-in postgres mode")
+	assert.True(t, values.BYOKafka, "expected BYO kafka mode")
+	assert.Empty(t, values.ExternalKafkaCIDRs, "expected kafka CIDR fallback")
+}
+
+func TestBuildBaselineValues_BYOEmptySecretFields(t *testing.T) {
+	scheme := newTestScheme(t)
+	objs := append(kubernetesServiceObjects(),
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "multicluster-global-hub-storage", Namespace: "gh-ns",
+			},
+			Data: map[string][]byte{"database_uri": {}},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "multicluster-global-hub-transport", Namespace: "gh-ns",
+			},
+			Data: map[string][]byte{"bootstrap_server": {}},
+		},
+	)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
+
+	values := BuildBaselineValues(t.Context(), c, "gh-ns", "postgres")
+	assert.True(t, values.BYOPostgres, "expected BYO postgres secret present")
+	assert.True(t, values.BYOKafka, "expected BYO kafka secret present")
+	assert.Empty(t, values.ExternalPostgresCIDRs, "empty database_uri should not resolve CIDRs")
+	assert.Empty(t, values.ExternalKafkaCIDRs, "empty bootstrap_server should not resolve CIDRs")
+}
+
+func TestBuildBaselineValues_BYOPostgresOnly(t *testing.T) {
+	scheme := newTestScheme(t)
+	objs := append(kubernetesServiceObjects(),
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "hoh-rw", Namespace: "multicluster-global-hub-postgres",
+			},
+			Spec: corev1.ServiceSpec{ClusterIP: "172.30.5.56"},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "multicluster-global-hub-storage", Namespace: "gh-ns",
+			},
+			Data: map[string][]byte{
+				"database_uri": []byte("postgresql://postgres:secret@hoh-rw.multicluster-global-hub-postgres.svc:5432/hoh"),
+			},
+		},
+	)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
+
+	values := BuildBaselineValues(t.Context(), c, "gh-ns", "postgres")
+	assert.True(t, values.BYOPostgres)
+	assert.False(t, values.BYOKafka)
+	assert.Equal(t, []string{"172.30.5.56/32"}, values.ExternalPostgresCIDRs)
+}
+
 func TestBuildAgentValues(t *testing.T) {
 	scheme := newTestScheme(t)
 	objs := append(

--- a/operator/pkg/networkpolicy/values_test.go
+++ b/operator/pkg/networkpolicy/values_test.go
@@ -122,7 +122,7 @@ func TestBuildBaselineValues_BYOPostgresFallback(t *testing.T) {
 			Namespace: "gh-ns",
 		},
 		Data: map[string][]byte{
-			"database_uri": []byte("postgresql://postgres:secret@missing-postgres.example.com:5432/hoh"),
+			"database_uri": []byte("postgresql://postgres:secret@missing-postgres.ghost-ns.svc:5432/hoh"),
 		},
 	})
 	c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
@@ -141,7 +141,7 @@ func TestBuildBaselineValues_BYOKafkaFallback(t *testing.T) {
 			Namespace: "gh-ns",
 		},
 		Data: map[string][]byte{
-			"bootstrap_server": []byte("missing-kafka.example.com:9093"),
+			"bootstrap_server": []byte("missing-kafka.ghost-ns.svc:9093"),
 		},
 	})
 	c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
@@ -154,7 +154,8 @@ func TestBuildBaselineValues_BYOKafkaFallback(t *testing.T) {
 
 func TestBuildBaselineValues_BYOEmptySecretFields(t *testing.T) {
 	scheme := newTestScheme(t)
-	objs := append(kubernetesServiceObjects(),
+	objs := append(
+		kubernetesServiceObjects(),
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "multicluster-global-hub-storage", Namespace: "gh-ns",
@@ -179,7 +180,8 @@ func TestBuildBaselineValues_BYOEmptySecretFields(t *testing.T) {
 
 func TestBuildBaselineValues_BYOPostgresOnly(t *testing.T) {
 	scheme := newTestScheme(t)
-	objs := append(kubernetesServiceObjects(),
+	objs := append(
+		kubernetesServiceObjects(),
 		&corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "hoh-rw", Namespace: "multicluster-global-hub-postgres",
@@ -198,9 +200,9 @@ func TestBuildBaselineValues_BYOPostgresOnly(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
 
 	values := BuildBaselineValues(t.Context(), c, "gh-ns", "postgres")
-	assert.True(t, values.BYOPostgres)
-	assert.False(t, values.BYOKafka)
-	assert.Equal(t, []string{"172.30.5.56/32"}, values.ExternalPostgresCIDRs)
+	assert.True(t, values.BYOPostgres, "expected BYO postgres mode")
+	assert.False(t, values.BYOKafka, "expected built-in kafka mode")
+	assert.Equal(t, []string{"172.30.5.56/32"}, values.ExternalPostgresCIDRs, "BYO postgres CIDRs")
 }
 
 func TestBuildAgentValues(t *testing.T) {


### PR DESCRIPTION
Fixes: [ACM-37165](https://redhat.atlassian.net/browse/ACM-37165)

## Summary

- Add ports-only egress on TCP 5432 (Postgres) and TCP 9091/9093 (Kafka) to the operator NetworkPolicy for external/BYO endpoints
- Keep existing in-namespace pod selectors for built-in Postgres and Strimzi Kafka deployments
- Document BYO NetworkPolicy behavior in `ai-doc/NETWORKPOLICY.md`

## Context

[ACM-37165](https://redhat.atlassian.net/browse/ACM-37165) reports MCGH stuck in `Progressing` on HoH 5.0 BYO install: operator logs show `connection timed out` to CNPG Postgres in `multicluster-global-hub-postgres` while the database cluster is healthy.

Root cause: GH 5.0 NetworkPolicy baseline (#2493) deploys `default-deny-all` plus component policies. The operator NP only allowed Postgres/Kafka egress to in-namespace pod labels (`name: multicluster-global-hub-postgresql`, `strimzi.io/cluster: kafka`). BYO Postgres/Kafka run in separate namespaces with different labels — no matching egress rule.

Grafana already uses ports-only TCP 5432 egress for in-cluster or external Postgres; the operator did not.

**Related work (merged today, separate scope):**
- multicluster-global-hub#2617 — ACM-32313 ipBlock hardening (API server + Kafka bootstrap resolution)
- [multicluster-global-hub-operator-bundle#1460](https://github.com/stolostron/multicluster-global-hub-operator-bundle/pull/1460) — syncs operator CSV RBAC (`endpointslices`, `networks`) required for #2617 ipBlock resolution on OLM installs

This PR addresses a **different gap** discovered during BYO QE: missing operator egress to external Postgres/Kafka namespaces. **No companion operator-bundle PR is needed** — this change is in embedded NetworkPolicy manifests only, not ClusterRole/CSV permissions.

## Test plan

- [ ] Fresh GH 5.0 BYO install (CNPG + Strimzi in separate namespaces): operator reaches Postgres, manager deploys, MCGH becomes Ready
- [ ] Built-in Postgres/Kafka install: in-namespace pod selector rules still apply; no regression
- [ ] Operator pod TCP test: `echo > /dev/tcp/<byo-postgres-svc>/5432` succeeds (was timeout before)
- [ ] QE workaround validation: patch/delete operator NP no longer required after fix


Made with [Cursor](https://cursor.com)

[ACM-37165]: https://redhat.atlassian.net/browse/ACM-37165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the operator NetworkPolicy egress rules to correctly handle cross-namespace Bring Your Own (BYO) PostgreSQL and Kafka, preferring resolved external CIDRs when available and falling back to pod selectors when not.
* **Documentation**
  * Added/expanded documentation for cross-namespace BYO PostgreSQL and Kafka connectivity requirements, including known limitations and follow-ups.
* **Tests**
  * Added unit tests for BYO PostgreSQL CIDR resolution, secret/URI error handling, and NetworkPolicy manifest rendering for CIDR-based and selector-based behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->