### PR TITLE
Add rohit-bharmal to OWNERS (release-2.16 backport)

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,11 +2,13 @@ approvers:
 - nirrozenbaum
 - bjoydeep
 - birsanv
+- rohit-bharmal
 
 reviewers:
 - nirrozenbaum
 - bjoydeep
 - birsanv
+- rohit-bharmal
 - github-actions[bot]
 
 emeritus_approvers:


### PR DESCRIPTION
## Summary
- Add `rohit-bharmal` to `approvers` and `reviewers` in `OWNERS` (same pattern as `birsanv`).

## Test plan
- [ ] `/lgtm` from existing approver

Made with [Cursor](https://cursor.com)