### PR TITLE
Bump Go to 1.26.4 on main [multicluster-globalhub-5.0]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/multicluster-global-hub
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/IBM/sarama v1.46.3

--- a/test/script/util.sh
+++ b/test/script/util.sh
@@ -8,7 +8,7 @@ export KUBECTL_VERSION=v1.28.1
 export CLUSTERADM_VERSION=1.1.1
 export KIND_VERSION=v0.19.0
 export ROUTE_VERSION=release-4.12
-export GO_VERSION=go1.26.3
+export GO_VERSION=go1.26.4
 export GINKGO_VERSION=v2.31.0
 
 # Environment Variables


### PR DESCRIPTION
## Summary

- Bump `go.mod` to **1.26.4** on `main`
- Update E2E `GO_VERSION` in `test/script/util.sh` to `go1.26.4`

## Why

Keep **Global Hub 5.0** (`release-5.0`) aligned with the z-stream Go 1.26.4 bumps for CVE-2026-27145 (crypto/x509 DNS SAN DoS, GO-2026-5037):

| GH line | Jira | Hub PR |
|---------|------|--------|
| 1.4 | ACM-36273 | [#2629](https://github.com/stolostron/multicluster-global-hub/pull/2629) |
| 1.5 | ACM-36274 | [#2630](https://github.com/stolostron/multicluster-global-hub/pull/2630) |
| 1.6 | ACM-36275 | [#2631](https://github.com/stolostron/multicluster-global-hub/pull/2631) |
| 1.7 | ACM-36276 | [#2632](https://github.com/stolostron/multicluster-global-hub/pull/2632) |
| 1.8 | ACM-36277 | [#2633](https://github.com/stolostron/multicluster-global-hub/pull/2633) |

This repo uses **main → release-5.0 fast-forward**; merging here propagates the Go 1.26.4 toolchain to `release-5.0` automatically.

## Test plan

- [ ] GitHub Actions `Go` workflow passes on `main`
- [ ] SonarCloud quality gate passes
- [ ] Confirm `release-5.0` fast-forwards after merge


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the supported Go toolchain version to Go 1.26.4.
  * Updated installation and verification scripts to use the same Go version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->