### PR TITLE
ACM-36043: fix Hub HA standby sync flake on ManagedCluster update

### DIFF
--- a/agent/pkg/spec/hubha/hubha_standby_syncer.go
+++ b/agent/pkg/spec/hubha/hubha_standby_syncer.go
@@ -5,6 +5,7 @@ package hubha
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -53,13 +54,14 @@ func (s *HubHAStandbySyncer) Sync(ctx context.Context, evt *cloudevents.Event) e
 	}
 
 	sourceHub := source
+	var syncErrs []error
 
 	// Apply created resources
 	for _, obj := range bundle.Create {
 		if err := s.createResource(ctx, obj, sourceHub); err != nil {
 			log.Errorf("failed to create resource %s/%s from active hub %s: %v",
 				obj.GetNamespace(), obj.GetName(), sourceHub, err)
-			// Continue with other resources instead of failing entirely
+			syncErrs = append(syncErrs, err)
 		}
 	}
 
@@ -68,6 +70,7 @@ func (s *HubHAStandbySyncer) Sync(ctx context.Context, evt *cloudevents.Event) e
 		if err := s.updateResource(ctx, obj, sourceHub); err != nil {
 			log.Errorf("failed to update resource %s/%s from active hub %s: %v",
 				obj.GetNamespace(), obj.GetName(), sourceHub, err)
+			syncErrs = append(syncErrs, err)
 		}
 	}
 
@@ -76,6 +79,7 @@ func (s *HubHAStandbySyncer) Sync(ctx context.Context, evt *cloudevents.Event) e
 		if err := s.updateResource(ctx, obj, sourceHub); err != nil {
 			log.Errorf("failed to resync resource %s/%s from active hub %s: %v",
 				obj.GetNamespace(), obj.GetName(), sourceHub, err)
+			syncErrs = append(syncErrs, err)
 		}
 	}
 
@@ -84,11 +88,16 @@ func (s *HubHAStandbySyncer) Sync(ctx context.Context, evt *cloudevents.Event) e
 		if err := s.deleteResource(ctx, &meta, sourceHub); err != nil {
 			log.Errorf("failed to delete resource %s/%s from active hub %s: %v",
 				meta.Namespace, meta.Name, sourceHub, err)
+			syncErrs = append(syncErrs, err)
 		}
 	}
 
 	log.Infof("standby hub processed Hub HA bundle from %s: created=%d, updated=%d, resynced=%d, deleted=%d",
 		sourceHub, len(bundle.Create), len(bundle.Update), len(bundle.Resync), len(bundle.Delete))
+
+	if len(syncErrs) > 0 {
+		return fmt.Errorf("failed to apply Hub HA bundle from %s: %w", sourceHub, stderrors.Join(syncErrs...))
+	}
 
 	return nil
 }

--- a/agent/pkg/spec/hubha/hubha_standby_syncer_sync_errors_test.go
+++ b/agent/pkg/spec/hubha/hubha_standby_syncer_sync_errors_test.go
@@ -1,5 +1,16 @@
-// Copyright (c) 2025 Red Hat, Inc.
-// Copyright Contributors to the Open Cluster Management project
+// Copyright Contributors to the Open Cluster Management project.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package hubha
 

