### PR TITLE
Security: Fix ACM-36273 - Go 1.26.4 z-stream [multicluster-globalhub-1.4]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/multicluster-global-hub
 
-go 1.26.3
+go 1.26.4
 
 tool (
 	github.com/daixiang0/gci

--- a/test/script/util.sh
+++ b/test/script/util.sh
@@ -8,7 +8,7 @@ export KUBECTL_VERSION=v1.28.1
 export CLUSTERADM_VERSION=0.8.2
 export KIND_VERSION=v0.19.0
 export ROUTE_VERSION=release-4.12
-export GO_VERSION=go1.26.3
+export GO_VERSION=go1.26.4
 export GINKGO_VERSION=v2.17.2
 
 # Environment Variables


### PR DESCRIPTION
## Summary

Fixes: [ACM-36273](https://redhat.atlassian.net/browse/ACM-36273)

- Bump `go.mod` to **1.26.4** on `release-2.13`
- Update E2E `GO_VERSION` in `test/script/util.sh` to `go1.26.4`

### ACM-36273 — CVE-2026-27145 (crypto/x509 DNS SAN DoS)

Go stdlib `crypto/x509` vulnerability (GO-2026-5037). `VerifyHostname` caused quadratic CPU use with large DNS SAN lists. Fixed in Go **1.26.4+** (or 1.25.11). GA Global Hub **1.4.6** shipped Go **1.25.7**; the 1.26.3 bump ([#2602](https://github.com/stolostron/multicluster-global-hub/pull/2602)) is insufficient — this PR moves to **1.26.4**.

Konflux builder `rhel_9_1.26` already ships Go 1.26.4; this aligns `go.mod` and E2E tooling with the patched stdlib.

## Why

Companion to postgres_exporter and glo-grafana Go 1.26.4 bumps for Global Hub **1.4** z-stream (1.4.7). Follows the 1.26.3 pattern ([#2602](https://github.com/stolostron/multicluster-global-hub/pull/2602)).

## Test plan

- [ ] GitHub Actions `Go` workflow `format` job passes
- [ ] SonarCloud quality gate passes
- [ ] Merge with companion PRs: postgres_exporter, glo-grafana


Made with [Cursor](https://cursor.com)

[ACM-36273]: https://redhat.atlassian.net/browse/ACM-36273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