### PR TITLE
ACM-38074: resolve standbyHub from local-cluster MC name

### DIFF
--- a/manager/pkg/migration/migration_controller_test.go
+++ b/manager/pkg/migration/migration_controller_test.go
@@ -46,13 +46,14 @@ func TestUpdateStatusWithRetry(t *testing.T) {
 	_ = migrationv1alpha1.AddToScheme(scheme)
 
 	tests := []struct {
-		name                    string
-		migration               *migrationv1alpha1.ManagedClusterMigration
-		condition               metav1.Condition
-		phase                   string
-		expectedPhase           string
-		expectedConditionStatus metav1.ConditionStatus
-		expectedConditionReason string
+		name                     string
+		migration                *migrationv1alpha1.ManagedClusterMigration
+		condition                metav1.Condition
+		phase                    string
+		expectedPhase            string
+		expectedConditionStatus  metav1.ConditionStatus
+		expectedConditionReason  string
+		expectedConditionMessage string
 	}{
 		{
 			name: "Should update condition and phase successfully",
@@ -72,10 +73,11 @@ func TestUpdateStatusWithRetry(t *testing.T) {
 				Reason:  ConditionReasonStarted,
 				Message: "Migration instance is started",
 			},
-			phase:                   migrationv1alpha1.PhaseValidating,
-			expectedPhase:           migrationv1alpha1.PhaseValidating,
-			expectedConditionStatus: metav1.ConditionTrue,
-			expectedConditionReason: ConditionReasonStarted,
+			phase:                    migrationv1alpha1.PhaseValidating,
+			expectedPhase:            migrationv1alpha1.PhaseValidating,
+			expectedConditionStatus:  metav1.ConditionTrue,
+			expectedConditionReason:  ConditionReasonStarted,
+			expectedConditionMessage: "Migration instance is started",
 		},
 		{
 			name: "Should update waiting condition",
@@ -95,10 +97,11 @@ func TestUpdateStatusWithRetry(t *testing.T) {
 				Reason:  ConditionReasonWaiting,
 				Message: "Waiting for validation to complete",
 			},
-			phase:                   migrationv1alpha1.PhaseValidating,
-			expectedPhase:           migrationv1alpha1.PhaseValidating,
-			expectedConditionStatus: metav1.ConditionFalse,
-			expectedConditionReason: ConditionReasonWaiting,
+			phase:                    migrationv1alpha1.PhaseValidating,
+			expectedPhase:            migrationv1alpha1.PhaseValidating,
+			expectedConditionStatus:  metav1.ConditionFalse,
+			expectedConditionReason:  ConditionReasonWaiting,
+			expectedConditionMessage: "Waiting for validation to complete",
 		},
 		{
 			name: "Should update rollback condition successfully",
@@ -125,10 +128,11 @@ func TestUpdateStatusWithRetry(t *testing.T) {
 				Reason:  ConditionReasonResourceRolledBack,
 				Message: "Migration rollback completed successfully",
 			},
-			phase:                   migrationv1alpha1.PhaseFailed,
-			expectedPhase:           migrationv1alpha1.PhaseFailed,
-			expectedConditionStatus: metav1.ConditionTrue,
-			expectedConditionReason: ConditionReasonResourceRolledBack,
+			phase:                    migrationv1alpha1.PhaseFailed,
+			expectedPhase:            migrationv1alpha1.PhaseFailed,
+			expectedConditionStatus:  metav1.ConditionTrue,
+			expectedConditionReason:  ConditionReasonResourceRolledBack,
+			expectedConditionMessage: "Migration rollback completed successfully",
 		},
 		{
 			name: "Should update rollback failure condition",
@@ -155,10 +159,11 @@ func TestUpdateStatusWithRetry(t *testing.T) {
 				Reason:  ConditionReasonError,
 				Message: "Migration rollback failed due to timeout",
 			},
-			phase:                   migrationv1alpha1.PhaseFailed,
-			expectedPhase:           migrationv1alpha1.PhaseFailed,
-			expectedConditionStatus: metav1.ConditionFalse,
-			expectedConditionReason: ConditionReasonError,
+			phase:                    migrationv1alpha1.PhaseFailed,
+			expectedPhase:            migrationv1alpha1.PhaseFailed,
+			expectedConditionStatus:  metav1.ConditionFalse,
+			expectedConditionReason:  ConditionReasonError,
+			expectedConditionMessage: "Migration rollback failed due to timeout",
 		},
 		{
 			name: "Should not regress Completed phase from stale reconcile",
@@ -186,10 +191,11 @@ func TestUpdateStatusWithRetry(t *testing.T) {
 				Reason:  ConditionReasonWaiting,
 				Message: "Waiting for the resources to be cleaned up from the both source and target hub clusters",
 			},
-			phase:                   migrationv1alpha1.PhaseCleaning,
-			expectedPhase:           migrationv1alpha1.PhaseCompleted,
-			expectedConditionStatus: metav1.ConditionTrue,
-			expectedConditionReason: ConditionReasonResourceCleaned,
+			phase:                    migrationv1alpha1.PhaseCleaning,
+			expectedPhase:            migrationv1alpha1.PhaseCompleted,
+			expectedConditionStatus:  metav1.ConditionTrue,
+			expectedConditionReason:  ConditionReasonResourceCleaned,
+			expectedConditionMessage: "Resources have been successfully cleaned up from the hub clusters",
 		},
 		{
 			name: "Should not regress Failed phase from stale reconcile",
@@ -217,10 +223,11 @@ func TestUpdateStatusWithRetry(t *testing.T) {
 				Reason:  ConditionReasonWaiting,
 				Message: "Waiting for validation to complete",
 			},
-			phase:                   migrationv1alpha1.PhaseValidating,
-			expectedPhase:           migrationv1alpha1.PhaseFailed,
-			expectedConditionStatus: metav1.ConditionFalse,
-			expectedConditionReason: ConditionReasonError,
+			phase:                    migrationv1alpha1.PhaseValidating,
+			expectedPhase:            migrationv1alpha1.PhaseFailed,
+			expectedConditionStatus:  metav1.ConditionFalse,
+			expectedConditionReason:  ConditionReasonError,
+			expectedConditionMessage: "Hub cluster invalid",
 		},
 	}
 
@@ -250,13 +257,7 @@ func TestUpdateStatusWithRetry(t *testing.T) {
 			assert.NotNil(t, condition, "Condition should exist")
 			assert.Equal(t, tt.expectedConditionStatus, condition.Status, "Expected condition status should match")
 			assert.Equal(t, tt.expectedConditionReason, condition.Reason, "Expected condition reason should match")
-			if tt.name == "Should not regress Completed phase from stale reconcile" {
-				assert.Equal(t, "Resources have been successfully cleaned up from the hub clusters", condition.Message)
-			} else if tt.name == "Should not regress Failed phase from stale reconcile" {
-				assert.Equal(t, "Hub cluster invalid", condition.Message)
-			} else {
-				assert.Equal(t, tt.condition.Message, condition.Message, "Expected condition message should match")
-			}
+			assert.Equal(t, tt.expectedConditionMessage, condition.Message, "Expected condition message should match")
 		})
 	}
 }

