### PR TITLE
ACM-35632: add Hub HA lifecycle E2E integration tests

### DIFF
--- a/test/integration/agent/hubha/lifecycle/hubha_lifecycle_e2e_test.go
+++ b/test/integration/agent/hubha/lifecycle/hubha_lifecycle_e2e_test.go
@@ -5,6 +5,7 @@ package lifecycle
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -24,8 +25,9 @@ import (
 )
 
 type mockProducer struct {
+	mu      sync.RWMutex
 	events  chan cloudevents.Event
-	closed  atomic.Bool
+	closed  bool
 	dropped atomic.Int64
 }
 
@@ -36,7 +38,9 @@ func newMockProducer() *mockProducer {
 }
 
 func (m *mockProducer) SendEvent(ctx context.Context, evt cloudevents.Event) error {
-	if m.closed.Load() {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.closed {
 		return nil
 	}
 
@@ -53,7 +57,12 @@ func (m *mockProducer) SendEvent(ctx context.Context, evt cloudevents.Event) err
 }
 
 func (m *mockProducer) Stop() {
-	m.closed.Store(true)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return
+	}
+	m.closed = true
 	close(m.events)
 }
 
@@ -84,7 +93,7 @@ func upsertAgentConfigCM(ctx context.Context, hubRole, standbyHub string) {
 	}, cm)
 	if err != nil {
 		cm.Data = map[string]string{}
-		Expect(k8sClient.Create(ctx, cm)).To(Succeed())
+		Expect(k8sClient.Create(ctx, cm)).To(Succeed(), "failed to create agent ConfigMap %s/%s", constants.GHAgentNamespace, constants.GHAgentConfigCMName)
 	}
 
 	Eventually(func() error {
@@ -109,7 +118,7 @@ func upsertAgentConfigCM(ctx context.Context, hubRole, standbyHub string) {
 			current.Data["standbyHub"] = standbyHub
 		}
 		return k8sClient.Update(ctx, current)
-	}, 5*time.Second, 200*time.Millisecond).Should(Succeed())
+	}, 5*time.Second, 200*time.Millisecond).Should(Succeed(), "failed to upsert agent ConfigMap with hubRole=%q standbyHub=%q", hubRole, standbyHub)
 }
 
 func waitForAgentHubRole(hubRole, standbyHub string) {
@@ -118,7 +127,7 @@ func waitForAgentHubRole(hubRole, standbyHub string) {
 		g.Expect(config).NotTo(BeNil())
 		g.Expect(config.GetHubRole()).To(Equal(hubRole))
 		g.Expect(config.GetStandbyHub()).To(Equal(standbyHub))
-	}, 10*time.Second, 200*time.Millisecond).Should(Succeed())
+	}, 10*time.Second, 200*time.Millisecond).Should(Succeed(), "agent config hubRole/standbyHub did not reach %q/%q", hubRole, standbyHub)
 }
 
 func deleteAgentConfigCM(ctx context.Context) {
@@ -128,7 +137,7 @@ func deleteAgentConfigCM(ctx context.Context) {
 			Namespace: constants.GHAgentNamespace,
 		},
 	}
