### PR TITLE
ACM-34442 Phase 3: route cluster migration over dedicated gh-migration topic

### DIFF
--- a/agent/pkg/configs/agent_sync_state.go
+++ b/agent/pkg/configs/agent_sync_state.go
@@ -2,6 +2,7 @@ package configs
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -31,10 +32,18 @@ func GetSyncStateConfigMap(ctx context.Context, c client.Client) (*corev1.Config
 	err := c.Get(ctx, client.ObjectKeyFromObject(agentStateConfigMap), agentStateConfigMap)
 	if err != nil && errors.IsNotFound(err) {
 		if e := c.Create(ctx, agentStateConfigMap); e != nil {
-			return nil, e
+			if !errors.IsAlreadyExists(e) {
+				return nil, fmt.Errorf("create sync-state ConfigMap: %w", e)
+			}
+			getErr := retry.OnError(retry.DefaultBackoff, errors.IsNotFound, func() error {
+				return c.Get(ctx, client.ObjectKeyFromObject(agentStateConfigMap), agentStateConfigMap)
+			})
+			if getErr != nil {
+				return nil, fmt.Errorf("get sync-state ConfigMap after AlreadyExists: %w", getErr)
+			}
 		}
 	} else if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get sync-state ConfigMap: %w", err)
 	}
 	return agentStateConfigMap, nil
 }

--- a/agent/pkg/spec/dispatcher.go
+++ b/agent/pkg/spec/dispatcher.go
@@ -21,14 +21,17 @@ import (
 
 var addToMgr = false
 
+const maxConcurrentSpecValidations = 32
+
 type genericDispatcher struct {
-	log         *zap.SugaredLogger
-	client      client.Client
-	consumer    transport.Consumer
-	agentConfig *configs.AgentConfig
-	syncers     map[string]Syncer
-	mu          sync.RWMutex
-	wg          sync.WaitGroup // Track in-flight syncer goroutines for graceful shutdown
+	log           *zap.SugaredLogger
+	client        client.Client
+	consumer      transport.Consumer
+	agentConfig   *configs.AgentConfig
+	syncers       map[string]Syncer
+	mu            sync.RWMutex
+	wg            sync.WaitGroup // Track in-flight syncer goroutines for graceful shutdown
+	validationSem chan struct{}  // Bounds concurrent async source validation
 }
 
 func AddGenericDispatcher(mgr ctrl.Manager, consumer transport.Consumer, config *configs.AgentConfig,
@@ -37,11 +40,12 @@ func AddGenericDispatcher(mgr ctrl.Manager, consumer transport.Consumer, config 
 		return nil, nil
 	}
 	dispatcher := &genericDispatcher{
-		log:         logger.DefaultZapLogger(),
-		client:      mgr.GetClient(),
-		consumer:    consumer,
-		agentConfig: config,
-		syncers:     make(map[string]Syncer),
+		log:           logger.DefaultZapLogger(),
+		client:        mgr.GetClient(),
+		consumer:      consumer,
+		agentConfig:   config,
+		syncers:       make(map[string]Syncer),
+		validationSem: make(chan struct{}, maxConcurrentSpecValidations),
 	}
 	if err := mgr.Add(dispatcher); err != nil {
 		return nil, err
@@ -108,13 +112,6 @@ func (d *genericDispatcher) dispatch(ctx context.Context) {
 				d.log.Infow("event dropped due to expiry", "type", evt.Type())
 				continue
 			}
-			validationCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-			allowed := specEventSourceAllowed(validationCtx, d.client, d.agentConfig, evt, subject)
-			cancel()
-			if !allowed {
-				d.log.Warnw("event dropped due to untrusted source", "type", evt.Type())
-				continue
-			}
 			d.mu.RLock()
 			syncer, found := d.syncers[evt.Type()]
 			if !found {
@@ -127,16 +124,32 @@ func (d *genericDispatcher) dispatch(ctx context.Context) {
 					"syncer", syncer, "event", evt)
 				continue
 			}
-			// Async call - don't block dispatcher for long-running syncers (e.g., migration)
+			// Async validation and sync - don't block the dispatch loop on K8s API calls.
+			select {
+			case d.validationSem <- struct{}{}:
+			default:
+				d.log.Warnw("event dropped due to validation backlog", "type", evt.Type())
+				continue
+			}
 			d.wg.Add(1)
-			go func(ctx context.Context, evt *cloudevents.Event, syncer Syncer) {
-				defer d.wg.Done()
+			go func(ctx context.Context, evt *cloudevents.Event, syncer Syncer, subject string) {
+				defer func() {
+					<-d.validationSem
+					d.wg.Done()
+				}()
+				validationCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+				allowed := specEventSourceAllowed(validationCtx, d.client, d.agentConfig, evt, subject)
+				cancel()
+				if !allowed {
+					d.log.Warnw("event dropped due to untrusted source", "type", evt.Type())
+					return
+				}
 				if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 					return syncer.Sync(ctx, evt)
 				}); err != nil {
 					d.log.Errorw("sync failed", "type", evt.Type(), "error", err)
 				}
-			}(ctx, evt, syncer)
+			}(ctx, evt, syncer, subject)
 		}
 	}
 }

