### PR TITLE
ACM-30175: Enable SecureServing for manager/agent metrics (#2487)

### DIFF
--- a/agent/cmd/main.go
+++ b/agent/cmd/main.go
@@ -222,8 +222,12 @@ func createManager(restConfig *rest.Config, agentConfig *configs.AgentConfig) (
 
 	options := ctrl.Options{
 		Metrics: metricsserver.Options{
-			BindAddress: agentConfig.MetricsAddress,
-			TLSOpts:     []func(*tls.Config){tlsConfigFunc},
+			BindAddress:   agentConfig.MetricsAddress,
+			SecureServing: true,
+			// TLSOpts applies APIServer profile min version/ciphers. Without
+			// SecureServing, controller-runtime serves metrics over plain HTTP
+			// and TLSOpts are ignored (ACM-30175 follow-up to #2487).
+			TLSOpts: []func(*tls.Config){tlsConfigFunc},
 		},
 		LeaderElection:          true,
 		Scheme:                  configs.GetRuntimeScheme(),

--- a/agent/cmd/main.go
+++ b/agent/cmd/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
 	"flag"
 	"fmt"
 	"os"
@@ -24,7 +23,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/configs"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/controllers"
@@ -221,14 +219,10 @@ func createManager(restConfig *rest.Config, agentConfig *configs.AgentConfig) (
 	}
 
 	options := ctrl.Options{
-		Metrics: metricsserver.Options{
-			BindAddress:   agentConfig.MetricsAddress,
-			SecureServing: true,
-			// TLSOpts applies APIServer profile min version/ciphers. Without
-			// SecureServing, controller-runtime serves metrics over plain HTTP
-			// and TLSOpts are ignored (ACM-30175 follow-up to #2487).
-			TLSOpts: []func(*tls.Config){tlsConfigFunc},
-		},
+		Metrics: utils.NewSecureMetricsServerOptions(
+			agentConfig.MetricsAddress,
+			tlsConfigFunc,
+		),
 		LeaderElection:          true,
 		Scheme:                  configs.GetRuntimeScheme(),
 		LeaderElectionConfig:    leaderElectionConfig,

--- a/agent/cmd/main.go
+++ b/agent/cmd/main.go
@@ -219,10 +219,8 @@ func createManager(restConfig *rest.Config, agentConfig *configs.AgentConfig) (
 	}
 
 	options := ctrl.Options{
-		Metrics: utils.NewSecureMetricsServerOptions(
-			agentConfig.MetricsAddress,
-			tlsConfigFunc,
-		),
+		// SecureServing + TLSOpts via helper (covered in pkg/utils); cmd wiring is one line.
+		Metrics:                 utils.NewSecureMetricsServerOptions(agentConfig.MetricsAddress, tlsConfigFunc),
 		LeaderElection:          true,
 		Scheme:                  configs.GetRuntimeScheme(),
 		LeaderElectionConfig:    leaderElectionConfig,

--- a/manager/cmd/main.go
+++ b/manager/cmd/main.go
@@ -151,8 +151,8 @@ func createManager(ctx context.Context,
 
 	metricsBindAddress := fmt.Sprintf("%s:%d", metricsHost, metricsPort)
 	options := ctrl.Options{
-		Scheme: configs.GetRuntimeScheme(),
-		Metrics: utils.NewSecureMetricsServerOptions(metricsBindAddress, tlsConfigFunc),
+		Scheme:                  configs.GetRuntimeScheme(),
+		Metrics:                 utils.NewSecureMetricsServerOptions(metricsBindAddress, tlsConfigFunc),
 		LeaderElection:          true,
 		LeaderElectionNamespace: managerConfig.ManagerNamespace,
 		LeaderElectionID:        leaderElectionLockID,

--- a/manager/cmd/main.go
+++ b/manager/cmd/main.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -21,7 +20,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/configs"
 	"github.com/stolostron/multicluster-global-hub/manager/pkg/controllers"
@@ -153,14 +151,10 @@ func createManager(ctx context.Context,
 
 	options := ctrl.Options{
 		Scheme: configs.GetRuntimeScheme(),
-		Metrics: metricsserver.Options{
-			BindAddress:   fmt.Sprintf("%s:%d", metricsHost, metricsPort),
-			SecureServing: true,
-			// TLSOpts applies APIServer profile min version/ciphers. Without
-			// SecureServing, controller-runtime serves metrics over plain HTTP
-			// and TLSOpts are ignored (ACM-30175 follow-up to #2487).
-			TLSOpts: []func(*tls.Config){tlsConfigFunc},
-		},
+		Metrics: utils.NewSecureMetricsServerOptions(
+			fmt.Sprintf("%s:%d", metricsHost, metricsPort),
+			tlsConfigFunc,
+		),
 		LeaderElection:          true,
 		LeaderElectionNamespace: managerConfig.ManagerNamespace,
 		LeaderElectionID:        leaderElectionLockID,

--- a/manager/cmd/main.go
+++ b/manager/cmd/main.go
@@ -151,10 +151,8 @@ func createManager(ctx context.Context,
 
 	options := ctrl.Options{
 		Scheme: configs.GetRuntimeScheme(),
-		Metrics: utils.NewSecureMetricsServerOptions(
-			fmt.Sprintf("%s:%d", metricsHost, metricsPort),
-			tlsConfigFunc,
-		),
+		// SecureServing + TLSOpts via helper (covered in pkg/utils); cmd wiring is one line.
+		Metrics:                 utils.NewSecureMetricsServerOptions(fmt.Sprintf("%s:%d", metricsHost, metricsPort), tlsConfigFunc),
 		LeaderElection:          true,
 		LeaderElectionNamespace: managerConfig.ManagerNamespace,
 		LeaderElectionID:        leaderElectionLockID,

--- a/manager/cmd/main.go
+++ b/manager/cmd/main.go
@@ -149,10 +149,10 @@ func createManager(ctx context.Context,
 		logger.DefaultZapLogger().Info("Using TLS 1.3 for metrics server (cluster APIServer profile unavailable)")
 	}
 
+	metricsBindAddress := fmt.Sprintf("%s:%d", metricsHost, metricsPort)
 	options := ctrl.Options{
 		Scheme: configs.GetRuntimeScheme(),
-		// SecureServing + TLSOpts via helper (covered in pkg/utils); cmd wiring is one line.
-		Metrics:                 utils.NewSecureMetricsServerOptions(fmt.Sprintf("%s:%d", metricsHost, metricsPort), tlsConfigFunc),
+		Metrics: utils.NewSecureMetricsServerOptions(metricsBindAddress, tlsConfigFunc),
 		LeaderElection:          true,
 		LeaderElectionNamespace: managerConfig.ManagerNamespace,
 		LeaderElectionID:        leaderElectionLockID,

--- a/manager/cmd/main.go
+++ b/manager/cmd/main.go
@@ -154,8 +154,12 @@ func createManager(ctx context.Context,
 	options := ctrl.Options{
 		Scheme: configs.GetRuntimeScheme(),
 		Metrics: metricsserver.Options{
-			BindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
-			TLSOpts:     []func(*tls.Config){tlsConfigFunc},
+			BindAddress:   fmt.Sprintf("%s:%d", metricsHost, metricsPort),
+			SecureServing: true,
+			// TLSOpts applies APIServer profile min version/ciphers. Without
+			// SecureServing, controller-runtime serves metrics over plain HTTP
+			// and TLSOpts are ignored (ACM-30175 follow-up to #2487).
+			TLSOpts: []func(*tls.Config){tlsConfigFunc},
 		},
 		LeaderElection:          true,
 		LeaderElectionNamespace: managerConfig.ManagerNamespace,

--- a/operator/pkg/controllers/manager/manager_reconciler.go
+++ b/operator/pkg/controllers/manager/manager_reconciler.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/restmapper"
+	"k8s.io/utils/ptr"
 	"open-cluster-management.io/api/addon/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -426,7 +427,15 @@ func (r *ManagerReconciler) setUpMetrics(ctx context.Context, mgh *v1alpha4.Mult
 				{
 					Port:     "metrics",
 					Path:     "/metrics",
+					Scheme:   "https",
 					Interval: promv1.Duration(config.GetMetricsScrapeInterval(mgh)),
+					// Manager metrics use a controller-runtime self-signed cert
+					// (SecureServing); skip verify until a serving-cert secret is wired.
+					TLSConfig: &promv1.TLSConfig{
+						SafeTLSConfig: promv1.SafeTLSConfig{
+							InsecureSkipVerify: ptr.To(true),
+						},
+					},
 				},
 			},
 		},

--- a/operator/pkg/controllers/manager/manager_reconciler.go
+++ b/operator/pkg/controllers/manager/manager_reconciler.go
@@ -424,19 +424,7 @@ func (r *ManagerReconciler) setUpMetrics(ctx context.Context, mgh *v1alpha4.Mult
 				},
 			},
 			Endpoints: []promv1.Endpoint{
-				{
-					Port:     "metrics",
-					Path:     "/metrics",
-					Scheme:   "https",
-					Interval: promv1.Duration(config.GetMetricsScrapeInterval(mgh)),
-					// Manager metrics use a controller-runtime self-signed cert
-					// (SecureServing); skip verify until a serving-cert secret is wired.
-					TLSConfig: &promv1.TLSConfig{
-						SafeTLSConfig: promv1.SafeTLSConfig{
-							InsecureSkipVerify: ptr.To(true),
-						},
-					},
-				},
+				managerMetricsEndpoint(config.GetMetricsScrapeInterval(mgh)),
 			},
 		},
 	}
@@ -456,6 +444,23 @@ func (r *ManagerReconciler) setUpMetrics(ctx context.Context, mgh *v1alpha4.Mult
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// managerMetricsEndpoint builds the ServiceMonitor scrape endpoint for manager
+// metrics. SecureServing uses a controller-runtime self-signed cert, so scrape
+// skips verify until a serving-cert secret is wired (ACM-30175).
+func managerMetricsEndpoint(interval string) promv1.Endpoint {
+	return promv1.Endpoint{
+		Port:     "metrics",
+		Path:     "/metrics",
+		Scheme:   "https",
+		Interval: promv1.Duration(interval),
+		TLSConfig: &promv1.TLSConfig{
+			SafeTLSConfig: promv1.SafeTLSConfig{
+				InsecureSkipVerify: ptr.To(true),
+			},
+		},
+	}
 }
 
 func storageConnectionUpdated(storageConn *config.PostgresConnection) bool {

--- a/operator/pkg/controllers/manager/manager_reconciler.go
+++ b/operator/pkg/controllers/manager/manager_reconciler.go
@@ -448,7 +448,8 @@ func (r *ManagerReconciler) setUpMetrics(ctx context.Context, mgh *v1alpha4.Mult
 
 // managerMetricsEndpoint builds the ServiceMonitor scrape endpoint for manager
 // metrics. SecureServing uses a controller-runtime self-signed cert, so scrape
-// skips verify until a serving-cert secret is wired (ACM-30175).
+// uses InsecureSkipVerify until a serving-cert secret is wired (ACM-30175
+// follow-up: replace skip-verify with CA-backed scrape TLS).
 func managerMetricsEndpoint(interval string) promv1.Endpoint {
 	return promv1.Endpoint{
 		Port:     "metrics",

--- a/operator/pkg/controllers/manager/manager_reconciler_metrics_test.go
+++ b/operator/pkg/controllers/manager/manager_reconciler_metrics_test.go
@@ -1,3 +1,7 @@
+/*
+Copyright Contributors to the Open Cluster Management project.
+*/
+
 package manager
 
 import (
@@ -16,6 +20,8 @@ func TestManagerMetricsEndpoint(t *testing.T) {
 	assert.Equal(t, promv1.Duration("30s"), ep.Interval)
 	require.NotNil(t, ep.TLSConfig)
 	require.NotNil(t, ep.TLSConfig.InsecureSkipVerify)
+	// Interim: controller-runtime self-signed metrics cert. Remove skip-verify
+	// when a serving-cert secret is wired (tracked under ACM-30175 follow-up).
 	assert.True(t, *ep.TLSConfig.InsecureSkipVerify)
 }
 
@@ -24,5 +30,6 @@ func TestManagerMetricsEndpointCustomInterval(t *testing.T) {
 	assert.Equal(t, promv1.Duration("1m"), ep.Interval)
 	assert.Equal(t, "https", ep.Scheme)
 	require.NotNil(t, ep.TLSConfig.InsecureSkipVerify)
+	// Same interim skip-verify as TestManagerMetricsEndpoint (ACM-30175).
 	assert.True(t, *ep.TLSConfig.InsecureSkipVerify)
 }

--- a/operator/pkg/controllers/manager/manager_reconciler_metrics_test.go
+++ b/operator/pkg/controllers/manager/manager_reconciler_metrics_test.go
@@ -1,0 +1,28 @@
+package manager
+
+import (
+	"testing"
+
+	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManagerMetricsEndpoint(t *testing.T) {
+	ep := managerMetricsEndpoint("30s")
+	assert.Equal(t, "metrics", ep.Port)
+	assert.Equal(t, "/metrics", ep.Path)
+	assert.Equal(t, "https", ep.Scheme)
+	assert.Equal(t, promv1.Duration("30s"), ep.Interval)
+	require.NotNil(t, ep.TLSConfig)
+	require.NotNil(t, ep.TLSConfig.InsecureSkipVerify)
+	assert.True(t, *ep.TLSConfig.InsecureSkipVerify)
+}
+
+func TestManagerMetricsEndpointCustomInterval(t *testing.T) {
+	ep := managerMetricsEndpoint("1m")
+	assert.Equal(t, promv1.Duration("1m"), ep.Interval)
+	assert.Equal(t, "https", ep.Scheme)
+	require.NotNil(t, ep.TLSConfig.InsecureSkipVerify)
+	assert.True(t, *ep.TLSConfig.InsecureSkipVerify)
+}

--- a/pkg/utils/metrics_server.go
+++ b/pkg/utils/metrics_server.go
@@ -1,3 +1,7 @@
+/*
+Copyright Contributors to the Open Cluster Management project.
+*/
+
 package utils
 
 import (

--- a/pkg/utils/metrics_server.go
+++ b/pkg/utils/metrics_server.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"crypto/tls"
+
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+)
+
+// NewSecureMetricsServerOptions builds controller-runtime metrics server options
+// with SecureServing enabled so TLSOpts are applied.
+//
+// Without SecureServing, controller-runtime serves metrics over plain HTTP and
+// TLSOpts are ignored (ACM-30175 follow-up to #2487).
+func NewSecureMetricsServerOptions(
+	bindAddress string,
+	tlsOpts ...func(*tls.Config),
+) metricsserver.Options {
+	return metricsserver.Options{
+		BindAddress:   bindAddress,
+		SecureServing: true,
+		TLSOpts:       tlsOpts,
+	}
+}

--- a/pkg/utils/metrics_server_test.go
+++ b/pkg/utils/metrics_server_test.go
@@ -1,0 +1,42 @@
+package utils
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestNewSecureMetricsServerOptions(t *testing.T) {
+	tlsOpt := func(cfg *tls.Config) {
+		cfg.MinVersion = tls.VersionTLS12
+	}
+
+	opts := NewSecureMetricsServerOptions(":8384", tlsOpt)
+	if opts.BindAddress != ":8384" {
+		t.Fatalf("expected BindAddress :8384, got %q", opts.BindAddress)
+	}
+	if !opts.SecureServing {
+		t.Fatal("expected SecureServing true so TLSOpts apply")
+	}
+	if len(opts.TLSOpts) != 1 {
+		t.Fatalf("expected 1 TLSOpt, got %d", len(opts.TLSOpts))
+	}
+
+	cfg := &tls.Config{}
+	opts.TLSOpts[0](cfg)
+	if cfg.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("expected TLSOpt to set MinVersion TLS1.2, got 0x%x", cfg.MinVersion)
+	}
+}
+
+func TestNewSecureMetricsServerOptionsNoTLSOpts(t *testing.T) {
+	opts := NewSecureMetricsServerOptions("0.0.0.0:8384")
+	if !opts.SecureServing {
+		t.Fatal("expected SecureServing true")
+	}
+	if opts.BindAddress != "0.0.0.0:8384" {
+		t.Fatalf("unexpected BindAddress %q", opts.BindAddress)
+	}
+	if len(opts.TLSOpts) != 0 {
+		t.Fatalf("expected no TLSOpts, got %d", len(opts.TLSOpts))
+	}
+}

--- a/pkg/utils/metrics_server_test.go
+++ b/pkg/utils/metrics_server_test.go
@@ -1,3 +1,7 @@
+/*
+Copyright Contributors to the Open Cluster Management project.
+*/
+
 package utils
 
 import (

--- a/test/integration/operator/controllers/manager_test.go
+++ b/test/integration/operator/controllers/manager_test.go
@@ -105,13 +105,27 @@ var _ = Describe("manager", Ordered, func() {
 		}, 10*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
 
 		Eventually(func() error {
-			// service monitor
+			// ServiceMonitor must scrape manager metrics over HTTPS with
+			// skip-verify for the controller-runtime self-signed cert (ACM-30175).
 			serviceMonitor := &promv1.ServiceMonitor{}
 			err = runtimeClient.Get(ctx, types.NamespacedName{
 				Namespace: mgh.Namespace,
 				Name:      operatorconstants.GHServiceMonitorName,
 			}, serviceMonitor)
-			return err
+			if err != nil {
+				return err
+			}
+			if len(serviceMonitor.Spec.Endpoints) == 0 {
+				return fmt.Errorf("ServiceMonitor has no endpoints")
+			}
+			ep := serviceMonitor.Spec.Endpoints[0]
+			if ep.Scheme != "https" {
+				return fmt.Errorf("expected ServiceMonitor scheme https, got %q", ep.Scheme)
+			}
+			if ep.TLSConfig == nil || ep.TLSConfig.InsecureSkipVerify == nil || !*ep.TLSConfig.InsecureSkipVerify {
+				return fmt.Errorf("expected ServiceMonitor insecureSkipVerify=true for SecureServing metrics")
+			}
+			return nil
 		}, 10*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
 
 		// NetworkPolicy is rendered alongside other manager manifests; verify it is created

--- a/test/script/util.sh
+++ b/test/script/util.sh
@@ -87,6 +87,8 @@ install_clusteradm() {
   local os arch artifact url tmp_root artifact_file cli_file
   local max_retries=5
   local attempt=0
+  local curl_connect_timeout=30
+  local curl_max_time=300
 
   os=$(uname | tr '[:upper:]' '[:lower:]')
   arch=$(uname -m)
@@ -106,7 +108,8 @@ install_clusteradm() {
     artifact_file="${tmp_root}/${artifact}"
 
     echo "Downloading clusteradm ${version} (attempt ${attempt}/${max_retries})..."
-    if ! curl -fSL --retry 3 --retry-delay 2 "$url" -o "$artifact_file"; then
+    if ! curl -fSL --connect-timeout "${curl_connect_timeout}" --max-time "${curl_max_time}" \
+      --retry 3 --retry-delay 2 "$url" -o "$artifact_file"; then
       echo "clusteradm download failed (curl error)"
       rm -rf "$tmp_root"
       sleep 5
@@ -129,14 +132,14 @@ install_clusteradm() {
 
     chmod +x "${tmp_root}/clusteradm"
     if [ -w "$INSTALL_DIR" ]; then
-      if ! cp "${tmp_root}/clusteradm" "$cli_file"; then
-        echo "failed to copy clusteradm to ${INSTALL_DIR}"
+      if ! install -m 0755 "${tmp_root}/clusteradm" "$cli_file"; then
+        echo "failed to install clusteradm to ${INSTALL_DIR}"
         rm -rf "$tmp_root"
         sleep 5
         continue
       fi
-    elif ! sudo cp "${tmp_root}/clusteradm" "$cli_file"; then
-      echo "failed to copy clusteradm to ${INSTALL_DIR} (sudo)"
+    elif ! sudo install -m 0755 "${tmp_root}/clusteradm" "$cli_file"; then
+      echo "failed to install clusteradm to ${INSTALL_DIR} (sudo)"
       rm -rf "$tmp_root"
       sleep 5
       continue

--- a/test/script/util.sh
+++ b/test/script/util.sh
@@ -82,14 +82,80 @@ check_kustomize() {
   echo "kustomize version: $(kustomize version)"
 }
 
+install_clusteradm() {
+  local version="v${CLUSTERADM_VERSION}"
+  local os arch artifact url tmp_root artifact_file cli_file
+  local max_retries=5
+  local attempt=0
+
+  os=$(uname | tr '[:upper:]' '[:lower:]')
+  arch=$(uname -m)
+  case $arch in
+    armv7*) arch="arm" ;;
+    aarch64) arch="arm64" ;;
+    x86_64) arch="amd64" ;;
+  esac
+
+  artifact="clusteradm_${os}_${arch}.tar.gz"
+  url="https://github.com/open-cluster-management-io/clusteradm/releases/download/${version}/${artifact}"
+  cli_file="${INSTALL_DIR}/clusteradm"
+
+  while [ $attempt -lt $max_retries ]; do
+    attempt=$((attempt + 1))
+    tmp_root=$(mktemp -dt clusteradm-install-XXXXXX)
+    artifact_file="${tmp_root}/${artifact}"
+
+    echo "Downloading clusteradm ${version} (attempt ${attempt}/${max_retries})..."
+    if ! curl -fSL --retry 3 --retry-delay 2 "$url" -o "$artifact_file"; then
+      echo "clusteradm download failed (curl error)"
+      rm -rf "$tmp_root"
+      sleep 5
+      continue
+    fi
+
+    if ! gzip -t "$artifact_file" 2>/dev/null; then
+      echo "clusteradm download is not a valid gzip archive ($(wc -c <"$artifact_file") bytes)"
+      rm -rf "$tmp_root"
+      sleep 5
+      continue
+    fi
+
+    if ! tar -xf "$artifact_file" -C "$tmp_root" clusteradm 2>/dev/null; then
+      echo "clusteradm archive failed to unpack"
+      rm -rf "$tmp_root"
+      sleep 5
+      continue
+    fi
+
+    chmod +x "${tmp_root}/clusteradm"
+    if [ -w "$INSTALL_DIR" ]; then
+      if ! cp "${tmp_root}/clusteradm" "$cli_file"; then
+        echo "failed to copy clusteradm to ${INSTALL_DIR}"
+        rm -rf "$tmp_root"
+        sleep 5
+        continue
+      fi
+    elif ! sudo cp "${tmp_root}/clusteradm" "$cli_file"; then
+      echo "failed to copy clusteradm to ${INSTALL_DIR} (sudo)"
+      rm -rf "$tmp_root"
+      sleep 5
+      continue
+    fi
+    rm -rf "$tmp_root"
+
+    if command -v clusteradm >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 5
+  done
+
+  echo "Failed to install clusteradm after ${max_retries} attempts"
+  return 1
+}
+
 check_clusteradm() {
   if ! command -v clusteradm >/dev/null 2>&1; then
-    # curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
-    curl -LO https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/v$CLUSTERADM_VERSION/install.sh
-    chmod +x ./install.sh
-    export INSTALL_DIR=$INSTALL_DIR
-    source ./install.sh $CLUSTERADM_VERSION
-    rm ./install.sh
+    install_clusteradm || exit 1
   fi
   echo "clusteradm path: $(which clusteradm)"
 }


### PR DESCRIPTION
Fixes: [ACM-30175](https://redhat.atlassian.net/browse/ACM-30175)

## Summary

- Set `SecureServing: true` on manager and agent controller-runtime metrics servers so APIServer-derived `TLSOpts` from #2487 actually take effect on `:8384`
- Update the manager ServiceMonitor to scrape `https` with `insecureSkipVerify` for the self-signed metrics cert (controller-runtime default until a serving-cert secret is wired)

## Context

- [#2487](https://github.com/stolostron/multicluster-global-hub/pull/2487) wired `TLSOpts` from `apiservers/cluster`, but without `SecureServing` metrics stayed on plain HTTP (`Serving metrics server ... secure=false`)
- HoH TLS suite ([acmqe-hoh-e2e#530](https://github.com/stolostron/acmqe-hoh-e2e/pull/530)) already probes webhook/Grafana/Kafka TLS; metrics TLS negotiation was blocked by this gap

Related:

- [stolostron/multicluster-global-hub#2487](https://github.com/stolostron/multicluster-global-hub/pull/2487) — parent TLS profile PR
- [ACM-30175](https://redhat.atlassian.net/browse/ACM-30175) — Jira
- [stolostron/acmqe-hoh-e2e#530](https://github.com/stolostron/acmqe-hoh-e2e/pull/530) — HoH TLS profile tests

## Test plan

- [ ] Unit/integration CI green
- [ ] After deploy: manager log shows `Serving metrics server ... secure=true`
- [ ] `oc port-forward` to manager `:8384` then `openssl s_client` / HTTPS curl succeeds; plain HTTP fails
- [ ] Prometheus still scrapes manager metrics via updated ServiceMonitor
- [ ] Re-run HoH `TEST_TAGS=tls` metrics-related coverage when available


Made with [Cursor](https://cursor.com)

[ACM-30175]: https://redhat.atlassian.net/browse/ACM-30175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-30175]: https://redhat.atlassian.net/browse/ACM-30175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metrics are now served over HTTPS by default.
  * Monitoring scrape endpoints now use HTTPS for metrics delivery.
* **Bug Fixes**
  * Improved alignment of TLS settings between the metrics server and monitoring configuration.
* **Refactor**
  * Centralized secure metrics server option construction and monitoring endpoint setup.
* **Tests**
  * Added unit tests covering secure metrics server and monitoring endpoint TLS behavior.
  * Strengthened integration assertions for monitoring endpoint scheme and TLS settings.
* **Chores**
  * Improved test tooling by installing `clusteradm` via a dedicated, retrying installer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->