### PR TITLE
ACM-38171: annotate newly imported clusters with HA klusterlet-config

### DIFF
--- a/agent/pkg/spec/hubha/hubha_config_annotator.go
+++ b/agent/pkg/spec/hubha/hubha_config_annotator.go
@@ -1,5 +1,19 @@
-// Copyright (c) 2025 Red Hat, Inc.
-// Copyright Contributors to the Open Cluster Management project
+/*
+Copyright (c) 2026 Red Hat, Inc.
+Copyright Contributors to the Open Cluster Management project
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package hubha
 
@@ -129,7 +143,7 @@ func annotateManagedCluster(ctx context.Context, c client.Client,
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		current := &clusterv1.ManagedCluster{}
 		if err := c.Get(ctx, client.ObjectKeyFromObject(mc), current); err != nil {
-			return err
+			return fmt.Errorf("failed to get ManagedCluster %s: %w", mc.Name, err)
 		}
 		// Re-check after reload: another controller may have marked this as local-cluster.
 		if isLocalManagedCluster(current) {
@@ -145,10 +159,11 @@ func annotateManagedCluster(ctx context.Context, c client.Client,
 		annotations[klusterletConfigAnnotation] = klusterletConfigName
 		current.SetAnnotations(annotations)
 		if err := c.Update(ctx, current); err != nil {
-			return err
+			return fmt.Errorf("failed to update ManagedCluster %s with klusterlet-config annotation: %w",
+				current.Name, err)
 		}
-		log.Infof("annotated managed cluster %s with klusterlet-config=%s",
-			current.Name, klusterletConfigName)
+		log.Infow("annotated managed cluster",
+			"cluster", current.Name, "klusterlet-config", klusterletConfigName)
 		return nil
 	})
 }

--- a/agent/pkg/spec/hubha/hubha_config_annotator.go
+++ b/agent/pkg/spec/hubha/hubha_config_annotator.go
@@ -131,6 +131,10 @@ func annotateManagedCluster(ctx context.Context, c client.Client,
 		if err := c.Get(ctx, client.ObjectKeyFromObject(mc), current); err != nil {
 			return err
 		}
+		// Re-check after reload: another controller may have marked this as local-cluster.
+		if isLocalManagedCluster(current) {
+			return nil
+		}
 		annotations := current.GetAnnotations()
 		if annotations == nil {
 			annotations = make(map[string]string)

--- a/agent/pkg/spec/hubha/hubha_config_annotator.go
+++ b/agent/pkg/spec/hubha/hubha_config_annotator.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2025 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package hubha
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/util/retry"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+)
+
+var klusterletConfigGVK = schema.GroupVersionKind{
+	Group:   "config.open-cluster-management.io",
+	Version: "v1alpha1",
+	Kind:    "KlusterletConfig",
+}
+
+// haConfigAnnotator ensures ManagedClusters created after the initial HAConfig
+// sync still receive agent.open-cluster-management.io/klusterlet-config.
+// HAConfigSyncer only annotates clusters present when the CloudEvent arrives.
+type haConfigAnnotator struct {
+	client client.Client
+}
+
+// AddHAConfigAnnotator watches ManagedCluster creates/updates and applies the
+// HA KlusterletConfig annotation when an ha-standby-* KlusterletConfig exists.
+func AddHAConfigAnnotator(mgr ctrl.Manager) error {
+	r := &haConfigAnnotator{client: mgr.GetClient()}
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("ha-config-annotator").
+		For(&clusterv1.ManagedCluster{}).
+		WithEventFilter(predicate.Funcs{
+			CreateFunc: func(e event.CreateEvent) bool {
+				return !isLocalManagedCluster(e.Object)
+			},
+			UpdateFunc: func(e event.UpdateEvent) bool {
+				if isLocalManagedCluster(e.ObjectNew) {
+					return false
+				}
+				// Reconcile when the annotation is missing or changed.
+				oldAnn := e.ObjectOld.GetAnnotations()[klusterletConfigAnnotation]
+				newAnn := e.ObjectNew.GetAnnotations()[klusterletConfigAnnotation]
+				return oldAnn != newAnn || newAnn == ""
+			},
+			DeleteFunc: func(e event.DeleteEvent) bool {
+				return false
+			},
+		}).
+		Complete(r)
+}
+
+// Reconcile annotates a ManagedCluster with the HA KlusterletConfig name when
+// Hub HA has already been configured on this regional hub.
+func (r *haConfigAnnotator) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	mc := &clusterv1.ManagedCluster{}
+	if err := r.client.Get(ctx, req.NamespacedName, mc); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("failed to get ManagedCluster %s: %w", req.Name, err)
+	}
+
+	if isLocalManagedCluster(mc) {
+		return ctrl.Result{}, nil
+	}
+
+	klusterletConfigName, err := findHAKlusterletConfigName(ctx, r.client)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to find HA KlusterletConfig: %w", err)
+	}
+	if klusterletConfigName == "" {
+		// HA config not applied yet; nothing to do until Sync creates it.
+		return ctrl.Result{}, nil
+	}
+
+	if err := annotateManagedCluster(ctx, r.client, mc, klusterletConfigName); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+// isLocalManagedCluster returns true for the hub's self-managed local cluster,
+// identified by the local-cluster=true label or the conventional name.
+func isLocalManagedCluster(obj client.Object) bool {
+	if obj.GetLabels()[constants.LocalClusterName] == "true" {
+		return true
+	}
+	return obj.GetName() == constants.LocalClusterName
+}
+
+// findHAKlusterletConfigName returns the name of the first KlusterletConfig with
+// the ha-standby- prefix, or "" if none exists.
+func findHAKlusterletConfigName(ctx context.Context, c client.Client) (string, error) {
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   klusterletConfigGVK.Group,
+		Version: klusterletConfigGVK.Version,
+		Kind:    klusterletConfigGVK.Kind + "List",
+	})
+	if err := c.List(ctx, list); err != nil {
+		return "", err
+	}
+	for i := range list.Items {
+		name := list.Items[i].GetName()
+		if strings.HasPrefix(name, klusterletConfigPrefix) {
+			return name, nil
+		}
+	}
+	return "", nil
+}
+
+// annotateManagedCluster sets the klusterlet-config annotation on mc when it
+// is missing or differs from klusterletConfigName.
+func annotateManagedCluster(ctx context.Context, c client.Client,
+	mc *clusterv1.ManagedCluster, klusterletConfigName string,
+) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current := &clusterv1.ManagedCluster{}
+		if err := c.Get(ctx, client.ObjectKeyFromObject(mc), current); err != nil {
+			return err
+		}
+		annotations := current.GetAnnotations()
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		if annotations[klusterletConfigAnnotation] == klusterletConfigName {
+			return nil
+		}
+		annotations[klusterletConfigAnnotation] = klusterletConfigName
+		current.SetAnnotations(annotations)
+		if err := c.Update(ctx, current); err != nil {
+			return err
+		}
+		log.Infof("annotated managed cluster %s with klusterlet-config=%s",
+			current.Name, klusterletConfigName)
+		return nil
+	})
+}

--- a/agent/pkg/spec/hubha/hubha_config_annotator_test.go
+++ b/agent/pkg/spec/hubha/hubha_config_annotator_test.go
@@ -1,5 +1,19 @@
-// Copyright (c) 2025 Red Hat, Inc.
-// Copyright Contributors to the Open Cluster Management project
+/*
+Copyright (c) 2026 Red Hat, Inc.
+Copyright Contributors to the Open Cluster Management project
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package hubha
 
@@ -21,9 +35,10 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 )
 
-func newAnnotatorTestScheme() *runtime.Scheme {
+func newAnnotatorTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
 	scheme := runtime.NewScheme()
-	_ = clusterv1.Install(scheme)
+	require.NoError(t, clusterv1.Install(scheme), "clusterv1 scheme registration should succeed")
 	return scheme
 }
 
@@ -36,7 +51,7 @@ func newHAKlusterletConfig(name string) *unstructured.Unstructured {
 }
 
 func TestHAConfigAnnotator_AnnotatesNewlyImportedCluster(t *testing.T) {
-	scheme := newAnnotatorTestScheme()
+	scheme := newAnnotatorTestScheme(t)
 	ksCluster := &clusterv1.ManagedCluster{
 		ObjectMeta: metav1.ObjectMeta{Name: "ks"},
 	}
@@ -54,13 +69,13 @@ func TestHAConfigAnnotator_AnnotatesNewlyImportedCluster(t *testing.T) {
 
 	mc := &clusterv1.ManagedCluster{}
 	err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "ks"}, mc)
-	require.NoError(t, err)
+	require.NoError(t, err, "should retrieve annotated ManagedCluster ks after reconcile")
 	assert.Equal(t, testKlusterletConfigName, mc.GetAnnotations()[klusterletConfigAnnotation],
-		"newly imported ManagedCluster must get agent.open-cluster-management.io/klusterlet-config")
+		"newly imported ManagedCluster must get agent.open-cluster-management.io/klusterlet-config so HA standby bootstrap is applied")
 }
 
 func TestHAConfigAnnotator_NoOpWithoutKlusterletConfig(t *testing.T) {
-	scheme := newAnnotatorTestScheme()
+	scheme := newAnnotatorTestScheme(t)
 	ksCluster := &clusterv1.ManagedCluster{
 		ObjectMeta: metav1.ObjectMeta{Name: "ks"},
 	}
@@ -77,13 +92,13 @@ func TestHAConfigAnnotator_NoOpWithoutKlusterletConfig(t *testing.T) {
 
 	mc := &clusterv1.ManagedCluster{}
 	err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "ks"}, mc)
-	require.NoError(t, err)
+	require.NoError(t, err, "should retrieve no-op ManagedCluster ks to verify it was left unchanged")
 	assert.Empty(t, mc.GetAnnotations()[klusterletConfigAnnotation],
 		"ManagedCluster must not be annotated before ha-standby-* KlusterletConfig exists")
 }
 
 func TestHAConfigAnnotator_SkipsLocalClusterByLabel(t *testing.T) {
-	scheme := newAnnotatorTestScheme()
+	scheme := newAnnotatorTestScheme(t)
 	localCluster := &clusterv1.ManagedCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "acm-local-cluster",
@@ -102,17 +117,17 @@ func TestHAConfigAnnotator_SkipsLocalClusterByLabel(t *testing.T) {
 	_, err := (&haConfigAnnotator{client: fakeClient}).Reconcile(context.Background(), reconcile.Request{
 		NamespacedName: types.NamespacedName{Name: "acm-local-cluster"},
 	})
-	require.NoError(t, err)
+	require.NoError(t, err, "reconcile of label-local cluster should succeed without annotating")
 
 	mc := &clusterv1.ManagedCluster{}
 	err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "acm-local-cluster"}, mc)
-	require.NoError(t, err)
+	require.NoError(t, err, "should retrieve label-local ManagedCluster to verify it remains unannotated")
 	assert.Empty(t, mc.GetAnnotations()[klusterletConfigAnnotation],
-		"local ManagedCluster (local-cluster=true) must not get klusterlet-config annotation")
+		"local ManagedCluster with local-cluster=true must remain unannotated so the hub self-management cluster is not given HA standby klusterlet-config")
 }
 
 func TestHAConfigAnnotator_SkipsLocalClusterByName(t *testing.T) {
-	scheme := newAnnotatorTestScheme()
+	scheme := newAnnotatorTestScheme(t)
 	localCluster := &clusterv1.ManagedCluster{
 		ObjectMeta: metav1.ObjectMeta{Name: constants.LocalClusterName},
 	}
@@ -126,17 +141,17 @@ func TestHAConfigAnnotator_SkipsLocalClusterByName(t *testing.T) {
 	_, err := (&haConfigAnnotator{client: fakeClient}).Reconcile(context.Background(), reconcile.Request{
 		NamespacedName: types.NamespacedName{Name: constants.LocalClusterName},
 	})
-	require.NoError(t, err)
+	require.NoError(t, err, "reconcile of name-local cluster should succeed without annotating")
 
 	mc := &clusterv1.ManagedCluster{}
 	err = fakeClient.Get(context.Background(), types.NamespacedName{Name: constants.LocalClusterName}, mc)
-	require.NoError(t, err)
+	require.NoError(t, err, "should retrieve name-local ManagedCluster to verify it remains unannotated")
 	assert.Empty(t, mc.GetAnnotations()[klusterletConfigAnnotation],
-		"ManagedCluster named local-cluster must not get klusterlet-config annotation")
+		"ManagedCluster named local-cluster must remain unannotated so the conventional local hub cluster is not given HA standby klusterlet-config")
 }
 
 func TestHAConfigAnnotator_IdempotentWhenAlreadyAnnotated(t *testing.T) {
-	scheme := newAnnotatorTestScheme()
+	scheme := newAnnotatorTestScheme(t)
 	ksCluster := &clusterv1.ManagedCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "ks",
@@ -159,17 +174,18 @@ func TestHAConfigAnnotator_IdempotentWhenAlreadyAnnotated(t *testing.T) {
 
 	mc := &clusterv1.ManagedCluster{}
 	err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "ks"}, mc)
-	require.NoError(t, err)
-	assert.Equal(t, testKlusterletConfigName, mc.GetAnnotations()[klusterletConfigAnnotation])
+	require.NoError(t, err, "should retrieve already-annotated ManagedCluster after idempotent reconcile")
+	assert.Equal(t, testKlusterletConfigName, mc.GetAnnotations()[klusterletConfigAnnotation],
+		"idempotent reconciliation must preserve the existing klusterlet-config annotation value")
 }
 
 func TestFindHAKlusterletConfigName(t *testing.T) {
-	scheme := newAnnotatorTestScheme()
+	scheme := newAnnotatorTestScheme(t)
 
 	t.Run("returns empty when none exist", func(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 		name, err := findHAKlusterletConfigName(context.Background(), fakeClient)
-		require.NoError(t, err)
+		require.NoError(t, err, "listing KlusterletConfigs should succeed when none exist")
 		assert.Empty(t, name, "expected empty name when no ha-standby-* KlusterletConfig exists")
 	})
 
@@ -179,7 +195,7 @@ func TestFindHAKlusterletConfigName(t *testing.T) {
 			WithObjects(newHAKlusterletConfig(testKlusterletConfigName)).
 			Build()
 		name, err := findHAKlusterletConfigName(context.Background(), fakeClient)
-		require.NoError(t, err)
+		require.NoError(t, err, "listing KlusterletConfigs should succeed when ha-standby-* exists")
 		assert.Equal(t, testKlusterletConfigName, name,
 			"should resolve KlusterletConfig with ha-standby- prefix")
 	})
@@ -191,7 +207,7 @@ func TestFindHAKlusterletConfigName(t *testing.T) {
 			WithObjects(other).
 			Build()
 		name, err := findHAKlusterletConfigName(context.Background(), fakeClient)
-		require.NoError(t, err)
+		require.NoError(t, err, "listing KlusterletConfigs should succeed when only non-HA configs exist")
 		assert.Empty(t, name, "non ha-standby-* KlusterletConfig must be ignored")
 	})
 }
@@ -216,18 +232,18 @@ func TestIsLocalManagedCluster(t *testing.T) {
 }
 
 func TestAnnotateManagedCluster(t *testing.T) {
-	scheme := newAnnotatorTestScheme()
+	scheme := newAnnotatorTestScheme(t)
 	mc := &clusterv1.ManagedCluster{
 		ObjectMeta: metav1.ObjectMeta{Name: "cluster1"},
 	}
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(mc).Build()
 
 	err := annotateManagedCluster(context.Background(), fakeClient, mc, testKlusterletConfigName)
-	require.NoError(t, err)
+	require.NoError(t, err, "annotateManagedCluster should succeed when setting klusterlet-config on a managed cluster")
 
 	updated := &clusterv1.ManagedCluster{}
 	err = fakeClient.Get(context.Background(), client.ObjectKeyFromObject(mc), updated)
-	require.NoError(t, err)
+	require.NoError(t, err, "should retrieve ManagedCluster after annotateManagedCluster to verify annotation was persisted")
 	assert.Equal(t, testKlusterletConfigName, updated.GetAnnotations()[klusterletConfigAnnotation],
 		"annotateManagedCluster should set klusterlet-config annotation")
 }

--- a/agent/pkg/spec/hubha/hubha_config_annotator_test.go
+++ b/agent/pkg/spec/hubha/hubha_config_annotator_test.go
@@ -71,7 +71,8 @@ func TestHAConfigAnnotator_AnnotatesNewlyImportedCluster(t *testing.T) {
 	err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "ks"}, mc)
 	require.NoError(t, err, "should retrieve annotated ManagedCluster ks after reconcile")
 	assert.Equal(t, testKlusterletConfigName, mc.GetAnnotations()[klusterletConfigAnnotation],
-		"newly imported ManagedCluster must get agent.open-cluster-management.io/klusterlet-config so HA standby bootstrap is applied")
+		"newly imported ManagedCluster must get "+
+			"agent.open-cluster-management.io/klusterlet-config so HA standby bootstrap is applied")
 }
 
 func TestHAConfigAnnotator_NoOpWithoutKlusterletConfig(t *testing.T) {
@@ -123,7 +124,8 @@ func TestHAConfigAnnotator_SkipsLocalClusterByLabel(t *testing.T) {
 	err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "acm-local-cluster"}, mc)
 	require.NoError(t, err, "should retrieve label-local ManagedCluster to verify it remains unannotated")
 	assert.Empty(t, mc.GetAnnotations()[klusterletConfigAnnotation],
-		"local ManagedCluster with local-cluster=true must remain unannotated so the hub self-management cluster is not given HA standby klusterlet-config")
+		"local ManagedCluster with local-cluster=true must remain unannotated so the hub "+
+			"self-management cluster is not given HA standby klusterlet-config")
 }
 
 func TestHAConfigAnnotator_SkipsLocalClusterByName(t *testing.T) {
@@ -147,7 +149,8 @@ func TestHAConfigAnnotator_SkipsLocalClusterByName(t *testing.T) {
 	err = fakeClient.Get(context.Background(), types.NamespacedName{Name: constants.LocalClusterName}, mc)
 	require.NoError(t, err, "should retrieve name-local ManagedCluster to verify it remains unannotated")
 	assert.Empty(t, mc.GetAnnotations()[klusterletConfigAnnotation],
-		"ManagedCluster named local-cluster must remain unannotated so the conventional local hub cluster is not given HA standby klusterlet-config")
+		"ManagedCluster named local-cluster must remain unannotated so the conventional "+
+			"local hub cluster is not given HA standby klusterlet-config")
 }
 
 func TestHAConfigAnnotator_IdempotentWhenAlreadyAnnotated(t *testing.T) {
@@ -243,7 +246,8 @@ func TestAnnotateManagedCluster(t *testing.T) {
 
 	updated := &clusterv1.ManagedCluster{}
 	err = fakeClient.Get(context.Background(), client.ObjectKeyFromObject(mc), updated)
-	require.NoError(t, err, "should retrieve ManagedCluster after annotateManagedCluster to verify annotation was persisted")
+	require.NoError(t, err,
+		"should retrieve ManagedCluster after annotateManagedCluster to verify annotation was persisted")
 	assert.Equal(t, testKlusterletConfigName, updated.GetAnnotations()[klusterletConfigAnnotation],
 		"annotateManagedCluster should set klusterlet-config annotation")
 }

--- a/agent/pkg/spec/hubha/hubha_config_annotator_test.go
+++ b/agent/pkg/spec/hubha/hubha_config_annotator_test.go
@@ -1,0 +1,233 @@
+// Copyright (c) 2025 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package hubha
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+)
+
+func newAnnotatorTestScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = clusterv1.Install(scheme)
+	return scheme
+}
+
+func newHAKlusterletConfig(name string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(klusterletConfigGVK)
+	obj.SetName(name)
+	obj.Object["spec"] = map[string]interface{}{}
+	return obj
+}
+
+func TestHAConfigAnnotator_AnnotatesNewlyImportedCluster(t *testing.T) {
+	scheme := newAnnotatorTestScheme()
+	ksCluster := &clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "ks"},
+	}
+	klusterletConfig := newHAKlusterletConfig(testKlusterletConfigName)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(ksCluster, klusterletConfig).
+		Build()
+
+	_, err := (&haConfigAnnotator{client: fakeClient}).Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "ks"},
+	})
+	require.NoError(t, err, "annotator should succeed for a newly imported cluster when HA KlusterletConfig exists")
+
+	mc := &clusterv1.ManagedCluster{}
+	err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "ks"}, mc)
+	require.NoError(t, err)
+	assert.Equal(t, testKlusterletConfigName, mc.GetAnnotations()[klusterletConfigAnnotation],
+		"newly imported ManagedCluster must get agent.open-cluster-management.io/klusterlet-config")
+}
+
+func TestHAConfigAnnotator_NoOpWithoutKlusterletConfig(t *testing.T) {
+	scheme := newAnnotatorTestScheme()
+	ksCluster := &clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "ks"},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(ksCluster).
+		Build()
+
+	_, err := (&haConfigAnnotator{client: fakeClient}).Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "ks"},
+	})
+	require.NoError(t, err, "annotator should no-op when HA has not been configured yet")
+
+	mc := &clusterv1.ManagedCluster{}
+	err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "ks"}, mc)
+	require.NoError(t, err)
+	assert.Empty(t, mc.GetAnnotations()[klusterletConfigAnnotation],
+		"ManagedCluster must not be annotated before ha-standby-* KlusterletConfig exists")
+}
+
+func TestHAConfigAnnotator_SkipsLocalClusterByLabel(t *testing.T) {
+	scheme := newAnnotatorTestScheme()
+	localCluster := &clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "acm-local-cluster",
+			Labels: map[string]string{
+				constants.LocalClusterName: "true",
+			},
+		},
+	}
+	klusterletConfig := newHAKlusterletConfig(testKlusterletConfigName)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(localCluster, klusterletConfig).
+		Build()
+
+	_, err := (&haConfigAnnotator{client: fakeClient}).Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "acm-local-cluster"},
+	})
+	require.NoError(t, err)
+
+	mc := &clusterv1.ManagedCluster{}
+	err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "acm-local-cluster"}, mc)
+	require.NoError(t, err)
+	assert.Empty(t, mc.GetAnnotations()[klusterletConfigAnnotation],
+		"local ManagedCluster (local-cluster=true) must not get klusterlet-config annotation")
+}
+
+func TestHAConfigAnnotator_SkipsLocalClusterByName(t *testing.T) {
+	scheme := newAnnotatorTestScheme()
+	localCluster := &clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: constants.LocalClusterName},
+	}
+	klusterletConfig := newHAKlusterletConfig(testKlusterletConfigName)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(localCluster, klusterletConfig).
+		Build()
+
+	_, err := (&haConfigAnnotator{client: fakeClient}).Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: constants.LocalClusterName},
+	})
+	require.NoError(t, err)
+
+	mc := &clusterv1.ManagedCluster{}
+	err = fakeClient.Get(context.Background(), types.NamespacedName{Name: constants.LocalClusterName}, mc)
+	require.NoError(t, err)
+	assert.Empty(t, mc.GetAnnotations()[klusterletConfigAnnotation],
+		"ManagedCluster named local-cluster must not get klusterlet-config annotation")
+}
+
+func TestHAConfigAnnotator_IdempotentWhenAlreadyAnnotated(t *testing.T) {
+	scheme := newAnnotatorTestScheme()
+	ksCluster := &clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ks",
+			Annotations: map[string]string{
+				klusterletConfigAnnotation: testKlusterletConfigName,
+			},
+		},
+	}
+	klusterletConfig := newHAKlusterletConfig(testKlusterletConfigName)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(ksCluster, klusterletConfig).
+		Build()
+
+	_, err := (&haConfigAnnotator{client: fakeClient}).Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "ks"},
+	})
+	require.NoError(t, err, "annotator should be idempotent when annotation already matches")
+
+	mc := &clusterv1.ManagedCluster{}
+	err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "ks"}, mc)
+	require.NoError(t, err)
+	assert.Equal(t, testKlusterletConfigName, mc.GetAnnotations()[klusterletConfigAnnotation])
+}
+
+func TestFindHAKlusterletConfigName(t *testing.T) {
+	scheme := newAnnotatorTestScheme()
+
+	t.Run("returns empty when none exist", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+		name, err := findHAKlusterletConfigName(context.Background(), fakeClient)
+		require.NoError(t, err)
+		assert.Empty(t, name, "expected empty name when no ha-standby-* KlusterletConfig exists")
+	})
+
+	t.Run("returns ha-standby prefixed name", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(newHAKlusterletConfig(testKlusterletConfigName)).
+			Build()
+		name, err := findHAKlusterletConfigName(context.Background(), fakeClient)
+		require.NoError(t, err)
+		assert.Equal(t, testKlusterletConfigName, name,
+			"should resolve KlusterletConfig with ha-standby- prefix")
+	})
+
+	t.Run("ignores non HA KlusterletConfig", func(t *testing.T) {
+		other := newHAKlusterletConfig("grpc-config")
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(other).
+			Build()
+		name, err := findHAKlusterletConfigName(context.Background(), fakeClient)
+		require.NoError(t, err)
+		assert.Empty(t, name, "non ha-standby-* KlusterletConfig must be ignored")
+	})
+}
+
+func TestIsLocalManagedCluster(t *testing.T) {
+	assert.True(t, isLocalManagedCluster(&clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: constants.LocalClusterName},
+	}), "name local-cluster should be treated as local")
+
+	assert.True(t, isLocalManagedCluster(&clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "acm-local-cluster",
+			Labels: map[string]string{
+				constants.LocalClusterName: "true",
+			},
+		},
+	}), "local-cluster=true label should be treated as local")
+
+	assert.False(t, isLocalManagedCluster(&clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "ks"},
+	}), "regular managed cluster should not be treated as local")
+}
+
+func TestAnnotateManagedCluster(t *testing.T) {
+	scheme := newAnnotatorTestScheme()
+	mc := &clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster1"},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(mc).Build()
+
+	err := annotateManagedCluster(context.Background(), fakeClient, mc, testKlusterletConfigName)
+	require.NoError(t, err)
+
+	updated := &clusterv1.ManagedCluster{}
+	err = fakeClient.Get(context.Background(), client.ObjectKeyFromObject(mc), updated)
+	require.NoError(t, err)
+	assert.Equal(t, testKlusterletConfigName, updated.GetAnnotations()[klusterletConfigAnnotation],
+		"annotateManagedCluster should set klusterlet-config annotation")
+}

--- a/agent/pkg/spec/hubha/hubha_config_syncer.go
+++ b/agent/pkg/spec/hubha/hubha_config_syncer.go
@@ -1,5 +1,19 @@
-// Copyright (c) 2025 Red Hat, Inc.
-// Copyright Contributors to the Open Cluster Management project
+/*
+Copyright (c) 2026 Red Hat, Inc.
+Copyright Contributors to the Open Cluster Management project
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package hubha
 

--- a/agent/pkg/spec/hubha/hubha_config_syncer.go
+++ b/agent/pkg/spec/hubha/hubha_config_syncer.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
 package hubha
 
 import (
@@ -190,29 +193,11 @@ func (s *HAConfigSyncer) annotateAllManagedClusters(ctx context.Context, kluster
 
 	for i := range mcList.Items {
 		mc := &mcList.Items[i]
-		if mc.Name == "local-cluster" {
+		if isLocalManagedCluster(mc) {
 			continue
 		}
 
-		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			if err := s.client.Get(ctx, client.ObjectKeyFromObject(mc), mc); err != nil {
-				return err
-			}
-			annotations := mc.GetAnnotations()
-			if annotations == nil {
-				annotations = make(map[string]string)
-			}
-			if annotations[klusterletConfigAnnotation] == klusterletConfigName {
-				return nil
-			}
-			annotations[klusterletConfigAnnotation] = klusterletConfigName
-			mc.SetAnnotations(annotations)
-			if err := s.client.Update(ctx, mc); err != nil {
-				return err
-			}
-			log.Infof("annotated managed cluster %s with klusterlet-config=%s", mc.Name, klusterletConfigName)
-			return nil
-		}); err != nil {
+		if err := annotateManagedCluster(ctx, s.client, mc, klusterletConfigName); err != nil {
 			return fmt.Errorf("failed to annotate managed cluster %s: %w", mc.Name, err)
 		}
 	}

--- a/agent/pkg/spec/spec.go
+++ b/agent/pkg/spec/spec.go
@@ -63,6 +63,11 @@ func AddToManager(context context.Context, mgr ctrl.Manager, transportClient tra
 	dispatcher.RegisterSyncer(constants.HAConfigMsgKey,
 		hubha.NewHAConfigSyncer(mgr.GetClient(), agentConfig))
 
+	// Annotate ManagedClusters imported after the initial HAConfig CloudEvent.
+	if err := hubha.AddHAConfigAnnotator(mgr); err != nil {
+		return fmt.Errorf("failed to add HA config annotator: %w", err)
+	}
+
 	log.Info("added the spec controllers to manager")
 	return nil
 }


### PR DESCRIPTION
Fixes: [ACM-38171](https://redhat.atlassian.net/browse/ACM-38171)

## Summary

- When Hub HA is enabled (`hub-role=active`), `HAConfigSyncer` only annotated ManagedClusters that already existed when the HAConfig CloudEvent arrived.
- Adds `HAConfigAnnotator` to watch ManagedCluster create/update and apply `agent.open-cluster-management.io/klusterlet-config` when an `ha-standby-*` KlusterletConfig already exists.
- Refactors shared annotate helper in the syncer and skips the local cluster via `local-cluster=true` or name `local-cluster`.

## Context

QE imported a regional hub into Global Hub, set `deploy-mode=hosted` and `hub-role=active`, then imported a managed cluster (`ks`) onto that regional hub. The new ManagedCluster never received the `klusterlet-config` annotation, because annotation ran only once during the initial HAConfig sync.

## Test plan

- [x] `go test -mod=mod ./agent/pkg/spec/hubha/ ./agent/pkg/spec/`
- [ ] Repro: enable HA on regional hub, then import a managed cluster → annotation is present
- [ ] Confirm `oc get klusterletconfig | grep ha-standby` exists on the regional hub

[ACM-38171]: https://redhat.atlassian.net/browse/ACM-38171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically applies the correct Hub HA `klusterlet-config` annotation to newly created imported managed clusters.
  * Continues to ignore local hub clusters (by name/role) for HA annotation.
* **Bug Fixes**
  * Improves reliability of HA annotation propagation by updating clusters safely and consistently when HA configuration becomes available.
* **Tests**
  * Added unit tests covering annotation, missing HA configuration, local-cluster skipping, and idempotent behavior.
* **Chores**
  * Minor header and syncer logic cleanup to centralize per-cluster annotation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->