--- a/manager/pkg/migration/migration_controller_test.go
+++ b/manager/pkg/migration/migration_controller_test.go
@@ -160,6 +160,68 @@ func TestUpdateStatusWithRetry(t *testing.T) {
 			expectedConditionStatus: metav1.ConditionFalse,
 			expectedConditionReason: ConditionReasonError,
 		},
+		{
+			name: "Should not regress Completed phase from stale reconcile",
+			migration: &migrationv1alpha1.ManagedClusterMigration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-migration-completed",
+					Namespace: utils.GetDefaultNamespace(),
+					UID:       types.UID("test-uid-completed"),
+				},
+				Status: migrationv1alpha1.ManagedClusterMigrationStatus{
+					Phase: migrationv1alpha1.PhaseCompleted,
+					Conditions: []migrationv1alpha1.MigrationCondition{
+						{Condition: metav1.Condition{
+							Type:    migrationv1alpha1.ConditionTypeCleaned,
+							Status:  metav1.ConditionTrue,
+							Reason:  ConditionReasonResourceCleaned,
+							Message: "Resources have been successfully cleaned up from the hub clusters",
+						}},
+					},
+				},
+			},
+			condition: metav1.Condition{
+				Type:    migrationv1alpha1.ConditionTypeCleaned,
+				Status:  metav1.ConditionFalse,
+				Reason:  ConditionReasonWaiting,
+				Message: "Waiting for the resources to be cleaned up from the both source and target hub clusters",
+			},
+			phase:                   migrationv1alpha1.PhaseCleaning,
+			expectedPhase:           migrationv1alpha1.PhaseCompleted,
+			expectedConditionStatus: metav1.ConditionTrue,
+			expectedConditionReason: ConditionReasonResourceCleaned,
+		},
+		{
+			name: "Should not regress Failed phase from stale reconcile",
+			migration: &migrationv1alpha1.ManagedClusterMigration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-migration-failed",
+					Namespace: utils.GetDefaultNamespace(),
+					UID:       types.UID("test-uid-failed"),
+				},
+				Status: migrationv1alpha1.ManagedClusterMigrationStatus{
+					Phase: migrationv1alpha1.PhaseFailed,
+					Conditions: []migrationv1alpha1.MigrationCondition{
+						{Condition: metav1.Condition{
+							Type:    migrationv1alpha1.ConditionTypeValidated,
+							Status:  metav1.ConditionFalse,
+							Reason:  ConditionReasonError,
+							Message: "Hub cluster invalid",
+						}},
+					},
+				},
+			},
+			condition: metav1.Condition{
+				Type:    migrationv1alpha1.ConditionTypeValidated,
+				Status:  metav1.ConditionFalse,
+				Reason:  ConditionReasonWaiting,
+				Message: "Waiting for validation to complete",
+			},
+			phase:                   migrationv1alpha1.PhaseValidating,
+			expectedPhase:           migrationv1alpha1.PhaseFailed,
+			expectedConditionStatus: metav1.ConditionFalse,
+			expectedConditionReason: ConditionReasonError,
+		},
 	}
 
 	for _, tt := range tests {
@@ -188,7 +250,13 @@ func TestUpdateStatusWithRetry(t *testing.T) {
 			assert.NotNil(t, condition, "Condition should exist")
 			assert.Equal(t, tt.expectedConditionStatus, condition.Status, "Expected condition status should match")
 			assert.Equal(t, tt.expectedConditionReason, condition.Reason, "Expected condition reason should match")
-			assert.Equal(t, tt.condition.Message, condition.Message, "Expected condition message should match")
+			if tt.name == "Should not regress Completed phase from stale reconcile" {
+				assert.Equal(t, "Resources have been successfully cleaned up from the hub clusters", condition.Message)
+			} else if tt.name == "Should not regress Failed phase from stale reconcile" {
+				assert.Equal(t, "Hub cluster invalid", condition.Message)
+			} else {
+				assert.Equal(t, tt.condition.Message, condition.Message, "Expected condition message should match")
+			}
 		})
 	}
 }

