### PR TITLE
ACM-38074: prefix global-hub standby subject and fix resolution priority

### DIFF
--- a/agent/pkg/spec/dispatcher.go
+++ b/agent/pkg/spec/dispatcher.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
 var addToMgr = false
@@ -98,7 +99,8 @@ func (d *genericDispatcher) dispatch(ctx context.Context) {
 				d.log.Infow("event dropped due to missing subject", "type", evt.Type())
 				continue
 			}
-			if subject != transport.Broadcast && subject != d.agentConfig.LeafHubName {
+			if subject != transport.Broadcast &&
+				!utils.MatchesGlobalHubStandbySubject(subject, d.agentConfig.LeafHubName) {
 				d.log.Infow("event dropped due to subject mismatch", "type", evt.Type(), "subject", subject)
 				continue
 			}

--- a/agent/pkg/spec/dispatcher_test.go
+++ b/agent/pkg/spec/dispatcher_test.go
@@ -105,6 +105,18 @@ func TestDispatch_DropsMissingSubject(t *testing.T) {
 	assert.Equal(t, 0, recorder.called)
 }
 
+func TestDispatch_AllowsPrefixedGlobalHubStandbySubject(t *testing.T) {
+	recorder := runDispatchScenario(t, dispatchScenario{
+		events: []*cloudevents.Event{
+			func() *cloudevents.Event {
+				evt := utils.ToCloudEvent("Policy", constants.CloudEventGlobalHubClusterName, "global-hub/hub2", nil)
+				return &evt
+			}(),
+		},
+	})
+	assert.Equal(t, 1, recorder.called)
+}
+
 func TestDispatch_DropsSubjectMismatch(t *testing.T) {
 	recorder := runDispatchScenario(t, dispatchScenario{
 		events: []*cloudevents.Event{
@@ -211,7 +223,7 @@ func countTrustedEvents(events []*cloudevents.Event) int {
 			continue
 		}
 		subject := evt.Subject()
-		if subject == "" || (subject != transport.Broadcast && subject != "hub2") {
+		if subject == "" || (subject != transport.Broadcast && !utils.MatchesGlobalHubStandbySubject(subject, "hub2")) {
 			continue
 		}
 		if expired, _ := isEventExpired(evt); expired {

--- a/agent/pkg/spec/dispatcher_test.go
+++ b/agent/pkg/spec/dispatcher_test.go
@@ -114,7 +114,8 @@ func TestDispatch_AllowsPrefixedGlobalHubStandbySubject(t *testing.T) {
 			}(),
 		},
 	})
-	assert.Equal(t, 1, recorder.called)
+	assert.Equal(t, 1, recorder.called,
+		"prefixed global-hub standby subjects must be delivered to the syncer")
 }
 
 func TestDispatch_DropsSubjectMismatch(t *testing.T) {

--- a/agent/pkg/spec/hubha/hubha_config_syncer.go
+++ b/agent/pkg/spec/hubha/hubha_config_syncer.go
@@ -78,7 +78,8 @@ func (s *HAConfigSyncer) Sync(ctx context.Context, evt *cloudevents.Event) error
 		log.Warnw("dropping HA config event with untrusted source", "source", standbyHub, "subject", activeHub)
 		return nil
 	}
-	if standbyHub != constants.CloudEventGlobalHubClusterName && s.standbyHub != "" && standbyHub != s.standbyHub {
+	if standbyHub != constants.CloudEventGlobalHubClusterName && s.standbyHub != "" &&
+		!utils.StandbyHubSourceMatches(standbyHub, s.standbyHub) {
 		log.Warnw("dropping HA config event from unexpected standby hub",
 			"source", standbyHub, "expectedStandby", s.standbyHub)
 		return nil

--- a/agent/pkg/spec/source_validation.go
+++ b/agent/pkg/spec/source_validation.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/configs"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/spec/migration"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
 func specEventSourceAllowed(
@@ -64,7 +65,7 @@ func hubHAResourceSourceAllowed(
 	if agentConfig.GetHubRole() != constants.GHHubRoleStandby {
 		return false
 	}
-	if subject != agentConfig.LeafHubName {
+	if !utils.MatchesGlobalHubStandbySubject(subject, agentConfig.LeafHubName) {
 		return false
 	}
 	if source == "" || source == constants.CloudEventGlobalHubClusterName || source == agentConfig.LeafHubName {
@@ -107,7 +108,7 @@ func haConfigSourceAllowed(agentConfig *configs.AgentConfig, source, subject str
 	}
 	standbyHub := agentConfig.GetStandbyHub()
 	if standbyHub != "" {
-		return source == standbyHub
+		return utils.StandbyHubSourceMatches(source, standbyHub)
 	}
 	return true
 }

--- a/agent/pkg/spec/source_validation_test.go
+++ b/agent/pkg/spec/source_validation_test.go
@@ -146,6 +146,9 @@ func TestHubHAResourceSourceAllowed(t *testing.T) {
 	if !hubHAResourceSourceAllowed(ctx, fakeClient, standby, "hub1", "hub2") {
 		t.Fatal("expected peer active hub source to be allowed")
 	}
+	if !hubHAResourceSourceAllowed(ctx, fakeClient, standby, "hub1", "global-hub/hub2") {
+		t.Fatal("expected prefixed global-hub HA resource subject to be allowed")
+	}
 	if hubHAResourceSourceAllowed(ctx, fakeClient, standby, "spoofed-hub", "hub2") {
 		t.Fatal("expected unexpected leaf hub source to be rejected")
 	}
@@ -230,6 +233,11 @@ func TestHaConfigSourceAllowed(t *testing.T) {
 	}
 	if !haConfigSourceAllowed(cfg, "hub1", "hub2") {
 		t.Fatal("expected configured standby hub source to be allowed")
+	}
+	cfgPrefixed := &configs.AgentConfig{LeafHubName: "hub2"}
+	cfgPrefixed.SetStandbyHub("global-hub/hub1")
+	if !haConfigSourceAllowed(cfgPrefixed, "hub1", "hub2") {
+		t.Fatal("expected unprefixed source to match prefixed configured standby hub")
 	}
 	if haConfigSourceAllowed(cfg, "hub3", "hub2") {
 		t.Fatal("expected unexpected standby hub source to be rejected")

--- a/manager/pkg/processes/hubmanagement/hub_management.go
+++ b/manager/pkg/processes/hubmanagement/hub_management.go
@@ -11,7 +11,6 @@ import (
 
 	"gorm.io/gorm"
 	"k8s.io/apimachinery/pkg/util/wait"
-	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -245,54 +244,9 @@ func (h *HubManagement) resync(ctx context.Context, hubName string) error {
 	return h.producer.SendEvent(ctx, e)
 }
 
-// findStandbyHub finds the standby hub name by querying ManagedCluster resources.
-// Returns the standby hub name, or the local cluster MC name when no standby is labeled.
+// findStandbyHub resolves the global-hub standby target for Hub HA messaging.
 func (h *HubManagement) findStandbyHub(ctx context.Context) (string, error) {
-	// List ManagedClusters with standby role label
-	managedClusterList := &clusterv1.ManagedClusterList{}
-	err := h.client.List(ctx, managedClusterList, client.MatchingLabels{
-		constants.GHHubRoleLabelKey: constants.GHHubRoleStandby,
-	})
-	if err != nil {
-		return "", fmt.Errorf("failed to list ManagedClusters with standby role: %w", err)
-	}
-
-	// If exactly one standby hub found, return it
-	if len(managedClusterList.Items) == 1 {
-		return managedClusterList.Items[0].Name, nil
-	}
-
-	// If no standby hub found, resolve the local cluster MC name (may differ from
-	// constants.LocalClusterName when hub self-managed uses e.g. acm-local-cluster).
-	if len(managedClusterList.Items) == 0 {
-		name, err := utils.ResolveLocalClusterManagedClusterName(ctx, h.client)
-		if err != nil {
-			return "", fmt.Errorf("failed to resolve local ManagedCluster name: %w", err)
-		}
-		return name, nil
-	}
-
-	// More than one standby hub found - this is a configuration error
-	// Choose the first one alphabetically for deterministic behavior and log a warning
-	hubNames := make([]string, len(managedClusterList.Items))
-	for i, hub := range managedClusterList.Items {
-		hubNames[i] = hub.Name
-	}
-
-	// Sort to ensure deterministic selection
-	chosen := managedClusterList.Items[0].Name
-	for _, name := range hubNames {
-		if name < chosen {
-			chosen = name
-		}
-	}
-
-	log.Warnw("multiple standby hubs found - using alphabetically first one. Only one standby hub should be configured",
-		"count", len(managedClusterList.Items),
-		"standbyHubs", hubNames,
-		"chosen", chosen)
-
-	return chosen, nil
+	return utils.FindStandbyHubTarget(ctx, h.client, "")
 }
 
 // getManagedClusterNames gets the list of managed cluster names for a given hub

--- a/manager/pkg/processes/hubmanagement/hub_management_test.go
+++ b/manager/pkg/processes/hubmanagement/hub_management_test.go
@@ -73,7 +73,30 @@ func TestFindStandbyHub(t *testing.T) {
 					},
 				},
 			},
-			expectedHub:   localClusterName,
+			expectedHub:   "global-hub/local-cluster",
+			expectedError: false,
+		},
+		{
+			name: "labeled local MC preferred over stale standby MC",
+			clusters: []client.Object{
+				&clusterv1.ManagedCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "acm-local-cluster",
+						Labels: map[string]string{
+							constants.LocalClusterName: "true",
+						},
+					},
+				},
+				&clusterv1.ManagedCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: localClusterName,
+						Labels: map[string]string{
+							constants.GHHubRoleLabelKey: constants.GHHubRoleStandby,
+						},
+					},
+				},
+			},
+			expectedHub:   "global-hub/acm-local-cluster",
 			expectedError: false,
 		},
 		{
@@ -96,7 +119,7 @@ func TestFindStandbyHub(t *testing.T) {
 					},
 				},
 			},
-			expectedHub:   "acm-local-cluster",
+			expectedHub:   "global-hub/acm-local-cluster",
 			expectedError: false,
 		},
 		{
@@ -147,7 +170,7 @@ func TestFindStandbyHub(t *testing.T) {
 		{
 			name:          "no clusters",
 			clusters:      []client.Object{},
-			expectedHub:   localClusterName,
+			expectedHub:   "global-hub/local-cluster",
 			expectedError: false,
 		},
 	}
@@ -299,7 +322,7 @@ func TestSendHubStatusUpdate_NoStandbyHub(t *testing.T) {
 	// This should fallback to local-cluster
 	standbyHub, err := hm.findStandbyHub(context.Background())
 	assert.NoError(t, err)
-	assert.Equal(t, localClusterName, standbyHub)
+	assert.Equal(t, "global-hub/local-cluster", standbyHub)
 
 	// Setup test cluster in database
 	testCluster := models.ManagedCluster{
@@ -482,7 +505,7 @@ func TestSendHubStatusUpdate_NoStandbyHubAvailable(t *testing.T) {
 	// sendHubStatusUpdate should still work
 	standbyHub, err := hm.findStandbyHub(context.Background())
 	assert.NoError(t, err)
-	assert.Equal(t, localClusterName, standbyHub)
+	assert.Equal(t, "global-hub/local-cluster", standbyHub)
 }
 
 // mockProducer implements transport.Producer for testing

--- a/manager/pkg/processes/hubmanagement/hub_management_test.go
+++ b/manager/pkg/processes/hubmanagement/hub_management_test.go
@@ -319,10 +319,11 @@ func TestSendHubStatusUpdate_NoStandbyHub(t *testing.T) {
 		producer: mockProducer,
 	}
 
-	// This should fallback to local-cluster
+	// When no standby MC exists, findStandbyHub should return the prefixed default local-cluster subject.
 	standbyHub, err := hm.findStandbyHub(context.Background())
 	assert.NoError(t, err)
-	assert.Equal(t, "global-hub/local-cluster", standbyHub)
+	assert.Equal(t, "global-hub/local-cluster", standbyHub,
+		"findStandbyHub should return prefixed global-hub/local-cluster when no standby MC is labeled")
 
 	// Setup test cluster in database
 	testCluster := models.ManagedCluster{
@@ -501,11 +502,11 @@ func TestSendHubStatusUpdate_NoStandbyHubAvailable(t *testing.T) {
 		producer: mockProducer,
 	}
 
-	// findStandbyHub returns local-cluster when no standby found
-	// sendHubStatusUpdate should still work
+	// findStandbyHub should still resolve a prefixed fallback when no standby MC exists.
 	standbyHub, err := hm.findStandbyHub(context.Background())
 	assert.NoError(t, err)
-	assert.Equal(t, "global-hub/local-cluster", standbyHub)
+	assert.Equal(t, "global-hub/local-cluster", standbyHub,
+		"findStandbyHub should return prefixed global-hub/local-cluster when no standby hub is available")
 }
 
 // mockProducer implements transport.Producer for testing

--- a/operator/pkg/controllers/agent/addon/addon_agent.go
+++ b/operator/pkg/controllers/agent/addon/addon_agent.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"strconv"
 
 	addonoperatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
@@ -223,52 +222,7 @@ func (a *GlobalHubAddonAgent) setImagePullSecret(mgh *globalhubv1alpha4.Multiclu
 	return nil
 }
 
-// findStandbyHub returns the standby hub name
-// If a ManagedCluster has the standby label, return that cluster name
-// If no ManagedCluster has the standby label, resolve the local cluster MC name
+// findStandbyHub returns the Kafka subject / config value for the global-hub standby target.
 func (a *GlobalHubAddonAgent) findStandbyHub() (string, error) {
-	managedClusterList := &clusterv1.ManagedClusterList{}
-	err := a.client.List(a.ctx, managedClusterList, client.MatchingLabels{
-		constants.GHHubRoleLabelKey: constants.GHHubRoleStandby,
-	})
-	if err != nil {
-		return "", err
-	}
-
-	// If exactly one standby hub found, return it
-	if len(managedClusterList.Items) == 1 {
-		return managedClusterList.Items[0].Name, nil
-	}
-
-	// If no standby hub found, resolve the local cluster MC name (may differ from
-	// constants.LocalClusterName when hub self-managed uses e.g. acm-local-cluster).
-	if len(managedClusterList.Items) == 0 {
-		name, err := commonutils.ResolveLocalClusterManagedClusterName(a.ctx, a.client)
-		if err != nil {
-			return "", fmt.Errorf("failed to resolve local ManagedCluster name: %w", err)
-		}
-		return name, nil
-	}
-
-	// More than one standby hub found - this is a configuration error
-	// Choose the first one alphabetically for deterministic behavior and log a warning
-	hubNames := make([]string, len(managedClusterList.Items))
-	for i, hub := range managedClusterList.Items {
-		hubNames[i] = hub.Name
-	}
-
-	// Sort to ensure deterministic selection
-	chosen := managedClusterList.Items[0].Name
-	for _, name := range hubNames {
-		if name < chosen {
-			chosen = name
-		}
-	}
-
-	log.Warnw("multiple standby hubs found - using alphabetically first one. Only one standby hub should be configured",
-		"count", len(managedClusterList.Items),
-		"standbyHubs", hubNames,
-		"chosen", chosen)
-
-	return chosen, nil
+	return commonutils.FindStandbyHubTarget(a.ctx, a.client, config.GetLocalClusterName())
 }

--- a/operator/pkg/controllers/agent/addon/addon_agent_findstandbyhub_test.go
+++ b/operator/pkg/controllers/agent/addon/addon_agent_findstandbyhub_test.go
@@ -9,7 +9,7 @@
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the License for the specific language governing permissions and
+// See the License for the specific language governing permissions and
 // limitations under the License.
 
 package addon
@@ -176,8 +176,9 @@ func TestGlobalHubAddonAgent_findStandbyHub(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			previousLocal := config.GetLocalClusterName()
 			config.SetLocalClusterName(tt.cachedLocal)
-			t.Cleanup(func() { config.SetLocalClusterName("") })
+			t.Cleanup(func() { config.SetLocalClusterName(previousLocal) })
 
 			fakeClient := fake.NewClientBuilder().
 				WithScheme(addonFindStandbyHubTestScheme(t)).

--- a/operator/pkg/controllers/agent/addon/addon_agent_findstandbyhub_test.go
+++ b/operator/pkg/controllers/agent/addon/addon_agent_findstandbyhub_test.go
@@ -9,7 +9,7 @@
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
+// See the License for the License for the specific language governing permissions and
 // limitations under the License.
 
 package addon
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 )
 
@@ -37,19 +38,18 @@ func addonFindStandbyHubTestScheme(t *testing.T) *runtime.Scheme {
 }
 
 func TestGlobalHubAddonAgent_findStandbyHub(t *testing.T) {
-	t.Parallel()
-
 	const localClusterName = "local-cluster"
 
 	tests := []struct {
 		name          string
 		clusters      []client.Object
+		cachedLocal   string
 		expectedHub   string
 		expectedError bool
 		errorContains string
 	}{
 		{
-			name: "standby hub exists",
+			name: "regional standby hub exists",
 			clusters: []client.Object{
 				&clusterv1.ManagedCluster{
 					ObjectMeta: metav1.ObjectMeta{
@@ -71,7 +71,7 @@ func TestGlobalHubAddonAgent_findStandbyHub(t *testing.T) {
 			expectedHub: "hub2",
 		},
 		{
-			name: "no standby hub - returns local-cluster fallback",
+			name: "no standby hub - returns prefixed local-cluster fallback",
 			clusters: []client.Object{
 				&clusterv1.ManagedCluster{
 					ObjectMeta: metav1.ObjectMeta{
@@ -82,10 +82,10 @@ func TestGlobalHubAddonAgent_findStandbyHub(t *testing.T) {
 					},
 				},
 			},
-			expectedHub: localClusterName,
+			expectedHub: "global-hub/local-cluster",
 		},
 		{
-			name: "no standby hub - resolves labeled local cluster MC name",
+			name: "labeled local MC preferred over stale standby MC",
 			clusters: []client.Object{
 				&clusterv1.ManagedCluster{
 					ObjectMeta: metav1.ObjectMeta{
@@ -97,14 +97,14 @@ func TestGlobalHubAddonAgent_findStandbyHub(t *testing.T) {
 				},
 				&clusterv1.ManagedCluster{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "hub1",
+						Name: localClusterName,
 						Labels: map[string]string{
-							constants.GHHubRoleLabelKey: constants.GHHubRoleActive,
+							constants.GHHubRoleLabelKey: constants.GHHubRoleStandby,
 						},
 					},
 				},
 			},
-			expectedHub: "acm-local-cluster",
+			expectedHub: "global-hub/acm-local-cluster",
 		},
 		{
 			name: "multiple standby hubs - returns alphabetically first",
@@ -152,16 +152,32 @@ func TestGlobalHubAddonAgent_findStandbyHub(t *testing.T) {
 			errorContains: "failed to resolve local ManagedCluster name",
 		},
 		{
-			name:          "no clusters - returns local-cluster fallback",
+			name:          "no clusters - returns prefixed local-cluster fallback",
 			clusters:      []client.Object{},
-			expectedHub:   localClusterName,
+			expectedHub:   "global-hub/local-cluster",
 			expectedError: false,
+		},
+		{
+			name: "operator cache used when resolver returns default name",
+			clusters: []client.Object{
+				&clusterv1.ManagedCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hub1",
+						Labels: map[string]string{
+							constants.GHHubRoleLabelKey: constants.GHHubRoleActive,
+						},
+					},
+				},
+			},
+			cachedLocal: "acm-local-cluster",
+			expectedHub: "global-hub/acm-local-cluster",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+			config.SetLocalClusterName(tt.cachedLocal)
+			t.Cleanup(func() { config.SetLocalClusterName("") })
 
 			fakeClient := fake.NewClientBuilder().
 				WithScheme(addonFindStandbyHubTestScheme(t)).

--- a/pkg/utils/standby_hub.go
+++ b/pkg/utils/standby_hub.go
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package utils
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+)
+
+const globalHubStandbySubjectSeparator = "/"
+
+// FormatGlobalHubStandbySubject returns the Kafka subject / standbyHub config value for the
+// global-hub local standby agent. The prefix disambiguates the global hub local ManagedCluster
+// from regional hubs that may use the same local cluster name (e.g. acm-local-cluster).
+func FormatGlobalHubStandbySubject(localManagedClusterName string) string {
+	if localManagedClusterName == "" {
+		return ""
+	}
+	return constants.CloudEventGlobalHubClusterName + globalHubStandbySubjectSeparator + localManagedClusterName
+}
+
+// ResolveGlobalHubStandbySubject strips the global-hub prefix from subject when present.
+func ResolveGlobalHubStandbySubject(subject string) (localManagedClusterName string, ok bool) {
+	prefix := constants.CloudEventGlobalHubClusterName + globalHubStandbySubjectSeparator
+	if !strings.HasPrefix(subject, prefix) {
+		return "", false
+	}
+	name := strings.TrimPrefix(subject, prefix)
+	if name == "" {
+		return "", false
+	}
+	return name, true
+}
+
+// MatchesGlobalHubStandbySubject reports whether subject routes to the agent whose
+// leaf-hub-name is leafHubName. Accepts both prefixed (global-hub/<name>) and legacy
+// unprefixed subjects for backward compatibility during upgrades.
+func MatchesGlobalHubStandbySubject(subject, leafHubName string) bool {
+	if subject == leafHubName {
+		return true
+	}
+	if localName, ok := ResolveGlobalHubStandbySubject(subject); ok {
+		return localName == leafHubName
+	}
+	return false
+}
+
+// StandbyHubSourceMatches reports whether an HA config event source matches the configured
+// standbyHub value, accounting for prefixed and unprefixed forms.
+func StandbyHubSourceMatches(source, configuredStandbyHub string) bool {
+	if source == configuredStandbyHub {
+		return true
+	}
+	if localName, ok := ResolveGlobalHubStandbySubject(configuredStandbyHub); ok {
+		return source == localName
+	}
+	if localName, ok := ResolveGlobalHubStandbySubject(source); ok {
+		return localName == configuredStandbyHub
+	}
+	return false
+}
+
+// FindStandbyHubTarget resolves the standby hub identity for active Hub HA agents.
+// cachedLocalClusterName is optional (from operator local-agent reconciler); pass "" when unavailable.
+func FindStandbyHubTarget(ctx context.Context, c client.Client, cachedLocalClusterName string) (string, error) {
+	if c == nil {
+		return "", fmt.Errorf("client is required")
+	}
+
+	localName, err := ResolveLocalClusterManagedClusterName(ctx, c)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve local ManagedCluster name: %w", err)
+	}
+	if localName == constants.LocalClusterName && cachedLocalClusterName != "" {
+		localName = cachedLocalClusterName
+	}
+
+	// Hub HA standby runs on the global-hub local agent. When the local MC has a
+	// non-default name, prefer it over hub-role=standby labels on other MCs (e.g. a stale
+	// literal "local-cluster" MC on ACM 5.0 hub-self-managed setups).
+	if localName != constants.LocalClusterName {
+		return FormatGlobalHubStandbySubject(localName), nil
+	}
+
+	standbyMCs, err := listStandbyRoleManagedClusters(ctx, c)
+	if err != nil {
+		return "", err
+	}
+
+	switch len(standbyMCs) {
+	case 0:
+		return FormatGlobalHubStandbySubject(constants.LocalClusterName), nil
+	case 1:
+		name := standbyMCs[0].Name
+		if name == constants.LocalClusterName {
+			return FormatGlobalHubStandbySubject(name), nil
+		}
+		// Separate regional standby hub (legacy topology): subject is the MC name.
+		return name, nil
+	default:
+		chosen := alphabeticallyFirstClusterName(standbyMCs)
+		if chosen == constants.LocalClusterName {
+			return FormatGlobalHubStandbySubject(chosen), nil
+		}
+		return chosen, nil
+	}
+}
+
+func listStandbyRoleManagedClusters(ctx context.Context, c client.Client) ([]clusterv1.ManagedCluster, error) {
+	list := &clusterv1.ManagedClusterList{}
+	if err := c.List(ctx, list, client.MatchingLabels{
+		constants.GHHubRoleLabelKey: constants.GHHubRoleStandby,
+	}); err != nil {
+		return nil, fmt.Errorf("failed to list ManagedClusters with standby role: %w", err)
+	}
+	return list.Items, nil
+}
+
+func alphabeticallyFirstClusterName(clusters []clusterv1.ManagedCluster) string {
+	if len(clusters) == 0 {
+		return ""
+	}
+	chosen := clusters[0].Name
+	for _, mc := range clusters[1:] {
+		if mc.Name < chosen {
+			chosen = mc.Name
+		}
+	}
+	return chosen
+}

--- a/pkg/utils/standby_hub.go
+++ b/pkg/utils/standby_hub.go
@@ -1,5 +1,17 @@
 // Copyright (c) 2026 Red Hat, Inc.
 // Copyright Contributors to the Open Cluster Management project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package utils
 
@@ -113,6 +125,7 @@ func FindStandbyHubTarget(ctx context.Context, c client.Client, cachedLocalClust
 	}
 }
 
+// listStandbyRoleManagedClusters returns ManagedClusters labeled hub-role=standby.
 func listStandbyRoleManagedClusters(ctx context.Context, c client.Client) ([]clusterv1.ManagedCluster, error) {
 	list := &clusterv1.ManagedClusterList{}
 	if err := c.List(ctx, list, client.MatchingLabels{
@@ -123,6 +136,7 @@ func listStandbyRoleManagedClusters(ctx context.Context, c client.Client) ([]clu
 	return list.Items, nil
 }
 
+// alphabeticallyFirstClusterName returns the lexicographically smallest cluster name.
 func alphabeticallyFirstClusterName(clusters []clusterv1.ManagedCluster) string {
 	if len(clusters) == 0 {
 		return ""

--- a/pkg/utils/standby_hub_test.go
+++ b/pkg/utils/standby_hub_test.go
@@ -1,0 +1,171 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package utils
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+)
+
+func TestFormatGlobalHubStandbySubject(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "global-hub/acm-local-cluster", FormatGlobalHubStandbySubject("acm-local-cluster"))
+	assert.Equal(t, "global-hub/local-cluster", FormatGlobalHubStandbySubject(constants.LocalClusterName))
+	assert.Empty(t, FormatGlobalHubStandbySubject(""))
+}
+
+func TestResolveGlobalHubStandbySubject(t *testing.T) {
+	t.Parallel()
+	name, ok := ResolveGlobalHubStandbySubject("global-hub/acm-local-cluster")
+	require.True(t, ok)
+	assert.Equal(t, "acm-local-cluster", name)
+
+	_, ok = ResolveGlobalHubStandbySubject("acm-local-cluster")
+	assert.False(t, ok)
+
+	_, ok = ResolveGlobalHubStandbySubject("global-hub/")
+	assert.False(t, ok)
+}
+
+func TestMatchesGlobalHubStandbySubject(t *testing.T) {
+	t.Parallel()
+	assert.True(t, MatchesGlobalHubStandbySubject("acm-local-cluster", "acm-local-cluster"))
+	assert.True(t, MatchesGlobalHubStandbySubject("global-hub/acm-local-cluster", "acm-local-cluster"))
+	assert.False(t, MatchesGlobalHubStandbySubject("global-hub/other-hub", "acm-local-cluster"))
+	assert.False(t, MatchesGlobalHubStandbySubject("other-hub", "acm-local-cluster"))
+}
+
+func TestStandbyHubSourceMatches(t *testing.T) {
+	t.Parallel()
+	assert.True(t, StandbyHubSourceMatches("acm-local-cluster", "acm-local-cluster"))
+	assert.True(t, StandbyHubSourceMatches("acm-local-cluster", "global-hub/acm-local-cluster"))
+	assert.True(t, StandbyHubSourceMatches("global-hub/acm-local-cluster", "acm-local-cluster"))
+	assert.False(t, StandbyHubSourceMatches("regional-hub", "global-hub/acm-local-cluster"))
+}
+
+func TestFindStandbyHubTarget(t *testing.T) {
+	t.Parallel()
+
+	const localClusterName = constants.LocalClusterName
+
+	tests := []struct {
+		name          string
+		clusters      []client.Object
+		cachedLocal   string
+		expected      string
+		expectedError bool
+	}{
+		{
+			name: "labeled local MC uses prefixed global-hub subject",
+			clusters: []client.Object{
+				&clusterv1.ManagedCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "acm-local-cluster",
+						Labels: map[string]string{
+							constants.LocalClusterName: "true",
+						},
+					},
+				},
+				&clusterv1.ManagedCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: localClusterName,
+						Labels: map[string]string{
+							constants.GHHubRoleLabelKey: constants.GHHubRoleStandby,
+						},
+					},
+				},
+			},
+			expected: "global-hub/acm-local-cluster",
+		},
+		{
+			name: "no standby MC falls back to prefixed local-cluster",
+			clusters: []client.Object{
+				&clusterv1.ManagedCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hub1",
+						Labels: map[string]string{
+							constants.GHHubRoleLabelKey: constants.GHHubRoleActive,
+						},
+					},
+				},
+			},
+			expected: "global-hub/local-cluster",
+		},
+		{
+			name: "operator cache used when resolver returns default name",
+			clusters: []client.Object{
+				&clusterv1.ManagedCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hub1",
+						Labels: map[string]string{
+							constants.GHHubRoleLabelKey: constants.GHHubRoleActive,
+						},
+					},
+				},
+			},
+			cachedLocal: "acm-local-cluster",
+			expected:    "global-hub/acm-local-cluster",
+		},
+		{
+			name: "regional standby MC without local-cluster name is unprefixed",
+			clusters: []client.Object{
+				&clusterv1.ManagedCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hub2",
+						Labels: map[string]string{
+							constants.GHHubRoleLabelKey: constants.GHHubRoleStandby,
+						},
+					},
+				},
+			},
+			expected: "hub2",
+		},
+		{
+			name: "multiple local clusters is an error",
+			clusters: []client.Object{
+				&clusterv1.ManagedCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "local-a",
+						Labels: map[string]string{constants.LocalClusterName: "true"},
+					},
+				},
+				&clusterv1.ManagedCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "local-b",
+						Labels: map[string]string{constants.LocalClusterName: "true"},
+					},
+				},
+			},
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			scheme := runtime.NewScheme()
+			require.NoError(t, clusterv1.Install(scheme))
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.clusters...).Build()
+
+			got, err := FindStandbyHubTarget(context.Background(), c, tt.cachedLocal)
+			if tt.expectedError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/pkg/utils/standby_hub_test.go
+++ b/pkg/utils/standby_hub_test.go
@@ -1,5 +1,17 @@
 // Copyright (c) 2026 Red Hat, Inc.
 // Copyright Contributors to the Open Cluster Management project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package utils
 
@@ -20,38 +32,50 @@ import (
 
 func TestFormatGlobalHubStandbySubject(t *testing.T) {
 	t.Parallel()
-	assert.Equal(t, "global-hub/acm-local-cluster", FormatGlobalHubStandbySubject("acm-local-cluster"))
-	assert.Equal(t, "global-hub/local-cluster", FormatGlobalHubStandbySubject(constants.LocalClusterName))
-	assert.Empty(t, FormatGlobalHubStandbySubject(""))
+	assert.Equal(t, "global-hub/acm-local-cluster", FormatGlobalHubStandbySubject("acm-local-cluster"),
+		"FormatGlobalHubStandbySubject should prefix global-hub local MC names")
+	assert.Equal(t, "global-hub/local-cluster", FormatGlobalHubStandbySubject(constants.LocalClusterName),
+		"FormatGlobalHubStandbySubject should prefix the default local-cluster name")
+	assert.Empty(t, FormatGlobalHubStandbySubject(""),
+		"FormatGlobalHubStandbySubject should return empty for empty input")
 }
 
 func TestResolveGlobalHubStandbySubject(t *testing.T) {
 	t.Parallel()
 	name, ok := ResolveGlobalHubStandbySubject("global-hub/acm-local-cluster")
-	require.True(t, ok)
-	assert.Equal(t, "acm-local-cluster", name)
+	require.True(t, ok, "ResolveGlobalHubStandbySubject should accept prefixed subjects")
+	assert.Equal(t, "acm-local-cluster", name,
+		"ResolveGlobalHubStandbySubject should strip the global-hub prefix")
 
 	_, ok = ResolveGlobalHubStandbySubject("acm-local-cluster")
-	assert.False(t, ok)
+	assert.False(t, ok, "ResolveGlobalHubStandbySubject should reject unprefixed subjects")
 
 	_, ok = ResolveGlobalHubStandbySubject("global-hub/")
-	assert.False(t, ok)
+	assert.False(t, ok, "ResolveGlobalHubStandbySubject should reject empty names after prefix")
 }
 
 func TestMatchesGlobalHubStandbySubject(t *testing.T) {
 	t.Parallel()
-	assert.True(t, MatchesGlobalHubStandbySubject("acm-local-cluster", "acm-local-cluster"))
-	assert.True(t, MatchesGlobalHubStandbySubject("global-hub/acm-local-cluster", "acm-local-cluster"))
-	assert.False(t, MatchesGlobalHubStandbySubject("global-hub/other-hub", "acm-local-cluster"))
-	assert.False(t, MatchesGlobalHubStandbySubject("other-hub", "acm-local-cluster"))
+	assert.True(t, MatchesGlobalHubStandbySubject("acm-local-cluster", "acm-local-cluster"),
+		"MatchesGlobalHubStandbySubject should accept legacy unprefixed subjects")
+	assert.True(t, MatchesGlobalHubStandbySubject("global-hub/acm-local-cluster", "acm-local-cluster"),
+		"MatchesGlobalHubStandbySubject should accept prefixed global-hub subjects")
+	assert.False(t, MatchesGlobalHubStandbySubject("global-hub/other-hub", "acm-local-cluster"),
+		"MatchesGlobalHubStandbySubject should reject mismatched prefixed subjects")
+	assert.False(t, MatchesGlobalHubStandbySubject("other-hub", "acm-local-cluster"),
+		"MatchesGlobalHubStandbySubject should reject unrelated subjects")
 }
 
 func TestStandbyHubSourceMatches(t *testing.T) {
 	t.Parallel()
-	assert.True(t, StandbyHubSourceMatches("acm-local-cluster", "acm-local-cluster"))
-	assert.True(t, StandbyHubSourceMatches("acm-local-cluster", "global-hub/acm-local-cluster"))
-	assert.True(t, StandbyHubSourceMatches("global-hub/acm-local-cluster", "acm-local-cluster"))
-	assert.False(t, StandbyHubSourceMatches("regional-hub", "global-hub/acm-local-cluster"))
+	assert.True(t, StandbyHubSourceMatches("acm-local-cluster", "acm-local-cluster"),
+		"StandbyHubSourceMatches should accept identical unprefixed values")
+	assert.True(t, StandbyHubSourceMatches("acm-local-cluster", "global-hub/acm-local-cluster"),
+		"StandbyHubSourceMatches should accept unprefixed source with prefixed config")
+	assert.True(t, StandbyHubSourceMatches("global-hub/acm-local-cluster", "acm-local-cluster"),
+		"StandbyHubSourceMatches should accept prefixed source with unprefixed config")
+	assert.False(t, StandbyHubSourceMatches("regional-hub", "global-hub/acm-local-cluster"),
+		"StandbyHubSourceMatches should reject unrelated standby sources")
 }
 
 func TestFindStandbyHubTarget(t *testing.T) {
@@ -136,13 +160,13 @@ func TestFindStandbyHubTarget(t *testing.T) {
 			clusters: []client.Object{
 				&clusterv1.ManagedCluster{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "local-a",
+						Name:   "local-a",
 						Labels: map[string]string{constants.LocalClusterName: "true"},
 					},
 				},
 				&clusterv1.ManagedCluster{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "local-b",
+						Name:   "local-b",
 						Labels: map[string]string{constants.LocalClusterName: "true"},
 					},
 				},
@@ -156,16 +180,18 @@ func TestFindStandbyHubTarget(t *testing.T) {
 			t.Parallel()
 
 			scheme := runtime.NewScheme()
-			require.NoError(t, clusterv1.Install(scheme))
+			require.NoError(t, clusterv1.Install(scheme),
+				"FindStandbyHubTarget test scheme should register clusterv1 types")
 			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.clusters...).Build()
 
 			got, err := FindStandbyHubTarget(context.Background(), c, tt.cachedLocal)
 			if tt.expectedError {
-				require.Error(t, err)
+				require.Error(t, err, "FindStandbyHubTarget(%q) should return error", tt.name)
 				return
 			}
-			require.NoError(t, err)
-			assert.Equal(t, tt.expected, got)
+			require.NoError(t, err, "FindStandbyHubTarget(%q) should not return error", tt.name)
+			assert.Equal(t, tt.expected, got,
+				"FindStandbyHubTarget(%q) should resolve the expected standby target", tt.name)
 		})
 	}
 }

