### PR TITLE
Add rohit-bharmal to OWNERS on main

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,11 +2,13 @@ approvers:
 - nirrozenbaum
 - bjoydeep
 - birsanv
+- rohit-bharmal
 
 reviewers:
 - nirrozenbaum
 - bjoydeep
 - birsanv
+- rohit-bharmal
 - github-actions[bot]
 
 emeritus_approvers:


### PR DESCRIPTION
## Summary
- Add `rohit-bharmal` to `OWNERS` approvers and reviewers (same placement as `bjoydeep` / `birsanv`)

## Test plan
- [ ] Prow/OWNERS validation passes on merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project approval and review assignments.
  * No user-facing functionality or behavior has changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->