--- a/manager/pkg/migration/migration_utils.go
+++ b/manager/pkg/migration/migration_utils.go
@@ -97,6 +97,15 @@ func (m *ClusterMigrationController) UpdateStatusWithRetry(ctx context.Context,
 			return err
 		}
 
+		// Stale reconciles can still be running when another worker marks the migration
+		// terminal; never regress Completed/Failed to an earlier phase.
+		if mcm.Status.Phase == migrationv1alpha1.PhaseCompleted && phase != migrationv1alpha1.PhaseCompleted {
+			return nil
+		}
+		if mcm.Status.Phase == migrationv1alpha1.PhaseFailed && phase != migrationv1alpha1.PhaseFailed {
+			return nil
+		}
+
 		if migrationv1alpha1.SetMigrationCondition(&mcm.Status.Conditions, condition) || mcm.Status.Phase != phase {
 			mcm.Status.Phase = phase
 

--- a/manager/pkg/processes/hubmanagement/hub_management.go
+++ b/manager/pkg/processes/hubmanagement/hub_management.go
@@ -245,8 +245,8 @@ func (h *HubManagement) resync(ctx context.Context, hubName string) error {
 	return h.producer.SendEvent(ctx, e)
 }
 
-// findStandbyHub finds the standby hub name by querying ManagedCluster resources
-// Returns the standby hub name, fallback to local-cluster
+// findStandbyHub finds the standby hub name by querying ManagedCluster resources.
+// Returns the standby hub name, or the local cluster MC name when no standby is labeled.
 func (h *HubManagement) findStandbyHub(ctx context.Context) (string, error) {
 	// List ManagedClusters with standby role label
 	managedClusterList := &clusterv1.ManagedClusterList{}
@@ -262,9 +262,14 @@ func (h *HubManagement) findStandbyHub(ctx context.Context) (string, error) {
 		return managedClusterList.Items[0].Name, nil
 	}
 
-	// If no standby hub found, fallback to local-cluster
+	// If no standby hub found, resolve the local cluster MC name (may differ from
+	// constants.LocalClusterName when hub self-managed uses e.g. acm-local-cluster).
 	if len(managedClusterList.Items) == 0 {
-		return constants.LocalClusterName, nil
+		name, err := utils.ResolveLocalClusterManagedClusterName(ctx, h.client)
+		if err != nil {
+			return "", fmt.Errorf("failed to resolve local ManagedCluster name: %w", err)
+		}
+		return name, nil
 	}
 
 	// More than one standby hub found - this is a configuration error

--- a/manager/pkg/processes/hubmanagement/hub_management_test.go
+++ b/manager/pkg/processes/hubmanagement/hub_management_test.go
@@ -77,6 +77,29 @@ func TestFindStandbyHub(t *testing.T) {
 			expectedError: false,
 		},
 		{
+			name: "no standby hub - returns labeled local cluster MC name",
+			clusters: []client.Object{
+				&clusterv1.ManagedCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "acm-local-cluster",
+						Labels: map[string]string{
+							constants.LocalClusterName: "true",
+						},
+					},
+				},
+				&clusterv1.ManagedCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hub1",
+						Labels: map[string]string{
+							constants.GHHubRoleLabelKey: constants.GHHubRoleActive,
+						},
+					},
+				},
+			},
+			expectedHub:   "acm-local-cluster",
+			expectedError: false,
+		},
+		{
 			name: "multiple standby hubs - returns first one",
 			clusters: []client.Object{
 				&clusterv1.ManagedCluster{

--- a/manager/pkg/processes/hubmanagement/hub_management_test.go
+++ b/manager/pkg/processes/hubmanagement/hub_management_test.go
@@ -100,6 +100,28 @@ func TestFindStandbyHub(t *testing.T) {
 			expectedError: false,
 		},
 		{
+			name: "no standby hub - multiple local clusters returns wrapped error",
+			clusters: []client.Object{
+				&clusterv1.ManagedCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "local-a",
+						Labels: map[string]string{
+							constants.LocalClusterName: "true",
+						},
+					},
+				},
+				&clusterv1.ManagedCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "local-b",
+						Labels: map[string]string{
+							constants.LocalClusterName: "true",
+						},
+					},
+				},
+			},
+			expectedError: true,
+		},
+		{
 			name: "multiple standby hubs - returns first one",
 			clusters: []client.Object{
 				&clusterv1.ManagedCluster{
@@ -144,6 +166,7 @@ func TestFindStandbyHub(t *testing.T) {
 			hub, err := hm.findStandbyHub(context.Background())
 			if tt.expectedError {
 				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "failed to resolve local ManagedCluster name")
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.expectedHub, hub)

--- a/operator/pkg/controllers/agent/addon/addon_agent.go
+++ b/operator/pkg/controllers/agent/addon/addon_agent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"strconv"
 
 	addonoperatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
@@ -28,6 +29,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/utils"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/logger"
+	commonutils "github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
 // GlobalHubAddonAgent defines the manifests of agent deployed on managed cluster
@@ -223,7 +225,7 @@ func (a *GlobalHubAddonAgent) setImagePullSecret(mgh *globalhubv1alpha4.Multiclu
 
 // findStandbyHub returns the standby hub name
 // If a ManagedCluster has the standby label, return that cluster name
-// If no ManagedCluster has the standby label, return "local-cluster" (local agent is standby)
+// If no ManagedCluster has the standby label, resolve the local cluster MC name
 func (a *GlobalHubAddonAgent) findStandbyHub() (string, error) {
 	managedClusterList := &clusterv1.ManagedClusterList{}
 	err := a.client.List(a.ctx, managedClusterList, client.MatchingLabels{
@@ -238,9 +240,14 @@ func (a *GlobalHubAddonAgent) findStandbyHub() (string, error) {
 		return managedClusterList.Items[0].Name, nil
 	}
 
-	// If no standby hub found, local-cluster is the standby
+	// If no standby hub found, resolve the local cluster MC name (may differ from
+	// constants.LocalClusterName when hub self-managed uses e.g. acm-local-cluster).
 	if len(managedClusterList.Items) == 0 {
-		return constants.LocalClusterName, nil
+		name, err := commonutils.ResolveLocalClusterManagedClusterName(a.ctx, a.client)
+		if err != nil {
+			return "", fmt.Errorf("failed to resolve local ManagedCluster name: %w", err)
+		}
+		return name, nil
 	}
 
 	// More than one standby hub found - this is a configuration error

--- a/operator/pkg/controllers/agent/addon/addon_agent_findstandbyhub_test.go
+++ b/operator/pkg/controllers/agent/addon/addon_agent_findstandbyhub_test.go
@@ -1,0 +1,190 @@
+// Copyright Contributors to the Open Cluster Management project.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package addon
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+)
+
+func addonFindStandbyHubTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, clusterv1.Install(scheme))
+	return scheme
+}
+
+func TestGlobalHubAddonAgent_findStandbyHub(t *testing.T) {
+	t.Parallel()
+
+	const localClusterName = "local-cluster"
+
+	tests := []struct {
+		name          string
+		clusters      []client.Object
+		expectedHub   string
+		expectedError bool
+		errorContains string
+	}{
+		{
+			name: "standby hub exists",
+			clusters: []client.Object{
+				&clusterv1.ManagedCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hub1",
+						Labels: map[string]string{
+							constants.GHHubRoleLabelKey: constants.GHHubRoleActive,
+						},
+					},
+				},
+				&clusterv1.ManagedCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hub2",
+						Labels: map[string]string{
+							constants.GHHubRoleLabelKey: constants.GHHubRoleStandby,
+						},
+					},
+				},
+			},
+			expectedHub: "hub2",
+		},
+		{
+			name: "no standby hub - returns local-cluster fallback",
+			clusters: []client.Object{
+				&clusterv1.ManagedCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hub1",
+						Labels: map[string]string{
+							constants.GHHubRoleLabelKey: constants.GHHubRoleActive,
+						},
+					},
+				},
+			},
+			expectedHub: localClusterName,
+		},
+		{
+			name: "no standby hub - resolves labeled local cluster MC name",
+			clusters: []client.Object{
+				&clusterv1.ManagedCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "acm-local-cluster",
+						Labels: map[string]string{
+							constants.LocalClusterName: "true",
+						},
+					},
+				},
+				&clusterv1.ManagedCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hub1",
+						Labels: map[string]string{
+							constants.GHHubRoleLabelKey: constants.GHHubRoleActive,
+						},
+					},
+				},
+			},
+			expectedHub: "acm-local-cluster",
+		},
+		{
+			name: "multiple standby hubs - returns alphabetically first",
+			clusters: []client.Object{
+				&clusterv1.ManagedCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hub-z",
+						Labels: map[string]string{
+							constants.GHHubRoleLabelKey: constants.GHHubRoleStandby,
+						},
+					},
+				},
+				&clusterv1.ManagedCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hub-a",
+						Labels: map[string]string{
+							constants.GHHubRoleLabelKey: constants.GHHubRoleStandby,
+						},
+					},
+				},
+			},
+			expectedHub: "hub-a",
+		},
+		{
+			name: "no standby hub - multiple local clusters is an error",
+			clusters: []client.Object{
+				&clusterv1.ManagedCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "local-a",
+						Labels: map[string]string{
+							constants.LocalClusterName: "true",
+						},
+					},
+				},
+				&clusterv1.ManagedCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "local-b",
+						Labels: map[string]string{
+							constants.LocalClusterName: "true",
+						},
+					},
+				},
+			},
+			expectedError: true,
+			errorContains: "failed to resolve local ManagedCluster name",
+		},
+		{
+			name:          "no clusters - returns local-cluster fallback",
+			clusters:      []client.Object{},
+			expectedHub:   localClusterName,
+			expectedError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(addonFindStandbyHubTestScheme(t)).
+				WithObjects(tt.clusters...).
+				Build()
+
+			agent := &GlobalHubAddonAgent{
+				ctx:    context.Background(),
+				client: fakeClient,
+			}
+
+			hub, err := agent.findStandbyHub()
+			if tt.expectedError {
+				require.Error(t, err, "findStandbyHub(%q) should return error", tt.name)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains,
+						"findStandbyHub(%q) error should contain expected context", tt.name)
+				}
+				return
+			}
+
+			require.NoError(t, err, "findStandbyHub(%q) should not return error", tt.name)
+			assert.Equal(t, tt.expectedHub, hub, "findStandbyHub(%q) returned unexpected hub name", tt.name)
+		})
+	}
+}

