### PR TITLE
ACM-34442 / ACM-38861: backport phase 1-2 Kafka transport identity fix to GH 1.4 (release-2.13)

### DIFF
--- a/agent/pkg/spec/dispatcher.go
+++ b/agent/pkg/spec/dispatcher.go
@@ -79,6 +79,10 @@ func (d *genericDispatcher) dispatch(ctx context.Context) {
 				// d.log.Infow("event dropped due to cluster name mismatch", "clusterName", clusterName)
 				continue
 			}
+			if !specEventSourceAllowed(evt) {
+				d.log.Warnw("event dropped due to untrusted source", "type", evt.Type(), "source", evt.Source())
+				continue
+			}
 			syncer, found := d.syncers[evt.Type()]
 			if !found {
 				d.log.Debugw("dispatching to the default generic syncer", "eventType", evt.Type())

--- a/agent/pkg/spec/source_validation.go
+++ b/agent/pkg/spec/source_validation.go
@@ -1,0 +1,30 @@
+// Copyright Contributors to the Open Cluster Management project.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+)
+
+// specEventSourceAllowed returns true when the CloudEvent source is the trusted manager identity.
+// GH 1.4 migration events are also published with source global-hub only.
+func specEventSourceAllowed(evt *cloudevents.Event) bool {
+	if evt == nil {
+		return false
+	}
+	return evt.Source() == constants.CloudEventSourceGlobalHub
+}

--- a/agent/pkg/spec/source_validation_test.go
+++ b/agent/pkg/spec/source_validation_test.go
@@ -1,0 +1,47 @@
+// Copyright Contributors to the Open Cluster Management project.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"testing"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+)
+
+func TestSpecEventSourceAllowed(t *testing.T) {
+	t.Run("accepts global-hub source", func(t *testing.T) {
+		evt := cloudevents.NewEvent()
+		evt.SetSource(constants.CloudEventSourceGlobalHub)
+		if !specEventSourceAllowed(&evt) {
+			t.Fatal("expected global-hub source to be allowed")
+		}
+	})
+
+	t.Run("rejects spoofed source", func(t *testing.T) {
+		evt := cloudevents.NewEvent()
+		evt.SetSource("victim-hub")
+		if specEventSourceAllowed(&evt) {
+			t.Fatal("expected spoofed source to be rejected")
+		}
+	})
+
+	t.Run("rejects nil event", func(t *testing.T) {
+		if specEventSourceAllowed(nil) {
+			t.Fatal("expected nil event to be rejected")
+		}
+	})
+}

--- a/manager/pkg/status/conflator/conflation_manager.go
+++ b/manager/pkg/status/conflator/conflation_manager.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 	"github.com/stolostron/multicluster-global-hub/pkg/statistics"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport/consumer"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport/identity"
 )
 
 // ConflationManager implements conflation units management.
@@ -52,13 +53,25 @@ func (cm *ConflationManager) Insert(evt *cloudevents.Event) {
 		cm.log.Infow("event type hasn't been registered", "type", evt.Type())
 		return
 	}
+	leafHubName, ok := identity.LeafHubForStatusEvent(evt)
+	if !ok {
+		cm.log.Warnw(
+			"dropping event due to untrusted source",
+			"type", evt.Type(),
+			"source", evt.Source(),
+			"authedhub", evt.Extensions()[identity.ExtensionAuthedHub],
+		)
+		return
+	}
+	evt.SetSource(leafHubName)
+
 	// metadata
 	conflationMetadata := metadata.NewThresholdMetadata(consumer.TransportID(), 3, evt)
 	if conflationMetadata == nil {
 		return
 	}
 
-	cm.getConflationUnit(evt.Source()).insert(evt, conflationMetadata)
+	cm.getConflationUnit(leafHubName).insert(evt, conflationMetadata)
 }
 
 // GetTransportMetadatas provides collections of the CU's bundle transport-metadata.

