### PR TITLE
ACM-34442 / ACM-38862: backport phase 1-2 Kafka transport identity fix to GH 1.5 (release-2.14)

### DIFF
--- a/agent/pkg/spec/dispatcher.go
+++ b/agent/pkg/spec/dispatcher.go
@@ -80,6 +80,10 @@ func (d *genericDispatcher) dispatch(ctx context.Context) {
 				// d.log.Infow("event dropped due to cluster name mismatch", "clusterName", clusterName)
 				continue
 			}
+			if !specEventSourceAllowed(evt, d.agentConfig.LeafHubName) {
+				d.log.Warnw("event dropped due to untrusted source", "type", evt.Type(), "source", evt.Source())
+				continue
+			}
 			syncer, found := d.syncers[evt.Type()]
 			if !found {
 				d.log.Debugw("dispatching to the default generic syncer", "eventType", evt.Type())

--- a/agent/pkg/spec/source_validation.go
+++ b/agent/pkg/spec/source_validation.go
@@ -1,0 +1,39 @@
+// Copyright Contributors to the Open Cluster Management project.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/spec/syncers"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+)
+
+func specEventSourceAllowed(evt *cloudevents.Event, leafHubName string) bool {
+	if evt == nil {
+		return false
+	}
+
+	source := evt.Source()
+	if source == constants.CloudEventGlobalHubClusterName {
+		return true
+	}
+
+	if evt.Type() == constants.MigrationTargetMsgKey {
+		return syncers.MigrationDeploySourceAllowed(source, leafHubName)
+	}
+
+	return false
+}

--- a/agent/pkg/spec/source_validation_test.go
+++ b/agent/pkg/spec/source_validation_test.go
@@ -1,0 +1,64 @@
+// Copyright Contributors to the Open Cluster Management project.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"testing"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/spec/syncers"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+)
+
+func TestSpecEventSourceAllowed(t *testing.T) {
+	t.Run("accepts global-hub source", func(t *testing.T) {
+		evt := cloudevents.NewEvent()
+		evt.SetSource(constants.CloudEventGlobalHubClusterName)
+		if !specEventSourceAllowed(&evt, "hub2") {
+			t.Fatal("expected global-hub source to be allowed")
+		}
+	})
+
+	t.Run("rejects spoofed generic spec source", func(t *testing.T) {
+		evt := cloudevents.NewEvent()
+		evt.SetType(constants.GenericSpecMsgKey)
+		evt.SetSource("victim-hub")
+		if specEventSourceAllowed(&evt, "hub2") {
+			t.Fatal("expected spoofed source to be rejected")
+		}
+	})
+
+	t.Run("accepts registered migration deploy source", func(t *testing.T) {
+		syncers.RegisterMigrationDeploySources("hub2", "migration-1", []string{"hub1"})
+		t.Cleanup(func() { syncers.ClearMigrationDeploySources("hub2", "migration-1") })
+
+		evt := cloudevents.NewEvent()
+		evt.SetType(constants.MigrationTargetMsgKey)
+		evt.SetSource("hub1")
+		if !specEventSourceAllowed(&evt, "hub2") {
+			t.Fatal("expected registered migration deploy source to be allowed")
+		}
+	})
+
+	t.Run("rejects unregistered migration deploy source", func(t *testing.T) {
+		evt := cloudevents.NewEvent()
+		evt.SetType(constants.MigrationTargetMsgKey)
+		evt.SetSource("spoofed-hub")
+		if specEventSourceAllowed(&evt, "hub2") {
+			t.Fatal("expected unregistered migration deploy source to be rejected")
+		}
+	})
+}

--- a/agent/pkg/spec/syncers/migration_source_validation.go
+++ b/agent/pkg/spec/syncers/migration_source_validation.go
@@ -1,0 +1,88 @@
+// Copyright Contributors to the Open Cluster Management project.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syncers
+
+import "sync"
+
+type migrationDeployRecord struct {
+	migrationID string
+	sourceHubs  map[string]struct{}
+}
+
+var (
+	migrationDeployMu       sync.RWMutex
+	migrationDeployByTarget = make(map[string]migrationDeployRecord)
+)
+
+// RegisterMigrationDeploySources records authorized source hubs for migration deploying traffic.
+func RegisterMigrationDeploySources(targetHub, migrationID string, sourceHubs []string) {
+	if targetHub == "" || migrationID == "" || len(sourceHubs) == 0 {
+		return
+	}
+
+	hubs := make(map[string]struct{}, len(sourceHubs))
+	for _, hub := range sourceHubs {
+		if hub == "" {
+			continue
+		}
+		hubs[hub] = struct{}{}
+	}
+	if len(hubs) == 0 {
+		return
+	}
+
+	migrationDeployMu.Lock()
+	defer migrationDeployMu.Unlock()
+	migrationDeployByTarget[targetHub] = migrationDeployRecord{
+		migrationID: migrationID,
+		sourceHubs:  hubs,
+	}
+}
+
+// ClearMigrationDeploySources removes in-flight migration deploy authorization for a target hub.
+func ClearMigrationDeploySources(targetHub, migrationID string) {
+	if targetHub == "" {
+		return
+	}
+
+	migrationDeployMu.Lock()
+	defer migrationDeployMu.Unlock()
+
+	record, ok := migrationDeployByTarget[targetHub]
+	if !ok {
+		return
+	}
+	if migrationID != "" && record.migrationID != migrationID {
+		return
+	}
+	delete(migrationDeployByTarget, targetHub)
+}
+
+// MigrationDeploySourceAllowed returns true when source may publish deploying bundles to targetHub.
+func MigrationDeploySourceAllowed(source, targetHub string) bool {
+	if source == "" || targetHub == "" {
+		return false
+	}
+
+	migrationDeployMu.RLock()
+	defer migrationDeployMu.RUnlock()
+
+	record, ok := migrationDeployByTarget[targetHub]
+	if !ok {
+		return false
+	}
+	_, ok = record.sourceHubs[source]
+	return ok
+}

--- a/agent/pkg/spec/syncers/migration_source_validation_test.go
+++ b/agent/pkg/spec/syncers/migration_source_validation_test.go
@@ -1,0 +1,34 @@
+// Copyright Contributors to the Open Cluster Management project.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syncers
+
+import "testing"
+
+func TestMigrationDeploySourceAllowed(t *testing.T) {
+	RegisterMigrationDeploySources("hub2", "migration-1", []string{"hub1", "hub3"})
+	t.Cleanup(func() { ClearMigrationDeploySources("hub2", "migration-1") })
+
+	if !MigrationDeploySourceAllowed("hub1", "hub2") {
+		t.Fatal("expected hub1 to be allowed for hub2")
+	}
+	if MigrationDeploySourceAllowed("spoofed", "hub2") {
+		t.Fatal("expected spoofed hub to be rejected")
+	}
+
+	ClearMigrationDeploySources("hub2", "migration-1")
+	if MigrationDeploySourceAllowed("hub1", "hub2") {
+		t.Fatal("expected deploy source to be cleared")
+	}
+}

--- a/agent/pkg/spec/syncers/migration_to_syncer.go
+++ b/agent/pkg/spec/syncers/migration_to_syncer.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	migrationv1alpha1 "github.com/stolostron/multicluster-global-hub/operator/api/migration/v1alpha1"
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/configs"
 	"github.com/stolostron/multicluster-global-hub/pkg/bundle/migration"
 	eventversion "github.com/stolostron/multicluster-global-hub/pkg/bundle/version"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
@@ -79,6 +80,11 @@ func (s *migrationTargetSyncer) Sync(ctx context.Context, evt *cloudevents.Event
 			s.currentMigrationId = managedClusterMigrationToEvent.MigrationId
 			// reset the bundle version for each new migration
 			s.bundleVersion.Reset()
+			RegisterMigrationDeploySources(
+				configs.GetLeafHubName(),
+				managedClusterMigrationToEvent.MigrationId,
+				managedClusterMigrationToEvent.SourceHubs,
+			)
 			if err := s.initializing(ctx, managedClusterMigrationToEvent); err != nil {
 				log.Errorf("failed to initialize the migration resources %v", err)
 				return err
@@ -138,6 +144,7 @@ func (s *migrationTargetSyncer) Sync(ctx context.Context, evt *cloudevents.Event
 				log.Errorf("failed to clean up the migration resources %v", err)
 				return nil
 			}
+			ClearMigrationDeploySources(configs.GetLeafHubName(), managedClusterMigrationToEvent.MigrationId)
 			log.Info("finished the cleaning up resources")
 		}
 	} else {
@@ -273,6 +280,10 @@ func (s *migrationTargetSyncer) initializing(ctx context.Context,
 func (s *migrationTargetSyncer) deploying(ctx context.Context, evt *cloudevents.Event) error {
 	// only the handle the current migration event, ignore the previous ones
 	log.Debugf("get migration event: %v", evt.Type())
+
+	if !MigrationDeploySourceAllowed(evt.Source(), configs.GetLeafHubName()) {
+		return fmt.Errorf("untrusted migration deploy source %q", evt.Source())
+	}
 
 	payload := evt.Data()
 	migrationResources := &migration.SourceClusterMigrationResources{}

--- a/agent/pkg/spec/syncers/migration_to_syncer.go
+++ b/agent/pkg/spec/syncers/migration_to_syncer.go
@@ -25,8 +25,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	migrationv1alpha1 "github.com/stolostron/multicluster-global-hub/operator/api/migration/v1alpha1"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/configs"
+	migrationv1alpha1 "github.com/stolostron/multicluster-global-hub/operator/api/migration/v1alpha1"
 	"github.com/stolostron/multicluster-global-hub/pkg/bundle/migration"
 	eventversion "github.com/stolostron/multicluster-global-hub/pkg/bundle/version"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"

--- a/agent/pkg/spec/syncers/migration_to_syncer_test.go
+++ b/agent/pkg/spec/syncers/migration_to_syncer_test.go
@@ -824,6 +824,8 @@ func TestDeploying(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 	// set agent config
 	configs.SetAgentConfig(&configs.AgentConfig{LeafHubName: "hub2"})
+	RegisterMigrationDeploySources("hub2", migrationId, []string{"hub1"})
+	t.Cleanup(func() { ClearMigrationDeploySources("hub2", migrationId) })
 	// set tranport config
 	transportConfig := &transport.TransportInternalConfig{KafkaCredential: &transport.KafkaConfig{StatusTopic: "status"}}
 	syncer := NewMigrationTargetSyncer(fakeClient, nil, transportConfig)

--- a/manager/pkg/migration/migration_controller.go
+++ b/manager/pkg/migration/migration_controller.go
@@ -325,6 +325,18 @@ func (m *ClusterMigrationController) sendEventToDestinationHub(ctx context.Conte
 		ManagedClusters: managedClusters,
 	}
 
+	if stage == migrationv1alpha1.PhaseInitializing {
+		sourceHubToClusters, err := getSourceClusters(migration)
+		if err != nil {
+			return err
+		}
+		sourceHubs := make([]string, 0, len(sourceHubToClusters))
+		for hub := range sourceHubToClusters {
+			sourceHubs = append(sourceHubs, hub)
+		}
+		managedClusterMigrationToEvent.SourceHubs = sourceHubs
+	}
+
 	// require the msa info when initializing or cleaning
 	if stage == migrationv1alpha1.PhaseInitializing || stage == migrationv1alpha1.PhaseCleaning {
 		// get the namespace from the managedserviceaccount addon

--- a/manager/pkg/status/conflator/conflation_manager.go
+++ b/manager/pkg/status/conflator/conflation_manager.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/statistics"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport/consumer"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport/identity"
 )
 
 // ConflationManager implements conflation units management.
@@ -57,13 +58,25 @@ func (cm *ConflationManager) Insert(evt *cloudevents.Event) {
 		cm.log.Infow("event type hasn't been registered", "type", evt.Type())
 		return
 	}
+	leafHubName, ok := identity.LeafHubForStatusEvent(evt)
+	if !ok {
+		cm.log.Warnw(
+			"dropping event due to untrusted source",
+			"type", evt.Type(),
+			"source", evt.Source(),
+			"authedhub", evt.Extensions()[identity.ExtensionAuthedHub],
+		)
+		return
+	}
+	evt.SetSource(leafHubName)
+
 	// metadata
 	conflationMetadata := metadata.NewThresholdMetadata(consumer.TransportID(), 3, evt)
 	if conflationMetadata == nil {
 		return
 	}
 
-	cm.getConflationUnit(evt.Source()).insert(evt, conflationMetadata)
+	cm.getConflationUnit(leafHubName).insert(evt, conflationMetadata)
 }
 
 // GetTransportMetadatas provides collections of the CU's bundle transport-metadata.

--- a/manager/pkg/status/conflator/conflation_manager_test.go
+++ b/manager/pkg/status/conflator/conflation_manager_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright Contributors to the Open Cluster Management project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conflator
+
+import (
+	"context"
+	"testing"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+
+	eventversion "github.com/stolostron/multicluster-global-hub/pkg/bundle/version"
+	"github.com/stolostron/multicluster-global-hub/pkg/enum"
+	"github.com/stolostron/multicluster-global-hub/pkg/statistics"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport/identity"
+)
+
+func newTestConflationManager() *ConflationManager {
+	return NewConflationManager(statistics.NewStatistics(&statistics.StatisticsConfig{
+		LogInterval: "1m",
+	}), nil)
+}
+
+func TestConflationManagerInsertRejectsSpoofedSource(t *testing.T) {
+	cm := newTestConflationManager()
+	eventType := string(enum.ManagedClusterType)
+	cm.Register(NewConflationRegistration(
+		HubClusterHeartbeatPriority,
+		enum.CompleteStateMode,
+		eventType,
+		func(context.Context, *cloudevents.Event) error { return nil },
+	))
+
+	evt := cloudevents.NewEvent()
+	evt.SetType(eventType)
+	evt.SetSource("victim-hub")
+	identity.SetAuthedHub(&evt, "writer-hub")
+
+	cm.Insert(&evt)
+
+	if _, found := cm.conflationUnits["victim-hub"]; found {
+		t.Fatal("spoofed event must not create a conflation unit for victim-hub")
+	}
+	if _, found := cm.conflationUnits["writer-hub"]; found {
+		t.Fatal("spoofed event must be dropped before conflation unit creation")
+	}
+}
+
+func TestConflationManagerInsertUsesAuthedHub(t *testing.T) {
+	cm := newTestConflationManager()
+	eventType := string(enum.ManagedClusterType)
+	cm.Register(NewConflationRegistration(
+		HubClusterHeartbeatPriority,
+		enum.CompleteStateMode,
+		eventType,
+		func(context.Context, *cloudevents.Event) error { return nil },
+	))
+
+	evt := cloudevents.NewEvent()
+	evt.SetType(eventType)
+	evt.SetSource("hub-a")
+	evt.SetExtension(eventversion.ExtVersion, "0.1")
+	identity.SetAuthedHub(&evt, "hub-a")
+
+	cm.Insert(&evt)
+
+	if _, found := cm.conflationUnits["hub-a"]; !found {
+		t.Fatal("expected conflation unit for hub-a")
+	}
+	if evt.Source() != "hub-a" {
+		t.Fatalf("event source = %q, want hub-a", evt.Source())
+	}
+}

--- a/pkg/bundle/migration/managedcluster_migration.go
+++ b/pkg/bundle/migration/managedcluster_migration.go
@@ -32,6 +32,8 @@ type ManagedClusterMigrationToEvent struct {
 	ManagedServiceAccountName             string   `json:"managedServiceAccountName"`
 	ManagedServiceAccountInstallNamespace string   `json:"installNamespace,omitempty"`
 	ManagedClusters                       []string `json:"managedClusters,omitempty"`
+	// SourceHubs lists authorized source hubs for deploying-stage bundles on gh-spec.
+	SourceHubs []string `json:"sourceHubs,omitempty"`
 }
 
 // The bundle sent from the managed hubs to the global hub

--- a/pkg/transport/consumer/generic_consumer.go
+++ b/pkg/transport/consumer/generic_consumer.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport/config"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport/identity"
 )
 
 var transportID string
@@ -34,6 +35,8 @@ type GenericConsumer struct {
 	eventChan            chan *cloudevents.Event
 	enableDatabaseOffset bool
 	clusterID            string
+	isManager            bool
+	statusTopicPattern   string
 
 	consumerCtx    context.Context
 	consumerCancel context.CancelFunc
@@ -80,6 +83,10 @@ func (c *GenericConsumer) initClient(tranConfig *transport.TransportInternalConf
 	var clientProtocol interface{}
 
 	c.clusterID = tranConfig.KafkaCredential.ClusterID
+	c.isManager = len(topics) > 0 && topics[0] == tranConfig.KafkaCredential.StatusTopic
+	if c.isManager {
+		c.statusTopicPattern = tranConfig.KafkaCredential.StatusTopic
+	}
 
 	switch tranConfig.TransportType {
 	case string(transport.Kafka):
@@ -165,14 +172,14 @@ func (c *GenericConsumer) Start(ctx context.Context) error {
 
 		chunk, isChunk := c.assembler.messageChunk(event)
 		if !isChunk {
-			c.eventChan <- &event
+			c.publishReceivedEvent(&event)
 			return ceprotocol.ResultACK
 		}
 		if payload := c.assembler.assemble(chunk); payload != nil {
 			if err := event.SetData(cloudevents.ApplicationJSON, payload); err != nil {
 				c.log.Errorw("failed the set the assembled data to event", "error", err)
 			} else {
-				c.eventChan <- &event
+				c.publishReceivedEvent(&event)
 			}
 		}
 		return ceprotocol.ResultACK
@@ -181,6 +188,13 @@ func (c *GenericConsumer) Start(ctx context.Context) error {
 		return fmt.Errorf("consumer receiver stopped with error: %w", err)
 	}
 	return nil
+}
+
+func (c *GenericConsumer) publishReceivedEvent(event *cloudevents.Event) {
+	if c.isManager {
+		identity.EnrichManagerStatusEvent(event, c.statusTopicPattern)
+	}
+	c.eventChan <- event
 }
 
 func (c *GenericConsumer) EventChan() chan *cloudevents.Event {
@@ -216,20 +230,6 @@ func getInitOffset(kafkaClusterIdentity string) ([]kafka.TopicPartition, error) 
 	}
 	return offsetToStart, nil
 }
-
-// func getSaramaReceiverProtocol(transportConfig *transport.TransportConfig) (interface{}, error) {
-// 	saramaConfig, err := config.GetSaramaConfig(transportConfig.KafkaConfig)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	// if set this to false, it will consume message from beginning when restart the client
-// 	saramaConfig.Consumer.Offsets.AutoCommit.Enable = true
-// 	saramaConfig.Consumer.Offsets.Initial = sarama.OffsetOldest
-// 	// set the consumer groupId = clientId
-// 	return kafka_sarama.NewConsumer([]string{transportConfig.KafkaConfig.BootstrapServer}, saramaConfig,
-// 		transportConfig.KafkaConfig.ConsumerConfig.ConsumerID,
-// 		transportConfig.KafkaConfig.ConsumerConfig.ConsumerTopic)
-// }
 
 func getConfluentReceiverProtocol(transportConfig *transport.TransportInternalConfig, topics []string) (
 	*kafka.Consumer, interface{}, error,

--- a/pkg/transport/identity/identity.go
+++ b/pkg/transport/identity/identity.go
@@ -1,0 +1,148 @@
+/*
+Copyright Contributors to the Open Cluster Management project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package identity provides helpers to derive and validate hub identity from Kafka transport metadata.
+package identity
+
+import (
+	"strings"
+
+	kafka_confluent "github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	cetypes "github.com/cloudevents/sdk-go/v2/types"
+)
+
+const (
+	// ExtensionAuthedHub is the CloudEvent extension carrying the transport-derived hub name.
+	ExtensionAuthedHub = "authedhub"
+
+	kafkaUserSuffix = "-kafka-user"
+)
+
+// HubFromKafkaUser maps a KafkaUser / mTLS CN (e.g. "hub1-kafka-user") to a hub cluster name.
+func HubFromKafkaUser(kafkaUser string) string {
+	if !strings.HasSuffix(kafkaUser, kafkaUserSuffix) {
+		return ""
+	}
+
+	hub := strings.TrimSuffix(kafkaUser, kafkaUserSuffix)
+	if hub == "" {
+		return ""
+	}
+
+	return hub
+}
+
+// HubFromStatusTopic extracts the managed-hub name from a Kafka status topic.
+// statusTopicPattern is the configured template, e.g. "gh-status.*" or "^gh-status.*".
+// Returns ("", false) for shared topics without a per-hub suffix (e.g. BYO "gh-status").
+func HubFromStatusTopic(topic, statusTopicPattern string) (string, bool) {
+	pattern := strings.TrimPrefix(statusTopicPattern, "^")
+	if !strings.Contains(pattern, "*") {
+		return "", false
+	}
+
+	prefix := strings.ReplaceAll(pattern, "*", "")
+	if prefix == "" || !strings.HasPrefix(topic, prefix) {
+		return "", false
+	}
+
+	hub := strings.TrimPrefix(topic, prefix)
+	if hub == "" {
+		return "", false
+	}
+
+	return hub, true
+}
+
+// KafkaTopicFromEvent reads the Kafka topic name from CloudEvent Kafka extensions.
+func KafkaTopicFromEvent(evt *cloudevents.Event) (string, bool) {
+	if evt == nil {
+		return "", false
+	}
+
+	topic, err := cetypes.ToString(evt.Extensions()[kafka_confluent.KafkaTopicKey])
+	if err != nil || topic == "" {
+		return "", false
+	}
+
+	return topic, true
+}
+
+// SetAuthedHub attaches the transport-derived hub identity to the event.
+func SetAuthedHub(evt *cloudevents.Event, hub string) {
+	if evt == nil || hub == "" {
+		return
+	}
+	evt.SetExtension(ExtensionAuthedHub, hub)
+}
+
+// AuthedHub returns the transport-derived hub from the event extension.
+func AuthedHub(evt *cloudevents.Event) (string, bool) {
+	if evt == nil {
+		return "", false
+	}
+
+	hub, err := cetypes.ToString(evt.Extensions()[ExtensionAuthedHub])
+	if err != nil || hub == "" {
+		return "", false
+	}
+
+	return hub, true
+}
+
+// LeafHubForStatusEvent returns the trusted leaf-hub name for a manager status event.
+// When authedhub is present, evt.Source() must match it. When absent (e.g. chan transport
+// in tests), source is used as a fallback.
+func LeafHubForStatusEvent(evt *cloudevents.Event) (string, bool) {
+	if evt == nil {
+		return "", false
+	}
+
+	authedHub, hasAuthed := AuthedHub(evt)
+	if hasAuthed {
+		if evt.Source() != authedHub {
+			return "", false
+		}
+		return authedHub, true
+	}
+
+	if evt.Source() == "" {
+		return "", false
+	}
+
+	return evt.Source(), true
+}
+
+// EnrichManagerStatusEvent sets authedhub from the Kafka status topic when the pattern
+// contains a per-hub wildcard segment.
+func EnrichManagerStatusEvent(evt *cloudevents.Event, statusTopicPattern string) {
+	if evt == nil {
+		return
+	}
+
+	topic, ok := KafkaTopicFromEvent(evt)
+	if !ok {
+		return
+	}
+
+	hub, ok := HubFromStatusTopic(topic, statusTopicPattern)
+	if !ok {
+		return
+	}
+
+	SetAuthedHub(evt, hub)
+}

--- a/pkg/transport/identity/identity_test.go
+++ b/pkg/transport/identity/identity_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright Contributors to the Open Cluster Management project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package identity
+
+import (
+	"testing"
+
+	kafka_confluent "github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+)
+
+func TestHubFromKafkaUser(t *testing.T) {
+	if got := HubFromKafkaUser("hub1-kafka-user"); got != "hub1" {
+		t.Fatalf("HubFromKafkaUser() = %q, want hub1", got)
+	}
+	if got := HubFromKafkaUser("global-hub-kafka-user"); got != "global-hub" {
+		t.Fatalf("HubFromKafkaUser() = %q, want global-hub", got)
+	}
+	if got := HubFromKafkaUser("other-user"); got != "" {
+		t.Fatalf("HubFromKafkaUser() = %q, want empty for malformed principal", got)
+	}
+}
+
+func TestHubFromStatusTopic(t *testing.T) {
+	tests := []struct {
+		name    string
+		topic   string
+		pattern string
+		want    string
+		ok      bool
+	}{
+		{
+			name:    "per-hub topic",
+			topic:   "gh-status.hub-east",
+			pattern: "gh-status.*",
+			want:    "hub-east",
+			ok:      true,
+		},
+		{
+			name:    "regex subscription pattern",
+			topic:   "gh-status.hub-west",
+			pattern: "^gh-status.*",
+			want:    "hub-west",
+			ok:      true,
+		},
+		{
+			name:    "shared BYO topic",
+			topic:   "gh-status",
+			pattern: "gh-status",
+			want:    "",
+			ok:      false,
+		},
+		{
+			name:    "spoof attempt wrong topic prefix",
+			topic:   "gh-spec.hub-east",
+			pattern: "gh-status.*",
+			want:    "",
+			ok:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := HubFromStatusTopic(tt.topic, tt.pattern)
+			if ok != tt.ok || got != tt.want {
+				t.Fatalf("HubFromStatusTopic(%q, %q) = (%q, %v), want (%q, %v)",
+					tt.topic, tt.pattern, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}
+
+func TestLeafHubForStatusEvent(t *testing.T) {
+	t.Run("matching authed hub", func(t *testing.T) {
+		evt := cloudevents.NewEvent()
+		evt.SetSource("hub-a")
+		SetAuthedHub(&evt, "hub-a")
+
+		hub, ok := LeafHubForStatusEvent(&evt)
+		if !ok || hub != "hub-a" {
+			t.Fatalf("LeafHubForStatusEvent() = (%q, %v), want (hub-a, true)", hub, ok)
+		}
+	})
+
+	t.Run("spoofed source rejected", func(t *testing.T) {
+		evt := cloudevents.NewEvent()
+		evt.SetSource("hub-b")
+		SetAuthedHub(&evt, "hub-a")
+
+		if hub, ok := LeafHubForStatusEvent(&evt); ok || hub != "" {
+			t.Fatalf("LeafHubForStatusEvent() = (%q, %v), want rejection", hub, ok)
+		}
+	})
+
+	t.Run("nil event rejected", func(t *testing.T) {
+		if hub, ok := LeafHubForStatusEvent(nil); ok || hub != "" {
+			t.Fatalf("LeafHubForStatusEvent(nil) = (%q, %v), want rejection", hub, ok)
+		}
+	})
+
+	t.Run("fallback without authed hub", func(t *testing.T) {
+		evt := cloudevents.NewEvent()
+		evt.SetSource("hub-a")
+
+		hub, ok := LeafHubForStatusEvent(&evt)
+		if !ok || hub != "hub-a" {
+			t.Fatalf("LeafHubForStatusEvent() = (%q, %v), want (hub-a, true)", hub, ok)
+		}
+	})
+}
+
+func TestEnrichManagerStatusEvent(t *testing.T) {
+	t.Run("enriches from kafka topic", func(t *testing.T) {
+		evt := cloudevents.NewEvent()
+		evt.SetSource("hub-a")
+		evt.SetExtension(kafka_confluent.KafkaTopicKey, "gh-status.hub-a")
+
+		EnrichManagerStatusEvent(&evt, "^gh-status.*")
+
+		hub, ok := AuthedHub(&evt)
+		if !ok || hub != "hub-a" {
+			t.Fatalf("AuthedHub() = (%q, %v), want (hub-a, true)", hub, ok)
+		}
+	})
+
+	t.Run("nil event is no-op", func(t *testing.T) {
+		EnrichManagerStatusEvent(nil, "^gh-status.*")
+	})
+}

--- a/test/integration/manager/status/status_identity_test.go
+++ b/test/integration/manager/status/status_identity_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright Contributors to the Open Cluster Management project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	kafka_confluent "github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gorm.io/gorm"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/bundle/generic"
+	eventversion "github.com/stolostron/multicluster-global-hub/pkg/bundle/version"
+	"github.com/stolostron/multicluster-global-hub/pkg/database"
+	"github.com/stolostron/multicluster-global-hub/pkg/database/models"
+	"github.com/stolostron/multicluster-global-hub/pkg/enum"
+)
+
+// go test ./test/integration/manager/status -ginkgo.focus "StatusEventIdentity"
+var _ = Describe("StatusEventIdentity", Ordered, func() {
+	const (
+		trustedHub = "identity-trusted-hub"
+		topicHub   = "identity-topic-only-hub"
+		victimHub  = "identity-victim-hub"
+	)
+
+	AfterEach(func() {
+		db := database.GetGorm()
+		Expect(db.Exec(
+			`DELETE FROM status.leaf_hub_heartbeats WHERE leaf_hub_name IN ($1, $2, $3)`,
+			trustedHub, topicHub, victimHub,
+		).Error).To(Succeed(), "failed to clean up identity test heartbeat rows")
+	})
+
+	It("accepts status events when CloudEvent source matches the Kafka status topic hub", func() {
+		version := eventversion.NewVersion()
+		version.Incr()
+		evt := ToKafkaStatusCloudEvent(
+			fmt.Sprintf("gh-status.%s", trustedHub),
+			trustedHub,
+			string(enum.HubClusterHeartbeatType),
+			version,
+			generic.GenericObjectBundle{},
+		)
+
+		Expect(producer.SendEvent(ctx, *evt)).To(Succeed(),
+			"trusted status event with matching topic and source should publish successfully")
+
+		Eventually(func() error {
+			var heartbeat models.LeafHubHeartbeat
+			err := database.GetGorm().Where("leaf_hub_name = ?", trustedHub).First(&heartbeat).Error
+			if err != nil {
+				return fmt.Errorf("expected heartbeat row for trusted hub %q: %w", trustedHub, err)
+			}
+			return nil
+		}, 30*time.Second, 100*time.Millisecond).Should(Succeed(),
+			"trusted status event should be persisted for the topic-derived hub name")
+	})
+
+	It("drops status events when CloudEvent source does not match the Kafka status topic hub", func() {
+		version := eventversion.NewVersion()
+		version.Incr()
+		evt := ToKafkaStatusCloudEvent(
+			fmt.Sprintf("gh-status.%s", topicHub),
+			victimHub,
+			string(enum.HubClusterHeartbeatType),
+			version,
+			generic.GenericObjectBundle{},
+		)
+
+		Expect(producer.SendEvent(ctx, *evt)).To(Succeed(),
+			"transport publish should succeed even when downstream identity validation will reject the event")
+
+		Consistently(func() error {
+			db := database.GetGorm()
+			for _, hub := range []string{topicHub, victimHub} {
+				var heartbeat models.LeafHubHeartbeat
+				err := db.Where("leaf_hub_name = ?", hub).First(&heartbeat).Error
+				if errors.Is(err, gorm.ErrRecordNotFound) {
+					continue
+				}
+				if err != nil {
+					return fmt.Errorf("query heartbeat for hub %q: %w", hub, err)
+				}
+				return fmt.Errorf("spoofed status event must not create heartbeat row for hub %q", hub)
+			}
+			return nil
+		}, 30*time.Second, 200*time.Millisecond).Should(Succeed(),
+			"spoofed status event must be dropped for both topic-derived and claimed hub names")
+	})
+})
+
+func ToKafkaStatusCloudEvent(kafkaTopic, source, eventType string, version *eventversion.Version, data interface{}) *cloudevents.Event {
+	evt := ToCloudEvent(source, eventType, version, data)
+	evt.SetExtension(kafka_confluent.KafkaTopicKey, kafkaTopic)
+	return evt
+}

--- a/test/integration/manager/status/suite_test.go
+++ b/test/integration/manager/status/suite_test.go
@@ -94,7 +94,7 @@ var _ = BeforeSuite(func() {
 			TransportType: string(transport.Chan),
 			KafkaCredential: &transport.KafkaConfig{
 				SpecTopic:   "spec",
-				StatusTopic: "event",
+				StatusTopic: "gh-status.*",
 			},
 		},
 		StatisticsConfig: &statistics.StatisticsConfig{


### PR DESCRIPTION
Fixes: [ACM-34442](https://redhat.atlassian.net/browse/ACM-34442) [ACM-38862](https://redhat.atlassian.net/browse/ACM-38862)

## Summary

Backport [ACM-34442](https://redhat.atlassian.net/browse/ACM-34442) phases 1–2 to **GH 1.5** (`release-2.14`):

- **Phase 1** ([#2564](https://github.com/stolostron/multicluster-global-hub/pull/2564)): topic-derived status identity (`pkg/transport/identity`), manager consumer enrichment, conflator spoof rejection.
- **Phase 2** ([#2623](https://github.com/stolostron/multicluster-global-hub/pull/2623), 1.5-scoped): agent spec dispatcher source validation with migration deploying exception; in-memory authorized source-hub tracking on target hubs.

### GH 1.5 adaptation notes

GH 1.5 has the newer migration model (deploying bundles published to `gh-spec` with `source=<fromHub>`) but still no Hub HA package. Phase 2 adds:

- `sourceHubs` on manager → target initializing events
- In-memory deploy-source registration on the target hub
- Dispatcher + `migration_to_syncer` reject unregistered sources

Follows the same pattern as [#2672](https://github.com/stolostron/multicluster-global-hub/pull/2672) (GH 1.4) with migration deploying support restored.

## Test plan

- [x] `go test -mod=mod ./pkg/transport/identity/... ./manager/pkg/status/conflator/... ./agent/pkg/spec/... ./agent/pkg/spec/syncers/...`
- [ ] OpenShift CI on `release-2.14`

[ACM-34442]: https://redhat.atlassian.net/browse/ACM-34442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-34442]: https://redhat.atlassian.net/browse/ACM-34442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ACM-38862]: https://redhat.atlassian.net/browse/ACM-38862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