--- a/pkg/utils/local_cluster.go
+++ b/pkg/utils/local_cluster.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package utils
+
+import (
+	"context"
+	"fmt"
+
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+)
+
+// ResolveLocalClusterManagedClusterName returns the ManagedCluster name for the
+// cluster labeled local-cluster=true. When no such cluster exists, it falls back
+// to constants.LocalClusterName for environments where the local cluster is
+// literally named "local-cluster" (e.g. KinD e2e).
+func ResolveLocalClusterManagedClusterName(ctx context.Context, c client.Client) (string, error) {
+	if c == nil {
+		return "", fmt.Errorf("client is required")
+	}
+
+	mcList := &clusterv1.ManagedClusterList{}
+	if err := c.List(ctx, mcList, client.MatchingLabels{
+		constants.LocalClusterName: "true",
+	}); err != nil {
+		return "", fmt.Errorf("failed to list local-cluster ManagedClusters: %w", err)
+	}
+
+	switch len(mcList.Items) {
+	case 0:
+		return constants.LocalClusterName, nil
+	case 1:
+		return mcList.Items[0].Name, nil
+	default:
+		return "", fmt.Errorf(
+			"found %d ManagedClusters labeled local-cluster=true, expected at most one",
+			len(mcList.Items),
+		)
+	}
+}

