### PR TITLE
Fix SonarCloud branch post-submit on main (librdkafka + tool install)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,8 +34,8 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false
-      - name: install ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo
+      - name: Setup test tools
+        run: go install tool
       - name: SET E2E
         run: |
           make kessel-e2e-setup

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,12 +27,9 @@ jobs:
           go-version: '1.26'
           cache: false
 
-      - name: Setup gci
-        run: go install github.com/daixiang0/gci
+      - name: Setup format tools
+        run: go install tool
 
-      - name: Setup gofumpt
-        run: go install mvdan.cc/gofumpt
-        
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:

--- a/go.mod
+++ b/go.mod
@@ -229,5 +229,6 @@ replace sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.19.1
 
 tool (
 	github.com/daixiang0/gci
+	github.com/onsi/ginkgo/v2/ginkgo
 	mvdan.cc/gofumpt
 )

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@ sonar.projectKey=open-cluster-management_hub-of-hubs
 sonar.projectName=hub-of-hubs
 
 sonar.sources=.
-sonar.exclusions=test/**,**/*.sql,**/*.yaml,**/*.py,**/*_test.go,**/*_generated*.go,**/*_generated/**,**/vendor/**,samples/**
+sonar.exclusions=test/**,**/*.sql,**/*.yaml,**/*.py,**/*_test.go,**/*_generated*.go,**/*_generated/**,**/vendor/**,librdkafka/**,samples/**
 
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go


### PR DESCRIPTION
## Summary

- Exclude `librdkafka/**` from Sonar analysis in `sonar-project.properties` (upstream submodule C code was driving overall security/reliability ratings to E on branch post-submit)
- Add `github.com/onsi/ginkgo/v2/ginkgo` to the `go.mod` `tool` block; switch `go.yml` and `e2e.yml` to `go install tool` (S8545), following [#2610](https://github.com/stolostron/multicluster-global-hub/pull/2610) / [#2589](https://github.com/stolostron/multicluster-global-hub/pull/2589)

## Why

`branch-ci-stolostron-multicluster-global-hub-main-sonarcloud-post-submit` (and `release-5.0` ffwd) has been failing since Jul 6 with overall **E** security/reliability ratings from `librdkafka/` findings plus low new-code coverage on dependency-only pushes. PR Sonar checks still pass; branch post-submit enforces overall branch ratings.

Workflow pinning (#2559, #2527) was already on main; this adds the remaining `go install tool` hygiene and stops scanning vendored submodule sources.

## Test plan

- [ ] SonarCloud Code Analysis passes on this PR
- [ ] GitHub Actions `Go` and `e2e` workflows pass
- [ ] After merge to `main`, `branch-ci-stolostron-multicluster-global-hub-main-sonarcloud-post-submit` quality gate returns green; `release-5.0` follows via ffwd


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined automation setup for end-to-end and formatting workflows by using a shared tool installation step.
  * Expanded project analysis exclusions to ignore an additional third-party directory during scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->