-	Expect(k8sClient.Delete(ctx, cm)).To(Succeed())
+	Expect(k8sClient.Delete(ctx, cm)).To(Succeed(), "failed to delete agent ConfigMap %s/%s", constants.GHAgentNamespace, constants.GHAgentConfigCMName)
 	Eventually(func() bool {
 		err := k8sClient.Get(ctx, types.NamespacedName{
 			Name:      constants.GHAgentConfigCMName,
@@ -149,6 +158,12 @@ func assertNoHubHAEvents(producer *mockProducer, reason string) {
 	}, 3*time.Second, 200*time.Millisecond).Should(BeTrue(), reason)
 }
 
+func assertSyncerDisabledFor(ctx context.Context, producer *mockProducer, cmName, reason string) {
+	drainProducerEvents(producer)
+	createSyncableConfigMap(ctx, cmName)
+	assertNoHubHAEvents(producer, reason)
+}
+
 func createSyncableConfigMap(ctx context.Context, name string) {
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -162,7 +177,7 @@ func createSyncableConfigMap(ctx context.Context, name string) {
 			"key": "value",
 		},
 	}
-	Expect(k8sClient.Create(ctx, cm)).To(Succeed())
+	Expect(k8sClient.Create(ctx, cm)).To(Succeed(), "failed to create syncable ConfigMap %s", name)
 }
 
 func waitForHubHAEvent(producer *mockProducer, name string) cloudevents.Event {
@@ -221,11 +236,12 @@ var _ = Describe("Hub HA Lifecycle E2E Integration", Ordered, func() {
 
 		upsertAgentConfigCM(testCtx, constants.GHHubRoleStandby, "hub2")
 		waitForAgentHubRole(constants.GHHubRoleStandby, "hub2")
-		drainProducerEvents(suiteProducer)
-
-		createSyncableConfigMap(testCtx, "lifecycle-e2e-standby-cm")
-
-		assertNoHubHAEvents(suiteProducer, "active syncer should not emit events in standby role")
+		assertSyncerDisabledFor(
+			testCtx,
+			suiteProducer,
+			"lifecycle-e2e-standby-cm",
+			"active syncer should not emit events in standby role",
+		)
 	})
 
 	It("should route events to the updated standby hub without restarting the agent", func() {
@@ -241,7 +257,7 @@ var _ = Describe("Hub HA Lifecycle E2E Integration", Ordered, func() {
 
 		createSyncableConfigMap(testCtx, "lifecycle-e2e-new-standby-cm")
 		evt := waitForHubHAEvent(suiteProducer, "lifecycle-e2e-new-standby-cm")
-		Expect(evt.Subject()).To(Equal("hub3"))
+		Expect(evt.Subject()).To(Equal("hub3"), "emitter should route events to updated standby hub")
 	})
 
 	It("should stop sending events when the agent ConfigMap is deleted", func() {
@@ -254,10 +270,11 @@ var _ = Describe("Hub HA Lifecycle E2E Integration", Ordered, func() {
 
 		deleteAgentConfigCM(testCtx)
 		waitForAgentHubRole("", "")
-		drainProducerEvents(suiteProducer)
-
-		createSyncableConfigMap(testCtx, "lifecycle-e2e-after-delete-cm")
-
-		assertNoHubHAEvents(suiteProducer, "active syncer should not emit events after agent ConfigMap deletion")
+		assertSyncerDisabledFor(
+			testCtx,
+			suiteProducer,
+			"lifecycle-e2e-after-delete-cm",
+			"active syncer should not emit events after agent ConfigMap deletion",
+		)
 	})
 })

--- a/test/integration/agent/hubha/lifecycle/hubha_lifecycle_e2e_test.go
+++ b/test/integration/agent/hubha/lifecycle/hubha_lifecycle_e2e_test.go
@@ -1,0 +1,225 @@
+// Copyright (c) 2025 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package lifecycle
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+
+	agentconfigs "github.com/stolostron/multicluster-global-hub/agent/pkg/configs"
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/syncers/configmap"
+	"github.com/stolostron/multicluster-global-hub/pkg/bundle/generic"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport"
+)
+
+type mockProducer struct {
+	events  chan cloudevents.Event
+	closed  atomic.Bool
+	dropped atomic.Int64
+}
+
+func newMockProducer() *mockProducer {
+	return &mockProducer{
+		events: make(chan cloudevents.Event, 1000),
+	}
+}
+
+func (m *mockProducer) SendEvent(ctx context.Context, evt cloudevents.Event) error {
+	if m.closed.Load() {
+		return nil
+	}
+
+	select {
+	case m.events <- evt:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		m.dropped.Add(1)
+		GinkgoWriter.Printf("WARNING: Event dropped! Total dropped: %d\n", m.dropped.Load())
+		return nil
+	}
+}
+
+func (m *mockProducer) Stop() {
+	m.closed.Store(true)
+	close(m.events)
+}
+
+func (m *mockProducer) Reconnect(config *transport.TransportInternalConfig, clusterName string) error {
+	return nil
+}
+
+func drainProducerEvents(producer *mockProducer) {
+	for {
+		select {
+		case <-producer.events:
+		default:
+			return
+		}
+	}
+}
+
+func upsertAgentConfigCM(ctx context.Context, hubRole, standbyHub string) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.GHAgentConfigCMName,
+			Namespace: constants.GHAgentNamespace,
+		},
+	}
+	err := k8sClient.Get(ctx, types.NamespacedName{
+		Name:      constants.GHAgentConfigCMName,
+		Namespace: constants.GHAgentNamespace,
+	}, cm)
+	if err != nil {
+		cm.Data = map[string]string{}
+		Expect(k8sClient.Create(ctx, cm)).To(Succeed())
+	}
+
+	Eventually(func() error {
+		current := &corev1.ConfigMap{}
+		if getErr := k8sClient.Get(ctx, types.NamespacedName{
+			Name:      constants.GHAgentConfigCMName,
+			Namespace: constants.GHAgentNamespace,
+		}, current); getErr != nil {
+			return getErr
+		}
+		if current.Data == nil {
+			current.Data = map[string]string{}
+		}
+		if hubRole == "" {
+			delete(current.Data, configmap.AgentHubRoleKey)
+		} else {
+			current.Data[configmap.AgentHubRoleKey] = hubRole
+		}
+		if standbyHub == "" {
+			delete(current.Data, "standbyHub")
+		} else {
+			current.Data["standbyHub"] = standbyHub
+		}
+		return k8sClient.Update(ctx, current)
+	}, 5*time.Second, 200*time.Millisecond).Should(Succeed())
+}
+
+func waitForAgentHubRole(hubRole, standbyHub string) {
+	Eventually(func(g Gomega) {
+		config := agentconfigs.GetAgentConfig()
+		g.Expect(config).NotTo(BeNil())
+		g.Expect(config.GetHubRole()).To(Equal(hubRole))
+		g.Expect(config.GetStandbyHub()).To(Equal(standbyHub))
+	}, 10*time.Second, 200*time.Millisecond).Should(Succeed())
+}
+
+func createSyncableConfigMap(ctx context.Context, name string) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels: map[string]string{
+				"hive.openshift.io/secret-type": "kubeconfig",
+			},
+		},
+		Data: map[string]string{
+			"key": "value",
+		},
+	}
+	Expect(k8sClient.Create(ctx, cm)).To(Succeed())
+}
+
+func waitForHubHAEvent(producer *mockProducer, name string) cloudevents.Event {
+	var evt cloudevents.Event
+	Eventually(func() bool {
+		select {
+		case received := <-producer.events:
+			Expect(received.Type()).To(Equal(constants.HubHAResourcesMsgKey))
+			Expect(received.Source()).To(Equal("hub1"))
+
+			bundle := generic.NewGenericBundle[*unstructured.Unstructured]()
+			Expect(received.DataAs(bundle)).To(Succeed())
+			for _, obj := range bundle.Update {
+				if obj.GetKind() == "ConfigMap" && obj.GetName() == name {
+					evt = received
+					return true
+				}
+			}
+			return false
+		case <-time.After(100 * time.Millisecond):
+			return false
+		}
+	}, 10*time.Second, 100*time.Millisecond).Should(BeTrue(), "expected Hub HA event for ConfigMap %s", name)
+	return evt
+}
+
+var _ = Describe("Hub HA Lifecycle E2E Integration", Ordered, func() {
+	var (
+		agentNamespace = constants.GHAgentNamespace
+		configMapName  = constants.GHAgentConfigCMName
+	)
+
+	AfterAll(func() {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      configMapName,
+				Namespace: agentNamespace,
+			},
+		}
+		_ = k8sClient.Delete(context.Background(), cm)
+	})
+
+	It("should start active syncer and send events when ConfigMap sets hubRole=active and standbyHub", func() {
+		testCtx := context.Background()
+
+		upsertAgentConfigCM(testCtx, constants.GHHubRoleActive, "hub2")
+		waitForAgentHubRole(constants.GHHubRoleActive, "hub2")
+		drainProducerEvents(suiteProducer)
+
+		createSyncableConfigMap(testCtx, "lifecycle-e2e-active-cm")
+		waitForHubHAEvent(suiteProducer, "lifecycle-e2e-active-cm")
+	})
+
+	It("should stop sending events when hubRole changes to standby", func() {
+		testCtx := context.Background()
+
+		upsertAgentConfigCM(testCtx, constants.GHHubRoleStandby, "hub2")
+		waitForAgentHubRole(constants.GHHubRoleStandby, "hub2")
+		drainProducerEvents(suiteProducer)
+
+		createSyncableConfigMap(testCtx, "lifecycle-e2e-standby-cm")
+
+		Consistently(func() bool {
+			select {
+			case <-suiteProducer.events:
+				return false
+			default:
+				return true
+			}
+		}, 3*time.Second, 200*time.Millisecond).Should(BeTrue(), "active syncer should not emit events in standby role")
+	})
+
+	It("should route events to the updated standby hub without restarting the agent", func() {
+		testCtx := context.Background()
+
+		upsertAgentConfigCM(testCtx, constants.GHHubRoleActive, "hub2")
+		waitForAgentHubRole(constants.GHHubRoleActive, "hub2")
+		drainProducerEvents(suiteProducer)
+
+		upsertAgentConfigCM(testCtx, constants.GHHubRoleActive, "hub3")
+		waitForAgentHubRole(constants.GHHubRoleActive, "hub3")
+		drainProducerEvents(suiteProducer)
+
+		createSyncableConfigMap(testCtx, "lifecycle-e2e-new-standby-cm")
+		evt := waitForHubHAEvent(suiteProducer, "lifecycle-e2e-new-standby-cm")
+		Expect(evt.Subject()).To(Equal("hub3"))
+	})
+})