--- a/pkg/utils/local_cluster_test.go
+++ b/pkg/utils/local_cluster_test.go
@@ -30,6 +30,16 @@ func localClusterTestScheme(t *testing.T) *runtime.Scheme {
 func TestResolveLocalClusterManagedClusterName(t *testing.T) {
 	t.Parallel()
 
+	t.Run("nil client returns error", func(t *testing.T) {
+		t.Parallel()
+
+		name, err := ResolveLocalClusterManagedClusterName(context.Background(), nil)
+		require.Error(t, err, "ResolveLocalClusterManagedClusterName with nil client should return error")
+		assert.Empty(t, name, "ResolveLocalClusterManagedClusterName with nil client should return empty name")
+		assert.Contains(t, err.Error(), "client is required",
+			"ResolveLocalClusterManagedClusterName(nil client) should report missing client")
+	})
+
 	tests := []struct {
 		name        string
 		clusters    []clusterv1.ManagedCluster

--- a/pkg/utils/local_cluster_test.go
+++ b/pkg/utils/local_cluster_test.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package utils
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+)
+
+// localClusterTestScheme returns a runtime.Scheme with clusterv1 types registered for tests.
+func localClusterTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	_ = clusterv1.Install(scheme)
+	return scheme
+}
+
+// TestResolveLocalClusterManagedClusterName verifies local-cluster ManagedCluster name resolution.
+func TestResolveLocalClusterManagedClusterName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		clusters    []clusterv1.ManagedCluster
+		expected    string
+		expectError bool
+	}{
+		{
+			name:     "no local cluster MC falls back to local-cluster",
+			expected: constants.LocalClusterName,
+		},
+		{
+			name: "returns actual MC name when labeled local-cluster",
+			clusters: []clusterv1.ManagedCluster{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "acm-local-cluster",
+						Labels: map[string]string{
+							constants.LocalClusterName: "true",
+						},
+					},
+				},
+			},
+			expected: "acm-local-cluster",
+		},
+		{
+			name: "ignores MC without local-cluster label",
+			clusters: []clusterv1.ManagedCluster{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "regional-hub-1",
+					},
+				},
+			},
+			expected: constants.LocalClusterName,
+		},
+		{
+			name: "multiple local clusters is an error",
+			clusters: []clusterv1.ManagedCluster{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "local-a",
+						Labels: map[string]string{
+							constants.LocalClusterName: "true",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "local-b",
+						Labels: map[string]string{
+							constants.LocalClusterName: "true",
+						},
+					},
+				},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			objs := make([]client.Object, len(tt.clusters))
+			for i := range tt.clusters {
+				objs[i] = &tt.clusters[i]
+			}
+
+			c := fake.NewClientBuilder().WithScheme(localClusterTestScheme(t)).WithObjects(objs...).Build()
+			name, err := ResolveLocalClusterManagedClusterName(context.Background(), c)
+			if tt.expectError {
+				require.Error(t, err, "ResolveLocalClusterManagedClusterName(%q) should return error", tt.name)
+				assert.Contains(t, err.Error(), "expected at most one",
+					"ResolveLocalClusterManagedClusterName(%q) should not include cluster names in error", tt.name)
+				return
+			}
+
+			require.NoError(t, err, "ResolveLocalClusterManagedClusterName(%q) should not return error", tt.name)
+			assert.Equal(t, tt.expected, name, "ResolveLocalClusterManagedClusterName(%q) returned unexpected name", tt.name)
+		})
+	}
+}