--- a/agent/pkg/spec/hubha/hubha_standby_syncer_sync_errors_test.go
+++ b/agent/pkg/spec/hubha/hubha_standby_syncer_sync_errors_test.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2025 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package hubha
+
+import (
+	"context"
+	stderrors "errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/bundle/generic"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+)
+
+func configMapUnstructured(name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": "default",
+			},
+		},
+	}
+}
+
+func hubHAResourceEvent(t *testing.T, bundle *generic.GenericBundle[*unstructured.Unstructured]) *cloudevents.Event {
+	t.Helper()
+
+	evt := cloudevents.NewEvent()
+	evt.SetType(constants.HubHAResourcesMsgKey)
+	evt.SetSource("hub1")
+	if err := evt.SetData(cloudevents.ApplicationJSON, bundle); err != nil {
+		t.Fatalf("SetData() error = %v", err)
+	}
+	return &evt
+}
+
+func assertSyncAggregateErrors(t *testing.T, err error, wantCount int, wantMessages ...string) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatal("expected aggregate sync error when bundle apply fails")
+	}
+
+	joined := stderrors.Unwrap(err)
+	if joined == nil {
+		t.Fatalf("expected wrapped aggregate error, got: %v", err)
+	}
+
+	unwrapMulti, ok := joined.(interface{ Unwrap() []error })
+	if !ok {
+		t.Fatalf("expected errors.Join aggregate, got: %v", joined)
+	}
+
+	syncErrs := unwrapMulti.Unwrap()
+	if len(syncErrs) != wantCount {
+		t.Fatalf("expected %d aggregated errors, got %d: %v", wantCount, len(syncErrs), syncErrs)
+	}
+
+	for _, want := range wantMessages {
+		found := false
+		for _, syncErr := range syncErrs {
+			if strings.Contains(syncErr.Error(), want) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expected %q in aggregate errors, got: %v", want, syncErrs)
+		}
+	}
+}
+
+func TestHubHAStandbySyncer_Sync_ReturnsAggregateErrorsOnCreateUpdateResync(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add corev1 to scheme: %v", err)
+	}
+
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: existingCMName, Namespace: "default"},
+	}
+	resyncCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "resync-cm", Namespace: "default"},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(existing, resyncCM).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				return fmt.Errorf("create failure")
+			},
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				return fmt.Errorf("update failure")
+			},
+		}).
+		Build()
+
+	syncer := NewHubHAStandbySyncer(fakeClient)
+
+	bundle := generic.NewGenericBundle[*unstructured.Unstructured]()
+	bundle.Create = []*unstructured.Unstructured{configMapUnstructured("new-cm")}
+	bundle.Update = []*unstructured.Unstructured{configMapUnstructured(existingCMName)}
+	bundle.Resync = []*unstructured.Unstructured{configMapUnstructured("resync-cm")}
+
+	err := syncer.Sync(context.Background(), hubHAResourceEvent(t, bundle))
+	assertSyncAggregateErrors(t, err, 3, "create failure", "update failure")
+}

--- a/agent/pkg/spec/hubha/hubha_standby_syncer_test.go
+++ b/agent/pkg/spec/hubha/hubha_standby_syncer_test.go
@@ -5,9 +5,7 @@ package hubha
 
 import (
 	"context"
-	stderrors "errors"
 	"fmt"
-	"strings"
 	"testing"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -677,36 +675,5 @@ func TestHubHAStandbySyncer_Sync_ReturnsAggregateErrors(t *testing.T) {
 	}
 
 	err := syncer.Sync(context.Background(), &evt)
-	if err == nil {
-		t.Fatal("expected aggregate sync error when bundle apply fails")
-	}
-
-	joined := stderrors.Unwrap(err)
-	if joined == nil {
-		t.Fatalf("expected wrapped aggregate error, got: %v", err)
-	}
-
-	unwrapMulti, ok := joined.(interface{ Unwrap() []error })
-	if !ok {
-		t.Fatalf("expected errors.Join aggregate, got: %v", joined)
-	}
-
-	syncErrs := unwrapMulti.Unwrap()
-	if len(syncErrs) != 2 {
-		t.Fatalf("expected 2 aggregated errors, got %d: %v", len(syncErrs), syncErrs)
-	}
-
-	gotOne, gotTwo := false, false
-	for _, syncErr := range syncErrs {
-		msg := syncErr.Error()
-		if strings.Contains(msg, "delete failure one") {
-			gotOne = true
-		}
-		if strings.Contains(msg, "delete failure two") {
-			gotTwo = true
-		}
-	}
-	if !gotOne || !gotTwo {
-		t.Fatalf("expected both delete failures in aggregate, got: %v", syncErrs)
-	}
+	assertSyncAggregateErrors(t, err, 2, "delete failure one", "delete failure two")
 }

--- a/agent/pkg/spec/hubha/hubha_standby_syncer_test.go
+++ b/agent/pkg/spec/hubha/hubha_standby_syncer_test.go
@@ -613,3 +613,29 @@ func TestHubHAStandbySyncer_UpdateManagedCluster_SetsHubAcceptsClient(t *testing
 		t.Errorf("Labels not updated correctly, got %v", labels)
 	}
 }