--- a/agent/pkg/spec/dispatcher_test.go
+++ b/agent/pkg/spec/dispatcher_test.go
@@ -163,9 +163,10 @@ func TestDispatch_UsesTypeSpecificSyncer(t *testing.T) {
 	agentConfig := &configs.AgentConfig{LeafHubName: "hub2"}
 
 	dispatcher := &genericDispatcher{
-		log:         logger.DefaultZapLogger(),
-		consumer:    &mockConsumer{eventChan: eventChan},
-		agentConfig: agentConfig,
+		log:           logger.DefaultZapLogger(),
+		consumer:      &mockConsumer{eventChan: eventChan},
+		agentConfig:   agentConfig,
+		validationSem: make(chan struct{}, maxConcurrentSpecValidations),
 		syncers: map[string]Syncer{
 			constants.GenericSpecMsgKey: genericRecorder,
 			"Policy":                    typedRecorder,
@@ -195,9 +196,10 @@ func runDispatchScenario(t *testing.T, scenario dispatchScenario) *recordingSync
 	agentConfig := &configs.AgentConfig{LeafHubName: "hub2"}
 
 	dispatcher := &genericDispatcher{
-		log:         logger.DefaultZapLogger(),
-		consumer:    &mockConsumer{eventChan: eventChan},
-		agentConfig: agentConfig,
+		log:           logger.DefaultZapLogger(),
+		consumer:      &mockConsumer{eventChan: eventChan},
+		agentConfig:   agentConfig,
+		validationSem: make(chan struct{}, maxConcurrentSpecValidations),
 		syncers: map[string]Syncer{
 			constants.GenericSpecMsgKey: recorder,
 		},
@@ -262,10 +264,11 @@ func TestDispatch_AllowsRegisteredMigrationDeploying(t *testing.T) {
 	agentConfig := &configs.AgentConfig{LeafHubName: "hub2"}
 
 	dispatcher := &genericDispatcher{
-		log:         logger.DefaultZapLogger(),
-		client:      fakeClient,
-		consumer:    &mockConsumer{eventChan: eventChan},
-		agentConfig: agentConfig,
+		log:           logger.DefaultZapLogger(),
+		client:        fakeClient,
+		consumer:      &mockConsumer{eventChan: eventChan},
+		agentConfig:   agentConfig,
+		validationSem: make(chan struct{}, maxConcurrentSpecValidations),
 		syncers: map[string]Syncer{
 			string(enum.ManagedClusterMigrationType): recorder,
 		},
@@ -294,9 +297,10 @@ func TestDispatch_SourceValidation(t *testing.T) {
 	agentConfig := &configs.AgentConfig{LeafHubName: "hub2"}
 
 	dispatcher := &genericDispatcher{
-		log:         logger.DefaultZapLogger(),
-		consumer:    &mockConsumer{eventChan: eventChan},
-		agentConfig: agentConfig,
+		log:           logger.DefaultZapLogger(),
+		consumer:      &mockConsumer{eventChan: eventChan},
+		agentConfig:   agentConfig,
+		validationSem: make(chan struct{}, maxConcurrentSpecValidations),
 		syncers: map[string]Syncer{
 			constants.GenericSpecMsgKey: recorder,
 		},

--- a/agent/pkg/spec/hubha/hubha_config_syncer_test.go
+++ b/agent/pkg/spec/hubha/hubha_config_syncer_test.go
@@ -341,3 +341,31 @@ func TestAnnotateSkipsAlreadyAnnotated(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, testKlusterletConfigName, mc.GetAnnotations()[klusterletConfigAnnotation])
 }
+
+func TestSync_AllowsBootstrapSourceWhenStandbyHubNotConfigured(t *testing.T) {
+	scheme := newHAConfigTestScheme()
+	mch := &mchv1.MultiClusterHub{
+		ObjectMeta: metav1.ObjectMeta{Name: "multiclusterhub"},
+		Status:     mchv1.MultiClusterHubStatus{CurrentVersion: testMCHVersion214},
+	}
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(mch).
+		WithStatusSubresource(mch).
+		Build()
+	syncer := &HAConfigSyncer{
+		client:      fakeClient,
+		leafHubName: "hub1",
+	}
+	evt := newHAConfigTestEvent(t, newHAConfigTestBundle())
+	evt.SetSource("hub2")
+
+	require.NoError(t, syncer.Sync(context.Background(), evt))
+
+	secret := &corev1.Secret{}
+	err := fakeClient.Get(context.Background(), types.NamespacedName{
+		Name:      testBootstrapSecretName,
+		Namespace: "multicluster-engine",
+	}, secret)
+	require.NoError(t, err)
+}

--- a/agent/pkg/spec/migration/migration_from_syncer.go
+++ b/agent/pkg/spec/migration/migration_from_syncer.go
@@ -41,6 +41,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/enum"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
+	genericproducer "github.com/stolostron/multicluster-global-hub/pkg/transport/producer"
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
@@ -409,9 +410,24 @@ func (s *MigrationSourceSyncer) sendMigrationBundle(
 	e := utils.ToMigrationEvent(eventType, fromHub, toHub,
 		s.processingMigrationId, migrationv1alpha1.PhaseDeploying, expireAfter, payloadBytes)
 
-	if err := s.transportClient.GetProducer().SendEvent(
-		cecontext.WithTopic(ctx, s.transportConfig.KafkaCredential.SpecTopic), e,
-	); err != nil {
+	topicCtx := cecontext.WithTopic(ctx, s.transportConfig.KafkaCredential.GetMigrationTopic())
+	const migrationPublishDeliveryTimeout = 30 * time.Second
+	err = wait.ExponentialBackoff(wait.Backoff{
+		Duration: 5 * time.Second,
+		Factor:   1.0,
+		Steps:    6,
+	}, func() (bool, error) {
+		sendErr := s.sendMigrationEventWithDelivery(topicCtx, e, migrationPublishDeliveryTimeout)
+		if sendErr == nil {
+			return true, nil
+		}
+		if !isMigrationTopicAuthorizationError(sendErr) {
+			return false, sendErr
+		}
+		log.Warnf("deploying: gh-migration publish not authorized yet from %s to %s: %v", fromHub, toHub, sendErr)
+		return false, nil
+	})
+	if err != nil {
 		return fmt.Errorf(errFailedToSendEvent, eventType, fromHub, toHub, err)
 	}
 
@@ -419,6 +435,25 @@ func (s *MigrationSourceSyncer) sendMigrationBundle(
 		fromHub, toHub, len(bundle.MigrationClusterResources), totalClusters, len(payloadBytes))
 
 	return nil
+}
+
+func (s *MigrationSourceSyncer) sendMigrationEventWithDelivery(
+	ctx context.Context, evt cloudevents.Event, timeout time.Duration,
+) error {
+	producer := s.transportClient.GetProducer()
+	if gp, ok := producer.(*genericproducer.GenericProducer); ok {
+		return gp.SendEventWithDeliveryConfirmation(ctx, evt, timeout)
+	}
+	return producer.SendEvent(ctx, evt)
+}
+
+func isMigrationTopicAuthorizationError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "Topic authorization failed") ||
+		strings.Contains(msg, "Broker: Topic authorization failed")
 }
 
 // processResourceByType applies resource-specific processing based on resource type

--- a/agent/pkg/spec/migration/migration_to_syncer.go
+++ b/agent/pkg/spec/migration/migration_to_syncer.go
@@ -1194,6 +1194,10 @@ func (s *MigrationTargetSyncer) queryFailedClusters(ctx context.Context,
 func (s *MigrationTargetSyncer) rollbackInitializing(ctx context.Context, spec *migration.MigrationTargetBundle,
 	clusterErrors map[string]string,
 ) error {
+	defer func() {
+		_ = DeleteLocalMigrationCR(ctx, s.client, spec.ManagedServiceAccountName)
+	}()
+
 	// For initializing rollback on target hub, we need to:
 	// 1. Remove the managed service account user from ClusterManager AutoApproveUsers list
 	// 2. Clean up RBAC resources created for the managed service account
@@ -1236,6 +1240,10 @@ func (s *MigrationTargetSyncer) rollbackInitializing(ctx context.Context, spec *
 func (s *MigrationTargetSyncer) rollbackDeploying(ctx context.Context, spec *migration.MigrationTargetBundle,
 	clusterErrors map[string]string,
 ) error {
+	defer func() {
+		_ = DeleteLocalMigrationCR(ctx, s.client, spec.ManagedServiceAccountName)
+	}()
+
 	log.Infof("rollback deploying stage for clusters: %v", spec.ManagedClusters)
 
 	// 1. Remove all migration resources (including ManagedClusters and KlusterletAddonConfigs)

--- a/agent/pkg/spec/migration/source_validation.go
+++ b/agent/pkg/spec/migration/source_validation.go
@@ -18,7 +18,10 @@ import (
 	migrationbundle "github.com/stolostron/multicluster-global-hub/pkg/bundle/migration"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/enum"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 )
+
+var migrationValidationLog = logger.DefaultZapLogger()
 
 type localMigrationRecord struct {
 	fromHub string
@@ -68,6 +71,7 @@ func MigrationSourceAllowed(ctx context.Context, c client.Client, source, target
 
 	list := &migrationv1alpha1.ManagedClusterMigrationList{}
 	if err := c.List(ctx, list); err != nil {
+		migrationValidationLog.Warnw("failed to list ManagedClusterMigration for source validation", "error", err)
 		return false
 	}
 
@@ -131,7 +135,7 @@ func EnsureLocalMigrationCR(
 	return nil
 }
 
-// DeleteLocalMigrationCR removes recorded local migration state after cleaning completes.
+// DeleteLocalMigrationCR removes recorded local migration state after cleaning or rollback.
 func DeleteLocalMigrationCR(_ context.Context, _ client.Client, migrationName string) error {
 	if migrationName == "" {
 		return nil

--- a/agent/pkg/spec/migration/source_validation_test.go
+++ b/agent/pkg/spec/migration/source_validation_test.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/configs"
 	migrationv1alpha1 "github.com/stolostron/multicluster-global-hub/operator/api/migration/v1alpha1"
 	migrationbundle "github.com/stolostron/multicluster-global-hub/pkg/bundle/migration"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
@@ -468,6 +469,39 @@ func TestDeleteLocalMigrationCR(t *testing.T) {
 	}
 	if err := DeleteLocalMigrationCR(ctx, nil, ""); err != nil {
 		t.Fatalf("empty migration name should be ignored, got %v", err)
+	}
+}
+
+func TestRollbackPathsClearLocalMigrationState(t *testing.T) {
+	resetLocalMigrationState()
+	t.Cleanup(resetLocalMigrationState)
+
+	ctx := context.Background()
+	spec := sampleMigrationTargetBundle()
+	if err := EnsureLocalMigrationCR(ctx, nil, "hub2", spec, migrationv1alpha1.PhaseDeploying); err != nil {
+		t.Fatalf("EnsureLocalMigrationCR() error = %v", err)
+	}
+	if !MigrationSourceAllowed(ctx, nil, "hub1", "hub2") {
+		t.Fatal("expected seeded local migration state to authorize source hub")
+	}
+
+	scheme := runtime.NewScheme()
+	_ = clusterv1.Install(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	syncer := NewMigrationTargetSyncer(fakeClient, nil, &configs.AgentConfig{LeafHubName: "hub2"})
+	clusterErrors := make(map[string]string)
+
+	_ = syncer.rollbackInitializing(ctx, spec, clusterErrors)
+	if MigrationSourceAllowed(ctx, nil, "hub1", "hub2") {
+		t.Fatal("expected rollbackInitializing to clear local migration state")
+	}
+
+	if err := EnsureLocalMigrationCR(ctx, nil, "hub2", spec, migrationv1alpha1.PhaseDeploying); err != nil {
+		t.Fatalf("EnsureLocalMigrationCR() error = %v", err)
+	}
+	_ = syncer.rollbackRegistering(ctx, spec, clusterErrors)
+	if MigrationSourceAllowed(ctx, nil, "hub1", "hub2") {
+		t.Fatal("expected rollbackRegistering to clear local migration state")
 	}
 }
 

--- a/agent/pkg/spec/source_validation.go
+++ b/agent/pkg/spec/source_validation.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2026 Red Hat, Inc.
 // Copyright Contributors to the Open Cluster Management project.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/agent/pkg/spec/source_validation_test.go
+++ b/agent/pkg/spec/source_validation_test.go
@@ -1,4 +1,5 @@
-// Copyright Contributors to the Open Cluster Management project.
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -224,6 +225,16 @@ func TestSpecEventSourceAllowed_GlobalHubSourceBypassesTypeChecks(t *testing.T) 
 	}
 }
 
+func TestSpecEventSourceAllowedRejectsUnknownNonMigrationType(t *testing.T) {
+	ctx := context.Background()
+	agentConfig := &configs.AgentConfig{LeafHubName: "hub2"}
+
+	unknownType := utils.ToCloudEvent("UnknownType", "hub1", "hub2", nil)
+	if specEventSourceAllowed(ctx, nil, agentConfig, &unknownType, "hub2") {
+		t.Fatal("expected unknown non-migration event type to be rejected")
+	}
+}
+
 func TestHaConfigSourceAllowed(t *testing.T) {
 	cfg := &configs.AgentConfig{LeafHubName: "hub2"}
 	cfg.SetStandbyHub("hub1")
@@ -250,7 +261,7 @@ func TestHaConfigSourceAllowed(t *testing.T) {
 	}
 
 	cfgWithoutPeer := &configs.AgentConfig{LeafHubName: "hub2"}
-	if !haConfigSourceAllowed(cfgWithoutPeer, "any-peer", "hub2") {
-		t.Fatal("expected peer source to be allowed when standby hub is not configured")
+	if !haConfigSourceAllowed(cfgWithoutPeer, "local-cluster", "hub2") {
+		t.Fatal("expected bootstrap HA config source to be allowed when standby hub is not configured")
 	}
 }

--- a/manager/pkg/migration/migration_deploying.go
+++ b/manager/pkg/migration/migration_deploying.go
@@ -3,6 +3,7 @@ package migration
 import (
 	"context"
 	"fmt"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -11,6 +12,10 @@ import (
 
 const (
 	ConditionReasonResourcesDeployed = "ResourcesDeployed"
+
+	// migrationDeployingACLPropagationWait allows Strimzi to propagate gh-migration
+	// Write ACLs from KafkaUser to brokers before source-hub agents publish bundles.
+	migrationDeployingACLPropagationWait = 45 * time.Second
 )
 
 // Migrating - deploying:
@@ -43,6 +48,25 @@ func (m *ClusterMigrationController) deploying(ctx context.Context,
 
 	fromHub := mcm.Spec.From
 	clusters := GetClusterList(string(mcm.UID))
+
+	// Allow the operator migration ACL reconciler to grant source-hub Write on
+	// gh-migration and Strimzi to propagate ACLs before hub agents publish bundles.
+	if !GetStarted(string(mcm.GetUID()), fromHub, migrationv1alpha1.PhaseDeploying) &&
+		!GetStarted(string(mcm.GetUID()), mcm.Spec.To, migrationv1alpha1.PhaseDeploying) {
+		migrationID := string(mcm.GetUID())
+		readyTime, scheduled := GetDeployingACLReadyTime(migrationID)
+		if !scheduled {
+			SetDeployingACLReadyTime(migrationID, time.Now().Add(migrationDeployingACLPropagationWait))
+			condition.Message = "Waiting for migration transport ACL to be provisioned"
+			setRetry(mcm, migrationv1alpha1.PhaseDeploying, migrationv1alpha1.ConditionTypeDeployed, fromHub)
+			return true, nil
+		}
+		if time.Now().Before(readyTime) {
+			condition.Message = "Waiting for migration transport ACL to propagate"
+			setRetry(mcm, migrationv1alpha1.PhaseDeploying, migrationv1alpha1.ConditionTypeDeployed, fromHub)
+			return true, nil
+		}
+	}
 
 	// 1. source hub: start and wait the confirmation
 	//    Target hub: no need to send events to trigger deploying. This handles target hub restarts where resources may

--- a/manager/pkg/migration/migration_deploying_test.go
+++ b/manager/pkg/migration/migration_deploying_test.go
@@ -77,6 +77,32 @@ func TestDeploying(t *testing.T) {
 			expectedConditionReason: "",                               // No reason change expected
 		},
 		{
+			name: "Should wait for migration transport ACL before triggering deploying",
+			migration: &migrationv1alpha1.ManagedClusterMigration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-migration",
+					Namespace: utils.GetDefaultNamespace(),
+					UID:       types.UID("test-uid-acl-wait"),
+				},
+				Spec: migrationv1alpha1.ManagedClusterMigrationSpec{
+					From:                    "source-hub",
+					To:                      "target-hub",
+					IncludedManagedClusters: []string{"cluster1"},
+				},
+				Status: migrationv1alpha1.ManagedClusterMigrationStatus{
+					Phase: migrationv1alpha1.PhaseDeploying,
+				},
+			},
+			setupState: func(migrationID string) {
+				AddMigrationStatus(migrationID)
+			},
+			expectedRequeue:         true,
+			expectedError:           false,
+			expectedPhase:           migrationv1alpha1.PhaseDeploying,
+			expectedConditionStatus: metav1.ConditionFalse,
+			expectedConditionReason: ConditionReasonWaiting,
+		},
+		{
 			name: "Should wait for source hub to complete deploying",
 			migration: &migrationv1alpha1.ManagedClusterMigration{
 				ObjectMeta: metav1.ObjectMeta{

--- a/manager/pkg/migration/migration_eventstatus.go
+++ b/manager/pkg/migration/migration_eventstatus.go
@@ -14,7 +14,8 @@ var (
 )
 
 type MigrationStatus struct {
-	HubState map[string]*StageState // key: hub-phase
+	HubState              map[string]*StageState // key: hub-phase
+	deployingACLReadyTime time.Time              // zero until set; deploy after this instant
 }
 
 type StageState struct {
@@ -168,6 +169,26 @@ func GetStarted(migrationId, hub, phase string) bool {
 		return p.started
 	}
 	return false
+}
+
+// SetDeployingACLReadyTime records when hub agents may publish to gh-migration.
+// Strimzi ACL updates on KafkaUser need time to propagate to Kafka brokers.
+func SetDeployingACLReadyTime(migrationId string, readyTime time.Time) {
+	mu.Lock()
+	defer mu.Unlock()
+	if status := getMigrationStatus(migrationId); status != nil {
+		status.deployingACLReadyTime = readyTime
+	}
+}
+
+// GetDeployingACLReadyTime returns the earliest time Deploying hub events may start.
+func GetDeployingACLReadyTime(migrationId string) (time.Time, bool) {
+	mu.RLock()
+	defer mu.RUnlock()
+	if status := getMigrationStatus(migrationId); status != nil {
+		return status.deployingACLReadyTime, !status.deployingACLReadyTime.IsZero()
+	}
+	return time.Time{}, false
 }
 
 // GetFinished returns true if the status of the given stage is finished for the hub cluster

--- a/manager/pkg/migration/migration_initializing.go
+++ b/manager/pkg/migration/migration_initializing.go
@@ -145,7 +145,9 @@ func (m *ClusterMigrationController) initializing(ctx context.Context,
 	nextPhase = migrationv1alpha1.PhaseDeploying
 
 	log.Infof("finish initializing: %s (uid: %s)", mcm.Name, mcm.UID)
-	return false, nil
+	// Requeue before deploying so the operator migration ACL reconciler can grant
+	// source-hub Write on gh-migration after the phase transitions to Deploying.
+	return true, nil
 }
 
 // handleStatusWithRollback updates the condition and phase, transitioning to Rollbacking for most phases

--- a/manager/pkg/migration/migration_initializing_test.go
+++ b/manager/pkg/migration/migration_initializing_test.go
@@ -285,7 +285,7 @@ func TestInitializing(t *testing.T) {
 				SetFinished(migrationID, "target-hub", migrationv1alpha1.PhaseInitializing)
 				SetFinished(migrationID, "source-hub", migrationv1alpha1.PhaseInitializing)
 			},
-			expectedRequeue:         false,
+			expectedRequeue:         true,
 			expectedError:           false,
 			expectedPhase:           migrationv1alpha1.PhaseDeploying,   // Should move to deploying phase
 			expectedConditionStatus: metav1.ConditionTrue,               // Condition should be true

--- a/operator/pkg/config/transport_config.go
+++ b/operator/pkg/config/transport_config.go
@@ -20,6 +20,7 @@ import (
 
 const (
 	DEFAULT_SPEC_TOPIC          = "gh-spec"
+	DEFAULT_MIGRATION_TOPIC     = "gh-migration"
 	DEFAULT_STATUS_TOPIC        = "gh-status.*"
 	DEFAULT_SHARED_STATUS_TOPIC = "gh-status"
 )
@@ -30,6 +31,7 @@ var (
 	enableInventory       = false
 	isBYOKafka            = false
 	specTopic             = ""
+	migrationTopic        = ""
 	statusTopic           = ""
 	kafkaResourceReady    = false
 	acmResourceReady      = false
@@ -85,11 +87,18 @@ func SetTransportConfig(ctx context.Context, runtimeClient client.Client, mgh *v
 	// set the topic
 	specTopic = mgh.Spec.DataLayerSpec.Kafka.KafkaTopics.SpecTopic
 	statusTopic = mgh.Spec.DataLayerSpec.Kafka.KafkaTopics.StatusTopic
+	migrationTopic = DEFAULT_MIGRATION_TOPIC
+	if specTopic == "" {
+		specTopic = DEFAULT_SPEC_TOPIC
+	}
+	if statusTopic == "" {
+		statusTopic = DEFAULT_STATUS_TOPIC
+	}
 	if !isValidKafkaTopicName(specTopic) {
 		return fmt.Errorf("the specTopic is invalid: %s", specTopic)
 	}
 	if !isValidKafkaTopicName(statusTopic) {
-		return fmt.Errorf("the specTopic is invalid: %s", statusTopic)
+		return fmt.Errorf("the statusTopic is invalid: %s", statusTopic)
 	}
 
 	// BYO Case:
@@ -136,6 +145,10 @@ func GetSpecTopic() string {
 	return specTopic
 }
 
+func GetMigrationTopic() string {
+	return migrationTopic
+}
+
 // GetStatusTopic return the status topic with clusterName, like 'gh-status.<clusterName>'
 func GetStatusTopic(clusterName string) string {
 	return strings.ReplaceAll(statusTopic, "*", clusterName)
@@ -176,6 +189,10 @@ func SetKafkaType(ctx context.Context, runtimeClient client.Client, namespace st
 
 func SetBYOKafka(byoKafka bool) {
 	isBYOKafka = byoKafka
+}
+
+func SetMigrationTopic(topic string) {
+	migrationTopic = topic
 }
 
 func IsBYOKafka() bool {

--- a/operator/pkg/config/transport_config_test.go
+++ b/operator/pkg/config/transport_config_test.go
@@ -1,37 +1,29 @@
 package config
 
-import (
-	"fmt"
-	"testing"
-)
+import "testing"
 
-// TestIsValidKafkaTopicName tests the isValidKafkaTopicName function.
-func TestIsValidKafkaTopicName(t *testing.T) {
-	// Define test cases
-	testCases := []struct {
-		name     string
-		input    string
-		expected bool
-	}{
-		{"Valid topic with letters and numbers", "validTopic1", true},
-		{"Valid topic with underscore", "valid_topic-2", true},
-		{"Valid topic with dot", "valid.topic.3", true},
-		{"Invalid topic with space", "invalid topic", false},
-		{"Invalid topic with invalid character", "invalidTopic$", false},
-		{"Empty topic name", "", false},
-		{"Invalid name .", ".", false},
-		{"Invalid name ..", "..", false},
-		{"Valid topic with asterisk", "validTopic*", true},
-		{"Invalid topic with asterisk not at the end", "invalidTopic*extra", false},
+func TestGetMigrationTopic(t *testing.T) {
+	original := migrationTopic
+	t.Cleanup(func() { migrationTopic = original })
+
+	migrationTopic = "gh-migration"
+	if got := GetMigrationTopic(); got != "gh-migration" {
+		t.Fatalf("GetMigrationTopic() = %q, want gh-migration", got)
 	}
+}
 
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			result := isValidKafkaTopicName(testCase.input)
-			if result != testCase.expected {
-				fmt.Println("len", len(testCase.input))
-				t.Errorf("isValidKafkaTopicName(%q) = %v; expected %v", testCase.input, result, testCase.expected)
-			}
-		})
+func TestGetKafkaUserName(t *testing.T) {
+	if got := GetKafkaUserName("hub1"); got != "hub1-kafka-user" {
+		t.Fatalf("GetKafkaUserName() = %q, want hub1-kafka-user", got)
+	}
+}
+
+func TestSetMigrationTopic(t *testing.T) {
+	original := migrationTopic
+	t.Cleanup(func() { migrationTopic = original })
+
+	SetMigrationTopic("custom-migration")
+	if got := GetMigrationTopic(); got != "custom-migration" {
+		t.Fatalf("SetMigrationTopic() = %q, want custom-migration", got)
 	}
 }

--- a/operator/pkg/controllers/transporter/migration_acl_reconciler.go
+++ b/operator/pkg/controllers/transporter/migration_acl_reconciler.go
@@ -1,0 +1,193 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transporter
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	migrationv1alpha1 "github.com/stolostron/multicluster-global-hub/operator/api/migration/v1alpha1"
+	operatorv1alpha4 "github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/transporter/protocol"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
+)
+
+var migrationACLLog = logger.DefaultZapLogger()
+
+// +kubebuilder:rbac:groups=global-hub.open-cluster-management.io,resources=managedclustermigrations,verbs=get;list
+// +kubebuilder:rbac:groups=global-hub.open-cluster-management.io,resources=managedclustermigrations,verbs=watch
+// +kubebuilder:rbac:groups=kafka.strimzi.io,resources=kafkausers,verbs=get;update;list;watch
+
+type MigrationACLReconciler struct {
+	mgr ctrl.Manager
+	client.Client
+}
+
+func (r *MigrationACLReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	if config.IsBYOKafka() {
+		return ctrl.Result{}, nil
+	}
+
+	mgh, err := config.GetMulticlusterGlobalHub(ctx, r.Client)
+	if err != nil || mgh == nil || config.IsPaused(mgh) {
+		return ctrl.Result{}, err
+	}
+
+	migration := &migrationv1alpha1.ManagedClusterMigration{}
+	if err := r.Get(ctx, req.NamespacedName, migration); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Migration was deleted; re-sync all managed hub KafkaUsers so revoked ACLs
+			// are cleaned up even though the trigger object's Spec.From is gone.
+			return ctrl.Result{}, r.syncAllMigrationWriteACLs(ctx, mgh, req.Namespace)
+		}
+		return ctrl.Result{}, err
+	}
+
+	if err := r.syncMigrationWriteACLs(ctx, mgh, req.Namespace, migration.Spec.From); err != nil {
+		return ctrl.Result{}, err
+	}
+	if migration.Status.Phase == migrationv1alpha1.PhaseDeploying {
+		migrationACLLog.Infow("synced migration write ACLs",
+			"migration", req.Name, "fromHub", migration.Spec.From, "phase", migration.Status.Phase)
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *MigrationACLReconciler) syncMigrationWriteACLs(
+	ctx context.Context,
+	mgh *operatorv1alpha4.MulticlusterGlobalHub,
+	namespace string,
+	triggerFromHub string,
+) error {
+	list := &migrationv1alpha1.ManagedClusterMigrationList{}
+	if err := r.List(ctx, list, client.InNamespace(namespace)); err != nil {
+		return fmt.Errorf("failed to list ManagedClusterMigration resources: %w", err)
+	}
+
+	needed := deployingSourceHubs(list)
+	hubsToSync := hubsToSyncForMigration(triggerFromHub, needed)
+	for _, fromHub := range hubsToSync {
+		_, grant := needed[fromHub]
+		if err := protocol.SyncMigrationWriteACL(r.mgr, mgh, fromHub, grant, protocol.WithContext(ctx)); err != nil {
+			return fmt.Errorf("failed to sync migration write ACL for hub %q: %w", fromHub, err)
+		}
+	}
+	return nil
+}
+
+func (r *MigrationACLReconciler) syncAllMigrationWriteACLs(
+	ctx context.Context,
+	mgh *operatorv1alpha4.MulticlusterGlobalHub,
+	namespace string,
+) error {
+	list := &migrationv1alpha1.ManagedClusterMigrationList{}
+	if err := r.List(ctx, list, client.InNamespace(namespace)); err != nil {
+		return fmt.Errorf("failed to list ManagedClusterMigration resources: %w", err)
+	}
+	needed := deployingSourceHubs(list)
+
+	kafkaUsers := &kafkav1beta2.KafkaUserList{}
+	if err := r.List(ctx, kafkaUsers, client.InNamespace(namespace)); err != nil {
+		return fmt.Errorf("failed to list KafkaUser resources: %w", err)
+	}
+
+	for i := range kafkaUsers.Items {
+		fromHub, ok := managedHubFromKafkaUser(&kafkaUsers.Items[i])
+		if !ok {
+			continue
+		}
+		_, grant := needed[fromHub]
+		if err := protocol.SyncMigrationWriteACL(r.mgr, mgh, fromHub, grant, protocol.WithContext(ctx)); err != nil {
+			return fmt.Errorf("failed to sync migration write ACL for hub %q: %w", fromHub, err)
+		}
+	}
+	return nil
+}
+
+func deployingSourceHubs(list *migrationv1alpha1.ManagedClusterMigrationList) map[string]struct{} {
+	needed := make(map[string]struct{})
+	for i := range list.Items {
+		addDeployingSourceHub(needed, &list.Items[i])
+	}
+	return needed
+}
+
+func addDeployingSourceHub(needed map[string]struct{}, mcm *migrationv1alpha1.ManagedClusterMigration) {
+	if mcm == nil || mcm.DeletionTimestamp != nil {
+		return
+	}
+	if mcm.Status.Phase == migrationv1alpha1.PhaseDeploying {
+		needed[mcm.Spec.From] = struct{}{}
+	}
+}
+
+func hubsToSyncForMigration(fromHub string, needed map[string]struct{}) []string {
+	hubs := sets.NewString()
+	if fromHub != "" {
+		hubs.Insert(fromHub)
+	}
+	for hub := range needed {
+		hubs.Insert(hub)
+	}
+	return hubs.UnsortedList()
+}
+
+func managedHubFromKafkaUser(user *kafkav1beta2.KafkaUser) (string, bool) {
+	if user.Name == protocol.DefaultGlobalHubKafkaUserName {
+		return "", false
+	}
+	if !strings.HasSuffix(user.Name, "-kafka-user") {
+		return "", false
+	}
+	fromHub := strings.TrimSuffix(user.Name, "-kafka-user")
+	if fromHub == constants.LocalClusterName || fromHub == config.GetLocalClusterName() {
+		return "", false
+	}
+	return fromHub, true
+}
+
+func (r *MigrationACLReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("migration-transport-acl").
+		For(&migrationv1alpha1.ManagedClusterMigration{}).
+		Complete(r)
+}
+
+func setupMigrationACLReconciler(mgr ctrl.Manager) error {
+	if migrationACLControllerStarted {
+		return nil
+	}
+	reconciler := &MigrationACLReconciler{
+		mgr:    mgr,
+		Client: mgr.GetClient(),
+	}
+	if err := reconciler.SetupWithManager(mgr); err != nil {
+		return err
+	}
+	migrationACLControllerStarted = true
+	return nil
+}
+
+var migrationACLControllerStarted bool

--- a/operator/pkg/controllers/transporter/migration_acl_reconciler_test.go
+++ b/operator/pkg/controllers/transporter/migration_acl_reconciler_test.go
@@ -1,0 +1,412 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transporter
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	crconfig "sigs.k8s.io/controller-runtime/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	migrationv1alpha1 "github.com/stolostron/multicluster-global-hub/operator/api/migration/v1alpha1"
+	operatorv1alpha4 "github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
+	operatorconfig "github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/transporter/protocol"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
+)
+
+func TestDeployingSourceHubs(t *testing.T) {
+	t.Parallel()
+
+	list := &migrationv1alpha1.ManagedClusterMigrationList{
+		Items: []migrationv1alpha1.ManagedClusterMigration{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "active"},
+				Spec:       migrationv1alpha1.ManagedClusterMigrationSpec{From: "hub1"},
+				Status:     migrationv1alpha1.ManagedClusterMigrationStatus{Phase: migrationv1alpha1.PhaseDeploying},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "done"},
+				Spec:       migrationv1alpha1.ManagedClusterMigrationSpec{From: "hub2"},
+				Status:     migrationv1alpha1.ManagedClusterMigrationStatus{Phase: migrationv1alpha1.PhaseCompleted},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "deleted",
+					DeletionTimestamp: &metav1.Time{Time: metav1.Now().Time},
+				},
+				Spec:   migrationv1alpha1.ManagedClusterMigrationSpec{From: "hub3"},
+				Status: migrationv1alpha1.ManagedClusterMigrationStatus{Phase: migrationv1alpha1.PhaseDeploying},
+			},
+		},
+	}
+
+	got := deployingSourceHubs(list)
+	if len(got) != 1 {
+		t.Fatalf("deployingSourceHubs() len = %d, want 1", len(got))
+	}
+	if _, ok := got["hub1"]; !ok {
+		t.Fatalf("deployingSourceHubs() = %#v, want hub1 only", got)
+	}
+}
+
+func TestHubsToSyncForMigration(t *testing.T) {
+	t.Parallel()
+
+	needed := map[string]struct{}{
+		"hub1": {},
+		"hub2": {},
+	}
+	got := hubsToSyncForMigration("hub3", needed)
+	if len(got) != 3 {
+		t.Fatalf("hubsToSyncForMigration() len = %d, want 3", len(got))
+	}
+}
+
+func TestManagedHubFromKafkaUser(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		user    *kafkav1beta2.KafkaUser
+		wantHub string
+		wantOK  bool
+	}{
+		{
+			name:    "managed hub user",
+			user:    &kafkav1beta2.KafkaUser{ObjectMeta: metav1.ObjectMeta{Name: "hub1-kafka-user"}},
+			wantHub: "hub1",
+			wantOK:  true,
+		},
+		{
+			name:   "global hub user skipped",
+			user:   &kafkav1beta2.KafkaUser{ObjectMeta: metav1.ObjectMeta{Name: protocol.DefaultGlobalHubKafkaUserName}},
+			wantOK: false,
+		},
+		{
+			name:   "non kafka-user skipped",
+			user:   &kafkav1beta2.KafkaUser{ObjectMeta: metav1.ObjectMeta{Name: "other-user"}},
+			wantOK: false,
+		},
+		{
+			name:   "local cluster skipped",
+			user:   &kafkav1beta2.KafkaUser{ObjectMeta: metav1.ObjectMeta{Name: constants.LocalClusterName + "-kafka-user"}},
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotHub, gotOK := managedHubFromKafkaUser(tt.user)
+			if gotHub != tt.wantHub || gotOK != tt.wantOK {
+				t.Fatalf("managedHubFromKafkaUser() = (%q, %v), want (%q, %v)", gotHub, gotOK, tt.wantHub, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestMigrationACLReconcilerReconcileSkipsBYO(t *testing.T) {
+	originalBYO := operatorconfig.IsBYOKafka()
+	t.Cleanup(func() { operatorconfig.SetBYOKafka(originalBYO) })
+	operatorconfig.SetBYOKafka(true)
+
+	reconciler := &MigrationACLReconciler{}
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: clientObjectKey("test-ns", "migration-1"),
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() BYO skip error = %v", err)
+	}
+}
+
+func TestMigrationACLReconcilerReconcileNotFound(t *testing.T) {
+	originalBYO := operatorconfig.IsBYOKafka()
+	t.Cleanup(func() { operatorconfig.SetBYOKafka(originalBYO) })
+	operatorconfig.SetBYOKafka(false)
+	operatorconfig.SetMigrationTopic("gh-migration")
+
+	scheme := runtime.NewScheme()
+	if err := operatorv1alpha4.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(MulticlusterGlobalHub) error = %v", err)
+	}
+	if err := migrationv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(ManagedClusterMigration) error = %v", err)
+	}
+	if err := kafkav1beta2.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(KafkaUser) error = %v", err)
+	}
+
+	mgh := &operatorv1alpha4.MulticlusterGlobalHub{
+		ObjectMeta: metav1.ObjectMeta{Name: "mgh", Namespace: "test-ns"},
+	}
+	kafkaUser := &kafkav1beta2.KafkaUser{
+		ObjectMeta: metav1.ObjectMeta{Name: "hub1-kafka-user", Namespace: "test-ns"},
+		Spec: &kafkav1beta2.KafkaUserSpec{
+			Authorization: simpleKafkaUserAuthorization(
+				utils.WriteTopicACL("gh-migration"),
+			),
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(mgh, kafkaUser).
+		Build()
+
+	reconciler := &MigrationACLReconciler{
+		mgr:    &migrationACLReconcilerMockManager{client: fakeClient},
+		Client: fakeClient,
+	}
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: clientObjectKey("test-ns", "missing"),
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() missing migration should succeed, got %v", err)
+	}
+
+	updated := &kafkav1beta2.KafkaUser{}
+	if err := fakeClient.Get(context.Background(), client.ObjectKeyFromObject(kafkaUser), updated); err != nil {
+		t.Fatalf("get updated kafka user: %v", err)
+	}
+	if updated.Spec.Authorization != nil {
+		for _, acl := range updated.Spec.Authorization.Acls {
+			if utils.GenerateACLKey(acl) == utils.GenerateACLKey(utils.WriteTopicACL("gh-migration")) {
+				t.Fatal("expected migration write ACL to be revoked after migration deletion")
+			}
+		}
+	}
+}
+
+func TestMigrationACLReconcilerReconcileDeployingGrantsACL(t *testing.T) {
+	originalBYO := operatorconfig.IsBYOKafka()
+	t.Cleanup(func() { operatorconfig.SetBYOKafka(originalBYO) })
+	operatorconfig.SetBYOKafka(false)
+	operatorconfig.SetMigrationTopic("gh-migration")
+
+	_, fakeClient, _, kafkaUser := newMigrationACLReconcilerFixtures(t)
+	migration := &migrationv1alpha1.ManagedClusterMigration{
+		ObjectMeta: metav1.ObjectMeta{Name: "migration-1", Namespace: "test-ns"},
+		Spec:       migrationv1alpha1.ManagedClusterMigrationSpec{From: "hub1", To: "hub2"},
+		Status:     migrationv1alpha1.ManagedClusterMigrationStatus{Phase: migrationv1alpha1.PhaseDeploying},
+	}
+	if err := fakeClient.Create(context.Background(), migration); err != nil {
+		t.Fatalf("create migration: %v", err)
+	}
+
+	reconciler := &MigrationACLReconciler{
+		mgr:    &migrationACLReconcilerMockManager{client: fakeClient},
+		Client: fakeClient,
+	}
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: clientObjectKey("test-ns", "migration-1"),
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() deploying migration error = %v", err)
+	}
+
+	updated := &kafkav1beta2.KafkaUser{}
+	if err := fakeClient.Get(context.Background(), client.ObjectKeyFromObject(kafkaUser), updated); err != nil {
+		t.Fatalf("get updated kafka user: %v", err)
+	}
+	wantKey := utils.GenerateACLKey(utils.WriteTopicACL("gh-migration"))
+	found := false
+	for _, acl := range updated.Spec.Authorization.Acls {
+		if utils.GenerateACLKey(acl) == wantKey {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected migration write ACL to be granted for deploying migration")
+	}
+}
+
+func TestMigrationACLReconcilerReconcileCompletedRevokesACL(t *testing.T) {
+	originalBYO := operatorconfig.IsBYOKafka()
+	t.Cleanup(func() { operatorconfig.SetBYOKafka(originalBYO) })
+	operatorconfig.SetBYOKafka(false)
+	operatorconfig.SetMigrationTopic("gh-migration")
+
+	scheme, fakeClient, _, kafkaUser := newMigrationACLReconcilerFixtures(t)
+	_ = scheme
+	kafkaUser.Spec.Authorization.Acls = []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
+		utils.WriteTopicACL("gh-migration"),
+	}
+	if err := fakeClient.Update(context.Background(), kafkaUser); err != nil {
+		t.Fatalf("update kafka user with migration ACL: %v", err)
+	}
+
+	migration := &migrationv1alpha1.ManagedClusterMigration{
+		ObjectMeta: metav1.ObjectMeta{Name: "migration-1", Namespace: "test-ns"},
+		Spec:       migrationv1alpha1.ManagedClusterMigrationSpec{From: "hub1", To: "hub2"},
+		Status:     migrationv1alpha1.ManagedClusterMigrationStatus{Phase: migrationv1alpha1.PhaseCompleted},
+	}
+	if err := fakeClient.Create(context.Background(), migration); err != nil {
+		t.Fatalf("create migration: %v", err)
+	}
+
+	reconciler := &MigrationACLReconciler{
+		mgr:    &migrationACLReconcilerMockManager{client: fakeClient},
+		Client: fakeClient,
+	}
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: clientObjectKey("test-ns", "migration-1"),
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() completed migration error = %v", err)
+	}
+
+	updated := &kafkav1beta2.KafkaUser{}
+	if err := fakeClient.Get(context.Background(), client.ObjectKeyFromObject(kafkaUser), updated); err != nil {
+		t.Fatalf("get updated kafka user: %v", err)
+	}
+	if updated.Spec.Authorization != nil {
+		for _, acl := range updated.Spec.Authorization.Acls {
+			if utils.GenerateACLKey(acl) == utils.GenerateACLKey(utils.WriteTopicACL("gh-migration")) {
+				t.Fatal("expected migration write ACL to be revoked after migration completed")
+			}
+		}
+	}
+}
+
+func TestMigrationACLReconcilerReconcileSkipsPausedMGH(t *testing.T) {
+	originalBYO := operatorconfig.IsBYOKafka()
+	t.Cleanup(func() { operatorconfig.SetBYOKafka(originalBYO) })
+	operatorconfig.SetBYOKafka(false)
+
+	_, fakeClient, mgh, _ := newMigrationACLReconcilerFixtures(t)
+	mgh.Annotations = map[string]string{"mgh-pause": "true"}
+	if err := fakeClient.Update(context.Background(), mgh); err != nil {
+		t.Fatalf("update paused mgh: %v", err)
+	}
+
+	reconciler := &MigrationACLReconciler{
+		mgr:    &migrationACLReconcilerMockManager{client: fakeClient},
+		Client: fakeClient,
+	}
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: clientObjectKey("test-ns", "migration-1"),
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() paused mgh should succeed, got %v", err)
+	}
+}
+
+func newMigrationACLReconcilerFixtures(
+	t *testing.T,
+) (*runtime.Scheme, client.Client, *operatorv1alpha4.MulticlusterGlobalHub, *kafkav1beta2.KafkaUser) {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	if err := operatorv1alpha4.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(MulticlusterGlobalHub) error = %v", err)
+	}
+	if err := migrationv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(ManagedClusterMigration) error = %v", err)
+	}
+	if err := kafkav1beta2.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(KafkaUser) error = %v", err)
+	}
+
+	mgh := &operatorv1alpha4.MulticlusterGlobalHub{
+		ObjectMeta: metav1.ObjectMeta{Name: "mgh", Namespace: "test-ns"},
+	}
+	kafkaUser := &kafkav1beta2.KafkaUser{
+		ObjectMeta: metav1.ObjectMeta{Name: "hub1-kafka-user", Namespace: "test-ns"},
+		Spec: &kafkav1beta2.KafkaUserSpec{
+			Authorization: simpleKafkaUserAuthorization(
+				utils.ReadTopicACL("gh-spec", false),
+			),
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(mgh, kafkaUser).
+		Build()
+
+	return scheme, fakeClient, mgh, kafkaUser
+}
+
+type migrationACLReconcilerMockManager struct {
+	client client.Client
+}
+
+func (m *migrationACLReconcilerMockManager) Add(manager.Runnable) error { return nil }
+func (m *migrationACLReconcilerMockManager) GetClient() client.Client   { return m.client }
+func (m *migrationACLReconcilerMockManager) GetScheme() *runtime.Scheme { return nil }
+func (m *migrationACLReconcilerMockManager) GetFieldIndexer() client.FieldIndexer {
+	return nil
+}
+func (m *migrationACLReconcilerMockManager) GetCache() cache.Cache { return nil }
+func (m *migrationACLReconcilerMockManager) GetEventRecorderFor(string) record.EventRecorder {
+	return nil
+}
+func (m *migrationACLReconcilerMockManager) GetRESTMapper() meta.RESTMapper { return nil }
+func (m *migrationACLReconcilerMockManager) GetAPIReader() client.Reader    { return nil }
+func (m *migrationACLReconcilerMockManager) Start(context.Context) error    { return nil }
+func (m *migrationACLReconcilerMockManager) GetWebhookServer() webhook.Server {
+	return nil
+}
+func (m *migrationACLReconcilerMockManager) GetLogger() logr.Logger { return logr.Discard() }
+func (m *migrationACLReconcilerMockManager) GetControllerOptions() crconfig.Controller {
+	return crconfig.Controller{}
+}
+func (m *migrationACLReconcilerMockManager) Elected() <-chan struct{} { return nil }
+func (m *migrationACLReconcilerMockManager) AddHealthzCheck(string, healthz.Checker) error {
+	return nil
+}
+
+func (m *migrationACLReconcilerMockManager) AddReadyzCheck(string, healthz.Checker) error {
+	return nil
+}
+func (m *migrationACLReconcilerMockManager) GetHTTPClient() *http.Client { return nil }
+func (m *migrationACLReconcilerMockManager) AddMetricsServerExtraHandler(string, http.Handler) error {
+	return nil
+}
+func (m *migrationACLReconcilerMockManager) GetConfig() *rest.Config { return nil }
+
+var _ ctrl.Manager = (*migrationACLReconcilerMockManager)(nil)
+
+func clientObjectKey(namespace, name string) types.NamespacedName {
+	return types.NamespacedName{Namespace: namespace, Name: name}
+}
+
+func simpleKafkaUserAuthorization(
+	acls ...kafkav1beta2.KafkaUserSpecAuthorizationAclsElem,
+) *kafkav1beta2.KafkaUserSpecAuthorization {
+	return &kafkav1beta2.KafkaUserSpecAuthorization{
+		Type: kafkav1beta2.KafkaUserSpecAuthorizationTypeSimple,
+		Acls: acls,
+	}
+}

--- a/operator/pkg/controllers/transporter/protocol/byo_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/byo_transporter.go
@@ -51,8 +51,9 @@ func (s *BYOTransporter) EnsureUser(clusterName string) (string, error) {
 
 func (s *BYOTransporter) EnsureTopic(clusterName string) (*transport.ClusterTopic, error) {
 	return &transport.ClusterTopic{
-		SpecTopic:   config.GetSpecTopic(),
-		StatusTopic: config.GetStatusTopic(clusterName),
+		SpecTopic:      config.GetSpecTopic(),
+		MigrationTopic: config.GetMigrationTopic(),
+		StatusTopic:    config.GetStatusTopic(clusterName),
 	}, nil
 }
 
@@ -90,10 +91,11 @@ func (s *BYOTransporter) GetConnCredential(clusterName string) (*transport.Kafka
 		ConsumerGroupID: config.GetConsumerGroupID(mgh.Spec.DataLayerSpec.Kafka.ConsumerGroupPrefix, clusterName),
 
 		// for the byo case, the status topic isn't change by the clusterName
-		StatusTopic: config.GetStatusTopic(""),
-		SpecTopic:   config.GetSpecTopic(),
-		CACert:      base64.StdEncoding.EncodeToString(kafkaSecret.Data[filepath.Join("ca.crt")]),
-		ClientCert:  base64.StdEncoding.EncodeToString(kafkaSecret.Data[filepath.Join("client.crt")]),
-		ClientKey:   base64.StdEncoding.EncodeToString(kafkaSecret.Data[filepath.Join("client.key")]),
+		StatusTopic:    config.GetStatusTopic(""),
+		SpecTopic:      config.GetSpecTopic(),
+		MigrationTopic: config.GetMigrationTopic(),
+		CACert:         base64.StdEncoding.EncodeToString(kafkaSecret.Data[filepath.Join("ca.crt")]),
+		ClientCert:     base64.StdEncoding.EncodeToString(kafkaSecret.Data[filepath.Join("client.crt")]),
+		ClientKey:      base64.StdEncoding.EncodeToString(kafkaSecret.Data[filepath.Join("client.key")]),
 	}, nil
 }

--- a/operator/pkg/controllers/transporter/protocol/manifests/global-hub-kafka-topic.yaml
+++ b/operator/pkg/controllers/transporter/protocol/manifests/global-hub-kafka-topic.yaml
@@ -3,6 +3,22 @@ kind: KafkaTopic
 metadata:
   labels:
     strimzi.io/cluster: {{.KafkaCluster}}
+  name: {{.MigrationTopic}}
+  namespace: {{.Namespace}}
+spec:
+  config:
+    cleanup.policy: compact,delete
+    retention.ms: "86400000"
+    retention.bytes: "1073741824"
+  partitions: {{.TopicPartition}}
+  replicas: {{.TopicReplicas}}
+
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  labels:
+    strimzi.io/cluster: {{.KafkaCluster}}
   name: {{.StatusPlaceholderTopic}}
   namespace: {{.Namespace}}
 spec:

--- a/operator/pkg/controllers/transporter/protocol/manifests/global-hub-kafka-user.yaml
+++ b/operator/pkg/controllers/transporter/protocol/manifests/global-hub-kafka-user.yaml
@@ -28,6 +28,15 @@ spec:
       operations:
       - Describe
       - Read
+      - Write
+      resource:
+        name: {{.MigrationTopic}}
+        patternType: literal
+        type: topic
+    - host: '*'
+      operations:
+      - Describe
+      - Read
       resource:
         name: {{.StatusTopic}}
         patternType: {{.StatusTopicPattern}}

--- a/operator/pkg/controllers/transporter/protocol/migration_acl.go
+++ b/operator/pkg/controllers/transporter/protocol/migration_acl.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protocol
+
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	operatorv1alpha4 "github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
+)
+
+// SyncMigrationWriteACL grants or revokes Write on the migration topic for a source hub.
+func SyncMigrationWriteACL(
+	mgr ctrl.Manager,
+	mgh *operatorv1alpha4.MulticlusterGlobalHub,
+	fromHub string,
+	grant bool,
+	opts ...KafkaOption,
+) error {
+	trans := NewStrimziTransporter(mgr, mgh, opts...)
+	return trans.SyncMigrationWriteACL(fromHub, grant)
+}

--- a/operator/pkg/controllers/transporter/protocol/migration_acl_test.go
+++ b/operator/pkg/controllers/transporter/protocol/migration_acl_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protocol
+
+import (
+	"context"
+	"testing"
+
+	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	operatorv1alpha4 "github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
+	operatorconfig "github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
+)
+
+func TestSyncMigrationWriteACLWrapper(t *testing.T) {
+	operatorconfig.SetMigrationTopic("gh-migration")
+
+	scheme := runtime.NewScheme()
+	if err := kafkav1beta2.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+
+	kafkaUser := &kafkav1beta2.KafkaUser{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hub1-kafka-user",
+			Namespace: "test-ns",
+		},
+		Spec: &kafkav1beta2.KafkaUserSpec{
+			Authorization: &kafkav1beta2.KafkaUserSpecAuthorization{
+				Type: kafkav1beta2.KafkaUserSpecAuthorizationTypeSimple,
+				Acls: []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
+					utils.ReadTopicACL("gh-spec", false),
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(kafkaUser).
+		Build()
+
+	mgh := &operatorv1alpha4.MulticlusterGlobalHub{
+		ObjectMeta: metav1.ObjectMeta{Name: "mgh", Namespace: "test-ns"},
+	}
+
+	mgr := &migrationACLMockManager{client: fakeClient}
+	if err := SyncMigrationWriteACL(mgr, mgh, "hub1", true, WithContext(context.Background())); err != nil {
+		t.Fatalf("SyncMigrationWriteACL() grant error = %v", err)
+	}
+
+	updated := &kafkav1beta2.KafkaUser{}
+	if err := fakeClient.Get(context.Background(), client.ObjectKeyFromObject(kafkaUser), updated); err != nil {
+		t.Fatalf("get updated kafka user: %v", err)
+	}
+	if len(updated.Spec.Authorization.Acls) != 2 {
+		t.Fatalf("expected read and write ACLs after grant, got %d", len(updated.Spec.Authorization.Acls))
+	}
+	wantKey := utils.GenerateACLKey(utils.WriteTopicACL("gh-migration"))
+	foundWrite := false
+	for _, acl := range updated.Spec.Authorization.Acls {
+		if utils.GenerateACLKey(acl) == wantKey {
+			foundWrite = true
+			break
+		}
+	}
+	if !foundWrite {
+		t.Fatal("expected migration topic write ACL")
+	}
+}

--- a/operator/pkg/controllers/transporter/protocol/strimzi_migration_acl.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_migration_acl.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protocol
+
+import (
+	"fmt"
+
+	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
+)
+
+func migrationWriteACLKey(topic string) string {
+	return utils.GenerateACLKey(utils.WriteTopicACL(topic))
+}
+
+func (k *strimziTransporter) hasMigrationWriteACL(acls []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem) bool {
+	key := migrationWriteACLKey(config.GetMigrationTopic())
+	for _, acl := range acls {
+		if utils.GenerateACLKey(acl) == key {
+			return true
+		}
+	}
+	return false
+}
+
+// SyncMigrationWriteACL grants or revokes Write on the migration topic for a source hub.
+func (k *strimziTransporter) SyncMigrationWriteACL(fromHub string, grant bool) error {
+	if fromHub == "" {
+		return nil
+	}
+
+	userName := config.GetKafkaUserName(fromHub)
+	kafkaUser := &kafkav1beta2.KafkaUser{}
+	err := k.manager.GetClient().Get(k.ctx, types.NamespacedName{
+		Name:      userName,
+		Namespace: k.kafkaClusterNamespace,
+	}, kafkaUser)
+	if errors.IsNotFound(err) {
+		if !grant {
+			return nil
+		}
+		return fmt.Errorf("kafka user %s not found for migration write ACL", userName)
+	}
+	if err != nil {
+		return err
+	}
+
+	migrationTopic := config.GetMigrationTopic()
+	desiredWriteACL := utils.WriteTopicACL(migrationTopic)
+
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latestKafkaUser := &kafkav1beta2.KafkaUser{}
+		if err := k.manager.GetClient().Get(k.ctx, types.NamespacedName{
+			Name:      userName,
+			Namespace: k.kafkaClusterNamespace,
+		}, latestKafkaUser); err != nil {
+			return err
+		}
+
+		currentACLs := currentKafkaUserACLs(latestKafkaUser)
+		if k.hasMigrationWriteACL(currentACLs) == grant {
+			return nil
+		}
+
+		updatedACLs := make([]kafkav1beta2.KafkaUserSpecAuthorizationAclsElem, 0, len(currentACLs))
+		for _, acl := range currentACLs {
+			if utils.GenerateACLKey(acl) == migrationWriteACLKey(migrationTopic) {
+				continue
+			}
+			updatedACLs = append(updatedACLs, acl)
+		}
+		if grant {
+			updatedACLs = append(updatedACLs, desiredWriteACL)
+		}
+
+		if len(updatedACLs) == 0 {
+			latestKafkaUser.Spec.Authorization = nil
+		} else {
+			if latestKafkaUser.Spec.Authorization == nil {
+				latestKafkaUser.Spec.Authorization = &kafkav1beta2.KafkaUserSpecAuthorization{
+					Type: kafkav1beta2.KafkaUserSpecAuthorizationTypeSimple,
+				}
+			}
+			if latestKafkaUser.Spec.Authorization.Type == "" {
+				latestKafkaUser.Spec.Authorization.Type = kafkav1beta2.KafkaUserSpecAuthorizationTypeSimple
+			}
+			latestKafkaUser.Spec.Authorization.Acls = updatedACLs
+		}
+		return k.manager.GetClient().Update(k.ctx, latestKafkaUser)
+	})
+}
+
+func currentKafkaUserACLs(kafkaUser *kafkav1beta2.KafkaUser) []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem {
+	if kafkaUser == nil || kafkaUser.Spec == nil || kafkaUser.Spec.Authorization == nil {
+		return nil
+	}
+	return kafkaUser.Spec.Authorization.Acls
+}

--- a/operator/pkg/controllers/transporter/protocol/strimzi_migration_acl_test.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_migration_acl_test.go
@@ -1,0 +1,275 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protocol
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	operatorconfig "github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
+)
+
+type migrationACLMockManager struct {
+	client client.Client
+}
+
+func (m *migrationACLMockManager) Add(manager.Runnable) error { return nil }
+func (m *migrationACLMockManager) GetClient() client.Client   { return m.client }
+func (m *migrationACLMockManager) GetScheme() *runtime.Scheme {
+	return nil
+}
+func (m *migrationACLMockManager) GetFieldIndexer() client.FieldIndexer { return nil }
+func (m *migrationACLMockManager) GetCache() cache.Cache                { return nil }
+func (m *migrationACLMockManager) GetEventRecorderFor(string) record.EventRecorder {
+	return nil
+}
+func (m *migrationACLMockManager) GetRESTMapper() meta.RESTMapper { return nil }
+func (m *migrationACLMockManager) GetAPIReader() client.Reader    { return nil }
+func (m *migrationACLMockManager) Start(context.Context) error    { return nil }
+func (m *migrationACLMockManager) GetWebhookServer() webhook.Server {
+	return nil
+}
+func (m *migrationACLMockManager) GetLogger() logr.Logger { return logr.Discard() }
+func (m *migrationACLMockManager) GetControllerOptions() config.Controller {
+	return config.Controller{}
+}
+func (m *migrationACLMockManager) Elected() <-chan struct{} { return nil }
+func (m *migrationACLMockManager) AddHealthzCheck(string, healthz.Checker) error {
+	return nil
+}
+
+func (m *migrationACLMockManager) AddReadyzCheck(string, healthz.Checker) error {
+	return nil
+}
+func (m *migrationACLMockManager) GetHTTPClient() *http.Client { return nil }
+func (m *migrationACLMockManager) AddMetricsServerExtraHandler(string, http.Handler) error {
+	return nil
+}
+func (m *migrationACLMockManager) GetConfig() *rest.Config { return nil }
+
+func TestMigrationWriteACLKey(t *testing.T) {
+	t.Parallel()
+
+	key := migrationWriteACLKey("gh-migration")
+	want := utils.GenerateACLKey(utils.WriteTopicACL("gh-migration"))
+	if key != want {
+		t.Fatalf("migrationWriteACLKey() = %q, want %q", key, want)
+	}
+}
+
+func TestHasMigrationWriteACL(t *testing.T) {
+	t.Parallel()
+
+	operatorconfig.SetMigrationTopic("gh-migration")
+	transporter := &strimziTransporter{}
+	withACL := []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
+		utils.WriteTopicACL("gh-migration"),
+	}
+	if !transporter.hasMigrationWriteACL(withACL) {
+		t.Fatal("expected migration write ACL to be present")
+	}
+	if transporter.hasMigrationWriteACL(nil) {
+		t.Fatal("expected nil ACL list to return false")
+	}
+}
+
+func TestCurrentKafkaUserACLs(t *testing.T) {
+	t.Parallel()
+
+	if got := currentKafkaUserACLs(&kafkav1beta2.KafkaUser{}); got != nil {
+		t.Fatalf("expected nil ACLs for missing spec, got %#v", got)
+	}
+	if got := currentKafkaUserACLs(nil); got != nil {
+		t.Fatalf("expected nil ACLs for nil user, got %#v", got)
+	}
+
+	acl := utils.WriteTopicACL("gh-migration")
+	user := &kafkav1beta2.KafkaUser{
+		Spec: &kafkav1beta2.KafkaUserSpec{
+			Authorization: &kafkav1beta2.KafkaUserSpecAuthorization{
+				Acls: []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{acl},
+			},
+		},
+	}
+	got := currentKafkaUserACLs(user)
+	if len(got) != 1 {
+		t.Fatalf("expected one ACL, got %d", len(got))
+	}
+}
+
+func TestSyncMigrationWriteACLSkipsEmptyHub(t *testing.T) {
+	t.Parallel()
+
+	transporter := &strimziTransporter{}
+	if err := transporter.SyncMigrationWriteACL("", true); err != nil {
+		t.Fatalf("SyncMigrationWriteACL with empty hub should succeed, got %v", err)
+	}
+}
+
+func TestSyncMigrationWriteACLGrantAndRevoke(t *testing.T) {
+	operatorconfig.SetMigrationTopic("gh-migration")
+
+	scheme := runtime.NewScheme()
+	if err := kafkav1beta2.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+
+	kafkaUser := &kafkav1beta2.KafkaUser{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hub1-kafka-user",
+			Namespace: "test-ns",
+		},
+		Spec: &kafkav1beta2.KafkaUserSpec{
+			Authorization: &kafkav1beta2.KafkaUserSpecAuthorization{
+				Type: kafkav1beta2.KafkaUserSpecAuthorizationTypeSimple,
+				Acls: []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
+					utils.ReadTopicACL("gh-spec", false),
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(kafkaUser).
+		Build()
+
+	transporter := &strimziTransporter{
+		ctx:                   context.Background(),
+		kafkaClusterNamespace: "test-ns",
+		manager:               &migrationACLMockManager{client: fakeClient},
+	}
+
+	if err := transporter.SyncMigrationWriteACL("hub1", true); err != nil {
+		t.Fatalf("grant migration write ACL: %v", err)
+	}
+
+	updated := &kafkav1beta2.KafkaUser{}
+	if err := fakeClient.Get(context.Background(), client.ObjectKeyFromObject(kafkaUser), updated); err != nil {
+		t.Fatalf("get updated kafka user: %v", err)
+	}
+	if !transporter.hasMigrationWriteACL(updated.Spec.Authorization.Acls) {
+		t.Fatal("expected migration write ACL to be granted")
+	}
+
+	if err := transporter.SyncMigrationWriteACL("hub1", false); err != nil {
+		t.Fatalf("revoke migration write ACL: %v", err)
+	}
+	if err := fakeClient.Get(context.Background(), client.ObjectKeyFromObject(kafkaUser), updated); err != nil {
+		t.Fatalf("get updated kafka user after revoke: %v", err)
+	}
+	if transporter.hasMigrationWriteACL(updated.Spec.Authorization.Acls) {
+		t.Fatal("expected migration write ACL to be revoked")
+	}
+}
+
+func TestSyncMigrationWriteACLNotFoundWhenGranting(t *testing.T) {
+	operatorconfig.SetMigrationTopic("gh-migration")
+
+	scheme := runtime.NewScheme()
+	if err := kafkav1beta2.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+
+	transporter := &strimziTransporter{
+		ctx:                   context.Background(),
+		kafkaClusterNamespace: "test-ns",
+		manager:               &migrationACLMockManager{client: fake.NewClientBuilder().WithScheme(scheme).Build()},
+	}
+
+	if err := transporter.SyncMigrationWriteACL("hub1", true); err == nil {
+		t.Fatal("expected error when kafka user is missing during grant")
+	}
+}
+
+func TestSyncMigrationWriteACLNotFoundWhenRevoking(t *testing.T) {
+	operatorconfig.SetMigrationTopic("gh-migration")
+
+	scheme := runtime.NewScheme()
+	if err := kafkav1beta2.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+
+	transporter := &strimziTransporter{
+		ctx:                   context.Background(),
+		kafkaClusterNamespace: "test-ns",
+		manager:               &migrationACLMockManager{client: fake.NewClientBuilder().WithScheme(scheme).Build()},
+	}
+
+	if err := transporter.SyncMigrationWriteACL("hub1", false); err != nil {
+		t.Fatalf("revoke on missing kafka user should succeed, got %v", err)
+	}
+}
+
+func TestSyncMigrationWriteACLInitializesNilAuthorization(t *testing.T) {
+	operatorconfig.SetMigrationTopic("gh-migration")
+
+	scheme := runtime.NewScheme()
+	if err := kafkav1beta2.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+
+	kafkaUser := &kafkav1beta2.KafkaUser{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hub1-kafka-user",
+			Namespace: "test-ns",
+		},
+		Spec: &kafkav1beta2.KafkaUserSpec{},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(kafkaUser).
+		Build()
+
+	transporter := &strimziTransporter{
+		ctx:                   context.Background(),
+		kafkaClusterNamespace: "test-ns",
+		manager:               &migrationACLMockManager{client: fakeClient},
+	}
+
+	if err := transporter.SyncMigrationWriteACL("hub1", true); err != nil {
+		t.Fatalf("grant migration write ACL with nil authorization: %v", err)
+	}
+
+	updated := &kafkav1beta2.KafkaUser{}
+	if err := fakeClient.Get(context.Background(), client.ObjectKeyFromObject(kafkaUser), updated); err != nil {
+		t.Fatalf("get updated kafka user: %v", err)
+	}
+	if updated.Spec.Authorization == nil || len(updated.Spec.Authorization.Acls) != 1 {
+		t.Fatal("expected authorization block with migration write ACL")
+	}
+}
+
+var _ ctrl.Manager = (*migrationACLMockManager)(nil)

--- a/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
@@ -135,6 +135,7 @@ func NewStrimziTransporter(mgr ctrl.Manager, mgh *operatorv1alpha4.MulticlusterG
 	}
 
 	transporter.mgh = mgh
+	transporter.manager = mgr
 	transporter.kafkaClusterNamespace = mgh.Namespace
 	// apply options
 	for _, opt := range opts {
@@ -268,6 +269,7 @@ func (k *strimziTransporter) renderKafkaResources(mgh *operatorv1alpha4.Multiclu
 				KafkaCluster           string
 				GlobalHubKafkaUser     string
 				SpecTopic              string
+				MigrationTopic         string
 				StatusTopic            string
 				StatusTopicPattern     string
 				StatusPlaceholderTopic string
@@ -283,6 +285,7 @@ func (k *strimziTransporter) renderKafkaResources(mgh *operatorv1alpha4.Multiclu
 				KafkaCluster:           KafkaClusterName,
 				GlobalHubKafkaUser:     DefaultGlobalHubKafkaUserName,
 				SpecTopic:              config.GetSpecTopic(),
+				MigrationTopic:         config.GetMigrationTopic(),
 				StatusTopic:            statusTopic,
 				StatusTopicPattern:     string(topicPattern),
 				StatusPlaceholderTopic: statusPlaceholderTopic,
@@ -357,6 +360,11 @@ func (k *strimziTransporter) EnsureUser(clusterName string) (string, error) {
 			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
 			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
 			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite,
+		}),
+		// consume migration deploying bundles from the dedicated migration topic
+		utils.GetTopicACL(clusterTopic.MigrationTopic, []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
 		}),
 		// report status into gh: allow the current hub to write messages to the specific status topic
 		utils.GetTopicACL(clusterTopic.StatusTopic, []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
@@ -443,7 +451,7 @@ func combineACLs(kafkaUserAcls []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem
 func (k *strimziTransporter) EnsureTopic(clusterName string) (*transport.ClusterTopic, error) {
 	clusterTopic := k.getClusterTopic(clusterName)
 
-	topicNames := []string{clusterTopic.SpecTopic, clusterTopic.StatusTopic}
+	topicNames := []string{clusterTopic.SpecTopic, clusterTopic.MigrationTopic, clusterTopic.StatusTopic}
 	for _, topicName := range topicNames {
 		if err := k.ensureTopic(topicName, nil); err != nil {
 			return nil, err
@@ -530,8 +538,9 @@ func (k *strimziTransporter) Prune(clusterName string) error {
 
 func (k *strimziTransporter) getClusterTopic(clusterName string) *transport.ClusterTopic {
 	topic := &transport.ClusterTopic{
-		SpecTopic:   config.GetSpecTopic(),
-		StatusTopic: config.GetStatusTopic(clusterName),
+		SpecTopic:      config.GetSpecTopic(),
+		MigrationTopic: config.GetMigrationTopic(),
+		StatusTopic:    config.GetStatusTopic(clusterName),
 	}
 	return topic
 }
@@ -551,6 +560,7 @@ func (k *strimziTransporter) GetConnCredential(clusterName string) (*transport.K
 	// topics
 	credential.StatusTopic = config.GetStatusTopic(clusterName)
 	credential.SpecTopic = config.GetSpecTopic()
+	credential.MigrationTopic = config.GetMigrationTopic()
 
 	// consumer group id
 	credential.ConsumerGroupID = config.GetConsumerGroupID(k.mgh.Spec.DataLayerSpec.Kafka.ConsumerGroupPrefix,

--- a/operator/pkg/controllers/transporter/transport_reconciler.go
+++ b/operator/pkg/controllers/transporter/transport_reconciler.go
@@ -61,6 +61,11 @@ func (c *TransportReconciler) IsResourceRemoved() bool {
 
 func StartController(controllerOption config.ControllerOption) (config.ControllerInterface, error) {
 	if transportReconciler != nil {
+		if !migrationACLControllerStarted {
+			if err := migrationACLReconcilerSetup(controllerOption.Manager); err != nil {
+				return nil, err
+			}
+		}
 		return transportReconciler, nil
 	}
 	log.Info("start transport controller")
@@ -77,9 +82,14 @@ func StartController(controllerOption config.ControllerOption) (config.Controlle
 		transportReconciler = nil
 		return nil, err
 	}
+	if err := migrationACLReconcilerSetup(controllerOption.Manager); err != nil {
+		return nil, err
+	}
 	log.Infof("inited transport controller")
 	return transportReconciler, nil
 }
+
+var migrationACLReconcilerSetup = setupMigrationACLReconciler
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *TransportReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/operator/pkg/controllers/transporter/transport_reconciler_test.go
+++ b/operator/pkg/controllers/transporter/transport_reconciler_test.go
@@ -1,21 +1,40 @@
 package transporter
 
 import (
+	"context"
+	"errors"
+	"net/http"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	crconfig "sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
+	migrationv1alpha1 "github.com/stolostron/multicluster-global-hub/operator/api/migration/v1alpha1"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/transporter/protocol"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
+
+var errMigrationACLSetup = errors.New("migration ACL controller registration failed")
 
 // Predicate Tests - These test critical watch logic for Kafka-related resources
 
@@ -286,15 +305,126 @@ func TestTransportReconcilerIsResourceRemoved(t *testing.T) {
 func TestStartControllerSingleton(t *testing.T) {
 	// Save and restore the singleton so we don't affect other tests.
 	original := transportReconciler
-	t.Cleanup(func() { transportReconciler = original })
+	originalMigrationACL := migrationACLControllerStarted
+	t.Cleanup(func() {
+		transportReconciler = original
+		migrationACLControllerStarted = originalMigrationACL
+	})
 
 	existing := &TransportReconciler{}
 	transportReconciler = existing
+	migrationACLControllerStarted = true
 
 	// Second call must return the pre-existing instance without error.
 	controller, err := StartController(config.ControllerOption{})
-	assert.NoError(t, err)
-	assert.Equal(t, existing, controller)
+	assert.NoError(t, err, "StartController should succeed when transport singleton is already initialized")
+	assert.Equal(t, existing, controller, "StartController should reuse the existing transport controller instance")
+}
+
+func TestStartControllerRetriesMigrationACLSetup(t *testing.T) {
+	originalTransport := transportReconciler
+	originalMigrationACL := migrationACLControllerStarted
+	originalSetup := migrationACLReconcilerSetup
+	t.Cleanup(func() {
+		transportReconciler = originalTransport
+		migrationACLControllerStarted = originalMigrationACL
+		migrationACLReconcilerSetup = originalSetup
+	})
+
+	scheme := runtime.NewScheme()
+	if err := migrationv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(ManagedClusterMigration) error = %v", err)
+	}
+	mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{migrationv1alpha1.GroupVersion})
+	mapper.Add(migrationv1alpha1.GroupVersion.WithKind("ManagedClusterMigration"), meta.RESTScopeNamespace)
+
+	transportReconciler = &TransportReconciler{}
+	migrationACLControllerStarted = false
+	migrationACLReconcilerSetup = func(ctrl.Manager) error { return errMigrationACLSetup }
+
+	mgr := &migrationACLSetupFailManager{
+		client:     fake.NewClientBuilder().WithScheme(scheme).Build(),
+		scheme:     scheme,
+		restMapper: mapper,
+	}
+
+	controller, err := StartController(config.ControllerOption{Manager: mgr})
+	assert.ErrorIs(t, err, errMigrationACLSetup, "StartController should return migration ACL setup error")
+	assert.Nil(t, controller, "StartController should not return a controller when migration ACL setup fails")
+	assert.False(
+		t,
+		migrationACLControllerStarted,
+		"migration ACL controller must not be marked started after setup failure",
+	)
+}
+
+type migrationACLSetupFailManager struct {
+	client     client.Client
+	scheme     *runtime.Scheme
+	restMapper meta.RESTMapper
+	addErr     error
+}
+
+func (m *migrationACLSetupFailManager) Add(manager.Runnable) error { return m.addErr }
+func (m *migrationACLSetupFailManager) GetClient() client.Client   { return m.client }
+func (m *migrationACLSetupFailManager) GetScheme() *runtime.Scheme { return m.scheme }
+func (m *migrationACLSetupFailManager) GetFieldIndexer() client.FieldIndexer {
+	return nil
+}
+func (m *migrationACLSetupFailManager) GetCache() cache.Cache { return nil }
+func (m *migrationACLSetupFailManager) GetEventRecorderFor(string) record.EventRecorder {
+	return nil
+}
+func (m *migrationACLSetupFailManager) GetRESTMapper() meta.RESTMapper { return m.restMapper }
+func (m *migrationACLSetupFailManager) GetAPIReader() client.Reader    { return m.client }
+func (m *migrationACLSetupFailManager) Start(context.Context) error    { return nil }
+func (m *migrationACLSetupFailManager) GetWebhookServer() webhook.Server {
+	return nil
+}
+func (m *migrationACLSetupFailManager) GetLogger() logr.Logger { return logr.Discard() }
+func (m *migrationACLSetupFailManager) GetControllerOptions() crconfig.Controller {
+	return crconfig.Controller{}
+}
+func (m *migrationACLSetupFailManager) Elected() <-chan struct{} { return nil }
+func (m *migrationACLSetupFailManager) AddHealthzCheck(string, healthz.Checker) error {
+	return nil
+}
+
+func (m *migrationACLSetupFailManager) AddReadyzCheck(string, healthz.Checker) error {
+	return nil
+}
+func (m *migrationACLSetupFailManager) GetHTTPClient() *http.Client { return nil }
+func (m *migrationACLSetupFailManager) AddMetricsServerExtraHandler(string, http.Handler) error {
+	return nil
+}
+func (m *migrationACLSetupFailManager) GetConfig() *rest.Config { return nil }
+
+var _ ctrl.Manager = (*migrationACLSetupFailManager)(nil)
+
+func TestAMigrationACLReconcilerSetupSuccess(t *testing.T) {
+	original := migrationACLControllerStarted
+	migrationACLControllerStarted = false
+	t.Cleanup(func() { migrationACLControllerStarted = original })
+
+	scheme := runtime.NewScheme()
+	if err := migrationv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(ManagedClusterMigration) error = %v", err)
+	}
+	mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{migrationv1alpha1.GroupVersion})
+	mapper.Add(migrationv1alpha1.GroupVersion.WithKind("ManagedClusterMigration"), meta.RESTScopeNamespace)
+
+	mgr := &migrationACLSetupFailManager{
+		client:     fake.NewClientBuilder().WithScheme(scheme).Build(),
+		scheme:     scheme,
+		restMapper: mapper,
+	}
+
+	if err := setupMigrationACLReconciler(mgr); err != nil {
+		t.Fatalf("setupMigrationACLReconciler() error = %v", err)
+	}
+	if !migrationACLControllerStarted {
+		t.Fatal("expected migration ACL controller to be marked started")
+	}
 }
 
 func TestNetworkPolicyCondCustomNamespace(t *testing.T) {

--- a/pkg/transport/consumer/generic_consumer.go
+++ b/pkg/transport/consumer/generic_consumer.go
@@ -161,10 +161,16 @@ func (c *GenericConsumer) Start(ctx context.Context) error {
 
 // initClient will init the consumer identity, clientProtocol, client
 func (c *GenericConsumer) initClient(tranConfig *transport.TransportInternalConfig) (cloudevents.Client, error) {
-	topics := []string{tranConfig.KafkaCredential.SpecTopic}
+	var topics []string
 	if c.isManager {
 		c.statusTopicPattern = tranConfig.KafkaCredential.StatusTopic
 		topics = []string{tranConfig.KafkaCredential.StatusTopic}
+	} else {
+		topics = []string{tranConfig.KafkaCredential.SpecTopic}
+		if migrationTopic := tranConfig.KafkaCredential.GetMigrationTopic(); migrationTopic != "" &&
+			migrationTopic != tranConfig.KafkaCredential.SpecTopic {
+			topics = append(topics, migrationTopic)
+		}
 	}
 
 	var err error
@@ -183,11 +189,15 @@ func (c *GenericConsumer) initClient(tranConfig *transport.TransportInternalConf
 		if tranConfig.Extends == nil {
 			tranConfig.Extends = make(map[string]interface{})
 		}
-		topic := topics[0]
-		if _, found := tranConfig.Extends[topic]; !found {
-			tranConfig.Extends[topic] = gochan.New()
+		primaryTopic := topics[0]
+		if _, found := tranConfig.Extends[primaryTopic]; !found {
+			tranConfig.Extends[primaryTopic] = gochan.New()
 		}
-		clientProtocol = tranConfig.Extends[topic]
+		primaryChan := tranConfig.Extends[primaryTopic]
+		for _, topic := range topics[1:] {
+			tranConfig.Extends[topic] = primaryChan
+		}
+		clientProtocol = primaryChan
 	default:
 		return nil, fmt.Errorf("transport-type - %s is not a valid option", tranConfig.TransportType)
 	}

--- a/pkg/transport/consumer/generic_consumer_test.go
+++ b/pkg/transport/consumer/generic_consumer_test.go
@@ -250,6 +250,46 @@ func TestInitClientWithChanTransport(t *testing.T) {
 		assert.NotNil(t, config.Extends)
 	})
 
+	t.Run("init client aliases migration topic to spec topic for Chan transport", func(t *testing.T) {
+		consumer, err := NewGenericConsumer(false, false)
+		assert.NoError(t, err)
+
+		config := &transport.TransportInternalConfig{
+			TransportType: string(transport.Chan),
+			KafkaCredential: &transport.KafkaConfig{
+				SpecTopic:      "gh-spec",
+				MigrationTopic: "gh-migration",
+			},
+			Extends: make(map[string]any),
+		}
+
+		client, err := consumer.initClient(config)
+		assert.NoError(t, err)
+		assert.NotNil(t, client)
+		assert.NotNil(t, config.Extends["gh-spec"])
+		assert.Equal(t, config.Extends["gh-spec"], config.Extends["gh-migration"])
+	})
+
+	t.Run("init client skips migration topic when same as spec topic", func(t *testing.T) {
+		consumer, err := NewGenericConsumer(false, false)
+		assert.NoError(t, err)
+
+		config := &transport.TransportInternalConfig{
+			TransportType: string(transport.Chan),
+			KafkaCredential: &transport.KafkaConfig{
+				SpecTopic:      "gh-spec",
+				MigrationTopic: "gh-spec",
+			},
+			Extends: make(map[string]any),
+		}
+
+		client, err := consumer.initClient(config)
+		assert.NoError(t, err)
+		assert.NotNil(t, client)
+		assert.NotNil(t, config.Extends["gh-spec"])
+		assert.Len(t, config.Extends, 1)
+	})
+
 	t.Run("init client with invalid transport type", func(t *testing.T) {
 		consumer, err := NewGenericConsumer(false, false)
 		assert.NoError(t, err)

--- a/pkg/transport/kafka_config.go
+++ b/pkg/transport/kafka_config.go
@@ -8,6 +8,7 @@ type KafkaConfig struct {
 	BootstrapServer  string `yaml:"bootstrap.server"`
 	StatusTopic      string `yaml:"topic.status,omitempty"`
 	SpecTopic        string `yaml:"topic.spec,omitempty"`
+	MigrationTopic   string `yaml:"topic.migration,omitempty"`
 	ClusterID        string `yaml:"cluster.id,omitempty"`
 	CACert           string `yaml:"ca.crt,omitempty"`
 	ClientCert       string `yaml:"client.crt,omitempty"`
@@ -38,6 +39,7 @@ func (k *KafkaConfig) DeepCopy() *KafkaConfig {
 		BootstrapServer:  k.BootstrapServer,
 		StatusTopic:      k.StatusTopic,
 		SpecTopic:        k.SpecTopic,
+		MigrationTopic:   k.MigrationTopic,
 		ClusterID:        k.ClusterID,
 		ConsumerGroupID:  k.ConsumerGroupID,
 		CACert:           k.CACert,
@@ -78,4 +80,16 @@ func (k *KafkaConfig) GetCASecretName() string {
 
 func (k *KafkaConfig) GetClientSecretName() string {
 	return k.ClientSecretName
+}
+
+// GetMigrationTopic returns the dedicated migration topic, falling back to the spec topic
+// when the credential has not yet been refreshed (upgrade window).
+func (k *KafkaConfig) GetMigrationTopic() string {
+	if k == nil {
+		return ""
+	}
+	if k.MigrationTopic != "" {
+		return k.MigrationTopic
+	}
+	return k.SpecTopic
 }

--- a/pkg/transport/kafka_config_test.go
+++ b/pkg/transport/kafka_config_test.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2023 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package transport
+
+import "testing"
+
+func TestKafkaConfigGetMigrationTopic(t *testing.T) {
+	cfg := &KafkaConfig{
+		SpecTopic:      "gh-spec",
+		MigrationTopic: "gh-migration",
+	}
+	if got := cfg.GetMigrationTopic(); got != "gh-migration" {
+		t.Fatalf("GetMigrationTopic() = %q, want gh-migration", got)
+	}
+
+	fallback := &KafkaConfig{SpecTopic: "gh-spec"}
+	if got := fallback.GetMigrationTopic(); got != "gh-spec" {
+		t.Fatalf("GetMigrationTopic() fallback = %q, want gh-spec", got)
+	}
+
+	var nilCfg *KafkaConfig
+	if got := nilCfg.GetMigrationTopic(); got != "" {
+		t.Fatalf("GetMigrationTopic() nil = %q, want empty string", got)
+	}
+}

--- a/pkg/transport/producer/generic_producer.go
+++ b/pkg/transport/producer/generic_producer.go
@@ -6,6 +6,7 @@ package producer
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	kafka_confluent "github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2"
@@ -23,12 +24,27 @@ import (
 )
 
 type GenericProducer struct {
-	log               *zap.SugaredLogger
-	ceProtocol        interface{}
-	ceClient          cloudevents.Client
-	kafkaProducer     *kafka.Producer
-	messageSizeLimit  int
-	eventErrorHandler func(event *kafka.Message)
+	log                  *zap.SugaredLogger
+	ceProtocol           interface{}
+	ceClient             cloudevents.Client
+	kafkaProducer        *kafka.Producer
+	messageSizeLimit     int
+	eventErrorHandler    func(event *kafka.Message)
+	sendMu               sync.Mutex
+	pendingDeliveryMu    sync.Mutex
+	pendingDelivery      *pendingDeliveryTracker
+	flushConfirmMu       sync.Mutex
+	flushConfirming      bool
+	flushFirstErr        error
+	asyncDeliveryMu      sync.Mutex
+	asyncDeliveryPending int
+}
+
+type pendingDeliveryTracker struct {
+	correlationID string
+	remaining     int
+	firstErr      error
+	done          chan error
 }
 
 func NewGenericProducer(transportConfig *transport.TransportInternalConfig, topic string,
@@ -56,6 +72,12 @@ func (p *GenericProducer) Protocol() *kafka_confluent.Protocol {
 }
 
 func (p *GenericProducer) SendEvent(ctx context.Context, evt cloudevents.Event) error {
+	p.sendMu.Lock()
+	defer p.sendMu.Unlock()
+	return p.sendEventLocked(ctx, evt)
+}
+
+func (p *GenericProducer) sendEventLocked(ctx context.Context, evt cloudevents.Event) error {
 	// cloudevent kafka/gochan client
 	// message key
 	evtCtx := cectx.WithLogger(ctx, logger.ZapLogger("cloudevents"))
@@ -88,6 +110,209 @@ func (p *GenericProducer) SendEvent(ctx context.Context, evt cloudevents.Event) 
 	return nil
 }
 
+// SendEventWithDeliveryConfirmation sends an event and waits for all Kafka delivery
+// reports for that event (including every chunk). Non-Kafka transports fall back to SendEvent.
+func (p *GenericProducer) SendEventWithDeliveryConfirmation(
+	ctx context.Context, evt cloudevents.Event, timeout time.Duration,
+) error {
+	if p.kafkaProducer == nil {
+		p.sendMu.Lock()
+		defer p.sendMu.Unlock()
+		return p.sendEventLocked(ctx, evt)
+	}
+
+	p.sendMu.Lock()
+	defer p.sendMu.Unlock()
+
+	// Drain in-flight messages from ordinary SendEvent traffic before capturing
+	// delivery errors, so unrelated failures are not attributed to this publish.
+	p.drainKafkaProducerQueue()
+	p.waitAsyncDeliveryReportsSettled(500 * time.Millisecond)
+
+	if err := p.sendEventLocked(ctx, evt); err != nil {
+		return err
+	}
+
+	p.beginFlushConfirmation()
+	defer p.endFlushConfirmation()
+
+	deadline := time.Now().Add(timeout)
+	for {
+		if err := p.flushDeliveryError(); err != nil {
+			return err
+		}
+
+		remaining := p.kafkaProducer.Flush(250)
+		if err := p.flushDeliveryError(); err != nil {
+			return err
+		}
+		if remaining == 0 {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf(
+				"timed out waiting for %d kafka delivery reports after %v",
+				remaining, timeout,
+			)
+		}
+	}
+}
+
+func (p *GenericProducer) beginFlushConfirmation() {
+	p.flushConfirmMu.Lock()
+	defer p.flushConfirmMu.Unlock()
+	p.flushConfirming = true
+	p.flushFirstErr = nil
+}
+
+func (p *GenericProducer) endFlushConfirmation() {
+	p.flushConfirmMu.Lock()
+	defer p.flushConfirmMu.Unlock()
+	p.flushConfirming = false
+	p.flushFirstErr = nil
+}
+
+func (p *GenericProducer) recordFlushDeliveryError(err error) {
+	if err == nil {
+		return
+	}
+	p.flushConfirmMu.Lock()
+	defer p.flushConfirmMu.Unlock()
+	if p.flushConfirming && p.flushFirstErr == nil {
+		p.flushFirstErr = err
+	}
+}
+
+func (p *GenericProducer) flushDeliveryError() error {
+	p.flushConfirmMu.Lock()
+	defer p.flushConfirmMu.Unlock()
+	return p.flushFirstErr
+}
+
+func (p *GenericProducer) drainKafkaProducerQueue() {
+	for {
+		if p.kafkaProducer.Flush(250) == 0 {
+			return
+		}
+	}
+}
+
+func (p *GenericProducer) beginAsyncDeliveryReport() {
+	p.asyncDeliveryMu.Lock()
+	p.asyncDeliveryPending++
+	p.asyncDeliveryMu.Unlock()
+}
+
+func (p *GenericProducer) endAsyncDeliveryReport() {
+	p.asyncDeliveryMu.Lock()
+	p.asyncDeliveryPending--
+	p.asyncDeliveryMu.Unlock()
+}
+
+func (p *GenericProducer) waitAsyncDeliveryReportsSettled(timeout time.Duration) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		p.asyncDeliveryMu.Lock()
+		pending := p.asyncDeliveryPending
+		p.asyncDeliveryMu.Unlock()
+		if pending == 0 {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func (p *GenericProducer) expectedDeliveryReports(evt cloudevents.Event) int {
+	expected := len(p.splitPayloadIntoChunks(evt.Data()))
+	if expected == 0 {
+		return 1
+	}
+	return expected
+}
+
+func (p *GenericProducer) beginPendingDelivery(expected int, correlationID string) *pendingDeliveryTracker {
+	p.pendingDeliveryMu.Lock()
+	defer p.pendingDeliveryMu.Unlock()
+	if p.pendingDelivery != nil {
+		return nil
+	}
+	tracker := &pendingDeliveryTracker{
+		correlationID: correlationID,
+		remaining:     expected,
+		done:          make(chan error, 1),
+	}
+	p.pendingDelivery = tracker
+	return tracker
+}
+
+func (p *GenericProducer) clearPendingDelivery(tracker *pendingDeliveryTracker) {
+	p.pendingDeliveryMu.Lock()
+	defer p.pendingDeliveryMu.Unlock()
+	if p.pendingDelivery == tracker {
+		p.pendingDelivery = nil
+	}
+}
+
+func (p *GenericProducer) recordDeliveryReport(m *kafka.Message) {
+	p.beginAsyncDeliveryReport()
+	defer p.endAsyncDeliveryReport()
+
+	if m != nil && m.TopicPartition.Error != nil {
+		p.recordFlushDeliveryError(m.TopicPartition.Error)
+	}
+
+	correlationID := deliveryCorrelationFromMessage(m)
+	if correlationID == "" {
+		return
+	}
+
+	var deliveryErr error
+	if m.TopicPartition.Error != nil {
+		deliveryErr = m.TopicPartition.Error
+	}
+
+	p.pendingDeliveryMu.Lock()
+	tracker := p.pendingDelivery
+	if tracker == nil || correlationID != tracker.correlationID {
+		p.pendingDeliveryMu.Unlock()
+		return
+	}
+
+	if deliveryErr != nil && tracker.firstErr == nil {
+		tracker.firstErr = deliveryErr
+		p.pendingDelivery = nil
+		p.pendingDeliveryMu.Unlock()
+		tracker.done <- deliveryErr
+		return
+	}
+
+	tracker.remaining--
+	if tracker.remaining <= 0 {
+		p.pendingDelivery = nil
+		pendingErr := tracker.firstErr
+		p.pendingDeliveryMu.Unlock()
+		tracker.done <- pendingErr
+		return
+	}
+	p.pendingDeliveryMu.Unlock()
+}
+
+func deliveryCorrelationFromMessage(m *kafka.Message) string {
+	if m == nil {
+		return ""
+	}
+	if correlationID, ok := m.Opaque.(string); ok && correlationID != "" {
+		return correlationID
+	}
+	headerKey := "ce_" + transport.DeliveryCorrelationKey
+	for _, header := range m.Headers {
+		if header.Key == headerKey {
+			return string(header.Value)
+		}
+	}
+	return ""
+}
+
 // Reconnect close the previous producer state and init a new producer
 func (p *GenericProducer) Reconnect(config *transport.TransportInternalConfig, topic string) error {
 	// cloudevent kafka/gochan client
@@ -113,7 +338,7 @@ func (p *GenericProducer) initClient(transportConfig *transport.TransportInterna
 		if err != nil {
 			return err
 		}
-		handleProducerEvents(p.log, eventChan, transportConfig.FailureThreshold, p.eventErrorHandler)
+		handleProducerEvents(p, eventChan, transportConfig.FailureThreshold)
 		p.ceProtocol = kafkaProtocol
 		p.kafkaProducer = producer
 	case string(transport.Chan):
@@ -178,9 +403,7 @@ func getConfluentSenderProtocol(logger *zap.SugaredLogger, kafkaCredentail *tran
 	return producer, protocol, nil
 }
 
-func handleProducerEvents(log *zap.SugaredLogger, eventChan chan kafka.Event, transportFailureThreshold int,
-	eventErrorHandler func(event *kafka.Message),
-) {
+func handleProducerEvents(p *GenericProducer, eventChan chan kafka.Event, transportFailureThreshold int) {
 	// Listen to all the events on the default events channel
 	// It's important to read these events otherwise the events channel will eventually fill up
 	go func() {
@@ -195,10 +418,13 @@ func handleProducerEvents(log *zap.SugaredLogger, eventChan chan kafka.Event, tr
 				// is already configured to do that.
 				m := ev
 				if m.TopicPartition.Error != nil {
-					if eventErrorHandler != nil {
-						eventErrorHandler(m)
+					p.recordDeliveryReport(m)
+					if p.eventErrorHandler != nil {
+						p.eventErrorHandler(m)
 					}
-					log.Warnw("delivery failed", "error", m.TopicPartition.Error)
+					p.log.Warnw("delivery failed", "error", m.TopicPartition.Error)
+				} else {
+					p.recordDeliveryReport(m)
 				}
 			case kafka.Error:
 				// Generic client instance-level errors, such as
@@ -213,13 +439,13 @@ func handleProducerEvents(log *zap.SugaredLogger, eventChan chan kafka.Event, tr
 					// to the application that currently there are no brokers to communicate with.
 					// But librdkafka will continue to try to reconnect indefinately,
 					// and it will attempt to re-send messages until message.timeout.ms or message.max.retries are exceeded.
-					log.Debugw("transport producer client error(ALL_BROKERS_DOWN), ignore it for most cases", "error", ev)
+					p.log.Debugw("transport producer client error(ALL_BROKERS_DOWN), ignore it for most cases", "error", ev)
 				} else {
-					log.Warnw("transport producer client error", "error", ev)
+					p.log.Warnw("transport producer client error", "error", ev)
 
 					errorCount++
 					if errorCount >= transportFailureThreshold {
-						log.Panicf("transport producer error > 10 in 5 minutes, error: %v", ev)
+						p.log.Panicf("transport producer error > 10 in 5 minutes, error: %v", ev)
 					}
 					// return panic when error more than 10 times in 5 minites
 					if lastErrorTime.Add(5 * time.Minute).Before(time.Now()) {

--- a/pkg/transport/producer/generic_producer_test.go
+++ b/pkg/transport/producer/generic_producer_test.go
@@ -4,8 +4,11 @@
 package producer
 
 import (
+	"errors"
 	"testing"
+	"time"
 
+	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	"github.com/stretchr/testify/require"
 
@@ -40,10 +43,208 @@ func Test_handleProducerEvents(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			log := logger.DefaultZapLogger()
+			p := &GenericProducer{log: logger.DefaultZapLogger()}
 			eventChan := make(chan kafka.Event)
-			go handleProducerEvents(log, eventChan, tt.transportFailureThreshold, nil)
+			go handleProducerEvents(p, eventChan, tt.transportFailureThreshold)
 			eventChan <- tt.event
 		})
 	}
+}
+
+func TestRecordDeliveryReport_multiChunkSuccess(t *testing.T) {
+	p := &GenericProducer{}
+	const correlationID = "corr-multi"
+	tracker := p.beginPendingDelivery(3, correlationID)
+	require.NotNil(t, tracker)
+
+	p.recordDeliveryReport(kafkaDeliveryReportWithOpaque(correlationID, nil))
+	p.recordDeliveryReport(kafkaDeliveryReportWithOpaque(correlationID, nil))
+	assertPendingNotDone(t, tracker)
+
+	p.recordDeliveryReport(kafkaDeliveryReportWithOpaque(correlationID, nil))
+	require.NoError(t, waitPendingDone(t, tracker))
+}
+
+func TestRecordDeliveryReport_firstChunkFailure(t *testing.T) {
+	p := &GenericProducer{}
+	const correlationID = "corr-fail"
+	tracker := p.beginPendingDelivery(3, correlationID)
+	require.NotNil(t, tracker)
+
+	sendErr := errors.New("Topic authorization failed")
+	p.recordDeliveryReport(kafkaDeliveryReport(correlationID, sendErr))
+
+	require.Equal(t, sendErr, waitPendingDone(t, tracker))
+}
+
+func TestRecordDeliveryReport_ignoredWithoutTracker(t *testing.T) {
+	p := &GenericProducer{}
+	require.NotPanics(t, func() {
+		p.recordDeliveryReport(kafkaDeliveryReport("corr-orphan", nil))
+		p.recordDeliveryReport(kafkaDeliveryReport("corr-orphan", errors.New("ignored")))
+	})
+}
+
+func TestRecordDeliveryReport_ignoresUnrelatedCorrelation(t *testing.T) {
+	p := &GenericProducer{}
+	const correlationID = "corr-current"
+	tracker := p.beginPendingDelivery(2, correlationID)
+	require.NotNil(t, tracker)
+
+	// Pre-existing or unrelated delivery reports must not advance this tracker.
+	p.recordDeliveryReport(kafkaDeliveryReport("corr-old", nil))
+	p.recordDeliveryReport(kafkaDeliveryReport("", nil))
+	assertPendingNotDone(t, tracker)
+
+	p.recordDeliveryReport(kafkaDeliveryReport(correlationID, nil))
+	p.recordDeliveryReport(kafkaDeliveryReport(correlationID, nil))
+	require.NoError(t, waitPendingDone(t, tracker))
+
+	// Late unrelated report after completion is ignored.
+	require.NotPanics(t, func() {
+		p.recordDeliveryReport(kafkaDeliveryReport("corr-old", nil))
+	})
+}
+
+func TestRecordDeliveryReport_lateReportAfterTrackerCleared(t *testing.T) {
+	p := &GenericProducer{}
+	const correlationA = "corr-a"
+	const correlationB = "corr-b"
+
+	trackerA := p.beginPendingDelivery(2, correlationA)
+	require.NotNil(t, trackerA)
+	// Simulate confirmation timeout clearing the tracker before all reports arrive.
+	p.clearPendingDelivery(trackerA)
+
+	trackerB := p.beginPendingDelivery(2, correlationB)
+	require.NotNil(t, trackerB)
+
+	// Late report from tracker A must not satisfy tracker B.
+	p.recordDeliveryReport(kafkaDeliveryReport(correlationA, nil))
+	assertPendingNotDone(t, trackerB)
+
+	p.recordDeliveryReport(kafkaDeliveryReport(correlationB, nil))
+	p.recordDeliveryReport(kafkaDeliveryReport(correlationB, nil))
+	require.NoError(t, waitPendingDone(t, trackerB))
+}
+
+func TestDeliveryCorrelationFromMessage(t *testing.T) {
+	require.Equal(t, "abc", deliveryCorrelationFromMessage(kafkaDeliveryReport("abc", nil)))
+	require.Equal(t, "opaque-id", deliveryCorrelationFromMessage(kafkaDeliveryReportWithOpaque("opaque-id", nil)))
+	require.Equal(t, "", deliveryCorrelationFromMessage(kafkaDeliveryReport("", nil)))
+	require.Equal(t, "", deliveryCorrelationFromMessage(nil))
+}
+
+func TestExpectedDeliveryReports(t *testing.T) {
+	p := &GenericProducer{messageSizeLimit: 4}
+
+	evt := cloudeventsEventWithData([]byte("123456789"))
+	require.Equal(t, 3, p.expectedDeliveryReports(evt))
+
+	evt = cloudeventsEventWithData(nil)
+	require.Equal(t, 1, p.expectedDeliveryReports(evt))
+}
+
+func TestBeginPendingDelivery_rejectsConcurrentTracker(t *testing.T) {
+	p := &GenericProducer{}
+	first := p.beginPendingDelivery(1, "corr-1")
+	require.NotNil(t, first)
+	require.Nil(t, p.beginPendingDelivery(1, "corr-2"))
+}
+
+func TestRecordFlushDeliveryError_ignoredWhenNotConfirming(t *testing.T) {
+	p := &GenericProducer{}
+	p.recordFlushDeliveryError(errors.New("unrelated"))
+	require.NoError(t, p.flushDeliveryError())
+}
+
+func TestFlushConfirmation_ignoresPredrainDeliveryErrors(t *testing.T) {
+	p := &GenericProducer{}
+
+	// Simulate an ordinary SendEvent failure still being processed before confirmation.
+	p.recordDeliveryReport(kafkaDeliveryReport("", errors.New("unrelated ordinary send failure")))
+	require.NoError(t, p.flushDeliveryError())
+
+	p.waitAsyncDeliveryReportsSettled(time.Second)
+
+	p.beginFlushConfirmation()
+	defer p.endFlushConfirmation()
+
+	p.recordDeliveryReport(kafkaDeliveryReport("", nil))
+	require.NoError(t, p.flushDeliveryError())
+}
+
+func TestFlushConfirmation_unrelatedErrorDuringConfirmationStillFails(t *testing.T) {
+	p := &GenericProducer{}
+
+	p.beginFlushConfirmation()
+	defer p.endFlushConfirmation()
+
+	unrelatedErr := errors.New("unrelated failure during confirmation window")
+	p.recordDeliveryReport(kafkaDeliveryReport("", unrelatedErr))
+	require.Equal(t, unrelatedErr, p.flushDeliveryError())
+}
+
+func TestWaitAsyncDeliveryReportsSettled_waitsForInFlightHandler(t *testing.T) {
+	p := &GenericProducer{}
+	p.beginAsyncDeliveryReport()
+
+	done := make(chan struct{})
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		p.endAsyncDeliveryReport()
+		close(done)
+	}()
+
+	p.waitAsyncDeliveryReportsSettled(time.Second)
+	<-done
+}
+
+func assertPendingNotDone(t *testing.T, tracker *pendingDeliveryTracker) {
+	t.Helper()
+	select {
+	case err := <-tracker.done:
+		t.Fatalf("expected pending delivery to remain open, got %v", err)
+	default:
+	}
+}
+
+func waitPendingDone(t *testing.T, tracker *pendingDeliveryTracker) error {
+	t.Helper()
+	select {
+	case err := <-tracker.done:
+		return err
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for pending delivery")
+		return nil
+	}
+}
+
+func kafkaDeliveryReport(correlationID string, deliveryErr error) *kafka.Message {
+	msg := &kafka.Message{}
+	if correlationID != "" {
+		msg.Headers = []kafka.Header{{
+			Key:   "ce_" + transport.DeliveryCorrelationKey,
+			Value: []byte(correlationID),
+		}}
+	}
+	if deliveryErr != nil {
+		msg.TopicPartition.Error = deliveryErr
+	}
+	return msg
+}
+
+func kafkaDeliveryReportWithOpaque(correlationID string, deliveryErr error) *kafka.Message {
+	msg := &kafka.Message{Opaque: correlationID}
+	if deliveryErr != nil {
+		msg.TopicPartition.Error = deliveryErr
+	}
+	return msg
+}
+
+func cloudeventsEventWithData(data []byte) cloudevents.Event {
+	evt := cloudevents.NewEvent()
+	evt.SetType("test.event")
+	_ = evt.SetData(cloudevents.ApplicationJSON, data)
+	return evt
 }

--- a/pkg/transport/type.go
+++ b/pkg/transport/type.go
@@ -8,6 +8,8 @@ const (
 	Broadcast      = "broadcast" // Broadcast can be used as destination when a bundle should be broadcasted.
 	ChunkSizeKey   = "extsize"   // ChunkSizeKey is the key used for total bundle size header.
 	ChunkOffsetKey = "extoffset" // ChunkOffsetKey is the key used for message fragment offset header.
+	// DeliveryCorrelationKey tags Kafka messages during producer delivery confirmation.
+	DeliveryCorrelationKey = "deliverycorrelation"
 )
 
 // indicate the transport type, only support kafka or go chan
@@ -67,8 +69,9 @@ type KafkaConsumerConfig struct {
 
 // topics
 type ClusterTopic struct {
-	SpecTopic   string
-	StatusTopic string
+	SpecTopic      string
+	MigrationTopic string
+	StatusTopic    string
 }
 
 type EventPosition struct {

--- a/test/integration/agent/migration/migration_to_syncer_test.go
+++ b/test/integration/agent/migration/migration_to_syncer_test.go
@@ -294,6 +294,10 @@ var _ = Describe("MigrationToSyncer", Ordered, func() {
 				},
 			}
 			Expect(runtimeClient.Create(testCtx, migrationCR)).Should(Succeed())
+			DeferCleanup(func() {
+				err := client.IgnoreNotFound(runtimeClient.Delete(testCtx, migrationCR))
+				Expect(err).NotTo(HaveOccurred())
+			})
 			migrationCR.Status.Phase = migrationv1alpha1.PhaseDeploying
 			Expect(runtimeClient.Status().Update(testCtx, migrationCR)).Should(Succeed())
 

--- a/test/integration/manager/controller/backup_test.go
+++ b/test/integration/manager/controller/backup_test.go
@@ -147,38 +147,33 @@ var _ = Describe("backup pvc", Ordered, func() {
 			return err
 		}, timeout, interval).Should(Succeed())
 		go func() {
-			for {
+			// Simulate volsync: wait for the reconciler to stamp CopyTrigger, then mark backup complete.
+			Eventually(func() error {
+				postgresPvc := &corev1.PersistentVolumeClaim{}
 				err := mgr.GetClient().Get(ctx, types.NamespacedName{
 					Namespace: pvcNamespace,
 					Name:      pvcName,
 				}, postgresPvc)
-				Expect(err).NotTo(HaveOccurred())
-				if len(postgresPvc.Annotations[constants.BackupPvcLatestCopyTrigger]) > 5 {
-					return
-				}
-				Eventually(func() error {
-					postgresPvc := &corev1.PersistentVolumeClaim{}
-					err := mgr.GetClient().Get(ctx, types.NamespacedName{
-						Namespace: pvcNamespace,
-						Name:      pvcName,
-					}, postgresPvc)
-					if err != nil {
-						return err
-					}
-
-					utils.MergeAnnotations(postgresPvc, map[string]string{
-						constants.BackupPvcLatestCopyTrigger: postgresPvc.Annotations[constants.BackupPvcCopyTrigger],
-						constants.BackupPvcLatestCopyStatus:  constants.BackupPvcCompletedTrigger,
-					})
-
-					err = mgr.GetClient().Update(ctx, postgresPvc)
-					if err != nil {
-						return err
-					}
+				if err != nil {
 					return err
-				}, timeout, interval).Should(Succeed())
-				time.Sleep(time.Second * 1)
-			}
+				}
+
+				copyTrigger := postgresPvc.Annotations[constants.BackupPvcCopyTrigger]
+				if copyTrigger == "" || copyTrigger == "now" {
+					return fmt.Errorf("waiting for reconciler copy trigger")
+				}
+				if utils.HasItem(postgresPvc.GetAnnotations(), constants.BackupPvcLatestCopyStatus, constants.BackupPvcCompletedTrigger) &&
+					utils.HasItem(postgresPvc.GetAnnotations(), constants.BackupPvcLatestCopyTrigger, copyTrigger) {
+					return nil
+				}
+
+				utils.MergeAnnotations(postgresPvc, map[string]string{
+					constants.BackupPvcLatestCopyTrigger: copyTrigger,
+					constants.BackupPvcLatestCopyStatus:  constants.BackupPvcCompletedTrigger,
+				})
+
+				return mgr.GetClient().Update(ctx, postgresPvc)
+			}, 2*time.Minute, interval).Should(Succeed())
 		}()
 		_, err := backupReconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: types.NamespacedName{

--- a/test/integration/operator/controllers/transporter_test.go
+++ b/test/integration/operator/controllers/transporter_test.go
@@ -428,13 +428,14 @@ var _ = Describe("transporter", Ordered, func() {
 		err = runtimeClient.Get(ctx, client.ObjectKeyFromObject(kafkaUser), kafkaUser)
 		Expect(err).To(Succeed())
 		// utils.PrettyPrint(kafkaUser.Spec.Authorization)
-		Expect(3).To(Equal(len(kafkaUser.Spec.Authorization.Acls)))
+		Expect(4).To(Equal(len(kafkaUser.Spec.Authorization.Acls)))
 
 		// topic: create
 		clusterTopic, err := trans.EnsureTopic(clusterName)
 		Expect(err).To(Succeed())
 		Expect("gh-spec").To(Equal(clusterTopic.SpecTopic))
 		Expect(config.GetStatusTopic(clusterName)).To(Equal(clusterTopic.StatusTopic))
+		Expect(config.GetMigrationTopic()).To(Equal(clusterTopic.MigrationTopic))
 
 		// topic: update
 		_, err = trans.EnsureTopic(clusterName)

--- a/test/manifest/kafka/kafka-cluster/kafka-byo-resource.yaml
+++ b/test/manifest/kafka/kafka-cluster/kafka-byo-resource.yaml
@@ -51,4 +51,13 @@ spec:
         name: gh-spec
         patternType: literal
         type: topic
+    - host: '*'
+      operations:
+      - Describe
+      - Read
+      - Write
+      resource:
+        name: gh-migration
+        patternType: literal
+        type: topic
     type: simple

--- a/test/manifest/kafka/kafka-cluster/kafka-topics.yaml
+++ b/test/manifest/kafka/kafka-cluster/kafka-topics.yaml
@@ -18,6 +18,20 @@ spec:
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
+  name: gh-migration
+  labels:
+    strimzi.io/cluster: kafka
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    cleanup.policy: compact,delete
+    retention.ms: "86400000"
+    retention.bytes: "1073741824"
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
   name: gh-status.global-hub
   labels:
     strimzi.io/cluster: kafka

--- a/test/script/e2e_run_byo.sh
+++ b/test/script/e2e_run_byo.sh
@@ -65,6 +65,7 @@ wait_cmd "kubectl get kafka kafka -n ${kafka_namespace} --kubeconfig ${KAFKA_KUB
 
 # wait the byo kafkatopic and kafkauser
 wait_cmd "kubectl get kafkatopic gh-spec -n ${kafka_namespace} --kubeconfig ${KAFKA_KUBECONFIG} | grep -C 1 True"
+wait_cmd "kubectl get kafkatopic gh-migration -n ${kafka_namespace} --kubeconfig ${KAFKA_KUBECONFIG} | grep -C 1 True"
 wait_cmd "kubectl get kafkatopic gh-status -n ${kafka_namespace} --kubeconfig ${KAFKA_KUBECONFIG} | grep -C 1 True"
 wait_cmd "kubectl get kafkauser ${byo_user} -n ${kafka_namespace} --kubeconfig ${KAFKA_KUBECONFIG} | grep -C 1 True"
 echo "Kafka topic and user is ready"


### PR DESCRIPTION
Fixes: [ACM-34442](https://redhat.atlassian.net/browse/ACM-34442)

**Phase 3**

## Summary

* Add dedicated `gh-migration` Kafka topic for cluster migration deploying bundles (separate from shared `gh-spec`)
* Operator creates the topic, adds migration topic to transport credentials, and grants manager Read+Write on `gh-migration`
* Source hub publishes deploying bundles to `gh-migration`; target hub agent consumes both `gh-spec` and `gh-migration`
* Migration ACL reconciler grants source-hub Write on `gh-migration` only during `PhaseDeploying`, revoking on completion

## Context

Phase 3 of the ACM-34442 remediation. Establishes the dedicated migration transport path over `gh-migration`, separate from shared `gh-spec`.

**Stacked on:** [#2623](https://github.com/stolostron/multicluster-global-hub/pull/2623) (Phase 2 agent spec source validation).

Related:

* [#2623](https://github.com/stolostron/multicluster-global-hub/pull/2623) — Phase 2 agent spec source validation
* [#2564](https://github.com/stolostron/multicluster-global-hub/pull/2564) — Phase 1 manager status identity validation

## Test plan

* `go build ./operator/pkg/controllers/transporter/... ./pkg/transport/... ./agent/pkg/spec/migration/...`
* `go test ./operator/pkg/controllers/transporter/... ./pkg/transport/consumer/... ./pkg/transport/...`
* OpenShift Prow CI (unit, format, operator integration)

[ACM-34442]: https://redhat.atlassian.net/browse/ACM-34442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kafka migration topic support end-to-end (default topic, config override/accessors, and Global Hub manifest updates).
  * Added migration ACL synchronization and phase-aware grant/revoke behavior for Strimzi.
  * Improved event publishing with delivery-confirmation and exponential backoff retries while migration topic permissions are preparing.
  * Added deployment deferral until migration transport ACL propagation is ready.
* **Bug Fixes**
  * Improved expired-event dropping and tightened/extended event source validation; improved concurrent ConfigMap initialization behavior.
* **Tests**
  * Expanded integration/unit tests for migration topic creation, ACLs, delivery confirmation, validation, and deploy readiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->