--- a/test/integration/manager/migration/migration_phase_test.go
+++ b/test/integration/manager/migration/migration_phase_test.go
@@ -267,9 +267,10 @@ var _ = Describe("Migration Phase Transitions - Simplified", func() {
 		}, "10s", "200ms").Should(Succeed())
 
 		By("Completing Cleaning -> Completed")
-		simulateHubConfirmation(m.GetUID(), fromHubName, migrationv1alpha1.PhaseCleaning)
-		simulateHubConfirmation(m.GetUID(), toHubName, migrationv1alpha1.PhaseCleaning)
 		Eventually(func() error {
+			simulateHubConfirmation(m.GetUID(), fromHubName, migrationv1alpha1.PhaseCleaning)
+			simulateHubConfirmation(m.GetUID(), toHubName, migrationv1alpha1.PhaseCleaning)
+
 			if err := mgr.GetClient().Get(ctx, client.ObjectKeyFromObject(m), m); err != nil {
 				return fmt.Errorf("failed to get migration: %v", err)
 			}


### PR DESCRIPTION
Fixes: [ACM-38074](https://redhat.atlassian.net/browse/ACM-38074)
Related: [ACM-38073](https://redhat.atlassian.net/browse/ACM-38073)

## Summary

- When no ManagedCluster has `hub-role=standby`, `findStandbyHub()` now resolves the actual local cluster MC name via the `local-cluster=true` label instead of hardcoding `"local-cluster"`.
- Adds `pkg/utils.ResolveLocalClusterManagedClusterName()` and uses it from the addon operator and hub management process.
- Fixes Hub HA resource sync (hive secrets, policies, etc.) on ACM 5.0 hub self-managed setups where the local MC is named e.g. `acm-local-cluster`.

## Context

On the QE cluster, the active hub agent sent `HubHAResources` with Kafka subject `local-cluster`, while the standby local agent runs with `--leaf-hub-name=acm-local-cluster`. The standby dispatcher dropped every event with `subject mismatch`, which surfaced as ACM-38073 (hive secrets not synced).

## Test plan

- [x] `go test -mod=mod ./pkg/utils/... -run TestResolveLocalClusterManagedClusterName`
- [x] `go test -mod=mod ./manager/pkg/processes/hubmanagement/... -run TestFindStandbyHub`
- [ ] Hub HA e2e: secret with `hive.openshift.io/secret-type=kubeconfig` syncs active → standby when local MC is not named `local-cluster`


Made with [Cursor](https://cursor.com)

[ACM-38074]: https://redhat.atlassian.net/browse/ACM-38074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-38073]: https://redhat.atlassian.net/browse/ACM-38073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved standby hub selection: when no standby hub is labeled, the system now resolves the local `ManagedCluster` name dynamically instead of using a fixed fallback.
  * Fixes self-managed hub setups where the local `ManagedCluster` name differs from the default.
  * Detects ambiguous configurations by erroring when multiple local-labeled `ManagedCluster` objects are found.
* **Tests**
  * Added/extended unit tests covering local `ManagedCluster` discovery, fallback behavior, label filtering, and multiple-match error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->