+
+func TestHubHAStandbySyncer_Sync_ReturnsAggregateErrors(t *testing.T) {
+	scheme := runtime.NewScheme()
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	syncer := NewHubHAStandbySyncer(client)
+
+	bundle := generic.NewGenericBundle[*unstructured.Unstructured]()
+	bundle.Delete = []generic.ObjectMetadata{
+		{
+			Name:      testCMName,
+			Namespace: "default",
+		},
+	}
+
+	evt := cloudevents.NewEvent()
+	evt.SetType(constants.HubHAResourcesMsgKey)
+	evt.SetSource("hub1")
+	if err := evt.SetData(cloudevents.ApplicationJSON, bundle); err != nil {
+		t.Fatalf("SetData() error = %v", err)
+	}
+
+	err := syncer.Sync(context.Background(), &evt)
+	if err == nil {
+		t.Fatal("expected aggregate sync error when bundle apply fails")
+	}
+}

--- a/agent/pkg/spec/hubha/hubha_standby_syncer_test.go
+++ b/agent/pkg/spec/hubha/hubha_standby_syncer_test.go
@@ -5,6 +5,9 @@ package hubha
 
 import (
 	"context"
+	stderrors "errors"
+	"fmt"
+	"strings"
 	"testing"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -14,7 +17,9 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"github.com/stolostron/multicluster-global-hub/pkg/bundle/generic"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
@@ -616,14 +621,51 @@ func TestHubHAStandbySyncer_UpdateManagedCluster_SetsHubAcceptsClient(t *testing
 
 func TestHubHAStandbySyncer_Sync_ReturnsAggregateErrors(t *testing.T) {
 	scheme := runtime.NewScheme()
-	client := fake.NewClientBuilder().WithScheme(scheme).Build()
-	syncer := NewHubHAStandbySyncer(client)
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add corev1 to scheme: %v", err)
+	}
+
+	cmOne := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "cm-one", Namespace: "default"},
+	}
+	cmTwo := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "cm-two", Namespace: "default"},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cmOne, cmTwo).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				switch obj.GetName() {
+				case "cm-one":
+					return fmt.Errorf("delete failure one")
+				case "cm-two":
+					return fmt.Errorf("delete failure two")
+				default:
+					return c.Delete(ctx, obj, opts...)
+				}
+			},
+		}).
+		Build()
+
+	syncer := NewHubHAStandbySyncer(fakeClient)
 
 	bundle := generic.NewGenericBundle[*unstructured.Unstructured]()
 	bundle.Delete = []generic.ObjectMetadata{
 		{
-			Name:      testCMName,
+			Name:      "cm-one",
 			Namespace: "default",
+			Group:     "",
+			Version:   "v1",
+			Kind:      "ConfigMap",
+		},
+		{
+			Name:      "cm-two",
+			Namespace: "default",
+			Group:     "",
+			Version:   "v1",
+			Kind:      "ConfigMap",
 		},
 	}
 
@@ -637,5 +679,34 @@ func TestHubHAStandbySyncer_Sync_ReturnsAggregateErrors(t *testing.T) {
 	err := syncer.Sync(context.Background(), &evt)
 	if err == nil {
 		t.Fatal("expected aggregate sync error when bundle apply fails")
+	}
+
+	joined := stderrors.Unwrap(err)
+	if joined == nil {
+		t.Fatalf("expected wrapped aggregate error, got: %v", err)
+	}
+
+	unwrapMulti, ok := joined.(interface{ Unwrap() []error })
+	if !ok {
+		t.Fatalf("expected errors.Join aggregate, got: %v", joined)
+	}
+
+	syncErrs := unwrapMulti.Unwrap()
+	if len(syncErrs) != 2 {
+		t.Fatalf("expected 2 aggregated errors, got %d: %v", len(syncErrs), syncErrs)
+	}
+
+	gotOne, gotTwo := false, false
+	for _, syncErr := range syncErrs {
+		msg := syncErr.Error()
+		if strings.Contains(msg, "delete failure one") {
+			gotOne = true
+		}
+		if strings.Contains(msg, "delete failure two") {
+			gotTwo = true
+		}
+	}
+	if !gotOne || !gotTwo {
+		t.Fatalf("expected both delete failures in aggregate, got: %v", syncErrs)
 	}
 }

--- a/test/Makefile
+++ b/test/Makefile
@@ -42,6 +42,7 @@ e2e-log/grafana:
 e2e-log/agent:
 	@export CLUSTER_NAME=hub1 COMPONENT=multicluster-global-hub-agent NAMESPACE=multicluster-global-hub-agent && ./test/script/e2e_log.sh
 	@export CLUSTER_NAME=hub2 COMPONENT=multicluster-global-hub-agent NAMESPACE=multicluster-global-hub-agent && ./test/script/e2e_log.sh
