### PR TITLE
ACM-30175: Use IngressController TLS profile for Grafana Route (#2487)

### DIFF
--- a/ai-doc/NETWORKPOLICY.md
+++ b/ai-doc/NETWORKPOLICY.md
@@ -24,7 +24,7 @@ Policies are **operator-managed**: the multicluster-global-hub operator reconcil
 3. **multicluster-global-hub-grafana**
    - Grafana: Port 3001 (internal)
    - Grafana alerts: Port 9094
-   - OAuth proxy: Port 9443 (external)
+   - OAuth proxy: Port 8080 (HTTP behind Route edge TLS; IngressController owns client TLS)
    - Needs: PostgreSQL (5432), Kubernetes API
 
 4. **PostgreSQL StatefulSet**
@@ -258,7 +258,7 @@ spec:
           network.openshift.io/policy-group: ingress
     ports:
     - protocol: TCP
-      port: 9443
+      port: 8080
   # Allow metrics scraping
   - from:
     - namespaceSelector:
@@ -268,7 +268,7 @@ spec:
     - protocol: TCP
       port: 3001
     - protocol: TCP
-      port: 9443
+      port: 8080
   egress:
   # Allow access to PostgreSQL
   - to:

--- a/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -361,6 +361,14 @@ spec:
           verbs:
           - get
         - apiGroups:
+          - operator.openshift.io
+          resources:
+          - ingresscontrollers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - addon.open-cluster-management.io
           resources:
           - addondeploymentconfigs
@@ -973,6 +981,14 @@ spec:
           - apiservers
           verbs:
           - get
+        - apiGroups:
+          - operator.openshift.io
+          resources:
+          - ingresscontrollers
+          verbs:
+          - get
+          - list
+          - watch
         - apiGroups:
           - config.openshift.io
           resources:

--- a/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -982,14 +982,6 @@ spec:
           verbs:
           - get
         - apiGroups:
-          - operator.openshift.io
-          resources:
-          - ingresscontrollers
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
           - config.openshift.io
           resources:
           - clusterversions
@@ -1188,6 +1180,14 @@ spec:
           - get
           - patch
           - update
+        - apiGroups:
+          - operator.openshift.io
+          resources:
+          - ingresscontrollers
+          verbs:
+          - get
+          - list
+          - watch
         - apiGroups:
           - operators.coreos.com
           resources:

--- a/operator/config/rbac/aggregated_role.yaml
+++ b/operator/config/rbac/aggregated_role.yaml
@@ -96,6 +96,14 @@ rules:
   - apiservers
   verbs:
   - get
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - ingresscontrollers
+  verbs:
+  - get
+  - list
+  - watch
 # Hub HA - Permissions for syncing all Hub HA resources to standby hub
 # Standby hub needs: create/update/delete/patch to apply resources from active hub
 - apiGroups:

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -327,6 +327,14 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - operator.openshift.io
+  resources:
+  - ingresscontrollers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - config.openshift.io
   resources:
   - clusterversions

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -327,14 +327,6 @@ rules:
   verbs:
   - get
 - apiGroups:
-  - operator.openshift.io
-  resources:
-  - ingresscontrollers
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - config.openshift.io
   resources:
   - clusterversions
@@ -533,6 +525,14 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - ingresscontrollers
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - operators.coreos.com
   resources:

--- a/operator/pkg/config/scheme_config.go
+++ b/operator/pkg/config/scheme_config.go
@@ -6,6 +6,7 @@ import (
 	postgresv1beta1 "github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 	configv1 "github.com/openshift/api/config/v1"
 	imagev1 "github.com/openshift/api/image/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	subv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -33,6 +34,7 @@ func GetRuntimeScheme() *runtime.Scheme {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(routev1.AddToScheme(scheme))
 	utilruntime.Must(configv1.AddToScheme(scheme))
+	utilruntime.Must(operatorv1.Install(scheme))
 	utilruntime.Must(clusterv1.Install(scheme))
 	utilruntime.Must(clusterv1beta1.Install(scheme))
 	utilruntime.Must(clusterv1beta2.Install(scheme))

--- a/operator/pkg/controllers/agent/local_agent_controller.go
+++ b/operator/pkg/controllers/agent/local_agent_controller.go
@@ -113,6 +113,7 @@ func (s *LocalAgentController) IsResourceRemoved() bool {
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=list;watch;get
 // +kubebuilder:rbac:groups=platform.stackrox.io,resources=centrals,verbs=get;list;watch
 // +kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=get
+// +kubebuilder:rbac:groups=operator.openshift.io,resources=ingresscontrollers,verbs=get;list;watch
 // +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get;list;watch
 // +kubebuilder:rbac:groups=internal.open-cluster-management.io,resources=managedclusterinfos,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=config.open-cluster-management.io,resources=klusterletconfigs,verbs=create;delete;get;list;patch;update;watch

--- a/operator/pkg/controllers/agent/local_agent_controller.go
+++ b/operator/pkg/controllers/agent/local_agent_controller.go
@@ -113,7 +113,6 @@ func (s *LocalAgentController) IsResourceRemoved() bool {
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=list;watch;get
 // +kubebuilder:rbac:groups=platform.stackrox.io,resources=centrals,verbs=get;list;watch
 // +kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=get
-// +kubebuilder:rbac:groups=operator.openshift.io,resources=ingresscontrollers,verbs=get;list;watch
 // +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get;list;watch
 // +kubebuilder:rbac:groups=internal.open-cluster-management.io,resources=managedclusterinfos,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=config.open-cluster-management.io,resources=klusterletconfigs,verbs=create;delete;get;list;patch;update;watch

--- a/operator/pkg/controllers/grafana/grafana_reconciler.go
+++ b/operator/pkg/controllers/grafana/grafana_reconciler.go
@@ -49,6 +49,7 @@ import (
 
 // +kubebuilder:rbac:groups=operator.open-cluster-management.io,resources=multiclusterglobalhubs,verbs=get;list;watch;
 // +kubebuilder:rbac:groups="route.openshift.io",resources=routes,verbs=get;list;watch;create;update;delete
+// +kubebuilder:rbac:groups=operator.openshift.io,resources=ingresscontrollers,verbs=get;list;watch
 // +kubebuilder:rbac:groups=image.openshift.io,resources=imagestreams,verbs=get;list;watch
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=clusterroles,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=clusterrolebindings,verbs=get;list;watch;create;update;delete
@@ -288,6 +289,13 @@ func (r *GrafanaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			log.Errorf("failed to update mgh status, err:%v", err)
 		}
 	}()
+	// Log the IngressController TLS profile that owns Grafana Route edge TLS (ACM-30175).
+	if ingressSpec, err := commonutils.FetchIngressControllerTLSProfileSpec(ctx, r.GetClient()); err != nil {
+		log.Debugf("unable to read IngressController TLS profile: %v", err)
+	} else {
+		log.Infof("Grafana Route edge TLS uses IngressController profile minTLSVersion=%s ciphers=%d",
+			ingressSpec.MinTLSVersion, len(ingressSpec.Ciphers))
+	}
 	// generate random session secret for oauth-proxy
 	proxySessionSecret, err := config.GetOauthSessionSecret()
 	if err != nil {

--- a/operator/pkg/controllers/grafana/grafana_reconciler.go
+++ b/operator/pkg/controllers/grafana/grafana_reconciler.go
@@ -289,19 +289,7 @@ func (r *GrafanaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			log.Errorf("failed to update mgh status, err:%v", err)
 		}
 	}()
-	// Log the IngressController TLS profile that owns Grafana Route edge TLS (ACM-30175).
-	ingressCtx, ingressCancel := context.WithTimeout(ctx, 10*time.Second)
-	defer ingressCancel()
-	if ingressSpec, err := commonutils.FetchIngressControllerTLSProfileSpec(ingressCtx, r.GetClient()); err != nil {
-		if errors.IsNotFound(err) {
-			log.Debugf("unable to read IngressController TLS profile: %v", err)
-		} else {
-			log.Warnf("unable to read IngressController TLS profile: %v", err)
-		}
-	} else {
-		log.Infof("Grafana Route edge TLS uses IngressController profile minTLSVersion=%s ciphers=%d",
-			ingressSpec.MinTLSVersion, len(ingressSpec.Ciphers))
-	}
+	r.logGrafanaIngressTLSProfile(ctx)
 	// generate random session secret for oauth-proxy
 	proxySessionSecret, err := config.GetOauthSessionSecret()
 	if err != nil {
@@ -317,7 +305,6 @@ func (r *GrafanaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if mgh.Spec.AvailabilityConfig == v1alpha4.HAHigh {
 		replicas = 2
 	}
-	// get the grafana objects
 	grafanaRenderer, grafanaDeployer := renderer.NewHoHRenderer(fs), deployer.NewHoHDeployer(r.GetClient())
 	grafanaObjects, err := grafanaRenderer.Render("manifests", "", func(profile string) (interface{}, error) {
 		return struct {
@@ -358,7 +345,6 @@ func (r *GrafanaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		reconcileErr = fmt.Errorf("failed to render grafana manifests: %w", err)
 		return ctrl.Result{}, reconcileErr
 	}
-	// create restmapper for deployer to find GVR
 	dc, err := discovery.NewDiscoveryClientForConfig(r.GetConfig())
 	if err != nil {
 		reconcileErr = err
@@ -399,6 +385,22 @@ func (r *GrafanaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	return ctrl.Result{}, nil
+}
+
+func (r *GrafanaReconciler) logGrafanaIngressTLSProfile(ctx context.Context) {
+	ingressCtx, ingressCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer ingressCancel()
+	ingressSpec, err := commonutils.FetchIngressControllerTLSProfileSpec(ingressCtx, r.client)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			log.Debugf("unable to read IngressController TLS profile: %v", err)
+		} else {
+			log.Warnf("unable to read IngressController TLS profile: %v", err)
+		}
+		return
+	}
+	log.Infof("Grafana Route edge TLS uses IngressController profile minTLSVersion=%s ciphers=%d",
+		ingressSpec.MinTLSVersion, len(ingressSpec.Ciphers))
 }
 
 // generateGranafaIni append the custom grafana.ini to default grafana.ini

--- a/operator/pkg/controllers/grafana/grafana_reconciler.go
+++ b/operator/pkg/controllers/grafana/grafana_reconciler.go
@@ -290,8 +290,14 @@ func (r *GrafanaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 	}()
 	// Log the IngressController TLS profile that owns Grafana Route edge TLS (ACM-30175).
-	if ingressSpec, err := commonutils.FetchIngressControllerTLSProfileSpec(ctx, r.GetClient()); err != nil {
-		log.Debugf("unable to read IngressController TLS profile: %v", err)
+	ingressCtx, ingressCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer ingressCancel()
+	if ingressSpec, err := commonutils.FetchIngressControllerTLSProfileSpec(ingressCtx, r.GetClient()); err != nil {
+		if errors.IsNotFound(err) {
+			log.Debugf("unable to read IngressController TLS profile: %v", err)
+		} else {
+			log.Warnf("unable to read IngressController TLS profile: %v", err)
+		}
 	} else {
 		log.Infof("Grafana Route edge TLS uses IngressController profile minTLSVersion=%s ciphers=%d",
 			ingressSpec.MinTLSVersion, len(ingressSpec.Ciphers))

--- a/operator/pkg/controllers/grafana/grafana_reconciler_test.go
+++ b/operator/pkg/controllers/grafana/grafana_reconciler_test.go
@@ -2,8 +2,11 @@ package grafana
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/ini.v1"
@@ -14,9 +17,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	fakekube "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	"github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
@@ -930,6 +935,75 @@ func TestNetworkPolicyPred_Grafana(t *testing.T) {
 	assert.False(t, networkPolicyPred.Update(event.UpdateEvent{ObjectNew: otherNP}), "Update: other NP should not match")
 	assert.True(t, networkPolicyPred.Delete(event.DeleteEvent{Object: np}), "Delete: grafana NP should match")
 	assert.False(t, networkPolicyPred.Delete(event.DeleteEvent{Object: otherNP}), "Delete: other NP should not match")
+}
+
+func ingressGrafanaTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	assert.Nil(t, clientgoscheme.AddToScheme(s))
+	assert.Nil(t, configv1.AddToScheme(s))
+	assert.Nil(t, operatorv1.Install(s))
+	return s
+}
+
+func TestLogGrafanaIngressTLSProfile(t *testing.T) {
+	ingressController := &operatorv1.IngressController{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: "openshift-ingress-operator",
+		},
+		Status: operatorv1.IngressControllerStatus{
+			TLSProfile: &configv1.TLSProfileSpec{
+				Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256"},
+				MinTLSVersion: configv1.VersionTLS12,
+			},
+		},
+	}
+
+	tests := []struct {
+		name   string
+		client client.Client
+	}{
+		{
+			name: "reads IngressController status TLS profile",
+			client: fake.NewClientBuilder().
+				WithScheme(ingressGrafanaTestScheme(t)).
+				WithObjects(ingressController).
+				Build(),
+		},
+		{
+			name: "falls back when IngressController is absent",
+			client: fake.NewClientBuilder().
+				WithScheme(ingressGrafanaTestScheme(t)).
+				Build(),
+		},
+		{
+			name: "warns when IngressController lookup fails",
+			client: fake.NewClientBuilder().
+				WithScheme(ingressGrafanaTestScheme(t)).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(
+						ctx context.Context,
+						c client.WithWatch,
+						key client.ObjectKey,
+						obj client.Object,
+						opts ...client.GetOption,
+					) error {
+						if _, ok := obj.(*operatorv1.IngressController); ok {
+							return fmt.Errorf("simulated ingress lookup failure")
+						}
+						return c.Get(ctx, key, obj, opts...)
+					},
+				}).
+				Build(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &GrafanaReconciler{client: tt.client}
+			r.logGrafanaIngressTLSProfile(context.Background())
+		})
+	}
 }
 
 func sectionCount(a []byte) int {

--- a/operator/pkg/controllers/grafana/grafana_reconciler_test.go
+++ b/operator/pkg/controllers/grafana/grafana_reconciler_test.go
@@ -9,6 +9,10 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 	"gopkg.in/ini.v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -17,7 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	fakekube "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -940,9 +943,9 @@ func TestNetworkPolicyPred_Grafana(t *testing.T) {
 func ingressGrafanaTestScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
 	s := runtime.NewScheme()
-	assert.Nil(t, clientgoscheme.AddToScheme(s))
-	assert.Nil(t, configv1.AddToScheme(s))
-	assert.Nil(t, operatorv1.Install(s))
+	require.NoError(t, scheme.AddToScheme(s), "client-go scheme registration must succeed for ingress TLS tests")
+	require.NoError(t, configv1.AddToScheme(s), "configv1 scheme registration must succeed for ingress TLS tests")
+	require.NoError(t, operatorv1.Install(s), "operatorv1 scheme registration must succeed for ingress TLS tests")
 	return s
 }
 
@@ -959,10 +962,13 @@ func TestLogGrafanaIngressTLSProfile(t *testing.T) {
 			},
 		},
 	}
+	intermediateProfile := configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
 
 	tests := []struct {
-		name   string
-		client client.Client
+		name          string
+		client        client.Client
+		wantLevel     zapcore.Level
+		wantSubstring string
 	}{
 		{
 			name: "reads IngressController status TLS profile",
@@ -970,12 +976,16 @@ func TestLogGrafanaIngressTLSProfile(t *testing.T) {
 				WithScheme(ingressGrafanaTestScheme(t)).
 				WithObjects(ingressController).
 				Build(),
+			wantLevel:     zap.InfoLevel,
+			wantSubstring: "minTLSVersion=" + string(configv1.VersionTLS12),
 		},
 		{
 			name: "falls back when IngressController is absent",
 			client: fake.NewClientBuilder().
 				WithScheme(ingressGrafanaTestScheme(t)).
 				Build(),
+			wantLevel:     zap.InfoLevel,
+			wantSubstring: "minTLSVersion=" + string(intermediateProfile.MinTLSVersion),
 		},
 		{
 			name: "warns when IngressController lookup fails",
@@ -996,12 +1006,26 @@ func TestLogGrafanaIngressTLSProfile(t *testing.T) {
 					},
 				}).
 				Build(),
+			wantLevel:     zap.WarnLevel,
+			wantSubstring: "unable to read IngressController TLS profile",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			core, recorded := observer.New(zap.DebugLevel)
+			oldLog := log
+			log = zap.New(core).Sugar()
+			t.Cleanup(func() { log = oldLog })
+
 			r := &GrafanaReconciler{client: tt.client}
 			r.logGrafanaIngressTLSProfile(context.Background())
+
+			entries := recorded.All()
+			require.Len(t, entries, 1, "expected exactly one log entry for %s", tt.name)
+			require.Equal(t, tt.wantLevel, entries[0].Level,
+				"unexpected log level for %s", tt.name)
+			require.Contains(t, entries[0].Message, tt.wantSubstring,
+				"log message should include expected ingress TLS details for %s", tt.name)
 		})
 	}
 }

--- a/operator/pkg/controllers/grafana/manifests/deployment.yaml
+++ b/operator/pkg/controllers/grafana/manifests/deployment.yaml
@@ -111,8 +111,8 @@ spec:
       - readinessProbe:
           httpGet:
             path: /oauth/healthz
-            port: 9443
-            scheme: HTTPS
+            port: 8080
+            scheme: HTTP
           timeoutSeconds: 1
           periodSeconds: 10
           successThreshold: 1
@@ -120,12 +120,10 @@ spec:
         name: grafana-proxy
         ports:
           - name: public
-            containerPort: 9443
+            containerPort: 8080
             protocol: TCP
         imagePullPolicy: IfNotPresent
         volumeMounts:
-          - name: tls-secret
-            mountPath: /etc/tls/private
           - mountPath: /etc/proxy/secrets
             name: cookie-secret
         image: {{.ProxyImage}}
@@ -133,13 +131,13 @@ spec:
         args:
           - '--provider=openshift'
           - '--upstream=http://localhost:3001'
-          - '--https-address=:9443'
+          # HTTP behind Route edge TLS so IngressController owns client TLS (ACM-30175).
+          - '--http-address=:8080'
+          - '--https-address='
           - '--cookie-secret-file=/etc/proxy/secrets/session_secret'
           - '--cookie-expire=12h0m0s'
           - '--cookie-refresh=8h0m0s'
           - '--openshift-delegate-urls={"/": {"resource": "projects", "verb": "list"}}'
-          - '--tls-cert=/etc/tls/private/tls.crt'
-          - '--tls-key=/etc/tls/private/tls.key'
           - '--openshift-service-account=multicluster-global-hub-grafana'
           - '--pass-user-bearer-token=true'
           - '--pass-access-token=true'
@@ -256,10 +254,6 @@ spec:
         secret:
           defaultMode: 420
           secretName: multicluster-global-hub-grafana-config
-      - name: tls-secret
-        secret:
-          defaultMode: 420
-          secretName: multicluster-global-hub-grafana-tls
       - name: cookie-secret
         secret:
           defaultMode: 420

--- a/operator/pkg/controllers/grafana/manifests/deployment.yaml
+++ b/operator/pkg/controllers/grafana/manifests/deployment.yaml
@@ -122,7 +122,6 @@ spec:
           - name: public
             containerPort: 8080
             protocol: TCP
-        imagePullPolicy: IfNotPresent
         volumeMounts:
           - mountPath: /etc/proxy/secrets
             name: cookie-secret

--- a/operator/pkg/controllers/grafana/manifests/networkpolicy.yaml
+++ b/operator/pkg/controllers/grafana/manifests/networkpolicy.yaml
@@ -20,7 +20,7 @@ spec:
           network.openshift.io/policy-group: ingress
     ports:
     - protocol: TCP
-      port: 9443
+      port: 8080
   # Allow metrics scraping from Prometheus
   - from:
     - namespaceSelector:
@@ -30,7 +30,7 @@ spec:
     - protocol: TCP
       port: 3001
     - protocol: TCP
-      port: 9443
+      port: 8080
   # Allow Grafana HA alerting between replicas
   - from:
     - podSelector:

--- a/operator/pkg/controllers/grafana/manifests/route.yaml
+++ b/operator/pkg/controllers/grafana/manifests/route.yaml
@@ -9,8 +9,12 @@ spec:
   port:
     targetPort: "oauth-proxy"
   tls:
+    # Edge termination so the OpenShift IngressController (status.tlsProfile)
+    # owns client-facing TLS. OpenShift oauth-proxy has no --tls-min-version /
+    # --tls-cipher-suite flags, so reencrypt cannot inherit Ingress/APIServer
+    # profiles on the router→proxy hop (ACM-30175).
     insecureEdgeTerminationPolicy: Redirect
-    termination: reencrypt
+    termination: edge
   to:
     kind: Service
     name: multicluster-global-hub-grafana

--- a/operator/pkg/controllers/grafana/manifests/service.yaml
+++ b/operator/pkg/controllers/grafana/manifests/service.yaml
@@ -5,14 +5,12 @@ metadata:
     name: multicluster-global-hub-grafana
   name: multicluster-global-hub-grafana
   namespace: {{.Namespace}}
-  annotations:
-    service.beta.openshift.io/serving-cert-secret-name: multicluster-global-hub-grafana-tls
 spec:
   ports:
   - name: oauth-proxy
-    port: 9443
+    port: 8080
     protocol: TCP
-    targetPort: 9443
+    targetPort: 8080
   selector:
     name: multicluster-global-hub-grafana
   type: ClusterIP

--- a/pkg/utils/tlsprofile_ingress.go
+++ b/pkg/utils/tlsprofile_ingress.go
@@ -1,0 +1,111 @@
+package utils
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	defaultIngressControllerName       = "default"
+	defaultIngressControllerNamespace  = "openshift-ingress-operator"
+	errMsgFailedToGetIngressController = "failed to get IngressController %s/%s: %w"
+)
+
+// FetchIngressControllerTLSProfileSpec returns the effective TLS profile from the
+// default OpenShift IngressController (status.tlsProfile).
+//
+// When status.tlsProfile is unset, it falls back to the IngressController
+// spec.tlsSecurityProfile (resolved via resolveSpec), then to the cluster
+// APIServer profile. A nil/empty result defaults to Intermediate.
+//
+// This is the TLS source for OpenShift Route edge/reencrypt client-facing hops
+// (HAProxy), as opposed to APIServer which is the source for first-party Go servers.
+func FetchIngressControllerTLSProfileSpec(
+	ctx context.Context,
+	c client.Client,
+) (*configv1.TLSProfileSpec, error) {
+	ic := &operatorv1.IngressController{}
+	key := client.ObjectKey{
+		Name:      defaultIngressControllerName,
+		Namespace: defaultIngressControllerNamespace,
+	}
+	if err := c.Get(ctx, key, ic); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Non-OpenShift or Ingress Operator not installed: fall back to APIServer.
+			return fetchAPIServerTLSProfileSpec(ctx, c)
+		}
+		return nil, fmt.Errorf(errMsgFailedToGetIngressController,
+			defaultIngressControllerNamespace, defaultIngressControllerName, err)
+	}
+
+	if ic.Status.TLSProfile != nil {
+		return ic.Status.TLSProfile.DeepCopy(), nil
+	}
+
+	if ic.Spec.TLSSecurityProfile != nil {
+		return resolveSpec(ic.Spec.TLSSecurityProfile)
+	}
+
+	return fetchAPIServerTLSProfileSpec(ctx, c)
+}
+
+func fetchAPIServerTLSProfileSpec(
+	ctx context.Context,
+	c client.Client,
+) (*configv1.TLSProfileSpec, error) {
+	apiserver := &configv1.APIServer{}
+	if err := c.Get(ctx, client.ObjectKey{Name: "cluster"}, apiserver); err != nil {
+		if apierrors.IsNotFound(err) {
+			return resolveSpec(nil)
+		}
+		return nil, fmt.Errorf(errMsgFailedToGetAPIServer, err)
+	}
+	return resolveSpec(apiserver.Spec.TLSSecurityProfile)
+}
+
+// BuildTLSConfigFromIngressProfileSpec builds a tls.Config from an IngressController
+// status.tlsProfile (or any resolved TLSProfileSpec).
+func BuildTLSConfigFromIngressProfileSpec(spec *configv1.TLSProfileSpec) (*tls.Config, error) {
+	if spec == nil {
+		resolved, err := resolveSpec(nil)
+		if err != nil {
+			return nil, err
+		}
+		spec = resolved
+	}
+
+	minVer, err := parseTLSVersion(string(spec.MinTLSVersion))
+	if err != nil {
+		return nil, fmt.Errorf("invalid MinTLSVersion: %w", err)
+	}
+
+	// #nosec G402 -- MinVersion comes from the cluster Ingress TLS profile.
+	cfg := &tls.Config{MinVersion: minVer}
+	if minVer < tls.VersionTLS13 && len(spec.Ciphers) > 0 {
+		suites := mapCipherSuites(spec.Ciphers)
+		if len(suites) == 0 {
+			return nil, fmt.Errorf(
+				"no valid cipher suites found for Ingress TLS profile (all %d cipher(s) unsupported by Go)",
+				len(spec.Ciphers),
+			)
+		}
+		cfg.CipherSuites = suites
+	}
+	return cfg, nil
+}
+
+// GetTLSConfigFromIngressController fetches the default IngressController TLS profile
+// and builds a tls.Config. Prefer this for surfaces that terminate behind OpenShift Routes.
+func GetTLSConfigFromIngressController(ctx context.Context, c client.Client) (*tls.Config, error) {
+	spec, err := FetchIngressControllerTLSProfileSpec(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+	return BuildTLSConfigFromIngressProfileSpec(spec)
+}

--- a/pkg/utils/tlsprofile_ingress.go
+++ b/pkg/utils/tlsprofile_ingress.go
@@ -1,3 +1,7 @@
+/*
+Copyright Contributors to the Open Cluster Management project.
+*/
+
 package utils
 
 import (

--- a/pkg/utils/tlsprofile_ingress_test.go
+++ b/pkg/utils/tlsprofile_ingress_test.go
@@ -1,0 +1,171 @@
+package utils
+
+import (
+	"context"
+	"crypto/tls"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func ingressTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		t.Fatalf("add client-go scheme: %v", err)
+	}
+	if err := configv1.AddToScheme(s); err != nil {
+		t.Fatalf("add configv1 scheme: %v", err)
+	}
+	if err := operatorv1.Install(s); err != nil {
+		t.Fatalf("add operatorv1 scheme: %v", err)
+	}
+	return s
+}
+
+func TestFetchIngressControllerTLSProfileSpecFromStatus(t *testing.T) {
+	s := ingressTestScheme(t)
+	ic := &operatorv1.IngressController{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultIngressControllerName,
+			Namespace: defaultIngressControllerNamespace,
+		},
+		Status: operatorv1.IngressControllerStatus{
+			TLSProfile: &configv1.TLSProfileSpec{
+				Ciphers:       []string{testCipherECDHERSAAES128},
+				MinTLSVersion: configv1.VersionTLS12,
+			},
+		},
+	}
+	c := fakeclient.NewClientBuilder().WithScheme(s).WithObjects(ic).Build()
+
+	spec, err := FetchIngressControllerTLSProfileSpec(context.Background(), c)
+	if err != nil {
+		t.Fatalf(testErrUnexpected, err)
+	}
+	if spec.MinTLSVersion != configv1.VersionTLS12 {
+		t.Fatalf("expected MinTLSVersion %s, got %s", configv1.VersionTLS12, spec.MinTLSVersion)
+	}
+	if len(spec.Ciphers) != 1 || spec.Ciphers[0] != testCipherECDHERSAAES128 {
+		t.Fatalf("unexpected ciphers: %#v", spec.Ciphers)
+	}
+}
+
+func TestFetchIngressControllerTLSProfileSpecFromSpec(t *testing.T) {
+	s := ingressTestScheme(t)
+	ic := &operatorv1.IngressController{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultIngressControllerName,
+			Namespace: defaultIngressControllerNamespace,
+		},
+		Spec: operatorv1.IngressControllerSpec{
+			TLSSecurityProfile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			},
+		},
+	}
+	c := fakeclient.NewClientBuilder().WithScheme(s).WithObjects(ic).Build()
+
+	spec, err := FetchIngressControllerTLSProfileSpec(context.Background(), c)
+	if err != nil {
+		t.Fatalf(testErrUnexpected, err)
+	}
+	expected := configv1.TLSProfiles[configv1.TLSProfileModernType]
+	if spec.MinTLSVersion != expected.MinTLSVersion {
+		t.Fatalf("expected MinTLSVersion %s, got %s", expected.MinTLSVersion, spec.MinTLSVersion)
+	}
+}
+
+func TestFetchIngressControllerTLSProfileSpecFallsBackToAPIServer(t *testing.T) {
+	s := ingressTestScheme(t)
+	ic := &operatorv1.IngressController{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultIngressControllerName,
+			Namespace: defaultIngressControllerNamespace,
+		},
+	}
+	apiserver := &configv1.APIServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec: configv1.APIServerSpec{
+			TLSSecurityProfile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileOldType,
+			},
+		},
+	}
+	c := fakeclient.NewClientBuilder().WithScheme(s).WithObjects(ic, apiserver).Build()
+
+	spec, err := FetchIngressControllerTLSProfileSpec(context.Background(), c)
+	if err != nil {
+		t.Fatalf(testErrUnexpected, err)
+	}
+	expected := configv1.TLSProfiles[configv1.TLSProfileOldType]
+	if spec.MinTLSVersion != expected.MinTLSVersion {
+		t.Fatalf("expected MinTLSVersion %s, got %s", expected.MinTLSVersion, spec.MinTLSVersion)
+	}
+}
+
+func TestFetchIngressControllerTLSProfileSpecMissingDefaultsToIntermediate(t *testing.T) {
+	s := ingressTestScheme(t)
+	c := fakeclient.NewClientBuilder().WithScheme(s).Build()
+
+	spec, err := FetchIngressControllerTLSProfileSpec(context.Background(), c)
+	if err != nil {
+		t.Fatalf(testErrUnexpected, err)
+	}
+	expected := configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+	if spec.MinTLSVersion != expected.MinTLSVersion {
+		t.Fatalf("expected Intermediate MinTLSVersion %s, got %s",
+			expected.MinTLSVersion, spec.MinTLSVersion)
+	}
+}
+
+func TestGetTLSConfigFromIngressController(t *testing.T) {
+	s := ingressTestScheme(t)
+	ic := &operatorv1.IngressController{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultIngressControllerName,
+			Namespace: defaultIngressControllerNamespace,
+		},
+		Status: operatorv1.IngressControllerStatus{
+			TLSProfile: &configv1.TLSProfileSpec{
+				Ciphers:       []string{testCipherECDHERSAAES128},
+				MinTLSVersion: configv1.VersionTLS12,
+			},
+		},
+	}
+	c := fakeclient.NewClientBuilder().WithScheme(s).WithObjects(ic).Build()
+
+	cfg, err := GetTLSConfigFromIngressController(context.Background(), c)
+	if err != nil {
+		t.Fatalf(testErrUnexpected, err)
+	}
+	if cfg.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("expected TLS 1.2, got 0x%x", cfg.MinVersion)
+	}
+	if len(cfg.CipherSuites) != 1 {
+		t.Fatalf("expected 1 cipher suite, got %d", len(cfg.CipherSuites))
+	}
+}
+
+func TestBuildTLSConfigFromIngressProfileSpecNilDefaults(t *testing.T) {
+	cfg, err := BuildTLSConfigFromIngressProfileSpec(nil)
+	if err != nil {
+		t.Fatalf(testErrUnexpected, err)
+	}
+	expected, err := resolveSpec(nil)
+	if err != nil {
+		t.Fatalf(testErrUnexpected, err)
+	}
+	minVer, err := parseTLSVersion(string(expected.MinTLSVersion))
+	if err != nil {
+		t.Fatalf(testErrUnexpected, err)
+	}
+	if cfg.MinVersion != minVer {
+		t.Fatalf("expected MinVersion 0x%x, got 0x%x", minVer, cfg.MinVersion)
+	}
+}