--- a/test/e2e/hubha_test.go
+++ b/test/e2e/hubha_test.go
@@ -97,10 +97,11 @@ var _ = Describe("Hub HA Sync", Label("e2e-test-hubha"), Ordered, func() {
 			return getAgentHubRole(ctx, activeHubClient, "multicluster-global-hub-agent")
 		}, 2*time.Minute, 5*time.Second).Should(Equal(constants.GHHubRoleActive))
 
-		By("Waiting for active hub agent to receive standby hub configuration")
+		By("Waiting for active hub agent to receive prefixed standby hub configuration")
 		Eventually(func() string {
 			return getStandByHub(ctx, activeHubClient, "multicluster-global-hub-agent")
-		}, 2*time.Minute, 5*time.Second).Should(Equal("global-hub/local-cluster"))
+		}, 2*time.Minute, 5*time.Second).Should(Equal("global-hub/local-cluster"),
+			"active hub agent must receive the prefixed standbyHub value for global-hub local standby routing")
 
 		By("Waiting for local agent on global hub to receive role configuration")
 		Eventually(func() string {

--- a/test/e2e/hubha_test.go
+++ b/test/e2e/hubha_test.go
@@ -100,7 +100,7 @@ var _ = Describe("Hub HA Sync", Label("e2e-test-hubha"), Ordered, func() {
 		By("Waiting for active hub agent to receive standby hub configuration")
 		Eventually(func() string {
 			return getStandByHub(ctx, activeHubClient, "multicluster-global-hub-agent")
-		}, 2*time.Minute, 5*time.Second).Should(Equal("local-cluster"))
+		}, 2*time.Minute, 5*time.Second).Should(Equal("global-hub/local-cluster"))
 
 		By("Waiting for local agent on global hub to receive role configuration")
 		Eventually(func() string {


### PR DESCRIPTION
## Summary

Follow-up to #2648 — QE retest showed the global-hub local agent got the correct `standbyHub` (`acm-local-cluster`) but **regional active hubs still had `standbyHub=local-cluster`**, so Hub HA events were dropped with subject mismatch.

- **Root cause:** `findStandbyHub()` checked `hub-role=standby` MCs first and could return a stale `local-cluster` MC before resolving the actual global-hub local MC name (`acm-local-cluster`).
- **Fix:** Centralize resolution in `FindStandbyHubTarget()` — prefer the labeled global-hub local MC when its name differs from the default, then fall back to explicit standby MC topology (KinD/regional standby).
- **Prefix concern:** Format global-hub local standby targets as `global-hub/<local-mc-name>` so the value cannot collide when regional hubs use the same local cluster name (e.g. both named `acm-local-cluster`). The standby agent still runs with `--leaf-hub-name=<local-mc>`; dispatcher and HA config validation accept both prefixed and legacy unprefixed subjects during upgrade.

## Changes

- `pkg/utils/standby_hub.go` — `FindStandbyHubTarget`, `FormatGlobalHubStandbySubject`, subject matching helpers
- `operator/.../addon_agent.go`, `manager/.../hub_management.go` — delegate to shared resolver
- `agent/pkg/spec/dispatcher.go`, `source_validation.go`, `hubha_config_syncer.go` — accept prefixed subjects / cross-format HA config sources
- Unit tests + e2e expectation update (`global-hub/local-cluster`)

Fixes: [ACM-38074](https://redhat.atlassian.net/browse/ACM-38074)

## Test plan

- [x] `go test -mod=mod ./pkg/utils/... -run 'TestFindStandbyHubTarget|TestFormatGlobalHubStandbySubject'`
- [x] `go test -mod=mod ./operator/pkg/controllers/agent/addon/... -run TestGlobalHubAddonAgent_findStandbyHub`
- [x] `go test -mod=mod ./manager/pkg/processes/hubmanagement/... -run TestFindStandbyHub`
- [x] `go test -mod=mod ./agent/pkg/spec/... -run 'TestDispatch_AllowsPrefixed|TestHubHAResourceSourceAllowed|TestHaConfigSourceAllowed'`
- [ ] QE: regional active hub ConfigMap shows `standbyHub: global-hub/acm-local-cluster`
- [ ] QE: Hub HA hive secret sync (ACM-38073) passes with no subject mismatch in standby agent logs


Made with [Cursor](https://cursor.com)

[ACM-38074]: https://redhat.atlassian.net/browse/ACM-38074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for global hub standby targets using the `global-hub/<cluster-name>` subject format (with legacy unprefixed compatibility).
  * Enhanced standby hub discovery to consistently resolve the correct global-hub standby target, including local-cluster fallback.

* **Bug Fixes**
  * Fixed event routing and HA configuration validation to properly trust and match prefixed global-hub standby subjects.
  * Improved standby source matching across supported naming formats.

* **Tests**
  * Added/updated unit and integration checks for prefixed subject handling, routing behavior, validation, and fallback selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->