+	@export CLUSTER_NAME=global-hub COMPONENT=multicluster-global-hub-agent && ./test/script/e2e_log.sh
 
 integration-test: setup_envtest
 	KUBEBUILDER_ASSETS="$(shell ${TMP_BIN}/setup-envtest use --use-env -p path)" ${GO_TEST} `go list ./test/integration/...`

--- a/test/e2e/hubha_test.go
+++ b/test/e2e/hubha_test.go
@@ -1051,6 +1051,9 @@ var _ = Describe("Hub HA Sync", Label("e2e-test-hubha"), Ordered, func() {
 					return nil
 				}, hubHASyncWait+30*time.Second, 5*time.Second).Should(Succeed())
 
+				By("Waiting for ManagedCluster resourceVersion to stabilize after initial sync")
+				waitForManagedClusterStable(ctx, activeHubClient, testClusterName, 10*time.Second)
+
 				By("Updating ManagedCluster on active hub (changing URL and labels)")
 				Eventually(func() error {
 					activeCluster := &clusterv1.ManagedCluster{}
@@ -1091,6 +1094,33 @@ var _ = Describe("Hub HA Sync", Label("e2e-test-hubha"), Ordered, func() {
 		})
 	})
 })
+
+// waitForManagedClusterStable waits until the ManagedCluster resourceVersion on the
+// active hub stops changing for stableDuration. This reduces races with create-time
+// webhook churn before Hub HA update bundles are emitted.
+func waitForManagedClusterStable(ctx context.Context, c client.Client, name string, stableDuration time.Duration) {
+	var lastRV string
+	stableSince := time.Time{}
+
+	Eventually(func() error {
+		cluster := &clusterv1.ManagedCluster{}
+		if err := c.Get(ctx, types.NamespacedName{Name: name}, cluster); err != nil {
+			return err
+		}
+
+		rv := cluster.ResourceVersion
+		now := time.Now()
+		if rv != lastRV {
+			lastRV = rv
+			stableSince = now
+			return fmt.Errorf("resourceVersion changed to %s, waiting for stability", rv)
+		}
+		if now.Sub(stableSince) < stableDuration {
+			return fmt.Errorf("resourceVersion %s stable for %v, need %v", rv, now.Sub(stableSince), stableDuration)
+		}
+		return nil
+	}, 2*time.Minute, 2*time.Second).Should(Succeed())
+}
 
 // getHubRoleLabel retrieves the hub role label from a managed cluster
 func getHubRoleLabel(ctx context.Context, c client.Client, clusterName string) string {


### PR DESCRIPTION
Fixes: [ACM-36043](https://redhat.atlassian.net/browse/ACM-36043)

## Summary
- Return aggregate apply errors from `HubHAStandbySyncer.Sync` so the spec dispatcher's `RetryOnConflict` loop retries failed standby applies instead of treating them as success
- Wait for ManagedCluster `resourceVersion` to stabilize on the active hub after initial create sync before applying the production label/URL update in `hubha_test.go`, reducing races with create-time webhook churn
- Collect global-hub local agent logs in `make e2e-log/agent` so Prow failures include standby-side apply/dispatcher output

## Test plan
- [x] `go test ./agent/pkg/spec/hubha/... -run HubHAStandbySyncer`
- [ ] Prow `pull-ci-stolostron-multicluster-global-hub-main-test-e2e` Hub HA ManagedCluster update spec stable across repeated runs


Made with [Cursor](https://cursor.com)

[ACM-36043]: https://redhat.atlassian.net/browse/ACM-36043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hub HA synchronization now returns a single aggregated (joined) error when multiple bundle operations (create, update, resync, delete) fail, instead of only logging and continuing.
  * Improved Hub HA end-to-end stability when updating `ManagedCluster` by waiting for the active hub’s `resourceVersion` to settle before assertions.
* **Tests**
  * Added coverage verifying joined/aggregated errors when bundle **delete** operations fail.
  * Added coverage verifying joined/aggregated errors when bundle **create/update/resync** operations fail.
* **Chores**
  * Extended the `e2e-log/agent` test target to also run for `global-hub`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->