--- a/test/integration/agent/hubha/lifecycle/hubha_lifecycle_e2e_test.go
+++ b/test/integration/agent/hubha/lifecycle/hubha_lifecycle_e2e_test.go
@@ -121,6 +121,34 @@ func waitForAgentHubRole(hubRole, standbyHub string) {
 	}, 10*time.Second, 200*time.Millisecond).Should(Succeed())
 }
 
+func deleteAgentConfigCM(ctx context.Context) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.GHAgentConfigCMName,
+			Namespace: constants.GHAgentNamespace,
+		},
+	}
+	Expect(k8sClient.Delete(ctx, cm)).To(Succeed())
+	Eventually(func() bool {
+		err := k8sClient.Get(ctx, types.NamespacedName{
+			Name:      constants.GHAgentConfigCMName,
+			Namespace: constants.GHAgentNamespace,
+		}, &corev1.ConfigMap{})
+		return err != nil
+	}, 10*time.Second, 200*time.Millisecond).Should(BeTrue(), "agent ConfigMap should be deleted")
+}
+
+func assertNoHubHAEvents(producer *mockProducer, reason string) {
+	Consistently(func() bool {
+		select {
+		case <-producer.events:
+			return false
+		default:
+			return true
+		}
+	}, 3*time.Second, 200*time.Millisecond).Should(BeTrue(), reason)
+}
+
 func createSyncableConfigMap(ctx context.Context, name string) {
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -197,14 +225,7 @@ var _ = Describe("Hub HA Lifecycle E2E Integration", Ordered, func() {
 
 		createSyncableConfigMap(testCtx, "lifecycle-e2e-standby-cm")
 
-		Consistently(func() bool {
-			select {
-			case <-suiteProducer.events:
-				return false
-			default:
-				return true
-			}
-		}, 3*time.Second, 200*time.Millisecond).Should(BeTrue(), "active syncer should not emit events in standby role")
+		assertNoHubHAEvents(suiteProducer, "active syncer should not emit events in standby role")
 	})
 
 	It("should route events to the updated standby hub without restarting the agent", func() {
@@ -221,5 +242,22 @@ var _ = Describe("Hub HA Lifecycle E2E Integration", Ordered, func() {
 		createSyncableConfigMap(testCtx, "lifecycle-e2e-new-standby-cm")
 		evt := waitForHubHAEvent(suiteProducer, "lifecycle-e2e-new-standby-cm")
 		Expect(evt.Subject()).To(Equal("hub3"))
+	})
+
+	It("should stop sending events when the agent ConfigMap is deleted", func() {
+		testCtx := context.Background()
+
+		// Prior spec leaves active/hub3; confirm syncer is still emitting before delete.
+		drainProducerEvents(suiteProducer)
+		createSyncableConfigMap(testCtx, "lifecycle-e2e-pre-delete-cm")
+		waitForHubHAEvent(suiteProducer, "lifecycle-e2e-pre-delete-cm")
+
+		deleteAgentConfigCM(testCtx)
+		waitForAgentHubRole("", "")
+		drainProducerEvents(suiteProducer)
+
+		createSyncableConfigMap(testCtx, "lifecycle-e2e-after-delete-cm")
+
+		assertNoHubHAEvents(suiteProducer, "active syncer should not emit events after agent ConfigMap deletion")
 	})
 })

--- a/test/integration/agent/hubha/lifecycle/suite_test.go
+++ b/test/integration/agent/hubha/lifecycle/suite_test.go
@@ -1,0 +1,157 @@
+// Copyright (c) 2025 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package lifecycle
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/configs"
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/generic"
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/syncers/configmap"
+	hubhastatus "github.com/stolostron/multicluster-global-hub/agent/pkg/status/syncers/hubha"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport"
+)
+
+func TestHubHALifecycleE2E(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Hub HA Lifecycle E2E Integration Suite")
+}
+
+var (
+	ctx             context.Context
+	cancel          context.CancelFunc
+	testenv         *envtest.Environment
+	cfg             *rest.Config
+	k8sClient       client.Client
+	mgr             ctrl.Manager
+	transportConfig *transport.TransportInternalConfig
+	suiteProducer   *mockProducer
+)
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	ctx, cancel = context.WithCancel(context.Background())
+
+	transportConfig = &transport.TransportInternalConfig{
+		TransportType: string(transport.Chan),
+		KafkaCredential: &transport.KafkaConfig{
+			SpecTopic:   "spec",
+			StatusTopic: "status",
+		},
+	}
+
+	By("Bootstrapping test environment")
+	var err error
+	testenv = &envtest.Environment{
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Paths: []string{
+				filepath.Join("..", "..", "..", "..", "manifest", "crd",
+					"0000_00_policy.open-cluster-management.io_policies.crd.yaml"),
+				filepath.Join("..", "..", "..", "..", "manifest", "crd",
+					"0000_00_policy.open-cluster-management.io_placementbindings.crd.yaml"),
+				filepath.Join("..", "..", "..", "..", "manifest", "crd",
+					"0000_00_cluster.open-cluster-management.io_placements.crd.yaml"),
+				filepath.Join("..", "..", "..", "..", "manifest", "crd",
+					"0000_02_clusters.open-cluster-management.io_managedclusters.crd.yaml"),
+			},
+		},
+		ErrorIfCRDPathMissing: false,
+	}
+
+	cfg, err = testenv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: configs.GetRuntimeScheme()})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	testNamespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "default",
+		},
+	}
+	err = k8sClient.Create(ctx, testNamespace)
+	if err != nil {
+		Expect(client.IgnoreAlreadyExists(err)).NotTo(HaveOccurred())
+	}
+
+	agentNamespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: constants.GHAgentNamespace,
+		},
+	}
+	err = k8sClient.Create(ctx, agentNamespace)
+	if err != nil {
+		Expect(client.IgnoreAlreadyExists(err)).NotTo(HaveOccurred())
+	}
+
+	By("Setting up controller manager")
+	mgr, err = ctrl.NewManager(cfg, ctrl.Options{
+		Metrics: metricsserver.Options{
+			BindAddress: "0",
+		},
+		Scheme: configs.GetRuntimeScheme(),
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	agentConfig := &configs.AgentConfig{
+		LeafHubName:     "hub1",
+		PodNamespace:    constants.GHAgentNamespace,
+		TransportConfig: transportConfig,
+	}
+	configs.SetAgentConfig(agentConfig)
+
+	err = configmap.AddConfigMapController(mgr, agentConfig)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Setting up Hub HA lifecycle controller with real resource syncer")
+	suiteProducer = newMockProducer()
+	suitePeriodicSyncer := &generic.PeriodicSyncer{}
+	// Register lifecycle controller without WithNoOpStartResourceSyncerFn so ConfigMap
+	// changes start the real GVK-watching active syncer end-to-end.
+	err = hubhastatus.AddHubHAController(mgr, suitePeriodicSyncer, suiteProducer, agentConfig)
+	Expect(err).NotTo(HaveOccurred(), "failed to register Hub HA lifecycle controller")
+
+	go func() {
+		defer GinkgoRecover()
+		err := mgr.Start(ctx)
+		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
+	}()
+
+	Expect(mgr.GetCache().WaitForCacheSync(ctx)).To(BeTrue())
+})
+
+var _ = AfterSuite(func() {
+	By("Tearing down the test environment")
+	if suiteProducer != nil {
+		suiteProducer.Stop()
+	}
+	if cancel != nil {
+		cancel()
+	}
+	if testenv != nil {
+		err := testenv.Stop()
+		if err != nil {
+			time.Sleep(4 * time.Second)
+			_ = testenv.Stop()
+		}
+	}
+})