--- a/pkg/utils/tlsprofile_ingress_test.go
+++ b/pkg/utils/tlsprofile_ingress_test.go
@@ -1,3 +1,7 @@
+/*
+Copyright Contributors to the Open Cluster Management project.
+*/
+
 package utils
 
 import (


### PR DESCRIPTION
Fixes: [ACM-30175](https://redhat.atlassian.net/browse/ACM-30175)

## Summary

- Switch Grafana Route to **edge** termination so OpenShift IngressController `status.tlsProfile` owns client-facing TLS
- Run oauth-proxy on **HTTP :8080** (no sidecar HTTPS) because openshift/oauth-proxy has no TLS min-version/cipher flags
- Add `pkg/utils/tlsprofile_ingress.go` helpers to read IngressController profile (with APIServer/Intermediate fallbacks)
- Update Grafana Service, NetworkPolicy, and deployment probes for port 8080
- Grant operator RBAC `ingresscontrollers` get/list/watch; sync bundle CSV

## Context

- [#2487](https://github.com/stolostron/multicluster-global-hub/pull/2487) wired APIServer TLS profile for first-party Go servers (webhook, metrics)
- Grafana user TLS was still **reencrypt** → oauth-proxy `:9443` with a local serving cert, which cannot inherit cluster TLS profiles
- Companion metrics HTTPS work: [#2625](https://github.com/stolostron/multicluster-global-hub/pull/2625)

Related:

- [ACM-30175](https://redhat.atlassian.net/browse/ACM-30175) — Jira
- [stolostron/multicluster-global-hub#2487](https://github.com/stolostron/multicluster-global-hub/pull/2487) — APIServer profile for Go components

## Test plan

- [ ] Unit: `go test ./pkg/utils/ -run Ingress`
- [ ] Integration/CI green (gofmt, test-unit, sonarcloud)
- [ ] Deploy on OCP: Grafana Route negotiates TLS per IngressController profile (`openssl s_client` on route host)
- [ ] OAuth login to Grafana succeeds via edge Route
- [ ] Operator logs show `Grafana Route edge TLS uses IngressController profile minTLSVersion=...`

Made with [Cursor](https://cursor.com)

[ACM-30175]: https://redhat.atlassian.net/browse/ACM-30175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-30175]: https://redhat.atlassian.net/browse/ACM-30175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Grafana now derives effective TLS settings from the cluster’s OpenShift IngressController TLS profile (with sensible fallbacks) to improve compatibility with routing.

* **Bug Fixes**
  * Updated Grafana proxy exposure to use **port 8080 over HTTP** (replacing **9443 over HTTPS**), including readiness checks and Service/Deployment configuration.
  * Changed the router→proxy TLS hop to **edge** termination.
  * Updated Grafana **NetworkPolicy** ingress rules to allow **TCP 8080**.

* **Documentation**
  * Refreshed Grafana network/port documentation to reflect the updated routing and NetworkPolicy behavior.

* **Tests**
  * Added unit tests covering TLS profile resolution and generated TLS config behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->