### PR TITLE
Security: Fix ACM-36275 - Go 1.26.4 z-stream [multicluster-globalhub-1.6]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/multicluster-global-hub
 
-go 1.26.3
+go 1.26.4
 
 tool (
 	github.com/daixiang0/gci


### PR DESCRIPTION
## Summary

Fixes: [ACM-36275](https://redhat.atlassian.net/browse/ACM-36275)

- Bump `go.mod` to **1.26.4** on `release-2.15`

### ACM-36275 — CVE-2026-27145 (crypto/x509 DNS SAN DoS)

Go stdlib `crypto/x509` vulnerability (GO-2026-5037). Fixed in Go **1.26.4+**. The 1.26.3 bump ([#2604](https://github.com/stolostron/multicluster-global-hub/pull/2604)) is insufficient.

## Test plan

- [ ] GitHub Actions `Go` workflow passes
- [ ] SonarCloud quality gate passes
- [ ] Merge with companion PRs: postgres_exporter, glo-grafana


Made with [Cursor](https://cursor.com)

[ACM-36275]: https://redhat.atlassian.net/browse/ACM-36275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