### PR TITLE
ACM-38171: skip HA klusterlet-config on imported regional hubs

### DIFF
--- a/agent/pkg/spec/hubha/hubha_config_annotator.go
+++ b/agent/pkg/spec/hubha/hubha_config_annotator.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/configs"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 )
 
@@ -41,15 +42,13 @@ var klusterletConfigGVK = schema.GroupVersionKind{
 	Kind:    "KlusterletConfig",
 }
 
-// haConfigAnnotator ensures ManagedClusters created after the initial HAConfig
-// sync still receive agent.open-cluster-management.io/klusterlet-config.
-// HAConfigSyncer only annotates clusters present when the CloudEvent arrives.
+// haConfigAnnotator annotates ManagedClusters created after the initial HAConfig sync.
 type haConfigAnnotator struct {
 	client client.Client
 }
 
-// AddHAConfigAnnotator watches ManagedCluster creates/updates and applies the
-// HA KlusterletConfig annotation when an ha-standby-* KlusterletConfig exists.
+// AddHAConfigAnnotator registers a controller that applies (or clears) the HA
+// klusterlet-config annotation on ManagedCluster create/update.
 func AddHAConfigAnnotator(mgr ctrl.Manager) error {
 	r := &haConfigAnnotator{client: mgr.GetClient()}
 	return ctrl.NewControllerManagedBy(mgr).
@@ -57,13 +56,15 @@ func AddHAConfigAnnotator(mgr ctrl.Manager) error {
 		For(&clusterv1.ManagedCluster{}).
 		WithEventFilter(predicate.Funcs{
 			CreateFunc: func(e event.CreateEvent) bool {
-				return !isLocalManagedCluster(e.Object)
+				if shouldSkipHAAnnotation(e.Object) {
+					return hasHAKlusterletConfigAnnotation(e.Object)
+				}
+				return true
 			},
 			UpdateFunc: func(e event.UpdateEvent) bool {
-				if isLocalManagedCluster(e.ObjectNew) {
-					return false
+				if shouldSkipHAAnnotation(e.ObjectNew) {
+					return hasHAKlusterletConfigAnnotation(e.ObjectNew)
 				}
-				// Reconcile when the annotation is missing or changed.
 				oldAnn := e.ObjectOld.GetAnnotations()[klusterletConfigAnnotation]
 				newAnn := e.ObjectNew.GetAnnotations()[klusterletConfigAnnotation]
 				return oldAnn != newAnn || newAnn == ""
@@ -75,8 +76,6 @@ func AddHAConfigAnnotator(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-// Reconcile annotates a ManagedCluster with the HA KlusterletConfig name when
-// Hub HA has already been configured on this regional hub.
 func (r *haConfigAnnotator) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	mc := &clusterv1.ManagedCluster{}
 	if err := r.client.Get(ctx, req.NamespacedName, mc); err != nil {
@@ -86,7 +85,15 @@ func (r *haConfigAnnotator) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, fmt.Errorf("failed to get ManagedCluster %s: %w", req.Name, err)
 	}
 
-	if isLocalManagedCluster(mc) {
+	if shouldSkipHAAnnotation(mc) {
+		if err := clearHAKlusterletConfigAnnotation(ctx, r.client, mc.Name); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
+	}
+
+	// Annotate spokes only on the active hub.
+	if !isActiveHub() {
 		return ctrl.Result{}, nil
 	}
 
@@ -95,7 +102,6 @@ func (r *haConfigAnnotator) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, fmt.Errorf("failed to find HA KlusterletConfig: %w", err)
 	}
 	if klusterletConfigName == "" {
-		// HA config not applied yet; nothing to do until Sync creates it.
 		return ctrl.Result{}, nil
 	}
 
@@ -105,8 +111,23 @@ func (r *haConfigAnnotator) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	return ctrl.Result{}, nil
 }
 
-// isLocalManagedCluster returns true for the hub's self-managed local cluster,
-// identified by the local-cluster=true label or the conventional name.
+func isActiveHub() bool {
+	cfg := configs.GetAgentConfig()
+	return cfg != nil && cfg.GetHubRole() == constants.GHHubRoleActive
+}
+
+// shouldSkipHAAnnotation is true for local-cluster and hubs imported into Global Hub.
+func shouldSkipHAAnnotation(obj client.Object) bool {
+	if isLocalManagedCluster(obj) {
+		return true
+	}
+	return isGlobalHubManagedHub(obj)
+}
+
+func hasHAKlusterletConfigAnnotation(obj client.Object) bool {
+	return obj.GetAnnotations()[klusterletConfigAnnotation] != ""
+}
+
 func isLocalManagedCluster(obj client.Object) bool {
 	if obj.GetLabels()[constants.LocalClusterName] == "true" {
 		return true
@@ -114,8 +135,20 @@ func isLocalManagedCluster(obj client.Object) bool {
 	return obj.GetName() == constants.LocalClusterName
 }
 
-// findHAKlusterletConfigName returns the name of the first KlusterletConfig with
-// the ha-standby- prefix, or "" if none exists.
+func isGlobalHubManagedHub(obj client.Object) bool {
+	labels := obj.GetLabels()
+	if labels == nil {
+		return false
+	}
+	if _, ok := labels[constants.GHDeployModeLabelKey]; ok {
+		return true
+	}
+	if _, ok := labels[constants.GHHubRoleLabelKey]; ok {
+		return true
+	}
+	return false
+}
+
 func findHAKlusterletConfigName(ctx context.Context, c client.Client) (string, error) {
 	list := &unstructured.UnstructuredList{}
 	list.SetGroupVersionKind(schema.GroupVersionKind{
@@ -135,8 +168,6 @@ func findHAKlusterletConfigName(ctx context.Context, c client.Client) (string, e
 	return "", nil
 }
 
-// annotateManagedCluster sets the klusterlet-config annotation on mc when it
-// is missing or differs from klusterletConfigName.
 func annotateManagedCluster(ctx context.Context, c client.Client,
 	mc *clusterv1.ManagedCluster, klusterletConfigName string,
 ) error {
@@ -145,9 +176,8 @@ func annotateManagedCluster(ctx context.Context, c client.Client,
 		if err := c.Get(ctx, client.ObjectKeyFromObject(mc), current); err != nil {
 			return fmt.Errorf("failed to get ManagedCluster %s: %w", mc.Name, err)
 		}
-		// Re-check after reload: another controller may have marked this as local-cluster.
-		if isLocalManagedCluster(current) {
-			return nil
+		if shouldSkipHAAnnotation(current) {
+			return clearHAAnnotationLocked(ctx, c, current)
 		}
 		annotations := current.GetAnnotations()
 		if annotations == nil {
@@ -166,4 +196,29 @@ func annotateManagedCluster(ctx context.Context, c client.Client,
 			"cluster", current.Name, "klusterlet-config", klusterletConfigName)
 		return nil
 	})
+}
+
+func clearHAKlusterletConfigAnnotation(ctx context.Context, c client.Client, name string) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current := &clusterv1.ManagedCluster{}
+		if err := c.Get(ctx, client.ObjectKey{Name: name}, current); err != nil {
+			return fmt.Errorf("failed to get ManagedCluster %s: %w", name, err)
+		}
+		return clearHAAnnotationLocked(ctx, c, current)
+	})
+}
+
+func clearHAAnnotationLocked(ctx context.Context, c client.Client, current *clusterv1.ManagedCluster) error {
+	annotations := current.GetAnnotations()
+	if annotations == nil || annotations[klusterletConfigAnnotation] == "" {
+		return nil
+	}
+	delete(annotations, klusterletConfigAnnotation)
+	current.SetAnnotations(annotations)
+	if err := c.Update(ctx, current); err != nil {
+		return fmt.Errorf("failed to clear klusterlet-config annotation on ManagedCluster %s: %w",
+			current.Name, err)
+	}
+	log.Infow("removed klusterlet-config annotation", "cluster", current.Name)
+	return nil
 }

--- a/agent/pkg/spec/hubha/hubha_config_annotator_test.go
+++ b/agent/pkg/spec/hubha/hubha_config_annotator_test.go
@@ -90,30 +90,25 @@ func TestHAConfigAnnotator_AnnotatesNewlyImportedCluster(t *testing.T) {
 func TestHAConfigAnnotator_NoOpWhenNotActiveHub(t *testing.T) {
 	setAnnotatorHubRole(t, constants.GHHubRoleStandby)
 	scheme := newAnnotatorTestScheme(t)
-	regionalHub := &clusterv1.ManagedCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "regional-hub",
-			Labels: map[string]string{
-				constants.GHDeployModeLabelKey: constants.GHDeployModeHosted,
-				constants.GHHubRoleLabelKey:    constants.GHHubRoleActive,
-			},
-		},
+	// Unlabeled spoke so reconcile reaches !isActiveHub() (not shouldSkipHAAnnotation).
+	spoke := &clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "spoke"},
 	}
 	klusterletConfig := newHAKlusterletConfig(testKlusterletConfigName)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
-		WithObjects(regionalHub, klusterletConfig).
+		WithObjects(spoke, klusterletConfig).
 		Build()
 
 	_, err := (&haConfigAnnotator{client: fakeClient}).Reconcile(context.Background(), reconcile.Request{
-		NamespacedName: types.NamespacedName{Name: "regional-hub"},
+		NamespacedName: types.NamespacedName{Name: "spoke"},
 	})
 	require.NoError(t, err, "standby hub annotator should no-op even if ha-standby KlusterletConfig exists")
 
 	mc := &clusterv1.ManagedCluster{}
-	err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "regional-hub"}, mc)
-	require.NoError(t, err, "should retrieve regional hub ManagedCluster after standby no-op")
+	err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "spoke"}, mc)
+	require.NoError(t, err, "should retrieve spoke ManagedCluster after standby no-op")
 	assert.Empty(t, mc.GetAnnotations()[klusterletConfigAnnotation],
 		"standby/global hub must not annotate ManagedClusters when ha-standby config is synced")
 }

--- a/agent/pkg/spec/hubha/hubha_config_annotator_test.go
+++ b/agent/pkg/spec/hubha/hubha_config_annotator_test.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/configs"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 )
 
@@ -40,6 +41,16 @@ func newAnnotatorTestScheme(t *testing.T) *runtime.Scheme {
 	scheme := runtime.NewScheme()
 	require.NoError(t, clusterv1.Install(scheme), "clusterv1 scheme registration should succeed")
 	return scheme
+}
+
+func setAnnotatorHubRole(t *testing.T, role string) {
+	t.Helper()
+	cfg := &configs.AgentConfig{}
+	cfg.SetHubRole(role)
+	configs.SetAgentConfig(cfg)
+	t.Cleanup(func() {
+		configs.SetAgentConfig(nil)
+	})
 }
 
 func newHAKlusterletConfig(name string) *unstructured.Unstructured {
@@ -51,6 +62,7 @@ func newHAKlusterletConfig(name string) *unstructured.Unstructured {
 }
 
 func TestHAConfigAnnotator_AnnotatesNewlyImportedCluster(t *testing.T) {
+	setAnnotatorHubRole(t, constants.GHHubRoleActive)
 	scheme := newAnnotatorTestScheme(t)
 	ksCluster := &clusterv1.ManagedCluster{
 		ObjectMeta: metav1.ObjectMeta{Name: "ks"},
@@ -75,7 +87,138 @@ func TestHAConfigAnnotator_AnnotatesNewlyImportedCluster(t *testing.T) {
 			"agent.open-cluster-management.io/klusterlet-config so HA standby bootstrap is applied")
 }
 
+func TestHAConfigAnnotator_NoOpWhenNotActiveHub(t *testing.T) {
+	setAnnotatorHubRole(t, constants.GHHubRoleStandby)
+	scheme := newAnnotatorTestScheme(t)
+	regionalHub := &clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "regional-hub",
+			Labels: map[string]string{
+				constants.GHDeployModeLabelKey: constants.GHDeployModeHosted,
+				constants.GHHubRoleLabelKey:    constants.GHHubRoleActive,
+			},
+		},
+	}
+	klusterletConfig := newHAKlusterletConfig(testKlusterletConfigName)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(regionalHub, klusterletConfig).
+		Build()
+
+	_, err := (&haConfigAnnotator{client: fakeClient}).Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "regional-hub"},
+	})
+	require.NoError(t, err, "standby hub annotator should no-op even if ha-standby KlusterletConfig exists")
+
+	mc := &clusterv1.ManagedCluster{}
+	err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "regional-hub"}, mc)
+	require.NoError(t, err, "should retrieve regional hub ManagedCluster after standby no-op")
+	assert.Empty(t, mc.GetAnnotations()[klusterletConfigAnnotation],
+		"standby/global hub must not annotate ManagedClusters when ha-standby config is synced")
+}
+
+func TestHAConfigAnnotator_SkipsImportedRegionalHub(t *testing.T) {
+	setAnnotatorHubRole(t, constants.GHHubRoleActive)
+	scheme := newAnnotatorTestScheme(t)
+	regionalHub := &clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "regional-hub",
+			Labels: map[string]string{
+				constants.GHDeployModeLabelKey: constants.GHDeployModeHosted,
+				constants.GHHubRoleLabelKey:    constants.GHHubRoleActive,
+			},
+		},
+	}
+	klusterletConfig := newHAKlusterletConfig(testKlusterletConfigName)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(regionalHub, klusterletConfig).
+		Build()
+
+	_, err := (&haConfigAnnotator{client: fakeClient}).Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "regional-hub"},
+	})
+	require.NoError(t, err, "reconcile of imported regional hub should succeed without annotating")
+
+	mc := &clusterv1.ManagedCluster{}
+	err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "regional-hub"}, mc)
+	require.NoError(t, err, "should retrieve imported regional hub ManagedCluster")
+	assert.Empty(t, mc.GetAnnotations()[klusterletConfigAnnotation],
+		"ManagedCluster for a regional hub imported into Global Hub must not get "+
+			"klusterlet-config annotation")
+}
+
+func TestHAConfigAnnotator_ClearsAnnotationWhenHubLabelsArriveLater(t *testing.T) {
+	// Import first (no GH labels) can annotate; labels added later must clear it.
+	setAnnotatorHubRole(t, constants.GHHubRoleActive)
+	scheme := newAnnotatorTestScheme(t)
+	regionalHub := &clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "regional-hub",
+			Labels: map[string]string{
+				constants.GHDeployModeLabelKey: constants.GHDeployModeHosted,
+				constants.GHHubRoleLabelKey:    constants.GHHubRoleActive,
+			},
+			Annotations: map[string]string{
+				klusterletConfigAnnotation: testKlusterletConfigName,
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(regionalHub).
+		Build()
+
+	_, err := (&haConfigAnnotator{client: fakeClient}).Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "regional-hub"},
+	})
+	require.NoError(t, err, "reconcile should clear a wrongly applied annotation after hub labels arrive")
+
+	mc := &clusterv1.ManagedCluster{}
+	err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "regional-hub"}, mc)
+	require.NoError(t, err, "should retrieve regional hub after clearing annotation")
+	assert.Empty(t, mc.GetAnnotations()[klusterletConfigAnnotation],
+		"wrong klusterlet-config annotation must be removed once deploy-mode/hub-role labels are set")
+}
+
+func TestHAConfigAnnotator_ClearsAnnotationOnStandbyHub(t *testing.T) {
+	// Standby must still heal a stuck annotation on an imported regional hub.
+	setAnnotatorHubRole(t, constants.GHHubRoleStandby)
+	scheme := newAnnotatorTestScheme(t)
+	regionalHub := &clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "regional-hub",
+			Labels: map[string]string{
+				constants.GHDeployModeLabelKey: constants.GHDeployModeHosted,
+			},
+			Annotations: map[string]string{
+				klusterletConfigAnnotation: testKlusterletConfigName,
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(regionalHub).
+		Build()
+
+	_, err := (&haConfigAnnotator{client: fakeClient}).Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "regional-hub"},
+	})
+	require.NoError(t, err, "standby reconcile should clear stuck annotation on skipped cluster")
+
+	mc := &clusterv1.ManagedCluster{}
+	err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "regional-hub"}, mc)
+	require.NoError(t, err, "should retrieve regional hub after standby clear")
+	assert.Empty(t, mc.GetAnnotations()[klusterletConfigAnnotation],
+		"standby agent must remove wrongly applied klusterlet-config from imported hubs")
+}
+
 func TestHAConfigAnnotator_NoOpWithoutKlusterletConfig(t *testing.T) {
+	setAnnotatorHubRole(t, constants.GHHubRoleActive)
 	scheme := newAnnotatorTestScheme(t)
 	ksCluster := &clusterv1.ManagedCluster{
 		ObjectMeta: metav1.ObjectMeta{Name: "ks"},
@@ -99,6 +242,7 @@ func TestHAConfigAnnotator_NoOpWithoutKlusterletConfig(t *testing.T) {
 }
 
 func TestHAConfigAnnotator_SkipsLocalClusterByLabel(t *testing.T) {
+	setAnnotatorHubRole(t, constants.GHHubRoleActive)
 	scheme := newAnnotatorTestScheme(t)
 	localCluster := &clusterv1.ManagedCluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -129,6 +273,7 @@ func TestHAConfigAnnotator_SkipsLocalClusterByLabel(t *testing.T) {
 }
 
 func TestHAConfigAnnotator_SkipsLocalClusterByName(t *testing.T) {
+	setAnnotatorHubRole(t, constants.GHHubRoleActive)
 	scheme := newAnnotatorTestScheme(t)
 	localCluster := &clusterv1.ManagedCluster{
 		ObjectMeta: metav1.ObjectMeta{Name: constants.LocalClusterName},
@@ -154,6 +299,7 @@ func TestHAConfigAnnotator_SkipsLocalClusterByName(t *testing.T) {
 }
 
 func TestHAConfigAnnotator_IdempotentWhenAlreadyAnnotated(t *testing.T) {
+	setAnnotatorHubRole(t, constants.GHHubRoleActive)
 	scheme := newAnnotatorTestScheme(t)
 	ksCluster := &clusterv1.ManagedCluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -232,6 +378,30 @@ func TestIsLocalManagedCluster(t *testing.T) {
 	assert.False(t, isLocalManagedCluster(&clusterv1.ManagedCluster{
 		ObjectMeta: metav1.ObjectMeta{Name: "ks"},
 	}), "regular managed cluster should not be treated as local")
+}
+
+func TestIsGlobalHubManagedHub(t *testing.T) {
+	assert.True(t, isGlobalHubManagedHub(&clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "regional-hub",
+			Labels: map[string]string{
+				constants.GHDeployModeLabelKey: constants.GHDeployModeHosted,
+			},
+		},
+	}), "deploy-mode label identifies a hub imported into Global Hub")
+
+	assert.True(t, isGlobalHubManagedHub(&clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "regional-hub",
+			Labels: map[string]string{
+				constants.GHHubRoleLabelKey: constants.GHHubRoleActive,
+			},
+		},
+	}), "hub-role label identifies a hub imported into Global Hub")
+
+	assert.False(t, isGlobalHubManagedHub(&clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "ks"},
+	}), "spoke ManagedCluster without GH hub labels should not be treated as a hub")
 }
 
 func TestAnnotateManagedCluster(t *testing.T) {

--- a/agent/pkg/spec/hubha/hubha_config_syncer.go
+++ b/agent/pkg/spec/hubha/hubha_config_syncer.go
@@ -207,7 +207,7 @@ func (s *HAConfigSyncer) annotateAllManagedClusters(ctx context.Context, kluster
 
 	for i := range mcList.Items {
 		mc := &mcList.Items[i]
-		if isLocalManagedCluster(mc) {
+		if shouldSkipHAAnnotation(mc) {
 			continue
 		}
 


### PR DESCRIPTION
## Summary

Follow-up to #2657 / ACM-38171. QA found that `ha-config-annotator` also annotated the regional hub ManagedCluster already imported into Global Hub.

- Annotate spoke ManagedClusters only when the agent hub role is **active**
- Skip clusters that must not get the HA annotation: `local-cluster` and hubs with Global Hub `deploy-mode` / `hub-role` labels
- If those labels arrive after create (or a bad annotation is already present), clear the stuck annotation (active or standby)

## Test plan

- [x] `go test ./agent/pkg/spec/hubha/`
- [ ] On Global Hub: imported regional hub ManagedCluster has **no** `agent.open-cluster-management.io/klusterlet-config`
- [ ] On active regional hub: newly imported spoke (e.g. `ks`) **does** get `ha-standby-*`
- [ ] On active regional hub: `local-cluster` stays unannotated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HA configuration annotations are now applied only by active hubs.
  * Annotations are removed from local clusters and hubs managed by Global Hub.
  * Incorrect or outdated annotations are cleared when cluster roles or labels change.
  * Standby hubs no longer leave stale HA configuration annotations behind.
* **Tests**
  * Added coverage for active, standby, imported, and Global Hub-managed cluster scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->