--- a/test/integration/agent/hubha/lifecycle/suite_test.go
+++ b/test/integration/agent/hubha/lifecycle/suite_test.go
@@ -76,12 +76,12 @@ var _ = BeforeSuite(func() {
 	}
 
 	cfg, err = testenv.Start()
-	Expect(err).NotTo(HaveOccurred())
-	Expect(cfg).NotTo(BeNil())
+	Expect(err).NotTo(HaveOccurred(), "failed to start envtest")
+	Expect(cfg).NotTo(BeNil(), "envtest config should not be nil")
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: configs.GetRuntimeScheme()})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient).NotTo(BeNil())
+	Expect(err).NotTo(HaveOccurred(), "failed to create kubernetes client")
+	Expect(k8sClient).NotTo(BeNil(), "kubernetes client should not be nil")
 
 	testNamespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -90,7 +90,7 @@ var _ = BeforeSuite(func() {
 	}
 	err = k8sClient.Create(ctx, testNamespace)
 	if err != nil {
-		Expect(client.IgnoreAlreadyExists(err)).NotTo(HaveOccurred())
+		Expect(client.IgnoreAlreadyExists(err)).NotTo(HaveOccurred(), "failed to create default namespace")
 	}
 
 	agentNamespace := &corev1.Namespace{
@@ -100,7 +100,7 @@ var _ = BeforeSuite(func() {
 	}
 	err = k8sClient.Create(ctx, agentNamespace)
 	if err != nil {
-		Expect(client.IgnoreAlreadyExists(err)).NotTo(HaveOccurred())
+		Expect(client.IgnoreAlreadyExists(err)).NotTo(HaveOccurred(), "failed to create agent namespace")
 	}
 
 	By("Setting up controller manager")
@@ -110,7 +110,7 @@ var _ = BeforeSuite(func() {
 		},
 		Scheme: configs.GetRuntimeScheme(),
 	})
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred(), "failed to create controller manager")
 
 	agentConfig := &configs.AgentConfig{
 		LeafHubName:     "hub1",
@@ -120,7 +120,7 @@ var _ = BeforeSuite(func() {
 	configs.SetAgentConfig(agentConfig)
 
 	err = configmap.AddConfigMapController(mgr, agentConfig)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred(), "failed to register configmap controller")
 
 	By("Setting up Hub HA lifecycle controller with real resource syncer")
 	suiteProducer = newMockProducer()
@@ -136,16 +136,18 @@ var _ = BeforeSuite(func() {
 		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
 	}()
 
-	Expect(mgr.GetCache().WaitForCacheSync(ctx)).To(BeTrue())
+	syncCtx, syncCancel := context.WithTimeout(ctx, 30*time.Second)
+	defer syncCancel()
+	Expect(mgr.GetCache().WaitForCacheSync(syncCtx)).To(BeTrue(), "controller cache should sync before lifecycle tests")
 })
 
 var _ = AfterSuite(func() {
 	By("Tearing down the test environment")
-	if suiteProducer != nil {
-		suiteProducer.Stop()
-	}
 	if cancel != nil {
 		cancel()
+	}
+	if suiteProducer != nil {
+		suiteProducer.Stop()
 	}
 	if testenv != nil {
 		err := testenv.Stop()


### PR DESCRIPTION
Fixes: [ACM-35632](https://redhat.atlassian.net/browse/ACM-35632)

## Summary

### [ACM-35632](https://redhat.atlassian.net/browse/ACM-35632) — Hub HA: add end-to-end integration test wiring lifecycle controller + active syncer (ConfigMap → events verified)

Sub-task of ACM-32677. Adds a dedicated envtest suite that wires the Hub HA lifecycle controller with the real active syncer (no no-op start fn), covering the three unchecked integration items from PR #2526 plus ConfigMap-delete hardening:

- ConfigMap with `hubRole=active` + `standbyHub` → active syncer starts and emits `HubHAResources` events
- `hubRole` changed to `standby` → active syncer stops emitting events
- `standbyHub` changed → emitter routes events to the new target without agent restart
- Agent ConfigMap deleted → lifecycle disables emitter and stops emitting events

## Changes

- Add `test/integration/agent/hubha/lifecycle/` suite with its own manager setup
- Register lifecycle controller without `WithNoOpStartResourceSyncerFn()` so ConfigMap mutations drive the real GVK-watching syncer
- Four ordered integration specs asserting event emission, suppression, standby hub subject updates, and post-delete silence

## Update: ConfigMap delete hardening

- Added spec: delete agent ConfigMap → `hubRole`/`standbyHub` cleared → no further `HubHAResources` events
- Refactored shared `assertNoHubHAEvents` helper for standby and delete cases
- Lifecycle suite now 4/4 passing

## Test plan

- [x] `go test ./test/integration/agent/hubha/lifecycle/...` — 4/4 pass
- [x] `go test ./test/integration/agent/hubha/...` — existing + new suites pass

[ACM-35632]: https://redhat.atlassian.net/browse/ACM-35632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-35632]: https://redhat.atlassian.net/browse/ACM-35632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new end-to-end scenario verifying agent behavior after the agent configuration ConfigMap is deleted, including hub/standby configuration clearance and confirmation that no further Hub HA events are produced.
  * Expanded validation of Hub HA lifecycle behavior across active-to-standby transitions and standby update routing.
  * Introduced an integration test suite harness that sets up and tears down a Kubernetes API environment and reliably runs the lifecycle checks with metrics enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->