### PR TITLE
Add rohit-bharmal to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,11 +2,13 @@ approvers:
 - nirrozenbaum
 - bjoydeep
 - birsanv
+- rohit-bharmal
 
 reviewers:
 - nirrozenbaum
 - bjoydeep
 - birsanv
+- rohit-bharmal
 - github-actions[bot]
 
 emeritus_approvers:


### PR DESCRIPTION
## Summary
- Add `rohit-bharmal` to `OWNERS` approvers and reviewers (same placement as `bjoydeep` / `birsanv`)
- Onboard new GH team developer

## Test plan
- [ ] Prow/OWNERS validation passes on merge
- [ ] After merge, OpenShift CI ffwd propagates `OWNERS` to active release branches (`release-2.13` … `release-5.1`)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated project maintenance and code review ownership assignments.
  - No changes were made to application functionality, user-facing behavior, or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->