--- a/manager/pkg/status/conflator/conflation_manager_test.go
+++ b/manager/pkg/status/conflator/conflation_manager_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright Contributors to the Open Cluster Management project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conflator
+
+import (
+	"context"
+	"testing"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+
+	eventversion "github.com/stolostron/multicluster-global-hub/pkg/bundle/version"
+	"github.com/stolostron/multicluster-global-hub/pkg/enum"
+	"github.com/stolostron/multicluster-global-hub/pkg/statistics"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport/identity"
+)
+
+func newTestConflationManager() *ConflationManager {
+	return NewConflationManager(statistics.NewStatistics(&statistics.StatisticsConfig{
+		LogInterval: "1m",
+	}))
+}
+
+func TestConflationManagerInsertRejectsSpoofedSource(t *testing.T) {
+	cm := newTestConflationManager()
+	eventType := string(enum.ManagedClusterType)
+	cm.Register(NewConflationRegistration(
+		HubClusterHeartbeatPriority,
+		enum.CompleteStateMode,
+		eventType,
+		func(context.Context, *cloudevents.Event) error { return nil },
+	))
+
+	evt := cloudevents.NewEvent()
+	evt.SetType(eventType)
+	evt.SetSource("victim-hub")
+	identity.SetAuthedHub(&evt, "writer-hub")
+
+	cm.Insert(&evt)
+
+	if _, found := cm.conflationUnits["victim-hub"]; found {
+		t.Fatal("spoofed event must not create a conflation unit for victim-hub")
+	}
+	if _, found := cm.conflationUnits["writer-hub"]; found {
+		t.Fatal("spoofed event must be dropped before conflation unit creation")
+	}
+}
+
+func TestConflationManagerInsertUsesAuthedHub(t *testing.T) {
+	cm := newTestConflationManager()
+	eventType := string(enum.ManagedClusterType)
+	cm.Register(NewConflationRegistration(
+		HubClusterHeartbeatPriority,
+		enum.CompleteStateMode,
+		eventType,
+		func(context.Context, *cloudevents.Event) error { return nil },
+	))
+
+	evt := cloudevents.NewEvent()
+	evt.SetType(eventType)
+	evt.SetSource("hub-a")
+	evt.SetExtension(eventversion.ExtVersion, "0.1")
+	identity.SetAuthedHub(&evt, "hub-a")
+
+	cm.Insert(&evt)
+
+	if _, found := cm.conflationUnits["hub-a"]; !found {
+		t.Fatal("expected conflation unit for hub-a")
+	}
+	if evt.Source() != "hub-a" {
+		t.Fatalf("event source = %q, want hub-a", evt.Source())
+	}
+}

--- a/pkg/transport/consumer/generic_consumer.go
+++ b/pkg/transport/consumer/generic_consumer.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport/config"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport/identity"
 )
 
 var transportID string
