### PR TITLE
ACM-37165: re-reconcile NetworkPolicy when BYO secrets change

### DIFF
--- a/operator/pkg/controllers/networkpolicy/networkpolicy_controller.go
+++ b/operator/pkg/controllers/networkpolicy/networkpolicy_controller.go
@@ -5,7 +5,9 @@ import (
 	"embed"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/kubernetes"
@@ -23,12 +25,14 @@ import (
 	nputils "github.com/stolostron/multicluster-global-hub/operator/pkg/networkpolicy"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/renderer"
 	operatorutils "github.com/stolostron/multicluster-global-hub/operator/pkg/utils"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 	commonutils "github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
 // +kubebuilder:rbac:groups=operator.open-cluster-management.io,resources=multiclusterglobalhubs,verbs=get;list;watch;
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;delete
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch
 // +kubebuilder:rbac:groups=discovery.k8s.io,resources=endpointslices,verbs=get;list;watch
 // +kubebuilder:rbac:groups=config.openshift.io,resources=networks,verbs=get;list;watch
@@ -42,6 +46,11 @@ const (
 	NetworkPolicyDefaultDenyAll = "default-deny-all"
 	NetworkPolicyAllowDNSAndAPI = "allow-dns-and-api"
 	NetworkPolicyOperator       = "multicluster-global-hub-operator"
+)
+
+var watchedByoSecrets = sets.NewString(
+	constants.GHStorageSecretName,
+	constants.GHTransportSecretName,
 )
 
 type NetworkPolicyReconciler struct {
@@ -100,9 +109,31 @@ func (r *NetworkPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Named("networkpolicyController").
 		For(&v1alpha4.MulticlusterGlobalHub{},
 			builder.WithPredicates(config.MGHPred)).
+		Watches(&corev1.Secret{},
+			&handler.EnqueueRequestForObject{}, builder.WithPredicates(byoSecretPred)).
 		Watches(&networkingv1.NetworkPolicy{},
 			&handler.EnqueueRequestForObject{}, builder.WithPredicates(networkPolicyPred)).
 		Complete(r)
+}
+
+func isWatchedByoSecret(obj client.Object) bool {
+	ns := networkPolicyWatchNamespace
+	if ns == "" {
+		ns = commonutils.GetDefaultNamespace()
+	}
+	return obj.GetNamespace() == ns && watchedByoSecrets.Has(obj.GetName())
+}
+
+var byoSecretPred = predicate.Funcs{
+	CreateFunc: func(e event.CreateEvent) bool {
+		return isWatchedByoSecret(e.Object)
+	},
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		return isWatchedByoSecret(e.ObjectNew)
+	},
+	DeleteFunc: func(e event.DeleteEvent) bool {
+		return isWatchedByoSecret(e.Object)
+	},
 }
 
 var networkPolicyPred = predicate.Funcs{

--- a/operator/pkg/controllers/networkpolicy/networkpolicy_controller_test.go
+++ b/operator/pkg/controllers/networkpolicy/networkpolicy_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -11,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
@@ -85,6 +87,104 @@ func TestNetworkPolicyPredicate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assertPredicateAllEvents(t, networkPolicyPred, tt.obj, tt.wantBool)
+		})
+	}
+}
+
+func TestByoSecretPredicate(t *testing.T) {
+	namespace := utils.GetDefaultNamespace()
+
+	tests := []struct {
+		name     string
+		obj      *corev1.Secret
+		wantBool bool
+	}{
+		{
+			name: "BYO storage secret should match",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.GHStorageSecretName,
+					Namespace: namespace,
+				},
+			},
+			wantBool: true,
+		},
+		{
+			name: "BYO transport secret should match",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.GHTransportSecretName,
+					Namespace: namespace,
+				},
+			},
+			wantBool: true,
+		},
+		{
+			name: "unrelated secret should not match",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "other-secret",
+					Namespace: namespace,
+				},
+			},
+			wantBool: false,
+		},
+		{
+			name: "BYO storage secret in wrong namespace should not match",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.GHStorageSecretName,
+					Namespace: "wrong-namespace",
+				},
+			},
+			wantBool: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertPredicateAllEvents(t, byoSecretPred, tt.obj, tt.wantBool)
+		})
+	}
+}
+
+func TestIsWatchedByoSecretCustomNamespace(t *testing.T) {
+	originalNS := networkPolicyWatchNamespace
+	t.Cleanup(func() { networkPolicyWatchNamespace = originalNS })
+
+	customNamespace := "custom-namespace"
+	networkPolicyWatchNamespace = customNamespace
+
+	tests := []struct {
+		name     string
+		obj      *corev1.Secret
+		wantBool bool
+	}{
+		{
+			name: "BYO secret in custom namespace should match",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.GHStorageSecretName,
+					Namespace: customNamespace,
+				},
+			},
+			wantBool: true,
+		},
+		{
+			name: "BYO secret in default namespace should NOT match when custom namespace is set",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.GHStorageSecretName,
+					Namespace: utils.GetDefaultNamespace(),
+				},
+			},
+			wantBool: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantBool, isWatchedByoSecret(tt.obj))
 		})
 	}
 }


### PR DESCRIPTION
Fixes: [ACM-37165](https://redhat.atlassian.net/browse/ACM-37165)

## Summary

- Watch `multicluster-global-hub-storage` and `multicluster-global-hub-transport` secrets in the NetworkPolicy controller so operator NetworkPolicy is re-rendered when BYO secrets are created or updated after the `MulticlusterGlobalHub` CR.
- Hardens the BYO Postgres/Kafka egress fix from #2618 for install flows where secrets land after the MGH CR (e.g. Jenkins BYO e2e).

## Context

#2618 adds BYO egress rules only when the storage/transport secret is present at reconcile time. Without a secret watch, netpol stayed stale if the MGH CR was applied first — operator could not reach external CNPG until the CR changed or netpol was patched manually.

## Test plan

- [x] `go test -mod=mod ./operator/pkg/controllers/networkpolicy/...`
- [ ] CI unit/integration checks on PR


Made with [Cursor](https://cursor.com)

[ACM-37165]: https://redhat.atlassian.net/browse/ACM-37165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The network policy controller now automatically refreshes reconciliation when the configured “BYO” storage or transport secrets change.
  * Secret change events are only processed within the intended watch namespace, limiting unnecessary reconciliations.

* **Tests**
  * Added unit tests covering the BYO secret predicate and namespace-scoped secret watch behavior, ensuring only the correct secrets trigger updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->