### PR TITLE
ACM-34442 / ACM-38863: backport Kafka transport identity fix phases 1-2 to release-2.15 (GH 1.6)

### DIFF
--- a/agent/pkg/configs/scheme.go
+++ b/agent/pkg/configs/scheme.go
@@ -26,6 +26,8 @@ import (
 	channelv1 "open-cluster-management.io/multicloud-operators-channel/pkg/apis/apps/v1"
 	placementrulev1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/placementrule/v1"
 	appv1beta1 "sigs.k8s.io/application/api/v1beta1"
+
+	migrationv1alpha1 "github.com/stolostron/multicluster-global-hub/operator/api/migration/v1alpha1"
 )
 
 func GetRuntimeScheme() *runtime.Scheme {
@@ -50,5 +52,6 @@ func GetRuntimeScheme() *runtime.Scheme {
 	utilruntime.Must(klusterletv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(addonv1.SchemeBuilder.AddToScheme(scheme))
 	utilruntime.Must(workv1.AddToScheme(scheme))
+	utilruntime.Must(migrationv1alpha1.AddToScheme(scheme))
 	return scheme
 }

--- a/agent/pkg/spec/dispatcher.go
+++ b/agent/pkg/spec/dispatcher.go
@@ -2,10 +2,12 @@ package spec
 
 import (
 	"context"
+	"time"
 
 	"go.uber.org/zap"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/configs"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
@@ -17,6 +19,7 @@ var addToMgr = false
 
 type genericDispatcher struct {
 	log         *zap.SugaredLogger
+	client      client.Client
 	consumer    transport.Consumer
 	agentConfig configs.AgentConfig
 	syncers     map[string]Syncer
@@ -29,6 +32,7 @@ func AddGenericDispatcher(mgr ctrl.Manager, consumer transport.Consumer, config 
 	}
 	dispatcher := &genericDispatcher{
 		log:         logger.DefaultZapLogger(),
+		client:      mgr.GetClient(),
 		consumer:    consumer,
 		agentConfig: config,
 		syncers:     make(map[string]Syncer),
@@ -78,6 +82,13 @@ func (d *genericDispatcher) dispatch(ctx context.Context) {
 			}
 			if clusterName != transport.Broadcast && clusterName != d.agentConfig.LeafHubName {
 				// d.log.Infow("event dropped due to cluster name mismatch", "clusterName", clusterName)
+				continue
+			}
+			validationCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			allowed := specEventSourceAllowed(validationCtx, d.client, d.agentConfig.LeafHubName, evt)
+			cancel()
+			if !allowed {
+				d.log.Warnw("event dropped due to untrusted source", "type", evt.Type(), "source", evt.Source())
 				continue
 			}
 			syncer, found := d.syncers[evt.Type()]

--- a/agent/pkg/spec/migration/migration_to_syncer.go
+++ b/agent/pkg/spec/migration/migration_to_syncer.go
@@ -108,6 +108,10 @@ func (s *MigrationTargetSyncer) Sync(ctx context.Context, evt *cloudevents.Event
 		return nil
 	}
 
+	if !MigrationSourceAllowed(ctx, s.client, evt.Source(), s.leafHubName) {
+		return fmt.Errorf("untrusted migration event source %q for target hub %q", evt.Source(), s.leafHubName)
+	}
+
 	clusterErrors := map[string]string{}
 	defer func() {
 		if s.receivedStage == "" || s.receivedMigrationId == "" {
@@ -239,6 +243,10 @@ func (s *MigrationTargetSyncer) cleaning(ctx context.Context,
 		log.Errorf("failed to cleanup migration RBAC resources: %v", err)
 		return err
 	}
+
+	if err := DeleteLocalMigrationCR(ctx, s.client, msaName); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -255,6 +263,12 @@ func (s *MigrationTargetSyncer) validating(
 		log.Infof("validated %d clusters for migration %s", len(source.ManagedClusters), source.MigrationId)
 	} else {
 		log.Infof("no clusters to validate for migration %s", source.MigrationId)
+	}
+
+	if err := EnsureLocalMigrationCR(
+		ctx, s.client, s.leafHubName, source, migrationv1alpha1.PhaseInitializing,
+	); err != nil {
+		return fmt.Errorf("failed to record local migration state: %w", err)
 	}
 
 	return nil
@@ -343,6 +357,12 @@ func (s *MigrationTargetSyncer) initializing(ctx context.Context,
 		return err
 	}
 
+	if err := EnsureLocalMigrationCR(
+		ctx, s.client, s.leafHubName, event, migrationv1alpha1.PhaseDeploying,
+	); err != nil {
+		return fmt.Errorf("failed to record local migration state: %w", err)
+	}
+
 	return nil
 }
 
@@ -404,7 +424,7 @@ func (s *MigrationTargetSyncer) syncMigrationResources(ctx context.Context,
 
 		// Process each resource in the cluster
 		for _, resource := range clusterResource.ResouceList {
-			if err := s.syncResource(ctx, &resource); err != nil {
+			if err := s.syncResource(ctx, clusterName, &resource); err != nil {
 				return fmt.Errorf("failed to sync resource %s/%s for cluster %s: %w",
 					resource.GetKind(), resource.GetName(), clusterName, err)
 			}
@@ -417,7 +437,16 @@ func (s *MigrationTargetSyncer) syncMigrationResources(ctx context.Context,
 
 // syncResource handles syncing individual resources from the migration bundle
 // Works directly with unstructured resources without type conversion
-func (s *MigrationTargetSyncer) syncResource(ctx context.Context, resource *unstructured.Unstructured) error {
+func (s *MigrationTargetSyncer) syncResource(
+	ctx context.Context,
+	clusterName string,
+	resource *unstructured.Unstructured,
+) error {
+	if !IsMigrationDeployResourceAllowed(resource, clusterName) {
+		return fmt.Errorf("migration deploying resource %s/%s is not allowed for cluster %s",
+			resource.GetKind(), resource.GetName(), clusterName)
+	}
+
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		operation, err := controllerutil.CreateOrUpdate(ctx, s.client, resource,
 			func() error {

--- a/agent/pkg/spec/migration/migration_to_syncer_test.go
+++ b/agent/pkg/spec/migration/migration_to_syncer_test.go
@@ -901,28 +901,8 @@ func TestMigrationDestinationHubSyncer(t *testing.T) {
 		initObjects                  []client.Object
 		expectedError                error
 	}{
-		{
-			name: "Deploying resources: migrate cluster from hub1 to hub2",
-			receivedMigrationEventBundle: migration.MigrationTargetBundle{
-				MigrationId:                           "020340324302432049234023040320",
-				Stage:                                 migrationv1alpha1.PhaseDeploying,
-				ManagedServiceAccountName:             "test", // the migration cr name
-				ManagedServiceAccountInstallNamespace: "test",
-			},
-			eventSource:   "source-hub",
-			expectedError: nil,
-			initObjects: []client.Object{
-				&operatorv1.ClusterManager{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "cluster-manager",
-					},
-					Spec: operatorv1.ClusterManagerSpec{
-						RegistrationImagePullSpec: "test",
-						WorkImagePullSpec:         "test",
-					},
-				},
-			},
-		},
+		// Deploying stage receives MigrationResourceBundle from the source hub, not MigrationTargetBundle.
+		// See TestDeploying for deploying coverage.
 		{
 			name: "Cleaning up resources: migrate cluster from hub1 to hub2",
 			receivedMigrationEventBundle: migration.MigrationTargetBundle{
@@ -1074,7 +1054,7 @@ func TestDeploying(t *testing.T) {
 	addonObj.SetKind("KlusterletAddonConfig")
 	addonObj.SetAPIVersion("agent.open-cluster-management.io/v1")
 
-	evt := utils.ToCloudEvent("test", "hub1", "hub2", migration.MigrationResourceBundle{
+	evt := utils.ToCloudEvent(constants.MigrationTargetMsgKey, "hub1", "hub2", migration.MigrationResourceBundle{
 		MigrationId: migrationId,
 		MigrationClusterResources: []migration.MigrationClusterResource{
 			{
@@ -1101,8 +1081,13 @@ func TestDeploying(t *testing.T) {
 	transportClient.SetProducer(&producer)
 	agentConfig := &configs.AgentConfig{
 		TransportConfig: transportConfig,
-		LeafHubName:     "hub1",
+		LeafHubName:     "hub2",
 	}
+	assert.NoError(t, EnsureLocalMigrationCR(ctx, fakeClient, "hub2", &migration.MigrationTargetBundle{
+		FromHub:                   "hub1",
+		ManagedClusters:           []string{"cluster1"},
+		ManagedServiceAccountName: "test-msa",
+	}, migrationv1alpha1.PhaseDeploying))
 	syncer := NewMigrationTargetSyncer(fakeClient, transportClient, agentConfig)
 	syncer.processingMigrationId = migrationId
 	err = syncer.Sync(ctx, &evt)

--- a/agent/pkg/spec/migration/source_validation.go
+++ b/agent/pkg/spec/migration/source_validation.go
@@ -1,0 +1,172 @@
+// Copyright (c) 2025 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package migration
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	migrationv1alpha1 "github.com/stolostron/multicluster-global-hub/operator/api/migration/v1alpha1"
+	migrationbundle "github.com/stolostron/multicluster-global-hub/pkg/bundle/migration"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+)
+
+type localMigrationRecord struct {
+	fromHub string
+	toHub   string
+	phase   string
+}
+
+var (
+	localMigrationMu sync.RWMutex
+	localMigrations  = make(map[string]localMigrationRecord)
+)
+
+var migrationDeployAllowedGVKs = map[schema.GroupVersionKind]struct{}{
+	{Group: "cluster.open-cluster-management.io", Version: "v1", Kind: "ManagedCluster"}:      {},
+	{Group: "agent.open-cluster-management.io", Version: "v1", Kind: "KlusterletAddonConfig"}: {},
+	{Group: "", Version: "v1", Kind: "Secret"}:                                                {},
+	{Group: "", Version: "v1", Kind: "ConfigMap"}:                                             {},
+	{Group: "", Version: "v1", Kind: "Namespace"}:                                             {},
+	{Group: "work.open-cluster-management.io", Version: "v1", Kind: "ManifestWork"}:           {},
+}
+
+// IsMigrationDeployingEvent reports whether evt is a source-hub migration deploying event.
+func IsMigrationDeployingEvent(evt *cloudevents.Event) bool {
+	if evt == nil || evt.Type() != constants.MigrationTargetMsgKey {
+		return false
+	}
+	source := evt.Source()
+	return source != "" && source != constants.CloudEventGlobalHubClusterName
+}
+
+// MigrationSourceAllowed returns true when source may publish migration events to targetHub.
+// Manager orchestration uses global-hub; source-hub deploying uses the registered from hub.
+func MigrationSourceAllowed(ctx context.Context, c client.Client, source, targetHub string) bool {
+	if source == constants.CloudEventGlobalHubClusterName {
+		return true
+	}
+	if source == "" || targetHub == "" {
+		return false
+	}
+	if localMigrationSourceAllowed(source, targetHub) {
+		return true
+	}
+	if c == nil {
+		return false
+	}
+
+	list := &migrationv1alpha1.ManagedClusterMigrationList{}
+	if err := c.List(ctx, list); err != nil {
+		return false
+	}
+
+	for i := range list.Items {
+		migration := &list.Items[i]
+		if migration.Spec.From != source || migration.Spec.To != targetHub {
+			continue
+		}
+		switch migration.Status.Phase {
+		case migrationv1alpha1.PhaseInitializing, migrationv1alpha1.PhaseDeploying:
+			return true
+		}
+	}
+
+	return false
+}
+
+func localMigrationSourceAllowed(source, targetHub string) bool {
+	localMigrationMu.RLock()
+	defer localMigrationMu.RUnlock()
+
+	for _, migration := range localMigrations {
+		if migration.fromHub != source || migration.toHub != targetHub {
+			continue
+		}
+		switch migration.phase {
+		case migrationv1alpha1.PhaseInitializing, migrationv1alpha1.PhaseDeploying:
+			return true
+		}
+	}
+	return false
+}
+
+// EnsureLocalMigrationCR records an in-flight migration on the target hub so deploying
+// bundles from the registered source hub pass MigrationSourceAllowed validation.
+// Managed hubs do not install the ManagedClusterMigration CRD, so state is kept in-memory.
+func EnsureLocalMigrationCR(
+	_ context.Context,
+	_ client.Client,
+	targetHub string,
+	event *migrationbundle.MigrationTargetBundle,
+	phase string,
+) error {
+	if event == nil || targetHub == "" {
+		return fmt.Errorf("invalid migration CR inputs")
+	}
+	if event.FromHub == "" || len(event.ManagedClusters) == 0 {
+		return nil
+	}
+	if event.ManagedServiceAccountName == "" {
+		return fmt.Errorf("managedServiceAccountName is required to record local migration state")
+	}
+
+	localMigrationMu.Lock()
+	defer localMigrationMu.Unlock()
+	localMigrations[event.ManagedServiceAccountName] = localMigrationRecord{
+		fromHub: event.FromHub,
+		toHub:   targetHub,
+		phase:   phase,
+	}
+	return nil
+}
+
+// DeleteLocalMigrationCR removes recorded local migration state after cleaning completes.
+func DeleteLocalMigrationCR(_ context.Context, _ client.Client, migrationName string) error {
+	if migrationName == "" {
+		return nil
+	}
+
+	localMigrationMu.Lock()
+	defer localMigrationMu.Unlock()
+	delete(localMigrations, migrationName)
+	return nil
+}
+
+// IsMigrationDeployResourceAllowed validates GVK and cluster binding for deploying-stage resources.
+func IsMigrationDeployResourceAllowed(resource *unstructured.Unstructured, clusterName string) bool {
+	if resource == nil || clusterName == "" {
+		return false
+	}
+
+	gvk := resource.GroupVersionKind()
+	if gvk.Group == "rbac.authorization.k8s.io" {
+		return false
+	}
+
+	if _, ok := migrationDeployAllowedGVKs[gvk]; !ok {
+		return false
+	}
+
+	switch gvk.Kind {
+	case "ManagedCluster":
+		return resource.GetName() == clusterName
+	case "KlusterletAddonConfig":
+		return resource.GetName() == clusterName && resource.GetNamespace() == clusterName
+	case "Namespace":
+		return resource.GetName() == clusterName
+	case "ManifestWork":
+		return resource.GetNamespace() == clusterName
+	case "Secret", "ConfigMap":
+		return resource.GetNamespace() == clusterName
+	default:
+		return false
+	}
+}

--- a/agent/pkg/spec/migration/source_validation_test.go
+++ b/agent/pkg/spec/migration/source_validation_test.go
@@ -1,0 +1,100 @@
+// Copyright Contributors to the Open Cluster Management project.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	"context"
+	"testing"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	migrationv1alpha1 "github.com/stolostron/multicluster-global-hub/operator/api/migration/v1alpha1"
+	migrationbundle "github.com/stolostron/multicluster-global-hub/pkg/bundle/migration"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+)
+
+func TestMigrationSourceAllowed(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	assert.NoError(t, migrationv1alpha1.AddToScheme(scheme))
+
+	t.Run("allows global hub", func(t *testing.T) {
+		assert.True(t, MigrationSourceAllowed(ctx, nil, constants.CloudEventGlobalHubClusterName, "hub2"))
+	})
+
+	t.Run("allows registered local migration", func(t *testing.T) {
+		t.Cleanup(func() {
+			localMigrationMu.Lock()
+			localMigrations = make(map[string]localMigrationRecord)
+			localMigrationMu.Unlock()
+		})
+		assert.NoError(t, EnsureLocalMigrationCR(ctx, nil, "hub2", &migrationbundle.MigrationTargetBundle{
+			FromHub:                   "hub1",
+			ManagedClusters:           []string{"c1"},
+			ManagedServiceAccountName: "msa",
+		}, migrationv1alpha1.PhaseDeploying))
+		assert.True(t, MigrationSourceAllowed(ctx, nil, "hub1", "hub2"))
+		assert.False(t, MigrationSourceAllowed(ctx, nil, "evil", "hub2"))
+	})
+
+	t.Run("allows migration CR on agent", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&migrationv1alpha1.ManagedClusterMigration{
+			ObjectMeta: metav1.ObjectMeta{Name: "msa"},
+			Spec: migrationv1alpha1.ManagedClusterMigrationSpec{
+				From: "hub1",
+				To:   "hub2",
+			},
+			Status: migrationv1alpha1.ManagedClusterMigrationStatus{
+				Phase: migrationv1alpha1.PhaseDeploying,
+			},
+		}).Build()
+		assert.True(t, MigrationSourceAllowed(ctx, c, "hub1", "hub2"))
+	})
+}
+
+func TestIsMigrationDeployResourceAllowed(t *testing.T) {
+	mc := &unstructured.Unstructured{}
+	mc.SetGroupVersionKind(schema.GroupVersionKind{
+		Group: "cluster.open-cluster-management.io", Version: "v1", Kind: "ManagedCluster",
+	})
+	mc.SetName("cluster1")
+
+	assert.True(t, IsMigrationDeployResourceAllowed(mc, "cluster1"))
+	assert.False(t, IsMigrationDeployResourceAllowed(mc, "cluster2"))
+
+	rbac := &unstructured.Unstructured{}
+	rbac.SetGroupVersionKind(schema.GroupVersionKind{
+		Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRole",
+	})
+	assert.False(t, IsMigrationDeployResourceAllowed(rbac, "cluster1"))
+}
+
+func TestIsMigrationDeployingEvent(t *testing.T) {
+	evt := cloudevents.NewEvent()
+	evt.SetType(constants.MigrationTargetMsgKey)
+	evt.SetSource("hub1")
+	assert.True(t, IsMigrationDeployingEvent(&evt))
+
+	globalEvt := cloudevents.NewEvent()
+	globalEvt.SetType(constants.MigrationTargetMsgKey)
+	globalEvt.SetSource(constants.CloudEventGlobalHubClusterName)
+	assert.False(t, IsMigrationDeployingEvent(&globalEvt))
+}

--- a/agent/pkg/spec/source_validation.go
+++ b/agent/pkg/spec/source_validation.go
@@ -1,0 +1,47 @@
+// Copyright Contributors to the Open Cluster Management project.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"context"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/spec/migration"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+)
+
+func specEventSourceAllowed(
+	ctx context.Context,
+	c client.Client,
+	leafHubName string,
+	evt *cloudevents.Event,
+) bool {
+	if evt == nil {
+		return false
+	}
+
+	source := evt.Source()
+	if source == constants.CloudEventGlobalHubClusterName {
+		return true
+	}
+
+	if migration.IsMigrationDeployingEvent(evt) {
+		return migration.MigrationSourceAllowed(ctx, c, source, leafHubName)
+	}
+
+	return false
+}

--- a/agent/pkg/spec/source_validation_test.go
+++ b/agent/pkg/spec/source_validation_test.go
@@ -1,0 +1,62 @@
+// Copyright Contributors to the Open Cluster Management project.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"context"
+	"testing"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/spec/migration"
+	migrationv1alpha1 "github.com/stolostron/multicluster-global-hub/operator/api/migration/v1alpha1"
+	migrationbundle "github.com/stolostron/multicluster-global-hub/pkg/bundle/migration"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+)
+
+func TestSpecEventSourceAllowed(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("allows global hub events", func(t *testing.T) {
+		evt := cloudevents.NewEvent()
+		evt.SetSource(constants.CloudEventGlobalHubClusterName)
+		evt.SetType(constants.GenericSpecMsgKey)
+		assert.True(t, specEventSourceAllowed(ctx, nil, "hub2", &evt))
+	})
+
+	t.Run("rejects unknown source", func(t *testing.T) {
+		evt := cloudevents.NewEvent()
+		evt.SetSource("evil")
+		evt.SetType(constants.GenericSpecMsgKey)
+		assert.False(t, specEventSourceAllowed(ctx, nil, "hub2", &evt))
+	})
+
+	t.Run("allows registered migration deploying", func(t *testing.T) {
+		t.Cleanup(func() {
+			_ = migration.DeleteLocalMigrationCR(ctx, nil, "msa")
+		})
+		assert.NoError(t, migration.EnsureLocalMigrationCR(ctx, nil, "hub2", &migrationbundle.MigrationTargetBundle{
+			FromHub:                   "hub1",
+			ManagedClusters:           []string{"c1"},
+			ManagedServiceAccountName: "msa",
+		}, migrationv1alpha1.PhaseDeploying))
+
+		evt := cloudevents.NewEvent()
+		evt.SetSource("hub1")
+		evt.SetType(constants.MigrationTargetMsgKey)
+		assert.True(t, specEventSourceAllowed(ctx, nil, "hub2", &evt))
+	})
+}

--- a/manager/pkg/migration/migration_controller.go
+++ b/manager/pkg/migration/migration_controller.go
@@ -250,6 +250,7 @@ func (m *ClusterMigrationController) sendEventToTargetHub(ctx context.Context,
 	managedClusterMigrationToEvent := &migrationbundle.MigrationTargetBundle{
 		MigrationId:               string(migration.GetUID()),
 		Stage:                     stage,
+		FromHub:                   migration.Spec.From,
 		ManagedClusters:           managedClusters,
 		RollbackStage:             rollbackStage,
 		ManagedServiceAccountName: migration.Name,

--- a/manager/pkg/migration/migration_initializing.go
+++ b/manager/pkg/migration/migration_initializing.go
@@ -89,7 +89,8 @@ func (m *ClusterMigrationController) initializing(ctx context.Context,
 	// Important: Registration must occur only after autoApprove is successfully set.
 	// Thinking - Ensure that autoApprove is properly configured before proceeding.
 	if !GetStarted(string(mcm.GetUID()), mcm.Spec.To, migrationv1alpha1.PhaseInitializing) {
-		if err := m.sendEventToTargetHub(ctx, mcm, migrationv1alpha1.PhaseInitializing, nil, ""); err != nil {
+		if err := m.sendEventToTargetHub(ctx, mcm, migrationv1alpha1.PhaseInitializing,
+			GetClusterList(string(mcm.GetUID())), ""); err != nil {
 			condition.Message = err.Error()
 			condition.Reason = ConditionReasonError
 			return false, err

--- a/manager/pkg/status/conflator/conflation_manager.go
+++ b/manager/pkg/status/conflator/conflation_manager.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/statistics"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport/config"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport/identity"
 )
 
 // ConflationManager implements conflation units management.
@@ -61,13 +62,25 @@ func (cm *ConflationManager) Insert(evt *cloudevents.Event) {
 		fmt.Print(evt)
 		return
 	}
+	leafHubName, ok := identity.LeafHubForStatusEvent(evt)
+	if !ok {
+		cm.log.Warnw(
+			"dropping event due to untrusted source",
+			"type", enum.ShortenEventType(evt.Type()),
+			"source", evt.Source(),
+			"authedhub", evt.Extensions()[identity.ExtensionAuthedHub],
+		)
+		return
+	}
+	evt.SetSource(leafHubName)
+
 	// metadata
 	conflationMetadata := metadata.NewThresholdMetadata(config.GetKafkaOwnerIdentity(), 3, evt)
 	if conflationMetadata == nil {
 		return
 	}
 
-	cm.getConflationUnit(evt.Source()).insert(evt, conflationMetadata)
+	cm.getConflationUnit(leafHubName).insert(evt, conflationMetadata)
 }
 
 // GetTransportMetadatas provides collections of the CU's bundle transport-metadata.

--- a/manager/pkg/status/conflator/conflation_manager_test.go
+++ b/manager/pkg/status/conflator/conflation_manager_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright Contributors to the Open Cluster Management project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conflator
+
+import (
+	"context"
+	"testing"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+
+	eventversion "github.com/stolostron/multicluster-global-hub/pkg/bundle/version"
+	"github.com/stolostron/multicluster-global-hub/pkg/enum"
+	"github.com/stolostron/multicluster-global-hub/pkg/statistics"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport/identity"
+)
+
+func newTestConflationManager() *ConflationManager {
+	return NewConflationManager(statistics.NewStatistics(&statistics.StatisticsConfig{
+		LogInterval: "1m",
+	}), nil)
+}
+
+func TestConflationManagerInsertRejectsSpoofedSource(t *testing.T) {
+	cm := newTestConflationManager()
+	eventType := string(enum.ManagedClusterType)
+	cm.Register(NewConflationRegistration(
+		HubClusterHeartbeatPriority,
+		enum.CompleteStateMode,
+		eventType,
+		func(context.Context, *cloudevents.Event) error { return nil },
+	))
+
+	evt := cloudevents.NewEvent()
+	evt.SetType(eventType)
+	evt.SetSource("victim-hub")
+	identity.SetAuthedHub(&evt, "writer-hub")
+
+	cm.Insert(&evt)
+
+	if _, found := cm.conflationUnits["victim-hub"]; found {
+		t.Fatal("spoofed event must not create a conflation unit for victim-hub")
+	}
+	if _, found := cm.conflationUnits["writer-hub"]; found {
+		t.Fatal("spoofed event must be dropped before conflation unit creation")
+	}
+}
+
+func TestConflationManagerInsertUsesAuthedHub(t *testing.T) {
+	cm := newTestConflationManager()
+	eventType := string(enum.ManagedClusterType)
+	cm.Register(NewConflationRegistration(
+		HubClusterHeartbeatPriority,
+		enum.CompleteStateMode,
+		eventType,
+		func(context.Context, *cloudevents.Event) error { return nil },
+	))
+
+	evt := cloudevents.NewEvent()
+	evt.SetType(eventType)
+	evt.SetSource("hub-a")
+	evt.SetExtension(eventversion.ExtVersion, "0.1")
+	identity.SetAuthedHub(&evt, "hub-a")
+
+	cm.Insert(&evt)
+
+	if _, found := cm.conflationUnits["hub-a"]; !found {
+		t.Fatal("expected conflation unit for hub-a")
+	}
+	if evt.Source() != "hub-a" {
+		t.Fatalf("event source = %q, want hub-a", evt.Source())
+	}
+}

--- a/operator/pkg/controllers/manager/manager_reconciler.go
+++ b/operator/pkg/controllers/manager/manager_reconciler.go
@@ -358,7 +358,7 @@ func (r *ManagerReconciler) pruneResources(ctx context.Context, namespace string
 	}
 	if len(mcms.Items) > 0 {
 		for _, mcm := range mcms.Items {
-			if err := r.GetClient().Delete(ctx, &mcm, &client.DeleteOptions{}); err != nil {
+			if err := r.GetClient().Delete(ctx, &mcm, &client.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
 				return err
 			}
 		}

--- a/pkg/bundle/migration/managedcluster_migration.go
+++ b/pkg/bundle/migration/managedcluster_migration.go
@@ -31,6 +31,7 @@ type MigrationSourceBundle struct {
 type MigrationTargetBundle struct {
 	MigrationId                           string   `json:"migrationId"`
 	Stage                                 string   `json:"stage"`
+	FromHub                               string   `json:"fromHub,omitempty"`
 	ManagedServiceAccountName             string   `json:"managedServiceAccountName"`
 	ManagedServiceAccountInstallNamespace string   `json:"installNamespace,omitempty"`
 	ManagedClusters                       []string `json:"managedClusters,omitempty"`

--- a/pkg/transport/consumer/generic_consumer.go
+++ b/pkg/transport/consumer/generic_consumer.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport/config"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport/identity"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport/utils"
 )
 
@@ -31,6 +32,8 @@ type GenericConsumer struct {
 	assembler            *messageAssembler
 	eventChan            chan *cloudevents.Event
 	enableDatabaseOffset bool
+	isManager            bool
+	statusTopicPattern   string
 
 	consumerCtx    context.Context
 	consumerCancel context.CancelFunc
@@ -89,6 +92,11 @@ func (c *GenericConsumer) KafkaConsumer() *kafka.Consumer {
 func (c *GenericConsumer) initClient(tranConfig *transport.TransportInternalConfig, topics []string) error {
 	var err error
 	var clientProtocol interface{}
+
+	c.isManager = len(topics) > 0 && topics[0] == tranConfig.KafkaCredential.StatusTopic
+	if c.isManager {
+		c.statusTopicPattern = tranConfig.KafkaCredential.StatusTopic
+	}
 
 	switch tranConfig.TransportType {
 	case string(transport.Kafka):
@@ -183,14 +191,14 @@ func (c *GenericConsumer) Start(ctx context.Context) error {
 
 		chunk, isChunk := c.assembler.messageChunk(event)
 		if !isChunk {
-			c.eventChan <- &event
+			c.publishReceivedEvent(&event)
 			return ceprotocol.ResultACK
 		}
 		if payload := c.assembler.assemble(chunk); payload != nil {
 			if err := event.SetData(cloudevents.ApplicationJSON, payload); err != nil {
 				log.Errorw("failed the set the assembled data to event", "error", err)
 			} else {
-				c.eventChan <- &event
+				c.publishReceivedEvent(&event)
 			}
 		}
 		return ceprotocol.ResultACK
@@ -200,6 +208,13 @@ func (c *GenericConsumer) Start(ctx context.Context) error {
 	}
 	receivedMessage = false
 	return nil
+}
+
+func (c *GenericConsumer) publishReceivedEvent(event *cloudevents.Event) {
+	if c.isManager {
+		identity.EnrichManagerStatusEvent(event, c.statusTopicPattern)
+	}
+	c.eventChan <- event
 }
 
 func (c *GenericConsumer) EventChan() chan *cloudevents.Event {

--- a/pkg/transport/identity/identity.go
+++ b/pkg/transport/identity/identity.go
@@ -1,0 +1,148 @@
+/*
+Copyright Contributors to the Open Cluster Management project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package identity provides helpers to derive and validate hub identity from Kafka transport metadata.
+package identity
+
+import (
+	"strings"
+
+	kafka_confluent "github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	cetypes "github.com/cloudevents/sdk-go/v2/types"
+)
+
+const (
+	// ExtensionAuthedHub is the CloudEvent extension carrying the transport-derived hub name.
+	ExtensionAuthedHub = "authedhub"
+
+	kafkaUserSuffix = "-kafka-user"
+)
+
+// HubFromKafkaUser maps a KafkaUser / mTLS CN (e.g. "hub1-kafka-user") to a hub cluster name.
+func HubFromKafkaUser(kafkaUser string) string {
+	if !strings.HasSuffix(kafkaUser, kafkaUserSuffix) {
+		return ""
+	}
+
+	hub := strings.TrimSuffix(kafkaUser, kafkaUserSuffix)
+	if hub == "" {
+		return ""
+	}
+
+	return hub
+}
+
+// HubFromStatusTopic extracts the managed-hub name from a Kafka status topic.
+// statusTopicPattern is the configured template, e.g. "gh-status.*" or "^gh-status.*".
+// Returns ("", false) for shared topics without a per-hub suffix (e.g. BYO "gh-status").
+func HubFromStatusTopic(topic, statusTopicPattern string) (string, bool) {
+	pattern := strings.TrimPrefix(statusTopicPattern, "^")
+	if !strings.Contains(pattern, "*") {
+		return "", false
+	}
+
+	prefix := strings.ReplaceAll(pattern, "*", "")
+	if prefix == "" || !strings.HasPrefix(topic, prefix) {
+		return "", false
+	}
+
+	hub := strings.TrimPrefix(topic, prefix)
+	if hub == "" {
+		return "", false
+	}
+
+	return hub, true
+}
+
+// KafkaTopicFromEvent reads the Kafka topic name from CloudEvent Kafka extensions.
+func KafkaTopicFromEvent(evt *cloudevents.Event) (string, bool) {
+	if evt == nil {
+		return "", false
+	}
+
+	topic, err := cetypes.ToString(evt.Extensions()[kafka_confluent.KafkaTopicKey])
+	if err != nil || topic == "" {
+		return "", false
+	}
+
+	return topic, true
+}
+
+// SetAuthedHub attaches the transport-derived hub identity to the event.
+func SetAuthedHub(evt *cloudevents.Event, hub string) {
+	if evt == nil || hub == "" {
+		return
+	}
+	evt.SetExtension(ExtensionAuthedHub, hub)
+}
+
+// AuthedHub returns the transport-derived hub from the event extension.
+func AuthedHub(evt *cloudevents.Event) (string, bool) {
+	if evt == nil {
+		return "", false
+	}
+
+	hub, err := cetypes.ToString(evt.Extensions()[ExtensionAuthedHub])
+	if err != nil || hub == "" {
+		return "", false
+	}
+
+	return hub, true
+}
+
+// LeafHubForStatusEvent returns the trusted leaf-hub name for a manager status event.
+// When authedhub is present, evt.Source() must match it. When absent (e.g. chan transport
+// in tests), source is used as a fallback.
+func LeafHubForStatusEvent(evt *cloudevents.Event) (string, bool) {
+	if evt == nil {
+		return "", false
+	}
+
+	authedHub, hasAuthed := AuthedHub(evt)
+	if hasAuthed {
+		if evt.Source() != authedHub {
+			return "", false
+		}
+		return authedHub, true
+	}
+
+	if evt.Source() == "" {
+		return "", false
+	}
+
+	return evt.Source(), true
+}
+
+// EnrichManagerStatusEvent sets authedhub from the Kafka status topic when the pattern
+// contains a per-hub wildcard segment.
+func EnrichManagerStatusEvent(evt *cloudevents.Event, statusTopicPattern string) {
+	if evt == nil {
+		return
+	}
+
+	topic, ok := KafkaTopicFromEvent(evt)
+	if !ok {
+		return
+	}
+
+	hub, ok := HubFromStatusTopic(topic, statusTopicPattern)
+	if !ok {
+		return
+	}
+
+	SetAuthedHub(evt, hub)
+}

--- a/pkg/transport/identity/identity_test.go
+++ b/pkg/transport/identity/identity_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright Contributors to the Open Cluster Management project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package identity
+
+import (
+	"testing"
+
+	kafka_confluent "github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+)
+
+func TestHubFromKafkaUser(t *testing.T) {
+	if got := HubFromKafkaUser("hub1-kafka-user"); got != "hub1" {
+		t.Fatalf("HubFromKafkaUser() = %q, want hub1", got)
+	}
+	if got := HubFromKafkaUser("global-hub-kafka-user"); got != "global-hub" {
+		t.Fatalf("HubFromKafkaUser() = %q, want global-hub", got)
+	}
+	if got := HubFromKafkaUser("other-user"); got != "" {
+		t.Fatalf("HubFromKafkaUser() = %q, want empty for malformed principal", got)
+	}
+}
+
+func TestHubFromStatusTopic(t *testing.T) {
+	tests := []struct {
+		name    string
+		topic   string
+		pattern string
+		want    string
+		ok      bool
+	}{
+		{
+			name:    "per-hub topic",
+			topic:   "gh-status.hub-east",
+			pattern: "gh-status.*",
+			want:    "hub-east",
+			ok:      true,
+		},
+		{
+			name:    "regex subscription pattern",
+			topic:   "gh-status.hub-west",
+			pattern: "^gh-status.*",
+			want:    "hub-west",
+			ok:      true,
+		},
+		{
+			name:    "shared BYO topic",
+			topic:   "gh-status",
+			pattern: "gh-status",
+			want:    "",
+			ok:      false,
+		},
+		{
+			name:    "spoof attempt wrong topic prefix",
+			topic:   "gh-spec.hub-east",
+			pattern: "gh-status.*",
+			want:    "",
+			ok:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := HubFromStatusTopic(tt.topic, tt.pattern)
+			if ok != tt.ok || got != tt.want {
+				t.Fatalf("HubFromStatusTopic(%q, %q) = (%q, %v), want (%q, %v)",
+					tt.topic, tt.pattern, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}
+
+func TestLeafHubForStatusEvent(t *testing.T) {
+	t.Run("matching authed hub", func(t *testing.T) {
+		evt := cloudevents.NewEvent()
+		evt.SetSource("hub-a")
+		SetAuthedHub(&evt, "hub-a")
+
+		hub, ok := LeafHubForStatusEvent(&evt)
+		if !ok || hub != "hub-a" {
+			t.Fatalf("LeafHubForStatusEvent() = (%q, %v), want (hub-a, true)", hub, ok)
+		}
+	})
+
+	t.Run("spoofed source rejected", func(t *testing.T) {
+		evt := cloudevents.NewEvent()
+		evt.SetSource("hub-b")
+		SetAuthedHub(&evt, "hub-a")
+
+		if hub, ok := LeafHubForStatusEvent(&evt); ok || hub != "" {
+			t.Fatalf("LeafHubForStatusEvent() = (%q, %v), want rejection", hub, ok)
+		}
+	})
+
+	t.Run("nil event rejected", func(t *testing.T) {
+		if hub, ok := LeafHubForStatusEvent(nil); ok || hub != "" {
+			t.Fatalf("LeafHubForStatusEvent(nil) = (%q, %v), want rejection", hub, ok)
+		}
+	})
+
+	t.Run("fallback without authed hub", func(t *testing.T) {
+		evt := cloudevents.NewEvent()
+		evt.SetSource("hub-a")
+
+		hub, ok := LeafHubForStatusEvent(&evt)
+		if !ok || hub != "hub-a" {
+			t.Fatalf("LeafHubForStatusEvent() = (%q, %v), want (hub-a, true)", hub, ok)
+		}
+	})
+}
+
+func TestEnrichManagerStatusEvent(t *testing.T) {
+	t.Run("enriches from kafka topic", func(t *testing.T) {
+		evt := cloudevents.NewEvent()
+		evt.SetSource("hub-a")
+		evt.SetExtension(kafka_confluent.KafkaTopicKey, "gh-status.hub-a")
+
+		EnrichManagerStatusEvent(&evt, "^gh-status.*")
+
+		hub, ok := AuthedHub(&evt)
+		if !ok || hub != "hub-a" {
+			t.Fatalf("AuthedHub() = (%q, %v), want (hub-a, true)", hub, ok)
+		}
+	})
+
+	t.Run("nil event is no-op", func(t *testing.T) {
+		EnrichManagerStatusEvent(nil, "^gh-status.*")
+	})
+}

--- a/test/integration/agent/migration/migration_to_syncer_test.go
+++ b/test/integration/agent/migration/migration_to_syncer_test.go
@@ -49,7 +49,7 @@ var _ = Describe("MigrationToSyncer", Ordered, func() {
 		receivedEvents = []*cloudevents.Event{}
 		agentConfig := &configs.AgentConfig{
 			TransportConfig: transportConfig,
-			LeafHubName:     "hub1",
+			LeafHubName:     testToHub,
 			PodNamespace:    testMSANamespace, // Set PodNamespace for configmap operations
 		}
 		configs.SetAgentConfig(agentConfig)
@@ -185,6 +185,8 @@ var _ = Describe("MigrationToSyncer", Ordered, func() {
 			event.DataEncoded, _ = json.Marshal(&migration.MigrationTargetBundle{
 				MigrationId:                           testMigrationID,
 				Stage:                                 migrationv1alpha1.PhaseInitializing,
+				FromHub:                               testFromHub,
+				ManagedClusters:                       []string{testClusterName},
 				ManagedServiceAccountName:             testMSAName,
 				ManagedServiceAccountInstallNamespace: testMSANamespace,
 			})
@@ -349,6 +351,11 @@ var _ = Describe("MigrationToSyncer", Ordered, func() {
 			}
 
 			By("Processing the deployment event")
+			Expect(migrationsyncer.EnsureLocalMigrationCR(testCtx, runtimeClient, testToHub, &migration.MigrationTargetBundle{
+				FromHub:                   testFromHub,
+				ManagedClusters:           []string{testClusterName},
+				ManagedServiceAccountName: testMSAName,
+			}, migrationv1alpha1.PhaseDeploying)).To(Succeed())
 			migrationSyncer.SetMigrationID(testMigrationID)
 			err = migrationSyncer.Sync(testCtx, event)
 			Expect(err).NotTo(HaveOccurred())

--- a/test/integration/manager/status/status_identity_test.go
+++ b/test/integration/manager/status/status_identity_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright Contributors to the Open Cluster Management project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	kafka_confluent "github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gorm.io/gorm"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/bundle/generic"
+	eventversion "github.com/stolostron/multicluster-global-hub/pkg/bundle/version"
+	"github.com/stolostron/multicluster-global-hub/pkg/database"
+	"github.com/stolostron/multicluster-global-hub/pkg/database/models"
+	"github.com/stolostron/multicluster-global-hub/pkg/enum"
+)
+
+// go test ./test/integration/manager/status -ginkgo.focus "StatusEventIdentity"
+var _ = Describe("StatusEventIdentity", Ordered, func() {
+	const (
+		trustedHub = "identity-trusted-hub"
+		topicHub   = "identity-topic-only-hub"
+		victimHub  = "identity-victim-hub"
+	)
+
+	AfterEach(func() {
+		db := database.GetGorm()
+		Expect(db.Exec(
+			`DELETE FROM status.leaf_hub_heartbeats WHERE leaf_hub_name IN ($1, $2, $3)`,
+			trustedHub, topicHub, victimHub,
+		).Error).To(Succeed(), "failed to clean up identity test heartbeat rows")
+	})
+
+	It("accepts status events when CloudEvent source matches the Kafka status topic hub", func() {
+		version := eventversion.NewVersion()
+		version.Incr()
+		evt := ToKafkaStatusCloudEvent(
+			fmt.Sprintf("gh-status.%s", trustedHub),
+			trustedHub,
+			string(enum.HubClusterHeartbeatType),
+			version,
+			generic.GenericObjectBundle{},
+		)
+
+		Expect(producer.SendEvent(ctx, *evt)).To(Succeed(),
+			"trusted status event with matching topic and source should publish successfully")
+
+		Eventually(func() error {
+			var heartbeat models.LeafHubHeartbeat
+			err := database.GetGorm().Where("leaf_hub_name = ?", trustedHub).First(&heartbeat).Error
+			if err != nil {
+				return fmt.Errorf("expected heartbeat row for trusted hub %q: %w", trustedHub, err)
+			}
+			return nil
+		}, 30*time.Second, 100*time.Millisecond).Should(Succeed(),
+			"trusted status event should be persisted for the topic-derived hub name")
+	})
+
+	It("drops status events when CloudEvent source does not match the Kafka status topic hub", func() {
+		version := eventversion.NewVersion()
+		version.Incr()
+		evt := ToKafkaStatusCloudEvent(
+			fmt.Sprintf("gh-status.%s", topicHub),
+			victimHub,
+			string(enum.HubClusterHeartbeatType),
+			version,
+			generic.GenericObjectBundle{},
+		)
+
+		Expect(producer.SendEvent(ctx, *evt)).To(Succeed(),
+			"transport publish should succeed even when downstream identity validation will reject the event")
+
+		Consistently(func() error {
+			db := database.GetGorm()
+			for _, hub := range []string{topicHub, victimHub} {
+				var heartbeat models.LeafHubHeartbeat
+				err := db.Where("leaf_hub_name = ?", hub).First(&heartbeat).Error
+				if errors.Is(err, gorm.ErrRecordNotFound) {
+					continue
+				}
+				if err != nil {
+					return fmt.Errorf("query heartbeat for hub %q: %w", hub, err)
+				}
+				return fmt.Errorf("spoofed status event must not create heartbeat row for hub %q", hub)
+			}
+			return nil
+		}, 30*time.Second, 200*time.Millisecond).Should(Succeed(),
+			"spoofed status event must be dropped for both topic-derived and claimed hub names")
+	})
+})
+
+func ToKafkaStatusCloudEvent(kafkaTopic, source, eventType string, version *eventversion.Version, data interface{}) *cloudevents.Event {
+	evt := ToCloudEvent(source, eventType, version, data)
+	evt.SetExtension(kafka_confluent.KafkaTopicKey, kafkaTopic)
+	return evt
+}

--- a/test/integration/manager/status/suite_test.go
+++ b/test/integration/manager/status/suite_test.go
@@ -95,7 +95,7 @@ var _ = BeforeSuite(func() {
 			TransportType: string(transport.Chan),
 			KafkaCredential: &transport.KafkaConfig{
 				SpecTopic:   "spec",
-				StatusTopic: "event",
+				StatusTopic: "gh-status.*",
 			},
 		},
 		StatisticsConfig: &statistics.StatisticsConfig{


### PR DESCRIPTION
Fixes: [ACM-34442](https://redhat.atlassian.net/browse/ACM-34442) [ACM-38863](https://redhat.atlassian.net/browse/ACM-38863)

## Summary

Backport **[ACM-34442](https://redhat.atlassian.net/browse/ACM-34442) phases 1–2** (Kafka transport identity / agent spec source validation) from main to **release-2.15** (Global Hub 1.6).

- **Phase 1:** Manager validates status hub identity from Kafka topic routing (`788e4903` / [#2564](https://github.com/stolostron/multicluster-global-hub/pull/2564))
- **Phase 2:** Agent rejects untrusted spec event sources; migration syncer hardening with in-memory `fromHub` pairing, GVK allow-list for deploying resources, and `FromHub` in manager target-hub events (adapted from [#2623](https://github.com/stolostron/multicluster-global-hub/pull/2623))

Adapted for 2.15: keeps `clustername` extension routing (no subject/async dispatcher refactor), no Hub HA paths, migration ID/stage remain in bundle JSON (no CloudEvents extension migration metadata).

## Test plan

- [x] `go test ./agent/pkg/spec/... ./agent/pkg/spec/migration/...`
- [ ] CI format / unit / integration on release-2.15

[ACM-34442]: https://redhat.atlassian.net/browse/ACM-34442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-34442]: https://redhat.atlassian.net/browse/ACM-34442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ACM-38863]: https://redhat.atlassian.net/browse/ACM-38863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