### PR TITLE
Security: Fix ACM-36274 - Go 1.26.4 z-stream [multicluster-globalhub-1.5]

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -66,4 +66,4 @@ jobs:
           version: "^1.34.1"
 
       - name: scorecard
-        run: cd operator && operator-sdk scorecard ./bundle/
+        run: cd operator && operator-sdk scorecard ./bundle/ --wait-time 120s

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/multicluster-global-hub
 
-go 1.26.3
+go 1.26.4
 
 tool (
 	github.com/daixiang0/gci

--- a/test/script/util.sh
+++ b/test/script/util.sh
@@ -8,7 +8,7 @@ export KUBECTL_VERSION=v1.28.1
 export CLUSTERADM_VERSION=0.10.1
 export KIND_VERSION=v0.19.0
 export ROUTE_VERSION=release-4.12
-export GO_VERSION=go1.26.3
+export GO_VERSION=go1.26.4
 export GINKGO_VERSION=v2.17.2
 
 # Environment Variables


### PR DESCRIPTION
## Summary

Fixes: [ACM-36274](https://redhat.atlassian.net/browse/ACM-36274)

- Bump `go.mod` to **1.26.4** on `release-2.14`
- Update E2E `GO_VERSION` in `test/script/util.sh` to `go1.26.4`

### ACM-36274 — CVE-2026-27145 (crypto/x509 DNS SAN DoS)

Go stdlib `crypto/x509` vulnerability (GO-2026-5037). Fixed in Go **1.26.4+**. The 1.26.3 bump ([#2603](https://github.com/stolostron/multicluster-global-hub/pull/2603)) is insufficient.

## Test plan

- [ ] GitHub Actions `Go` workflow passes
- [ ] SonarCloud quality gate passes
- [ ] Merge with companion PRs: postgres_exporter, glo-grafana


Made with [Cursor](https://cursor.com)

[ACM-36274]: https://redhat.atlassian.net/browse/ACM-36274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