@@ -33,6 +34,8 @@ type GenericConsumer struct {
 	eventChan            chan *cloudevents.Event
 	enableDatabaseOffset bool
 	clusterID            string
+	isManager            bool
+	statusTopicPattern   string
 
 	consumerCtx    context.Context
 	consumerCancel context.CancelFunc
@@ -74,9 +77,12 @@ func (c *GenericConsumer) initClient(tranConfig *transport.TransportInternalConf
 	var clientProtocol interface{}
 
 	c.clusterID = tranConfig.KafkaCredential.ClusterID
+	c.isManager = tranConfig.IsManager
 	topics := []string{tranConfig.KafkaCredential.StatusTopic}
 	if !tranConfig.IsManager {
 		topics[0] = tranConfig.KafkaCredential.SpecTopic
+	} else {
+		c.statusTopicPattern = tranConfig.KafkaCredential.StatusTopic
 	}
 
 	switch tranConfig.TransportType {
@@ -159,14 +165,14 @@ func (c *GenericConsumer) Start(ctx context.Context) error {
 
 		chunk, isChunk := c.assembler.messageChunk(event)
 		if !isChunk {
-			c.eventChan <- &event
+			c.publishReceivedEvent(&event)
 			return ceprotocol.ResultACK
 		}
 		if payload := c.assembler.assemble(chunk); payload != nil {
 			if err := event.SetData(cloudevents.ApplicationJSON, payload); err != nil {
 				c.log.Error(err, "failed the set the assembled data to event")
 			} else {
-				c.eventChan <- &event
+				c.publishReceivedEvent(&event)
 			}
 		}
 		return ceprotocol.ResultACK
@@ -176,6 +182,13 @@ func (c *GenericConsumer) Start(ctx context.Context) error {
 	}
 	c.log.Info("receiver stopped\n")
 	return nil
+}
+
+func (c *GenericConsumer) publishReceivedEvent(event *cloudevents.Event) {
+	if c.isManager {
+		identity.EnrichManagerStatusEvent(event, c.statusTopicPattern)
+	}
+	c.eventChan <- event
 }
 
 func (c *GenericConsumer) EventChan() chan *cloudevents.Event {

--- a/pkg/transport/identity/identity.go
+++ b/pkg/transport/identity/identity.go
@@ -1,0 +1,148 @@
+/*
+Copyright Contributors to the Open Cluster Management project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package identity provides helpers to derive and validate hub identity from Kafka transport metadata.
+package identity
+
+import (
+	"strings"
+
+	kafka_confluent "github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	cetypes "github.com/cloudevents/sdk-go/v2/types"
+)
+
+const (
+	// ExtensionAuthedHub is the CloudEvent extension carrying the transport-derived hub name.
+	ExtensionAuthedHub = "authedhub"
+
+	kafkaUserSuffix = "-kafka-user"
+)
+
+// HubFromKafkaUser maps a KafkaUser / mTLS CN (e.g. "hub1-kafka-user") to a hub cluster name.
+func HubFromKafkaUser(kafkaUser string) string {
+	if !strings.HasSuffix(kafkaUser, kafkaUserSuffix) {
+		return ""
+	}
+
+	hub := strings.TrimSuffix(kafkaUser, kafkaUserSuffix)
+	if hub == "" {
+		return ""
+	}
+
+	return hub
+}
+
+// HubFromStatusTopic extracts the managed-hub name from a Kafka status topic.
+// statusTopicPattern is the configured template, e.g. "gh-status.*" or "^gh-status.*".
+// Returns ("", false) for shared topics without a per-hub suffix (e.g. BYO "gh-status").
+func HubFromStatusTopic(topic, statusTopicPattern string) (string, bool) {
+	pattern := strings.TrimPrefix(statusTopicPattern, "^")
+	if !strings.Contains(pattern, "*") {
+		return "", false
+	}
+
+	prefix := strings.ReplaceAll(pattern, "*", "")
+	if prefix == "" || !strings.HasPrefix(topic, prefix) {
+		return "", false
+	}
+
+	hub := strings.TrimPrefix(topic, prefix)
+	if hub == "" {
+		return "", false
+	}
+
+	return hub, true
+}
+
+// KafkaTopicFromEvent reads the Kafka topic name from CloudEvent Kafka extensions.
+func KafkaTopicFromEvent(evt *cloudevents.Event) (string, bool) {
+	if evt == nil {
+		return "", false
+	}
+
+	topic, err := cetypes.ToString(evt.Extensions()[kafka_confluent.KafkaTopicKey])
+	if err != nil || topic == "" {
+		return "", false
+	}
+
+	return topic, true
+}
+
+// SetAuthedHub attaches the transport-derived hub identity to the event.
+func SetAuthedHub(evt *cloudevents.Event, hub string) {
+	if evt == nil || hub == "" {
+		return
+	}
+	evt.SetExtension(ExtensionAuthedHub, hub)
+}
+
+// AuthedHub returns the transport-derived hub from the event extension.
+func AuthedHub(evt *cloudevents.Event) (string, bool) {
+	if evt == nil {
+		return "", false
+	}
+
+	hub, err := cetypes.ToString(evt.Extensions()[ExtensionAuthedHub])
+	if err != nil || hub == "" {
+		return "", false
+	}
+
+	return hub, true
+}
+
+// LeafHubForStatusEvent returns the trusted leaf-hub name for a manager status event.
+// When authedhub is present, evt.Source() must match it. When absent (e.g. chan transport
+// in tests), source is used as a fallback.
+func LeafHubForStatusEvent(evt *cloudevents.Event) (string, bool) {
+	if evt == nil {
+		return "", false
+	}
+
+	authedHub, hasAuthed := AuthedHub(evt)
+	if hasAuthed {
+		if evt.Source() != authedHub {
+			return "", false
+		}
+		return authedHub, true
+	}
+
+	if evt.Source() == "" {
+		return "", false
+	}
+
+	return evt.Source(), true
+}
+
+// EnrichManagerStatusEvent sets authedhub from the Kafka status topic when the pattern
+// contains a per-hub wildcard segment.
+func EnrichManagerStatusEvent(evt *cloudevents.Event, statusTopicPattern string) {
+	if evt == nil {
+		return
+	}
+
+	topic, ok := KafkaTopicFromEvent(evt)
+	if !ok {
+		return
+	}
+
+	hub, ok := HubFromStatusTopic(topic, statusTopicPattern)
+	if !ok {
+		return
+	}
+
+	SetAuthedHub(evt, hub)
+}

--- a/pkg/transport/identity/identity_test.go
+++ b/pkg/transport/identity/identity_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright Contributors to the Open Cluster Management project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package identity
+
+import (
+	"testing"
+
+	kafka_confluent "github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+)
+
+func TestHubFromKafkaUser(t *testing.T) {
+	if got := HubFromKafkaUser("hub1-kafka-user"); got != "hub1" {
+		t.Fatalf("HubFromKafkaUser() = %q, want hub1", got)
+	}
+	if got := HubFromKafkaUser("global-hub-kafka-user"); got != "global-hub" {
+		t.Fatalf("HubFromKafkaUser() = %q, want global-hub", got)
+	}
+	if got := HubFromKafkaUser("other-user"); got != "" {
+		t.Fatalf("HubFromKafkaUser() = %q, want empty for malformed principal", got)
+	}
+}
+
+func TestHubFromStatusTopic(t *testing.T) {
+	tests := []struct {
+		name    string
+		topic   string
+		pattern string
+		want    string
+		ok      bool
+	}{
+		{
+			name:    "per-hub topic",
+			topic:   "gh-status.hub-east",
+			pattern: "gh-status.*",
+			want:    "hub-east",
+			ok:      true,
+		},
+		{
+			name:    "regex subscription pattern",
+			topic:   "gh-status.hub-west",
+			pattern: "^gh-status.*",
+			want:    "hub-west",
+			ok:      true,
+		},
+		{
+			name:    "shared BYO topic",
+			topic:   "gh-status",
+			pattern: "gh-status",
+			want:    "",
+			ok:      false,
+		},
+		{
+			name:    "spoof attempt wrong topic prefix",
+			topic:   "gh-spec.hub-east",
+			pattern: "gh-status.*",
+			want:    "",
+			ok:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := HubFromStatusTopic(tt.topic, tt.pattern)
+			if ok != tt.ok || got != tt.want {
+				t.Fatalf("HubFromStatusTopic(%q, %q) = (%q, %v), want (%q, %v)",
+					tt.topic, tt.pattern, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}
+
+func TestLeafHubForStatusEvent(t *testing.T) {
+	t.Run("matching authed hub", func(t *testing.T) {
+		evt := cloudevents.NewEvent()
+		evt.SetSource("hub-a")
+		SetAuthedHub(&evt, "hub-a")
+
+		hub, ok := LeafHubForStatusEvent(&evt)
+		if !ok || hub != "hub-a" {
+			t.Fatalf("LeafHubForStatusEvent() = (%q, %v), want (hub-a, true)", hub, ok)
+		}
+	})
+
+	t.Run("spoofed source rejected", func(t *testing.T) {
+		evt := cloudevents.NewEvent()
+		evt.SetSource("hub-b")
+		SetAuthedHub(&evt, "hub-a")
+
+		if hub, ok := LeafHubForStatusEvent(&evt); ok || hub != "" {
+			t.Fatalf("LeafHubForStatusEvent() = (%q, %v), want rejection", hub, ok)
+		}
+	})
+
+	t.Run("nil event rejected", func(t *testing.T) {
+		if hub, ok := LeafHubForStatusEvent(nil); ok || hub != "" {
+			t.Fatalf("LeafHubForStatusEvent(nil) = (%q, %v), want rejection", hub, ok)
+		}
+	})
+
+	t.Run("fallback without authed hub", func(t *testing.T) {
+		evt := cloudevents.NewEvent()
+		evt.SetSource("hub-a")
+
+		hub, ok := LeafHubForStatusEvent(&evt)
+		if !ok || hub != "hub-a" {
+			t.Fatalf("LeafHubForStatusEvent() = (%q, %v), want (hub-a, true)", hub, ok)
+		}
+	})
+}
+
+func TestEnrichManagerStatusEvent(t *testing.T) {
+	t.Run("enriches from kafka topic", func(t *testing.T) {
+		evt := cloudevents.NewEvent()
+		evt.SetSource("hub-a")
+		evt.SetExtension(kafka_confluent.KafkaTopicKey, "gh-status.hub-a")
+
+		EnrichManagerStatusEvent(&evt, "^gh-status.*")
+
+		hub, ok := AuthedHub(&evt)
+		if !ok || hub != "hub-a" {
+			t.Fatalf("AuthedHub() = (%q, %v), want (hub-a, true)", hub, ok)
+		}
+	})
+
+	t.Run("nil event is no-op", func(t *testing.T) {
+		EnrichManagerStatusEvent(nil, "^gh-status.*")
+	})
+}

--- a/test/e2e/cluster_test.go
+++ b/test/e2e/cluster_test.go
@@ -301,6 +301,9 @@ func assertAddLabel(cluster clusterv1.ManagedCluster, labelKey, labelVal string)
 		if err != nil {
 			return err
 		}
+		if managedClusterInfo == nil {
+			return fmt.Errorf("managed cluster %s not found in global hub API", cluster.Name)
+		}
 		if val, ok := managedClusterInfo.Labels[labelKey]; ok {
 			if labelVal == val {
 				return nil
@@ -327,6 +330,9 @@ func assertRemoveLabel(cluster clusterv1.ManagedCluster, labelKey, labelVal stri
 		managedClusterInfo, err := getManagedClusterByName(httpClient, cluster.Name)
 		if err != nil {
 			return err
+		}
+		if managedClusterInfo == nil {
+			return fmt.Errorf("managed cluster %s not found in global hub API", cluster.Name)
 		}
 		if val, ok := managedClusterInfo.Labels[labelKey]; ok {
 			if val == labelVal {

--- a/test/integration/manager/status/status_identity_test.go
+++ b/test/integration/manager/status/status_identity_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright Contributors to the Open Cluster Management project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	kafka_confluent "github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gorm.io/gorm"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/bundle/generic"
+	eventversion "github.com/stolostron/multicluster-global-hub/pkg/bundle/version"
+	"github.com/stolostron/multicluster-global-hub/pkg/database"
+	"github.com/stolostron/multicluster-global-hub/pkg/database/models"
+	"github.com/stolostron/multicluster-global-hub/pkg/enum"
+)
+
+// go test ./test/integration/manager/status -ginkgo.focus "StatusEventIdentity"
+var _ = Describe("StatusEventIdentity", Ordered, func() {
+	const (
+		trustedHub = "identity-trusted-hub"
+		topicHub   = "identity-topic-only-hub"
+		victimHub  = "identity-victim-hub"
+	)
+
+	AfterEach(func() {
+		db := database.GetGorm()
+		Expect(db.Exec(
+			`DELETE FROM status.leaf_hub_heartbeats WHERE leaf_hub_name IN ($1, $2, $3)`,
+			trustedHub, topicHub, victimHub,
+		).Error).To(Succeed(), "failed to clean up identity test heartbeat rows")
+	})
+
+	It("accepts status events when CloudEvent source matches the Kafka status topic hub", func() {
+		version := eventversion.NewVersion()
+		version.Incr()
+		evt := ToKafkaStatusCloudEvent(
+			fmt.Sprintf("gh-status.%s", trustedHub),
+			trustedHub,
+			string(enum.HubClusterHeartbeatType),
+			version,
+			generic.GenericObjectBundle{},
+		)
+
+		Expect(producer.SendEvent(ctx, *evt)).To(Succeed(),
+			"trusted status event with matching topic and source should publish successfully")
+
+		Eventually(func() error {
+			var heartbeat models.LeafHubHeartbeat
+			err := database.GetGorm().Where("leaf_hub_name = ?", trustedHub).First(&heartbeat).Error
+			if err != nil {
+				return fmt.Errorf("expected heartbeat row for trusted hub %q: %w", trustedHub, err)
+			}
+			return nil
+		}, 30*time.Second, 100*time.Millisecond).Should(Succeed(),
+			"trusted status event should be persisted for the topic-derived hub name")
+	})
+
+	It("drops status events when CloudEvent source does not match the Kafka status topic hub", func() {
+		version := eventversion.NewVersion()
+		version.Incr()
+		evt := ToKafkaStatusCloudEvent(
+			fmt.Sprintf("gh-status.%s", topicHub),
+			victimHub,
+			string(enum.HubClusterHeartbeatType),
+			version,
+			generic.GenericObjectBundle{},
+		)
+
+		Expect(producer.SendEvent(ctx, *evt)).To(Succeed(),
+			"transport publish should succeed even when downstream identity validation will reject the event")
+
+		Consistently(func() error {
+			db := database.GetGorm()
+			for _, hub := range []string{topicHub, victimHub} {
+				var heartbeat models.LeafHubHeartbeat
+				err := db.Where("leaf_hub_name = ?", hub).First(&heartbeat).Error
+				if errors.Is(err, gorm.ErrRecordNotFound) {
+					continue
+				}
+				if err != nil {
+					return fmt.Errorf("query heartbeat for hub %q: %w", hub, err)
+				}
+				return fmt.Errorf("spoofed status event must not create heartbeat row for hub %q", hub)
+			}
+			return nil
+		}, 30*time.Second, 200*time.Millisecond).Should(Succeed(),
+			"spoofed status event must be dropped for both topic-derived and claimed hub names")
+	})
+})
+
+func ToKafkaStatusCloudEvent(kafkaTopic, source, eventType string, version *eventversion.Version, data interface{}) *cloudevents.Event {
+	evt := ToCloudEvent(source, eventType, version, data)
+	evt.SetExtension(kafka_confluent.KafkaTopicKey, kafkaTopic)
+	return evt
+}

--- a/test/integration/manager/status/suite_test.go
+++ b/test/integration/manager/status/suite_test.go
@@ -90,7 +90,7 @@ var _ = BeforeSuite(func() {
 			TransportType: string(transport.Chan),
 			KafkaCredential: &transport.KafkaConfig{
 				SpecTopic:   "spec",
-				StatusTopic: "event",
+				StatusTopic: "gh-status.*",
 			},
 		},
 		StatisticsConfig: &statistics.StatisticsConfig{


### PR DESCRIPTION
Fixes: [ACM-34442](https://redhat.atlassian.net/browse/ACM-34442) [ACM-38861](https://redhat.atlassian.net/browse/ACM-38861)

## Summary

Backport [ACM-34442](https://redhat.atlassian.net/browse/ACM-34442) phases 1–2 to **GH 1.4** (`release-2.13`):

- **Phase 1** ([#2564](https://github.com/stolostron/multicluster-global-hub/pull/2564)): `pkg/transport/identity` helpers; manager consumer enriches status events with topic-derived `authedhub`; conflation manager rejects spoofed `source`.
- **Phase 2** ([#2623](https://github.com/stolostron/multicluster-global-hub/pull/2623), 1.4-scoped): agent spec dispatcher rejects CloudEvents whose `source` is not `global-hub`.

### GH 1.4 adaptation notes

`release-2.13` predates Hub HA and the newer migration deploying-stage transport model on `gh-spec`. A straight cherry-pick of [#2623](https://github.com/stolostron/multicluster-global-hub/pull/2623) conflicted across removed packages (`agent/pkg/spec/hubha`, `agent/pkg/spec/migration`, etc.). Phase 2 here is the applicable subset: **global-hub-only source validation** in the spec dispatcher (1.4 migration events already publish with `source=global-hub`).

## Test plan

- [x] `go test -mod=mod ./pkg/transport/identity/...`
- [x] `go test -mod=mod ./manager/pkg/status/conflator/...`
- [x] `go test -mod=mod ./agent/pkg/spec -run TestSpecEventSourceAllowed`
- [ ] OpenShift CI on `release-2.13`

[ACM-34442]: https://redhat.atlassian.net/browse/ACM-34442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-34442]: https://redhat.atlassian.net/browse/ACM-34442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ACM-38861]: https://redhat.atlassian.net/browse/ACM-38861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