### PR TITLE
ACM-34442 / ACM-38860: backport Kafka transport identity fix phases 1-2 to release-2.17 (GH 1.8)

### DIFF
--- a/agent/pkg/configs/scheme.go
+++ b/agent/pkg/configs/scheme.go
@@ -23,6 +23,8 @@ import (
 	operatorv1 "open-cluster-management.io/api/operator/v1"
 	workv1 "open-cluster-management.io/api/work/v1"
 	policyv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+
+	migrationv1alpha1 "github.com/stolostron/multicluster-global-hub/operator/api/migration/v1alpha1"
 )
 
 func GetRuntimeScheme() *runtime.Scheme {
@@ -44,5 +46,6 @@ func GetRuntimeScheme() *runtime.Scheme {
 	utilruntime.Must(klusterletv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(addonv1.SchemeBuilder.AddToScheme(scheme))
 	utilruntime.Must(workv1.Install(scheme))
+	utilruntime.Must(migrationv1alpha1.AddToScheme(scheme))
 	return scheme
 }

--- a/agent/pkg/spec/dispatcher.go
+++ b/agent/pkg/spec/dispatcher.go
@@ -10,6 +10,7 @@ import (
 	"go.uber.org/zap"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/configs"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
@@ -21,6 +22,7 @@ var addToMgr = false
 
 type genericDispatcher struct {
 	log         *zap.SugaredLogger
+	client      client.Client
 	consumer    transport.Consumer
 	agentConfig *configs.AgentConfig
 	syncers     map[string]Syncer
@@ -35,6 +37,7 @@ func AddGenericDispatcher(mgr ctrl.Manager, consumer transport.Consumer, config 
 	}
 	dispatcher := &genericDispatcher{
 		log:         logger.DefaultZapLogger(),
+		client:      mgr.GetClient(),
 		consumer:    consumer,
 		agentConfig: config,
 		syncers:     make(map[string]Syncer),
@@ -99,9 +102,15 @@ func (d *genericDispatcher) dispatch(ctx context.Context) {
 				d.log.Infow("event dropped due to subject mismatch", "type", evt.Type(), "subject", subject)
 				continue
 			}
-			if expired, expiry := isEventExpired(evt); expired {
-				d.log.Infow("event dropped due to expiry",
-					"type", evt.Type(), "source", evt.Source(), "subject", subject, "expiry", expiry)
+			if expired, _ := isEventExpired(evt); expired {
+				d.log.Infow("event dropped due to expiry", "type", evt.Type())
+				continue
+			}
+			validationCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			allowed := specEventSourceAllowed(validationCtx, d.client, d.agentConfig, evt, subject)
+			cancel()
+			if !allowed {
+				d.log.Warnw("event dropped due to untrusted source", "type", evt.Type())
 				continue
 			}
 			d.mu.RLock()

--- a/agent/pkg/spec/dispatcher.go
+++ b/agent/pkg/spec/dispatcher.go
@@ -18,7 +18,10 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 )
 
-var addToMgr = false
+var (
+	addToMgr              = false
+	genericDispatcherInst *genericDispatcher
+)
 
 type genericDispatcher struct {
 	log         *zap.SugaredLogger
@@ -33,7 +36,7 @@ type genericDispatcher struct {
 func AddGenericDispatcher(mgr ctrl.Manager, consumer transport.Consumer, config *configs.AgentConfig,
 ) (Dispatcher, error) {
 	if addToMgr {
-		return nil, nil
+		return genericDispatcherInst, nil
 	}
 	dispatcher := &genericDispatcher{
 		log:         logger.DefaultZapLogger(),
@@ -47,6 +50,7 @@ func AddGenericDispatcher(mgr ctrl.Manager, consumer transport.Consumer, config 
 	}
 
 	addToMgr = true
+	genericDispatcherInst = dispatcher
 	return dispatcher, nil
 }
 

--- a/agent/pkg/spec/dispatcher_test.go
+++ b/agent/pkg/spec/dispatcher_test.go
@@ -1,13 +1,23 @@
 package spec
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/configs"
+	migrationv1alpha1 "github.com/stolostron/multicluster-global-hub/operator/api/migration/v1alpha1"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/enum"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport"
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
 func TestIsEventExpired(t *testing.T) {
@@ -52,4 +62,244 @@ func TestIsEventExpired(t *testing.T) {
 			assert.Equal(t, tt.expired, expired)
 		})
 	}
+}
+
+type mockConsumer struct {
+	eventChan chan *cloudevents.Event
+}
+
+func (m *mockConsumer) Start(context.Context) error { return nil }
+
+func (m *mockConsumer) EventChan() chan *cloudevents.Event { return m.eventChan }
+
+func (m *mockConsumer) ConfigChan() chan *transport.TransportInternalConfig {
+	return make(chan *transport.TransportInternalConfig)
+}
+
+type recordingSyncer struct {
+	called int
+}
+
+func (s *recordingSyncer) Sync(context.Context, *cloudevents.Event) error {
+	s.called++
+	return nil
+}
+
+func TestIsEventExpired_InvalidFormat(t *testing.T) {
+	evt := cloudevents.NewEvent()
+	evt.SetExtension(constants.CloudEventExtensionKeyExpireTime, "not-a-timestamp")
+	expired, expireStr := isEventExpired(&evt)
+	assert.False(t, expired)
+	assert.Empty(t, expireStr)
+}
+
+func TestDispatch_DropsMissingSubject(t *testing.T) {
+	recorder := runDispatchScenario(t, dispatchScenario{
+		events: []*cloudevents.Event{
+			func() *cloudevents.Event {
+				evt := utils.ToCloudEvent("Policy", constants.CloudEventGlobalHubClusterName, "", nil)
+				return &evt
+			}(),
+		},
+	})
+	assert.Equal(t, 0, recorder.called)
+}
+
+func TestDispatch_DropsSubjectMismatch(t *testing.T) {
+	recorder := runDispatchScenario(t, dispatchScenario{
+		events: []*cloudevents.Event{
+			func() *cloudevents.Event {
+				evt := utils.ToCloudEvent("Policy", constants.CloudEventGlobalHubClusterName, "other-hub", nil)
+				return &evt
+			}(),
+		},
+	})
+	assert.Equal(t, 0, recorder.called)
+}
+
+func TestDispatch_AllowsBroadcastSubject(t *testing.T) {
+	recorder := runDispatchScenario(t, dispatchScenario{
+		events: []*cloudevents.Event{
+			func() *cloudevents.Event {
+				evt := utils.ToCloudEvent("Policy", constants.CloudEventGlobalHubClusterName, transport.Broadcast, nil)
+				return &evt
+			}(),
+		},
+	})
+	assert.Equal(t, 1, recorder.called)
+}
+
+func TestDispatch_DropsExpiredEvent(t *testing.T) {
+	recorder := runDispatchScenario(t, dispatchScenario{
+		events: []*cloudevents.Event{
+			func() *cloudevents.Event {
+				evt := utils.ToCloudEvent("Policy", constants.CloudEventGlobalHubClusterName, "hub2", nil)
+				evt.SetExtension(constants.CloudEventExtensionKeyExpireTime,
+					time.Now().Add(-1*time.Minute).Format(time.RFC3339))
+				return &evt
+			}(),
+		},
+	})
+	assert.Equal(t, 0, recorder.called)
+}
+
+func TestDispatch_UsesTypeSpecificSyncer(t *testing.T) {
+	eventChan := make(chan *cloudevents.Event, 1)
+	genericRecorder := &recordingSyncer{}
+	typedRecorder := &recordingSyncer{}
+	agentConfig := &configs.AgentConfig{LeafHubName: "hub2"}
+
+	dispatcher := &genericDispatcher{
+		log:         logger.DefaultZapLogger(),
+		consumer:    &mockConsumer{eventChan: eventChan},
+		agentConfig: agentConfig,
+		syncers: map[string]Syncer{
+			constants.GenericSpecMsgKey: genericRecorder,
+			"Policy":                    typedRecorder,
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go dispatcher.dispatch(ctx)
+
+	evt := utils.ToCloudEvent("Policy", constants.CloudEventGlobalHubClusterName, "hub2", nil)
+	eventChan <- &evt
+
+	assert.Eventually(t, func() bool {
+		return typedRecorder.called == 1 && genericRecorder.called == 0
+	}, time.Second, 10*time.Millisecond)
+}
+
+type dispatchScenario struct {
+	events []*cloudevents.Event
+}
+
+func runDispatchScenario(t *testing.T, scenario dispatchScenario) *recordingSyncer {
+	t.Helper()
+	eventChan := make(chan *cloudevents.Event, len(scenario.events))
+	recorder := &recordingSyncer{}
+	agentConfig := &configs.AgentConfig{LeafHubName: "hub2"}
+
+	dispatcher := &genericDispatcher{
+		log:         logger.DefaultZapLogger(),
+		consumer:    &mockConsumer{eventChan: eventChan},
+		agentConfig: agentConfig,
+		syncers: map[string]Syncer{
+			constants.GenericSpecMsgKey: recorder,
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go dispatcher.dispatch(ctx)
+
+	for _, evt := range scenario.events {
+		eventChan <- evt
+	}
+
+	assert.Eventually(t, func() bool {
+		return recorder.called == countTrustedEvents(scenario.events)
+	}, time.Second, 10*time.Millisecond)
+	return recorder
+}
+
+func countTrustedEvents(events []*cloudevents.Event) int {
+	count := 0
+	for _, evt := range events {
+		if evt == nil {
+			continue
+		}
+		subject := evt.Subject()
+		if subject == "" || (subject != transport.Broadcast && subject != "hub2") {
+			continue
+		}
+		if expired, _ := isEventExpired(evt); expired {
+			continue
+		}
+		if evt.Source() != constants.CloudEventGlobalHubClusterName {
+			continue
+		}
+		count++
+	}
+	return count
+}
+
+func TestDispatch_AllowsRegisteredMigrationDeploying(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = migrationv1alpha1.AddToScheme(scheme)
+	migrationCR := &migrationv1alpha1.ManagedClusterMigration{
+		ObjectMeta: metav1.ObjectMeta{Name: "migration-1"},
+		Spec: migrationv1alpha1.ManagedClusterMigrationSpec{
+			From: "hub1",
+			To:   "hub2",
+		},
+		Status: migrationv1alpha1.ManagedClusterMigrationStatus{
+			Phase: migrationv1alpha1.PhaseDeploying,
+		},
+	}
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(migrationCR).
+		WithStatusSubresource(migrationCR).
+		Build()
+
+	eventChan := make(chan *cloudevents.Event, 2)
+	recorder := &recordingSyncer{}
+	agentConfig := &configs.AgentConfig{LeafHubName: "hub2"}
+
+	dispatcher := &genericDispatcher{
+		log:         logger.DefaultZapLogger(),
+		client:      fakeClient,
+		consumer:    &mockConsumer{eventChan: eventChan},
+		agentConfig: agentConfig,
+		syncers: map[string]Syncer{
+			string(enum.ManagedClusterMigrationType): recorder,
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go dispatcher.dispatch(ctx)
+
+	deploying := utils.ToCloudEvent(string(enum.ManagedClusterMigrationType), "hub1", "hub2", nil)
+	deploying.SetExtension(constants.CloudEventExtensionKeyMigrationStage, migrationv1alpha1.PhaseDeploying)
+	eventChan <- &deploying
+
+	spoofed := utils.ToCloudEvent(string(enum.ManagedClusterMigrationType), "spoofed-hub", "hub2", nil)
+	spoofed.SetExtension(constants.CloudEventExtensionKeyMigrationStage, migrationv1alpha1.PhaseDeploying)
+	eventChan <- &spoofed
+
+	assert.Eventually(t, func() bool {
+		return recorder.called == 1
+	}, time.Second, 10*time.Millisecond, "expected only registered migration source to reach syncer")
+}
+
+func TestDispatch_SourceValidation(t *testing.T) {
+	eventChan := make(chan *cloudevents.Event, 2)
+	recorder := &recordingSyncer{}
+	agentConfig := &configs.AgentConfig{LeafHubName: "hub2"}
+
+	dispatcher := &genericDispatcher{
+		log:         logger.DefaultZapLogger(),
+		consumer:    &mockConsumer{eventChan: eventChan},
+		agentConfig: agentConfig,
+		syncers: map[string]Syncer{
+			constants.GenericSpecMsgKey: recorder,
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go dispatcher.dispatch(ctx)
+
+	trusted := utils.ToCloudEvent("Policy", constants.CloudEventGlobalHubClusterName, "hub2", nil)
+	eventChan <- &trusted
+
+	spoofed := utils.ToCloudEvent("Policy", "spoofed-hub", "hub2", nil)
+	eventChan <- &spoofed
+
+	assert.Eventually(t, func() bool {
+		return recorder.called == 1
+	}, time.Second, 10*time.Millisecond, "expected only trusted manager event to reach syncer")
 }

--- a/agent/pkg/spec/dispatcher_test.go
+++ b/agent/pkg/spec/dispatcher_test.go
@@ -303,3 +303,19 @@ func TestDispatch_SourceValidation(t *testing.T) {
 		return recorder.called == 1
 	}, time.Second, 10*time.Millisecond, "expected only trusted manager event to reach syncer")
 }
+
+func TestAddGenericDispatcherReturnsExistingInstance(t *testing.T) {
+	t.Cleanup(func() {
+		addToMgr = false
+		genericDispatcherInst = nil
+	})
+
+	existing := &genericDispatcher{syncers: make(map[string]Syncer)}
+	addToMgr = true
+	genericDispatcherInst = existing
+
+	dispatcher, err := AddGenericDispatcher(nil, &mockConsumer{eventChan: make(chan *cloudevents.Event)},
+		&configs.AgentConfig{})
+	assert.NoError(t, err)
+	assert.Same(t, existing, dispatcher)
+}

--- a/agent/pkg/spec/hubha/hubha_config_syncer.go
+++ b/agent/pkg/spec/hubha/hubha_config_syncer.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/configs"
 	haconfigbundle "github.com/stolostron/multicluster-global-hub/pkg/bundle/haconfig"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
@@ -30,6 +31,7 @@ const (
 type HAConfigSyncer struct {
 	client      client.Client
 	leafHubName string
+	standbyHub  string
 }
 
 func NewHAConfigSyncer(client client.Client,
@@ -38,16 +40,32 @@ func NewHAConfigSyncer(client client.Client,
 	return &HAConfigSyncer{
 		client:      client,
 		leafHubName: agentConfig.LeafHubName,
+		standbyHub:  agentConfig.GetStandbyHub(),
 	}
 }
 
 func (s *HAConfigSyncer) Sync(ctx context.Context, evt *cloudevents.Event) error {
+	// Dispatcher-level haConfigSourceAllowed already filters untrusted sources; keep
+	// these checks as defense-in-depth for direct syncer invocation paths.
 	bundle := &haconfigbundle.HAConfigBundle{}
 	if err := json.Unmarshal(evt.Data(), bundle); err != nil {
 		return fmt.Errorf("failed to unmarshal HA config bundle: %w", err)
 	}
 	activeHub := evt.Subject()
 	standbyHub := evt.Source()
+	if activeHub != s.leafHubName {
+		log.Warnw("dropping HA config event for unexpected subject", "subject", activeHub, "leafHub", s.leafHubName)
+		return nil
+	}
+	if standbyHub == "" || standbyHub == activeHub {
+		log.Warnw("dropping HA config event with untrusted source", "source", standbyHub, "subject", activeHub)
+		return nil
+	}
+	if standbyHub != constants.CloudEventGlobalHubClusterName && s.standbyHub != "" && standbyHub != s.standbyHub {
+		log.Warnw("dropping HA config event from unexpected standby hub",
+			"source", standbyHub, "expectedStandby", s.standbyHub)
+		return nil
+	}
 	log.Infof("received HA config event: activeHub=%s, standbyHub=%s", activeHub, standbyHub)
 
 	if bundle.BootstrapSecret == nil {

--- a/agent/pkg/spec/hubha/hubha_config_syncer_test.go
+++ b/agent/pkg/spec/hubha/hubha_config_syncer_test.go
@@ -239,8 +239,82 @@ func TestNewHAConfigSyncer(t *testing.T) {
 		LeafHubName:     "hub1",
 		TransportConfig: &transport.TransportInternalConfig{},
 	}
+	agentConfig.SetStandbyHub("hub2")
 	syncer := NewHAConfigSyncer(nil, agentConfig)
 	assert.Equal(t, "hub1", syncer.leafHubName)
+	assert.Equal(t, "hub2", syncer.standbyHub)
+}
+
+func TestSync_RejectsUntrustedSource(t *testing.T) {
+	scheme := newHAConfigTestScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	syncer := &HAConfigSyncer{
+		client:      fakeClient,
+		leafHubName: "hub1",
+		standbyHub:  "hub2",
+	}
+	bundle := newHAConfigTestBundle()
+	ctx := context.Background()
+
+	wrongSubject := newHAConfigTestEvent(t, bundle)
+	wrongSubject.SetSubject("other-hub")
+	assert.NoError(t, syncer.Sync(ctx, wrongSubject))
+
+	selfSource := newHAConfigTestEvent(t, bundle)
+	selfSource.SetSource("hub1")
+	assert.NoError(t, syncer.Sync(ctx, selfSource))
+
+	unexpectedPeer := newHAConfigTestEvent(t, bundle)
+	unexpectedPeer.SetSource("hub3")
+	assert.NoError(t, syncer.Sync(ctx, unexpectedPeer))
+}
+
+func TestSync_AllowsManagerSource(t *testing.T) {
+	scheme := newHAConfigTestScheme()
+	mch := &mchv1.MultiClusterHub{
+		ObjectMeta: metav1.ObjectMeta{Name: "multiclusterhub"},
+		Status:     mchv1.MultiClusterHubStatus{CurrentVersion: testMCHVersion214},
+	}
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(mch).
+		WithStatusSubresource(mch).
+		Build()
+
+	syncer := &HAConfigSyncer{
+		client:      fakeClient,
+		leafHubName: "hub1",
+		standbyHub:  "hub2",
+	}
+	bundle := newHAConfigTestBundle()
+	evt := newHAConfigTestEvent(t, bundle)
+	evt.SetSource(constants.CloudEventGlobalHubClusterName)
+
+	assert.NoError(t, syncer.Sync(context.Background(), evt))
+
+	secret := &corev1.Secret{}
+	err := fakeClient.Get(context.Background(), types.NamespacedName{
+		Name:      testBootstrapSecretName,
+		Namespace: "multicluster-engine",
+	}, secret)
+	require.NoError(t, err)
+}
+
+func TestSync_InvalidBundleData(t *testing.T) {
+	scheme := newHAConfigTestScheme()
+	syncer := &HAConfigSyncer{
+		client:      fake.NewClientBuilder().WithScheme(scheme).Build(),
+		leafHubName: "hub1",
+	}
+	evt := cloudevents.NewEvent()
+	evt.SetType(constants.HAConfigMsgKey)
+	evt.SetSource("hub2")
+	evt.SetSubject("hub1")
+	_ = evt.SetData(cloudevents.ApplicationJSON, []byte("not-json"))
+
+	err := syncer.Sync(context.Background(), &evt)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to unmarshal HA config bundle")
 }
 
 func TestAnnotateSkipsAlreadyAnnotated(t *testing.T) {

--- a/agent/pkg/spec/hubha/hubha_standby_syncer.go
+++ b/agent/pkg/spec/hubha/hubha_standby_syncer.go
@@ -38,7 +38,13 @@ func (s *HubHAStandbySyncer) Sync(ctx context.Context, evt *cloudevents.Event) e
 		return nil
 	}
 
-	log.Infof("standby hub received Hub HA resources from active hub: %s", evt.Source())
+	source := evt.Source()
+	if source == "" || source == constants.CloudEventGlobalHubClusterName {
+		log.Warnw("dropping Hub HA resource event with untrusted source", "source", source, "type", evt.Type())
+		return nil
+	}
+
+	log.Infof("standby hub received Hub HA resources from active hub: %s", source)
 
 	// Unmarshal the bundle
 	bundle := generic.NewGenericBundle[*unstructured.Unstructured]()
@@ -46,7 +52,7 @@ func (s *HubHAStandbySyncer) Sync(ctx context.Context, evt *cloudevents.Event) e
 		return fmt.Errorf("failed to unmarshal Hub HA resource bundle: %w", err)
 	}
 
-	sourceHub := evt.Source()
+	sourceHub := source
 
 	// Apply created resources
 	for _, obj := range bundle.Create {

--- a/agent/pkg/spec/hubha/hubha_standby_syncer_test.go
+++ b/agent/pkg/spec/hubha/hubha_standby_syncer_test.go
@@ -63,6 +63,74 @@ func TestHubHAStandbySyncer_Sync_WrongEventType(t *testing.T) {
 	}
 }
 
+func TestHubHAStandbySyncer_Sync_RejectsInvalidBundle(t *testing.T) {
+	scheme := runtime.NewScheme()
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	syncer := NewHubHAStandbySyncer(client)
+	ctx := context.Background()
+
+	evt := cloudevents.NewEvent()
+	evt.SetType(constants.HubHAResourcesMsgKey)
+	evt.SetSource("hub1")
+	_ = evt.SetData(cloudevents.ApplicationJSON, []byte("not-json"))
+
+	if err := syncer.Sync(ctx, &evt); err == nil {
+		t.Fatal("expected invalid bundle data to return an error")
+	}
+}
+
+func TestHubHAStandbySyncer_DeleteResource_MissingKind(t *testing.T) {
+	scheme := runtime.NewScheme()
+	syncer := NewHubHAStandbySyncer(fake.NewClientBuilder().WithScheme(scheme).Build())
+
+	meta := &generic.ObjectMetadata{
+		Name:      testCMName,
+		Namespace: "default",
+	}
+	err := syncer.deleteResource(context.Background(), meta, "hub1")
+	if err == nil {
+		t.Fatal("expected missing kind to return an error")
+	}
+}
+
+func TestHubHAStandbySyncer_DeleteResource_NotFound(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	syncer := NewHubHAStandbySyncer(fake.NewClientBuilder().WithScheme(scheme).Build())
+
+	meta := &generic.ObjectMetadata{
+		Name:      "missing-cm",
+		Namespace: "default",
+		Group:     "",
+		Version:   "v1",
+		Kind:      "ConfigMap",
+	}
+	if err := syncer.deleteResource(context.Background(), meta, "hub1"); err != nil {
+		t.Fatalf("deleting missing resource should succeed, got %v", err)
+	}
+}
+
+func TestHubHAStandbySyncer_Sync_RejectsUntrustedSource(t *testing.T) {
+	scheme := runtime.NewScheme()
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	syncer := NewHubHAStandbySyncer(client)
+	ctx := context.Background()
+
+	emptySource := cloudevents.NewEvent()
+	emptySource.SetType(constants.HubHAResourcesMsgKey)
+	emptySource.SetSource("")
+	if err := syncer.Sync(ctx, &emptySource); err != nil {
+		t.Fatalf("Sync() with empty source should drop event without error, got: %v", err)
+	}
+
+	managerSource := cloudevents.NewEvent()
+	managerSource.SetType(constants.HubHAResourcesMsgKey)
+	managerSource.SetSource(constants.CloudEventGlobalHubClusterName)
+	if err := syncer.Sync(ctx, &managerSource); err != nil {
+		t.Fatalf("Sync() with global-hub source should drop event without error, got: %v", err)
+	}
+}
+
 func TestHubHAStandbySyncer_CreateResource(t *testing.T) {
 	scheme := runtime.NewScheme()
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()

--- a/agent/pkg/spec/migration/migration_to_syncer.go
+++ b/agent/pkg/spec/migration/migration_to_syncer.go
@@ -151,6 +151,9 @@ func (s *MigrationTargetSyncer) Sync(ctx context.Context, evt *cloudevents.Event
 	if receivedStage == "" {
 		return fmt.Errorf("migrationstage is required but not provided in event extensions")
 	}
+	if !MigrationSourceAllowed(ctx, s.client, evt.Source(), s.leafHubName) {
+		return fmt.Errorf("untrusted migration event source %q for target hub %q", evt.Source(), s.leafHubName)
+	}
 	if evt.Source() != constants.CloudEventGlobalHubClusterName && receivedStage != migrationv1alpha1.PhaseDeploying {
 		err = fmt.Errorf("source-hub migration event must use stage %q, got %q",
 			migrationv1alpha1.PhaseDeploying, receivedStage)
@@ -395,6 +398,10 @@ func (s *MigrationTargetSyncer) cleaning(ctx context.Context,
 		return fmt.Errorf("cleaning failed with %d error(s): %s", len(clusterErrors), formatErrorMessages(clusterErrors))
 	}
 
+	if err := DeleteLocalMigrationCR(ctx, s.client, msaName); err != nil {
+		return err
+	}
+
 	log.Infof("successfully completed cleaning stage")
 	return nil
 }
@@ -412,6 +419,12 @@ func (s *MigrationTargetSyncer) validating(
 		log.Infof("validated %d clusters for migration %s", len(source.ManagedClusters), source.MigrationId)
 	} else {
 		log.Infof("no clusters to validate for migration %s", source.MigrationId)
+	}
+
+	if err := EnsureLocalMigrationCR(
+		ctx, s.client, s.leafHubName, source, migrationv1alpha1.PhaseInitializing,
+	); err != nil {
+		return fmt.Errorf("failed to record local migration state: %w", err)
 	}
 
 	return nil
@@ -503,6 +516,10 @@ func (s *MigrationTargetSyncer) initializing(ctx context.Context,
 	if isOCM, _ := s.isOCMEnvironment(ctx); isOCM {
 		log.Infof("OCM environment detected, delaying 1 minute after initializing to allow manual resource mocking")
 		time.Sleep(1 * time.Minute)
+	}
+
+	if err := EnsureLocalMigrationCR(ctx, s.client, s.leafHubName, event, migrationv1alpha1.PhaseDeploying); err != nil {
+		return fmt.Errorf("failed to record local migration state: %w", err)
 	}
 
 	return nil
@@ -615,7 +632,7 @@ func (s *MigrationTargetSyncer) syncMigrationResources(ctx context.Context,
 				clusterName, resIdx+1, len(clusterResource.ResourceList),
 				resource.GetKind(), resource.GetName(), resource.GetNamespace())
 
-			if err := s.syncResource(ctx, &resource); err != nil {
+			if err := s.syncResource(ctx, clusterName, &resource); err != nil {
 				return fmt.Errorf("failed to sync resource %s/%s for cluster %s: %w",
 					resource.GetKind(), resource.GetName(), clusterName, err)
 			}
@@ -637,9 +654,19 @@ func (s *MigrationTargetSyncer) syncMigrationResources(ctx context.Context,
 
 // syncResource handles syncing individual resources from the migration bundle
 // Works directly with unstructured resources without type conversion
-func (s *MigrationTargetSyncer) syncResource(ctx context.Context, resource *unstructured.Unstructured) error {
+func (s *MigrationTargetSyncer) syncResource(
+	ctx context.Context,
+	clusterName string,
+	resource *unstructured.Unstructured,
+) error {
 	resourceKey := fmt.Sprintf("%s/%s/%s", resource.GetKind(), resource.GetNamespace(), resource.GetName())
 	log.Debugf("deploying: syncResource started for resource=%s", resourceKey)
+
+	if !IsMigrationDeployResourceAllowed(resource, clusterName) {
+		log.Warnf("deploying: rejecting disallowed resource kind=%s namespace=%s name=%s",
+			resource.GetKind(), resource.GetNamespace(), resource.GetName())
+		return fmt.Errorf("migration deploying resource %s is not allowed", resourceKey)
+	}
 
 	// Store the source resource data that needs to be applied
 	sourceLabels := resource.GetLabels()

--- a/agent/pkg/spec/migration/migration_to_syncer_source_validation_test.go
+++ b/agent/pkg/spec/migration/migration_to_syncer_source_validation_test.go
@@ -1,0 +1,171 @@
+// Copyright (c) 2025 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package migration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/configs"
+	migrationv1alpha1 "github.com/stolostron/multicluster-global-hub/operator/api/migration/v1alpha1"
+	migrationbundle "github.com/stolostron/multicluster-global-hub/pkg/bundle/migration"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/enum"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport/controller"
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
+)
+
+func deployingMigrationCR(from, to string) *migrationv1alpha1.ManagedClusterMigration {
+	return &migrationv1alpha1.ManagedClusterMigration{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-migration"},
+		Spec: migrationv1alpha1.ManagedClusterMigrationSpec{
+			From: from,
+			To:   to,
+		},
+		Status: migrationv1alpha1.ManagedClusterMigrationStatus{
+			Phase: migrationv1alpha1.PhaseDeploying,
+		},
+	}
+}
+
+func migrationTestScheme() *runtime.Scheme {
+	scheme := configs.GetRuntimeScheme()
+	_ = migrationv1alpha1.AddToScheme(scheme)
+	return scheme
+}
+
+func TestMigrationTargetSyncer_Sync_RejectsUntrustedSource(t *testing.T) {
+	ctx := context.Background()
+	scheme := migrationTestScheme()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&migrationv1alpha1.ManagedClusterMigration{}).
+		WithObjects(deployingMigrationCR("hub1", "hub2")).
+		Build()
+
+	transportClient := &controller.TransportClient{}
+	agentConfig := &configs.AgentConfig{
+		TransportConfig: &transport.TransportInternalConfig{
+			KafkaCredential: &transport.KafkaConfig{StatusTopic: "status"},
+		},
+		LeafHubName:  "hub2",
+		PodNamespace: "open-cluster-management",
+	}
+	configs.SetAgentConfig(agentConfig)
+	syncer := NewMigrationTargetSyncer(fakeClient, transportClient, agentConfig)
+
+	evt := utils.ToCloudEvent(string(enum.ManagedClusterMigrationType), "spoofed-hub", "hub2", nil)
+	evt.SetExtension(constants.CloudEventExtensionKeyMigrationId, "migration-1")
+	evt.SetExtension(constants.CloudEventExtensionKeyMigrationStage, migrationv1alpha1.PhaseDeploying)
+
+	err := syncer.Sync(ctx, &evt)
+	assert.Error(t, err, "untrusted migration source should fail Sync")
+	assert.Contains(t, err.Error(), "untrusted migration event source", "error should identify untrusted source")
+}
+
+func TestMigrationTargetSyncer_SyncResource_RejectsClusterRole(t *testing.T) {
+	ctx := context.Background()
+	scheme := migrationTestScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	syncer := NewMigrationTargetSyncer(fakeClient, nil, &configs.AgentConfig{LeafHubName: "hub2"})
+
+	clusterRole := &unstructured.Unstructured{}
+	clusterRole.SetGroupVersionKind(rbacv1.SchemeGroupVersion.WithKind("ClusterRole"))
+	clusterRole.SetName("admin")
+
+	err := syncer.syncResource(ctx, "cluster1", clusterRole)
+	assert.Error(t, err, "cluster role should be rejected by deploy allow-list")
+	assert.Contains(t, err.Error(), "not allowed", "error should name disallowed resource")
+}
+
+func TestMigrationTargetSyncer_Sync_RejectsSourceHubWrongStage(t *testing.T) {
+	ctx := context.Background()
+	scheme := migrationTestScheme()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&migrationv1alpha1.ManagedClusterMigration{}).
+		WithObjects(deployingMigrationCR("hub1", "hub2")).
+		Build()
+
+	syncer := NewMigrationTargetSyncer(fakeClient, nil, &configs.AgentConfig{LeafHubName: "hub2"})
+
+	evt := utils.ToCloudEvent(string(enum.ManagedClusterMigrationType), "hub1", "hub2", nil)
+	evt.SetExtension(constants.CloudEventExtensionKeyMigrationId, "migration-1")
+	evt.SetExtension(constants.CloudEventExtensionKeyMigrationStage, migrationv1alpha1.PhaseInitializing)
+
+	err := syncer.Sync(ctx, &evt)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "source-hub migration event must use stage")
+}
+
+func TestMigrationTargetSyncer_Sync_AllowsRegisteredSourceDeploying(t *testing.T) {
+	ctx := context.Background()
+	scheme := migrationTestScheme()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&migrationv1alpha1.ManagedClusterMigration{}).
+		WithObjects(deployingMigrationCR("hub1", "hub2")).
+		Build()
+
+	producer := ProducerMock{}
+	transportClient := &controller.TransportClient{}
+	transportClient.SetProducer(&producer)
+	agentConfig := &configs.AgentConfig{
+		TransportConfig: &transport.TransportInternalConfig{
+			KafkaCredential: &transport.KafkaConfig{StatusTopic: "status"},
+		},
+		LeafHubName:  "hub2",
+		PodNamespace: "open-cluster-management",
+	}
+	configs.SetAgentConfig(agentConfig)
+	syncer := NewMigrationTargetSyncer(fakeClient, transportClient, agentConfig)
+
+	payload := migrationbundle.MigrationResourceBundle{
+		TotalClusters:             1,
+		MigrationClusterResources: []migrationbundle.MigrationClusterResource{},
+	}
+	evt := utils.ToCloudEvent(string(enum.ManagedClusterMigrationType), "hub1", "hub2", payload)
+	evt.SetExtension(constants.CloudEventExtensionKeyMigrationId, "migration-1")
+	evt.SetExtension(constants.CloudEventExtensionKeyMigrationStage, migrationv1alpha1.PhaseDeploying)
+	evt.SetTime(time.Now())
+
+	err := syncer.Sync(ctx, &evt)
+	assert.NoError(t, err, "registered source hub deploying event should pass source validation")
+}
+
+func TestMigrationTargetSyncer_syncResource_AllowsConfigMap(t *testing.T) {
+	ctx := context.Background()
+	scheme := migrationTestScheme()
+	_ = corev1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	syncer := NewMigrationTargetSyncer(fakeClient, nil, &configs.AgentConfig{LeafHubName: "hub2"})
+
+	configMap := &unstructured.Unstructured{}
+	configMap.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("ConfigMap"))
+	configMap.SetNamespace("cluster1")
+	configMap.SetName("extra-manifests")
+	_ = unstructured.SetNestedField(configMap.Object, map[string]interface{}{
+		"key": "value",
+	}, "data")
+
+	assert.NoError(t, syncer.syncResource(ctx, "cluster1", configMap))
+
+	got := &corev1.ConfigMap{}
+	assert.NoError(t, fakeClient.Get(ctx, types.NamespacedName{
+		Name:      "extra-manifests",
+		Namespace: "cluster1",
+	}, got))
+	assert.Equal(t, "value", got.Data["key"])
+}

--- a/agent/pkg/spec/migration/migration_to_syncer_test.go
+++ b/agent/pkg/spec/migration/migration_to_syncer_test.go
@@ -292,7 +292,8 @@ func TestMigrationToSyncer(t *testing.T) {
 			},
 		},
 		{
-			name: "migration with cluster manager having registration configuration with other feature gates and auto approve users",
+			name: "migration with cluster manager having registration configuration " +
+				"with other feature gates and auto approve users",
 			migrationEvent: &migration.MigrationTargetBundle{
 				MigrationId:                           "020340324302432049234023040320",
 				Stage:                                 migrationv1alpha1.PhaseInitializing,
@@ -844,7 +845,11 @@ func TestMigrationToSyncer(t *testing.T) {
 									Mode:    operatorv1.FeatureGateModeTypeEnable,
 								},
 							},
-							AutoApproveUsers: []string{"system:serviceaccount:other:user", "system:serviceaccount:test:test", "system:serviceaccount:another:user"},
+							AutoApproveUsers: []string{
+								"system:serviceaccount:other:user",
+								"system:serviceaccount:test:test",
+								"system:serviceaccount:another:user",
+							},
 						},
 					},
 				},
@@ -909,7 +914,10 @@ func TestMigrationToSyncer(t *testing.T) {
 								Mode:    operatorv1.FeatureGateModeTypeEnable,
 							},
 						},
-						AutoApproveUsers: []string{"system:serviceaccount:other:user", "system:serviceaccount:another:user"}, // Only migration user should be removed
+						AutoApproveUsers: []string{
+							"system:serviceaccount:other:user",
+							"system:serviceaccount:another:user",
+						}, // Only migration user should be removed
 					},
 				},
 			},
@@ -1334,12 +1342,13 @@ func TestDeploying(t *testing.T) {
 	evt.SetExtension(constants.CloudEventExtensionKeyMigrationStage, migrationv1alpha1.PhaseDeploying)
 	evt.SetTime(time.Now()) // Set event time to avoid time-based skipping in shouldSkipMigrationEvent
 
-	scheme := configs.GetRuntimeScheme()
+	scheme := migrationTestScheme()
 	ctx := context.Background()
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(
 		&clusterv1.ManagedCluster{},
 		&addonv1.KlusterletAddonConfig{},
-	).Build()
+		&migrationv1alpha1.ManagedClusterMigration{},
+	).WithObjects(deployingMigrationCR("hub1", "hub2")).Build()
 	// set agent config
 	configs.SetAgentConfig(&configs.AgentConfig{LeafHubName: "hub2"})
 	// set tranport config
@@ -1350,7 +1359,7 @@ func TestDeploying(t *testing.T) {
 	transportClient.SetProducer(&producer)
 	agentConfig := &configs.AgentConfig{
 		TransportConfig: transportConfig,
-		LeafHubName:     "hub1",
+		LeafHubName:     "hub2",
 	}
 	syncer := NewMigrationTargetSyncer(fakeClient, transportClient, agentConfig)
 	syncer.processingMigrationId = migrationId
@@ -1516,7 +1525,7 @@ func TestRegistering(t *testing.T) {
 // TestDeployingBatchReceiving tests receiving multiple batches of resources during deploying stage
 func TestDeployingBatchReceiving(t *testing.T) {
 	migrationId := "test-migration-batch-456"
-	scheme := configs.GetRuntimeScheme()
+	scheme := migrationTestScheme()
 	ctx := context.Background()
 
 	cases := []struct {
@@ -1550,7 +1559,8 @@ func TestDeployingBatchReceiving(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(
 				&clusterv1.ManagedCluster{},
 				&addonv1.KlusterletAddonConfig{},
-			).Build()
+				&migrationv1alpha1.ManagedClusterMigration{},
+			).WithObjects(deployingMigrationCR("hub1", "hub2")).Build()
 			configs.SetAgentConfig(&configs.AgentConfig{LeafHubName: "hub2"})
 
 			transportConfig := &transport.TransportInternalConfig{
@@ -1562,7 +1572,7 @@ func TestDeployingBatchReceiving(t *testing.T) {
 			transportClient.SetProducer(&producer)
 			agentConfig := &configs.AgentConfig{
 				TransportConfig: transportConfig,
-				LeafHubName:     "hub1",
+				LeafHubName:     "hub2",
 			}
 
 			syncer := NewMigrationTargetSyncer(fakeClient, transportClient, agentConfig)
@@ -2634,7 +2644,11 @@ func TestInitializing(t *testing.T) {
 				assert.True(t, hasAutoApprove, "ManagedClusterAutoApproval feature should be enabled")
 
 				// Check that the MSA user is in auto-approve list
-				expectedUser := fmt.Sprintf("system:serviceaccount:%s:%s", c.event.ManagedServiceAccountInstallNamespace, c.event.ManagedServiceAccountName)
+				expectedUser := fmt.Sprintf(
+					"system:serviceaccount:%s:%s",
+					c.event.ManagedServiceAccountInstallNamespace,
+					c.event.ManagedServiceAccountName,
+				)
 				assert.Contains(t, cm.Spec.RegistrationConfiguration.AutoApproveUsers, expectedUser)
 			}
 		})
@@ -2644,11 +2658,13 @@ func TestInitializing(t *testing.T) {
 // TestDeployingBatchReceivingError tests error handling during batch receiving
 func TestDeployingBatchReceivingError(t *testing.T) {
 	migrationId := "test-migration-error-789"
-	scheme := configs.GetRuntimeScheme()
+	scheme := migrationTestScheme()
 	ctx := context.Background()
 
 	t.Run("Receive bundle with mismatched migration ID", func(t *testing.T) {
-		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+			WithStatusSubresource(&migrationv1alpha1.ManagedClusterMigration{}).
+			WithObjects(deployingMigrationCR("hub1", "hub2")).Build()
 		configs.SetAgentConfig(&configs.AgentConfig{LeafHubName: "hub2"})
 
 		transportConfig := &transport.TransportInternalConfig{
@@ -2660,7 +2676,7 @@ func TestDeployingBatchReceivingError(t *testing.T) {
 		transportClient.SetProducer(&producer)
 		agentConfig := &configs.AgentConfig{
 			TransportConfig: transportConfig,
-			LeafHubName:     "hub1",
+			LeafHubName:     "hub2",
 		}
 
 		syncer := NewMigrationTargetSyncer(fakeClient, transportClient, agentConfig)
@@ -2803,13 +2819,7 @@ func TestAddPauseAnnotationBeforeDeletion(t *testing.T) {
 				assert.Equal(t, "true", annotations[HivePauseAnnotation])
 
 				// Verify existing annotations are preserved
-				if origAnnotations := c.resource.GetAnnotations(); origAnnotations != nil {
-					for key, value := range origAnnotations {
-						if key != HivePauseAnnotation {
-							assert.Equal(t, value, annotations[key], "Original annotation %s should be preserved", key)
-						}
-					}
-				}
+				assertOriginalAnnotationsPreserved(t, c.resource.GetAnnotations(), annotations)
 			}
 		})
 	}
@@ -3161,7 +3171,8 @@ func parseResourceIdentifier(identifier string) resourceIdentifier {
 	}
 }
 
-// TestRemoveVeleroRestoreLabelFromImageClusterInstall tests the removeVeleroRestoreLabelFromImageClusterInstall function
+// TestRemoveVeleroRestoreLabelFromImageClusterInstall tests
+// removeVeleroRestoreLabelFromImageClusterInstall.
 func TestRemoveVeleroRestoreLabelFromImageClusterInstall(t *testing.T) {
 	scheme := configs.GetRuntimeScheme()
 	ctx := context.Background()
@@ -3489,7 +3500,11 @@ func TestInitializingWithOCMClusterRole(t *testing.T) {
 
 	// Verify ClusterRoleBinding was created with OCM ClusterRole
 	foundClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
-	err = fakeClient.Get(ctx, types.NamespacedName{Name: GetAgentRegistrationClusterRoleBindingName("test")}, foundClusterRoleBinding)
+	err = fakeClient.Get(
+		ctx,
+		types.NamespacedName{Name: GetAgentRegistrationClusterRoleBindingName("test")},
+		foundClusterRoleBinding,
+	)
 	assert.Nil(t, err)
 	assert.Equal(t, DefaultOCMBootstrapClusterRole, foundClusterRoleBinding.RoleRef.Name)
 }
@@ -4471,8 +4486,9 @@ func TestQueryFailedClusters(t *testing.T) {
 			expectedFailedClusters: []string{},
 		},
 		{
-			name:                   "Mixed status - one success, one ManifestWork failed, one ManifestWork ready but cluster unavailable",
-			expectedFailedClusters: []string{"cluster2"}, // Only cluster2 fails (ManifestWork not applied), cluster3 is success (ManifestWork ready)
+			name: "Mixed status - one success, one ManifestWork failed, " +
+				"one ManifestWork ready but cluster unavailable",
+			expectedFailedClusters: []string{"cluster2"},
 			managedClusters:        []string{"cluster1", "cluster2", "cluster3"},
 			initObjects: []client.Object{
 				// Cluster 1 - fully successful
@@ -4710,7 +4726,8 @@ func TestDeleteBMHAndDependentResources(t *testing.T) {
 			expectedSecretExist: false,
 		},
 		{
-			name: "BareMetalHost with credentialsName and secret exists with finalizers - should remove finalizers and delete secret",
+			name: "BareMetalHost with credentialsName and secret exists with finalizers - " +
+				"should remove finalizers and delete secret",
 			bmh: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"apiVersion": "metal3.io/v1alpha1",
@@ -4799,5 +4816,18 @@ func TestDeleteBMHAndDependentResources(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func assertOriginalAnnotationsPreserved(t *testing.T, original, updated map[string]string) {
+	t.Helper()
+	if original == nil {
+		return
+	}
+	for key, value := range original {
+		if key == HivePauseAnnotation {
+			continue
+		}
+		assert.Equal(t, value, updated[key], "Original annotation %s should be preserved", key)
 	}
 }

--- a/agent/pkg/spec/migration/source_validation.go
+++ b/agent/pkg/spec/migration/source_validation.go
@@ -1,0 +1,175 @@
+// Copyright (c) 2025 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package migration
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	cetypes "github.com/cloudevents/sdk-go/v2/types"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	migrationv1alpha1 "github.com/stolostron/multicluster-global-hub/operator/api/migration/v1alpha1"
+	migrationbundle "github.com/stolostron/multicluster-global-hub/pkg/bundle/migration"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/enum"
+)
+
+type localMigrationRecord struct {
+	fromHub string
+	toHub   string
+	phase   string
+}
+
+var (
+	localMigrationMu sync.RWMutex
+	localMigrations  = make(map[string]localMigrationRecord)
+)
+
+var migrationDeployAllowedGVKs = map[schema.GroupVersionKind]struct{}{
+	{Group: "cluster.open-cluster-management.io", Version: "v1", Kind: "ManagedCluster"}:      {},
+	{Group: "agent.open-cluster-management.io", Version: "v1", Kind: "KlusterletAddonConfig"}: {},
+	{Group: "", Version: "v1", Kind: "Secret"}:                                                {},
+	{Group: "", Version: "v1", Kind: "ConfigMap"}:                                             {},
+	{Group: "", Version: "v1", Kind: "Namespace"}:                                             {},
+	{Group: "work.open-cluster-management.io", Version: "v1", Kind: "ManifestWork"}:           {},
+}
+
+// IsMigrationDeployingEvent reports whether evt is a migration resource deploying event.
+func IsMigrationDeployingEvent(evt *cloudevents.Event) bool {
+	if evt == nil || evt.Type() != string(enum.ManagedClusterMigrationType) {
+		return false
+	}
+
+	stage, err := cetypes.ToString(evt.Extensions()[constants.CloudEventExtensionKeyMigrationStage])
+	return err == nil && stage == migrationv1alpha1.PhaseDeploying
+}
+
+// MigrationSourceAllowed returns true when source may publish migration events to targetHub.
+// Manager orchestration uses global-hub; source-hub deploying uses the registered from hub.
+func MigrationSourceAllowed(ctx context.Context, c client.Client, source, targetHub string) bool {
+	if source == constants.CloudEventGlobalHubClusterName {
+		return true
+	}
+	if source == "" || targetHub == "" {
+		return false
+	}
+	if localMigrationSourceAllowed(source, targetHub) {
+		return true
+	}
+	if c == nil {
+		return false
+	}
+
+	list := &migrationv1alpha1.ManagedClusterMigrationList{}
+	if err := c.List(ctx, list); err != nil {
+		return false
+	}
+
+	for i := range list.Items {
+		migration := &list.Items[i]
+		if migration.Spec.From != source || migration.Spec.To != targetHub {
+			continue
+		}
+		switch migration.Status.Phase {
+		case migrationv1alpha1.PhaseInitializing, migrationv1alpha1.PhaseDeploying:
+			return true
+		}
+	}
+
+	return false
+}
+
+func localMigrationSourceAllowed(source, targetHub string) bool {
+	localMigrationMu.RLock()
+	defer localMigrationMu.RUnlock()
+
+	for _, migration := range localMigrations {
+		if migration.fromHub != source || migration.toHub != targetHub {
+			continue
+		}
+		switch migration.phase {
+		case migrationv1alpha1.PhaseInitializing, migrationv1alpha1.PhaseDeploying:
+			return true
+		}
+	}
+	return false
+}
+
+// EnsureLocalMigrationCR records an in-flight migration on the target hub so deploying
+// bundles from the registered source hub pass MigrationSourceAllowed validation.
+// Managed hubs do not install the ManagedClusterMigration CRD, so state is kept in-memory.
+func EnsureLocalMigrationCR(
+	_ context.Context,
+	_ client.Client,
+	targetHub string,
+	event *migrationbundle.MigrationTargetBundle,
+	phase string,
+) error {
+	if event == nil || targetHub == "" {
+		return fmt.Errorf("invalid migration CR inputs")
+	}
+	if event.FromHub == "" || len(event.ManagedClusters) == 0 {
+		return nil
+	}
+	if event.ManagedServiceAccountName == "" {
+		return fmt.Errorf("managedServiceAccountName is required to record local migration state")
+	}
+
+	localMigrationMu.Lock()
+	defer localMigrationMu.Unlock()
+	localMigrations[event.ManagedServiceAccountName] = localMigrationRecord{
+		fromHub: event.FromHub,
+		toHub:   targetHub,
+		phase:   phase,
+	}
+	return nil
+}
+
+// DeleteLocalMigrationCR removes recorded local migration state after cleaning completes.
+func DeleteLocalMigrationCR(_ context.Context, _ client.Client, migrationName string) error {
+	if migrationName == "" {
+		return nil
+	}
+
+	localMigrationMu.Lock()
+	defer localMigrationMu.Unlock()
+	delete(localMigrations, migrationName)
+	return nil
+}
+
+// IsMigrationDeployResourceAllowed validates GVK and cluster binding for deploying-stage resources.
+func IsMigrationDeployResourceAllowed(resource *unstructured.Unstructured, clusterName string) bool {
+	if resource == nil || clusterName == "" {
+		return false
+	}
+
+	gvk := resource.GroupVersionKind()
+	if gvk.Group == "rbac.authorization.k8s.io" {
+		return false
+	}
+
+	if _, ok := migrationDeployAllowedGVKs[gvk]; !ok {
+		return false
+	}
+
+	switch gvk.Kind {
+	case "ManagedCluster":
+		return resource.GetName() == clusterName
+	case "KlusterletAddonConfig":
+		return resource.GetName() == clusterName && resource.GetNamespace() == clusterName
+	case "Namespace":
+		return resource.GetName() == clusterName
+	case "ManifestWork":
+		return resource.GetNamespace() == clusterName
+	case "Secret", "ConfigMap":
+		return resource.GetNamespace() == clusterName
+	default:
+		return false
+	}
+}

--- a/agent/pkg/spec/migration/source_validation_test.go
+++ b/agent/pkg/spec/migration/source_validation_test.go
@@ -1,0 +1,493 @@
+// Copyright (c) 2025 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package migration
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	migrationv1alpha1 "github.com/stolostron/multicluster-global-hub/operator/api/migration/v1alpha1"
+	migrationbundle "github.com/stolostron/multicluster-global-hub/pkg/bundle/migration"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/enum"
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
+)
+
+func TestIsMigrationDeployingEvent(t *testing.T) {
+	t.Run("nil event", func(t *testing.T) {
+		if IsMigrationDeployingEvent(nil) {
+			t.Fatal("expected nil event to be rejected")
+		}
+	})
+
+	t.Run("non-migration type", func(t *testing.T) {
+		wrongType := utils.ToCloudEvent("Policy", "hub1", "hub2", nil)
+		if IsMigrationDeployingEvent(&wrongType) {
+			t.Fatal("expected non-migration event type to be rejected")
+		}
+	})
+
+	t.Run("deploying phase", func(t *testing.T) {
+		deploying := utils.ToCloudEvent(string(enum.ManagedClusterMigrationType), "hub1", "hub2", nil)
+		deploying.SetExtension(constants.CloudEventExtensionKeyMigrationStage, migrationv1alpha1.PhaseDeploying)
+		if !IsMigrationDeployingEvent(&deploying) {
+			t.Fatal("expected deploying migration event to be recognized")
+		}
+	})
+
+	t.Run("non-deploying phase", func(t *testing.T) {
+		initializing := utils.ToCloudEvent(
+			string(enum.ManagedClusterMigrationType),
+			constants.CloudEventGlobalHubClusterName,
+			"hub2",
+			nil,
+		)
+		initializing.SetExtension(constants.CloudEventExtensionKeyMigrationStage, migrationv1alpha1.PhaseInitializing)
+		if IsMigrationDeployingEvent(&initializing) {
+			t.Fatal("expected non-deploying migration event to be rejected")
+		}
+	})
+}
+
+func resetLocalMigrationState() {
+	localMigrationMu.Lock()
+	defer localMigrationMu.Unlock()
+	localMigrations = make(map[string]localMigrationRecord)
+}
+
+func TestMigrationSourceAllowed(t *testing.T) {
+	resetLocalMigrationState()
+	t.Cleanup(resetLocalMigrationState)
+	scheme := runtime.NewScheme()
+	_ = migrationv1alpha1.AddToScheme(scheme)
+
+	migrationCR := &migrationv1alpha1.ManagedClusterMigration{
+		ObjectMeta: metav1.ObjectMeta{Name: "migration-1"},
+		Spec: migrationv1alpha1.ManagedClusterMigrationSpec{
+			From: "hub1",
+			To:   "hub2",
+		},
+		Status: migrationv1alpha1.ManagedClusterMigrationStatus{
+			Phase: migrationv1alpha1.PhaseDeploying,
+		},
+	}
+	deployingClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(migrationCR).
+		WithStatusSubresource(migrationCR).
+		Build()
+
+	wrongPhaseCR := migrationCR.DeepCopy()
+	wrongPhaseCR.Name = "migration-2"
+	wrongPhaseCR.Status.Phase = migrationv1alpha1.PhaseRegistering
+	initializingClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(wrongPhaseCR).
+		WithStatusSubresource(wrongPhaseCR).
+		Build()
+
+	ctx := context.Background()
+
+	cases := []struct {
+		name        string
+		client      client.Client
+		source      string
+		target      string
+		wantAllowed bool
+		setup       func()
+	}{
+		{
+			name:        "manager global-hub source",
+			client:      deployingClient,
+			source:      constants.CloudEventGlobalHubClusterName,
+			target:      "hub2",
+			wantAllowed: true,
+		},
+		{
+			name:        "registered source hub during deploying",
+			client:      deployingClient,
+			source:      "hub1",
+			target:      "hub2",
+			wantAllowed: true,
+		},
+		{
+			name:        "spoofed source hub",
+			client:      deployingClient,
+			source:      "spoofed-hub",
+			target:      "hub2",
+			wantAllowed: false,
+		},
+		{
+			name:        "unregistered target hub",
+			client:      deployingClient,
+			source:      "hub1",
+			target:      "hub3",
+			wantAllowed: false,
+		},
+		{
+			name:   "in-memory registered source hub during deploying",
+			client: nil,
+			setup: func() {
+				err := EnsureLocalMigrationCR(
+					ctx, nil, "hub2", sampleMigrationTargetBundle(), migrationv1alpha1.PhaseDeploying,
+				)
+				if err != nil {
+					t.Fatalf("EnsureLocalMigrationCR() error = %v", err)
+				}
+			},
+			source:      "hub1",
+			target:      "hub2",
+			wantAllowed: true,
+		},
+		{
+			name:        "nil client without in-memory registration",
+			client:      nil,
+			source:      "hub1",
+			target:      "hub2",
+			wantAllowed: false,
+		},
+		{
+			name: "registered source hub during initializing",
+			client: func() client.Client {
+				initializingCR := migrationCR.DeepCopy()
+				initializingCR.Name = "migration-3"
+				initializingCR.Status.Phase = migrationv1alpha1.PhaseInitializing
+				return fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(initializingCR).
+					WithStatusSubresource(initializingCR).
+					Build()
+			}(),
+			source:      "hub1",
+			target:      "hub2",
+			wantAllowed: true,
+		},
+		{
+			name:        "wrong migration phase",
+			client:      initializingClient,
+			source:      "hub1",
+			target:      "hub2",
+			wantAllowed: false,
+		},
+		{
+			name:        "empty source",
+			client:      deployingClient,
+			source:      "",
+			target:      "hub2",
+			wantAllowed: false,
+		},
+		{
+			name:        "empty target hub",
+			client:      deployingClient,
+			source:      "hub1",
+			target:      "",
+			wantAllowed: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetLocalMigrationState()
+			if tc.setup != nil {
+				tc.setup()
+			}
+			got := MigrationSourceAllowed(ctx, tc.client, tc.source, tc.target)
+			if got != tc.wantAllowed {
+				t.Fatalf("MigrationSourceAllowed(%q, %q) = %v, want %v", tc.source, tc.target, got, tc.wantAllowed)
+			}
+		})
+	}
+}
+
+func TestIsMigrationDeployResourceAllowed_AllowedGVKs(t *testing.T) {
+	namespace := &unstructured.Unstructured{}
+	namespace.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Namespace"))
+	namespace.SetName("cluster1")
+
+	manifestWork := &unstructured.Unstructured{}
+	manifestWork.SetGroupVersionKind(schema.GroupVersionKind{
+		Group: "work.open-cluster-management.io", Version: "v1", Kind: "ManifestWork",
+	})
+	manifestWork.SetNamespace("cluster1")
+	manifestWork.SetName("work1")
+
+	configMap := &unstructured.Unstructured{}
+	configMap.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("ConfigMap"))
+	configMap.SetNamespace("cluster1")
+	configMap.SetName("extra-manifests")
+
+	foreignManifestWork := manifestWork.DeepCopy()
+	foreignManifestWork.SetNamespace("kube-system")
+
+	foreignNamespace := namespace.DeepCopy()
+	foreignNamespace.SetName("other-cluster")
+
+	cases := []struct {
+		name        string
+		resource    *unstructured.Unstructured
+		clusterName string
+		allowed     bool
+	}{
+		{name: "namespace allowed", resource: namespace, clusterName: "cluster1", allowed: true},
+		{name: "manifest work allowed", resource: manifestWork, clusterName: "cluster1", allowed: true},
+		{name: "configmap allowed", resource: configMap, clusterName: "cluster1", allowed: true},
+		{name: "foreign manifest work denied", resource: foreignManifestWork, clusterName: "cluster1", allowed: false},
+		{name: "foreign namespace denied", resource: foreignNamespace, clusterName: "cluster1", allowed: false},
+		{name: "nil resource denied", resource: nil, clusterName: "cluster1", allowed: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsMigrationDeployResourceAllowed(tc.resource, tc.clusterName)
+			if got != tc.allowed {
+				t.Fatalf("IsMigrationDeployResourceAllowed() = %v, want %v", got, tc.allowed)
+			}
+		})
+	}
+}
+
+func TestIsMigrationDeployResourceAllowed(t *testing.T) {
+	mc := &unstructured.Unstructured{}
+	mc.SetGroupVersionKind(schema.GroupVersionKind{Group: clusterv1.GroupName, Version: "v1", Kind: "ManagedCluster"})
+	mc.SetName("cluster1")
+
+	foreignMC := mc.DeepCopy()
+	foreignMC.SetName("other-cluster")
+
+	kac := &unstructured.Unstructured{}
+	kac.SetGroupVersionKind(schema.GroupVersionKind{
+		Group: "agent.open-cluster-management.io", Version: "v1", Kind: "KlusterletAddonConfig",
+	})
+	kac.SetNamespace("cluster1")
+	kac.SetName("cluster1")
+
+	foreignKAC := kac.DeepCopy()
+	foreignKAC.SetName("other-cluster")
+
+	clusterRole := &unstructured.Unstructured{}
+	clusterRole.SetGroupVersionKind(rbacv1.SchemeGroupVersion.WithKind("ClusterRole"))
+	clusterRole.SetName("admin")
+
+	secret := &unstructured.Unstructured{}
+	secret.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Secret"))
+	secret.SetNamespace("cluster1")
+	secret.SetName("bootstrap")
+
+	foreignSecret := secret.DeepCopy()
+	foreignSecret.SetNamespace("kube-system")
+
+	cases := []struct {
+		name        string
+		resource    *unstructured.Unstructured
+		clusterName string
+		allowed     bool
+	}{
+		{name: "managed cluster allowed", resource: mc, clusterName: "cluster1", allowed: true},
+		{name: "foreign managed cluster denied", resource: foreignMC, clusterName: "cluster1", allowed: false},
+		{name: "klusterlet addon config allowed", resource: kac, clusterName: "cluster1", allowed: true},
+		{name: "foreign klusterlet addon config denied", resource: foreignKAC, clusterName: "cluster1", allowed: false},
+		{name: "cluster role denied", resource: clusterRole, clusterName: "cluster1", allowed: false},
+		{name: "cluster secret allowed", resource: secret, clusterName: "cluster1", allowed: true},
+		{name: "foreign namespace secret denied", resource: foreignSecret, clusterName: "cluster1", allowed: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsMigrationDeployResourceAllowed(tc.resource, tc.clusterName)
+			if got != tc.allowed {
+				t.Fatalf("IsMigrationDeployResourceAllowed() = %v, want %v", got, tc.allowed)
+			}
+		})
+	}
+}
+
+func sampleMigrationTargetBundle() *migrationbundle.MigrationTargetBundle {
+	return &migrationbundle.MigrationTargetBundle{
+		FromHub:                   "hub1",
+		ManagedServiceAccountName: "migration-hub1-cluster1",
+		ManagedClusters:           []string{"cluster1"},
+	}
+}
+
+func TestEnsureLocalMigrationCR(t *testing.T) {
+	resetLocalMigrationState()
+	t.Cleanup(resetLocalMigrationState)
+
+	ctx := context.Background()
+	event := sampleMigrationTargetBundle()
+	if err := EnsureLocalMigrationCR(ctx, nil, "hub2", event, migrationv1alpha1.PhaseDeploying); err != nil {
+		t.Fatalf("EnsureLocalMigrationCR() error = %v", err)
+	}
+	if !MigrationSourceAllowed(ctx, nil, "hub1", "hub2") {
+		t.Fatal("expected in-memory migration state to authorize source hub")
+	}
+}
+
+func TestEnsureLocalMigrationCR_UpdatesExistingCR(t *testing.T) {
+	resetLocalMigrationState()
+	t.Cleanup(resetLocalMigrationState)
+
+	ctx := context.Background()
+	event := sampleMigrationTargetBundle()
+	if err := EnsureLocalMigrationCR(ctx, nil, "hub2", event, migrationv1alpha1.PhaseInitializing); err != nil {
+		t.Fatalf("EnsureLocalMigrationCR() error = %v", err)
+	}
+	if err := EnsureLocalMigrationCR(ctx, nil, "hub2", event, migrationv1alpha1.PhaseDeploying); err != nil {
+		t.Fatalf("EnsureLocalMigrationCR() error = %v", err)
+	}
+	if !MigrationSourceAllowed(ctx, nil, "hub1", "hub2") {
+		t.Fatal("expected updated in-memory migration state to authorize source hub")
+	}
+}
+
+func TestEnsureLocalMigrationCR_ReusesExistingNamespace(t *testing.T) {
+	resetLocalMigrationState()
+	t.Cleanup(resetLocalMigrationState)
+
+	ctx := context.Background()
+	err := EnsureLocalMigrationCR(
+		ctx, nil, "hub2", sampleMigrationTargetBundle(), migrationv1alpha1.PhaseInitializing,
+	)
+	if err != nil {
+		t.Fatalf("EnsureLocalMigrationCR() error = %v", err)
+	}
+	if !MigrationSourceAllowed(ctx, nil, "hub1", "hub2") {
+		t.Fatal("expected in-memory migration state to authorize source hub")
+	}
+}
+
+func TestEnsureLocalMigrationCR_InvalidInputs(t *testing.T) {
+	resetLocalMigrationState()
+	t.Cleanup(resetLocalMigrationState)
+
+	ctx := context.Background()
+	event := sampleMigrationTargetBundle()
+
+	cases := []struct {
+		name    string
+		target  string
+		event   *migrationbundle.MigrationTargetBundle
+		wantErr string
+	}{
+		{
+			name:    "nil event",
+			target:  "hub2",
+			event:   nil,
+			wantErr: "invalid migration CR inputs",
+		},
+		{
+			name:    "empty target hub",
+			target:  "",
+			event:   event,
+			wantErr: "invalid migration CR inputs",
+		},
+		{
+			name:   "missing managed service account name",
+			target: "hub2",
+			event: &migrationbundle.MigrationTargetBundle{
+				FromHub:         "hub1",
+				ManagedClusters: []string{"cluster1"},
+			},
+			wantErr: "managedServiceAccountName is required",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := EnsureLocalMigrationCR(ctx, nil, tc.target, tc.event, migrationv1alpha1.PhaseDeploying)
+			if err == nil || err.Error() == "" {
+				t.Fatal("expected error")
+			}
+			if tc.wantErr != "" && !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error = %q, want substring %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestEnsureLocalMigrationCR_NoOpWithoutFromHubOrClusters(t *testing.T) {
+	resetLocalMigrationState()
+	t.Cleanup(resetLocalMigrationState)
+
+	ctx := context.Background()
+	cases := []*migrationbundle.MigrationTargetBundle{
+		{
+			ManagedServiceAccountName: "migration-hub1-cluster1",
+			ManagedClusters:           []string{"cluster1"},
+		},
+		{
+			FromHub:                   "hub1",
+			ManagedServiceAccountName: "migration-hub1-cluster1",
+		},
+	}
+
+	for i, event := range cases {
+		if err := EnsureLocalMigrationCR(ctx, nil, "hub2", event, migrationv1alpha1.PhaseDeploying); err != nil {
+			t.Fatalf("case %d: expected no-op, got error %v", i, err)
+		}
+	}
+
+	if MigrationSourceAllowed(ctx, nil, "hub1", "hub2") {
+		t.Fatal("expected no in-memory migration state to be recorded")
+	}
+}
+
+func TestDeleteLocalMigrationCR(t *testing.T) {
+	resetLocalMigrationState()
+	t.Cleanup(resetLocalMigrationState)
+
+	ctx := context.Background()
+	err := EnsureLocalMigrationCR(
+		ctx, nil, "hub2", sampleMigrationTargetBundle(), migrationv1alpha1.PhaseDeploying,
+	)
+	if err != nil {
+		t.Fatalf("EnsureLocalMigrationCR() error = %v", err)
+	}
+
+	if err := DeleteLocalMigrationCR(ctx, nil, "migration-hub1-cluster1"); err != nil {
+		t.Fatalf("DeleteLocalMigrationCR() error = %v", err)
+	}
+	if MigrationSourceAllowed(ctx, nil, "hub1", "hub2") {
+		t.Fatal("expected migration state to be deleted")
+	}
+
+	if err := DeleteLocalMigrationCR(ctx, nil, "missing-migration"); err != nil {
+		t.Fatalf("deleting missing migration state should succeed, got %v", err)
+	}
+	if err := DeleteLocalMigrationCR(ctx, nil, ""); err != nil {
+		t.Fatalf("empty migration name should be ignored, got %v", err)
+	}
+}
+
+func TestMigrationSourceAllowed_ListError(t *testing.T) {
+	resetLocalMigrationState()
+	t.Cleanup(resetLocalMigrationState)
+
+	ctx := context.Background()
+	clientWithoutScheme := fake.NewClientBuilder().WithScheme(runtime.NewScheme()).Build()
+	if MigrationSourceAllowed(ctx, clientWithoutScheme, "hub1", "hub2") {
+		t.Fatal("expected list failure to reject migration source")
+	}
+}
+
+func TestIsMigrationDeployResourceAllowed_EmptyClusterName(t *testing.T) {
+	secret := &unstructured.Unstructured{}
+	secret.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Secret"))
+	secret.SetNamespace("cluster1")
+	secret.SetName("bootstrap")
+	if IsMigrationDeployResourceAllowed(secret, "") {
+		t.Fatal("expected empty cluster name to be rejected")
+	}
+}

--- a/agent/pkg/spec/source_validation.go
+++ b/agent/pkg/spec/source_validation.go
@@ -1,0 +1,113 @@
+// Copyright Contributors to the Open Cluster Management project.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"context"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/configs"
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/spec/migration"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+)
+
+func specEventSourceAllowed(
+	ctx context.Context,
+	c client.Client,
+	agentConfig *configs.AgentConfig,
+	evt *cloudevents.Event,
+	subject string,
+) bool {
+	if evt == nil || agentConfig == nil {
+		return false
+	}
+
+	source := evt.Source()
+	if source == constants.CloudEventGlobalHubClusterName {
+		return true
+	}
+
+	switch evt.Type() {
+	case constants.HubHAResourcesMsgKey:
+		return hubHAResourceSourceAllowed(ctx, c, agentConfig, source, subject)
+	case constants.HAConfigMsgKey:
+		return haConfigSourceAllowed(agentConfig, source, subject)
+	default:
+		if migration.IsMigrationDeployingEvent(evt) {
+			return migration.MigrationSourceAllowed(ctx, c, source, subject)
+		}
+		return false
+	}
+}
+
+func hubHAResourceSourceAllowed(
+	ctx context.Context,
+	c client.Client,
+	agentConfig *configs.AgentConfig,
+	source, subject string,
+) bool {
+	if agentConfig.GetHubRole() != constants.GHHubRoleStandby {
+		return false
+	}
+	if subject != agentConfig.LeafHubName {
+		return false
+	}
+	if source == "" || source == constants.CloudEventGlobalHubClusterName || source == agentConfig.LeafHubName {
+		return false
+	}
+
+	activeHub, ok := expectedActiveHubName(ctx, c)
+	if !ok {
+		return false
+	}
+	return source == activeHub
+}
+
+func expectedActiveHubName(ctx context.Context, c client.Client) (string, bool) {
+	if c == nil {
+		return "", false
+	}
+
+	list := &clusterv1.ManagedClusterList{}
+	if err := c.List(ctx, list, client.MatchingLabels{
+		constants.GHHubRoleLabelKey: constants.GHHubRoleActive,
+	}); err != nil {
+		return "", false
+	}
+	if len(list.Items) != 1 {
+		return "", false
+	}
+	return list.Items[0].Name, true
+}
+
+func haConfigSourceAllowed(agentConfig *configs.AgentConfig, source, subject string) bool {
+	if subject != agentConfig.LeafHubName {
+		return false
+	}
+	if source == "" || source == subject {
+		return false
+	}
+	if source == constants.CloudEventGlobalHubClusterName {
+		return true
+	}
+	standbyHub := agentConfig.GetStandbyHub()
+	if standbyHub != "" {
+		return source == standbyHub
+	}
+	return true
+}

--- a/agent/pkg/spec/source_validation_test.go
+++ b/agent/pkg/spec/source_validation_test.go
@@ -1,0 +1,248 @@
+// Copyright Contributors to the Open Cluster Management project.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"context"
+	"testing"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/configs"
+	migrationv1alpha1 "github.com/stolostron/multicluster-global-hub/operator/api/migration/v1alpha1"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/enum"
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
+)
+
+func activeHubManagedCluster(name string) *clusterv1.ManagedCluster {
+	return &clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				constants.GHHubRoleLabelKey: constants.GHHubRoleActive,
+			},
+		},
+	}
+}
+
+func TestSpecEventSourceAllowed(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = migrationv1alpha1.AddToScheme(scheme)
+	_ = clusterv1.Install(scheme)
+
+	migrationCR := &migrationv1alpha1.ManagedClusterMigration{
+		ObjectMeta: metav1.ObjectMeta{Name: "migration-1"},
+		Spec: migrationv1alpha1.ManagedClusterMigrationSpec{
+			From: "hub1",
+			To:   "hub2",
+		},
+		Status: migrationv1alpha1.ManagedClusterMigrationStatus{
+			Phase: migrationv1alpha1.PhaseDeploying,
+		},
+	}
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(migrationCR, activeHubManagedCluster("hub1")).
+		WithStatusSubresource(migrationCR).
+		Build()
+	ctx := context.Background()
+
+	agentConfig := &configs.AgentConfig{
+		LeafHubName: "hub2",
+	}
+	agentConfig.SetHubRole(constants.GHHubRoleStandby)
+
+	policyEvent := utils.ToCloudEvent("Policy", constants.CloudEventGlobalHubClusterName, "hub2", nil)
+	spoofedPolicyEvent := utils.ToCloudEvent("Policy", "spoofed-hub", "hub2", nil)
+
+	deployingEvent := utils.ToCloudEvent(string(enum.ManagedClusterMigrationType), "hub1", "hub2", nil)
+	deployingEvent.SetExtension(constants.CloudEventExtensionKeyMigrationStage, migrationv1alpha1.PhaseDeploying)
+
+	haResourcesEvent := utils.ToCloudEvent(constants.HubHAResourcesMsgKey, "hub1", "hub2", nil)
+	haConfigEvent := utils.ToCloudEvent(constants.HAConfigMsgKey, "local-cluster", "hub2", nil)
+
+	if !specEventSourceAllowed(ctx, fakeClient, agentConfig, &policyEvent, "hub2") {
+		t.Fatal("expected trusted manager policy event to be allowed")
+	}
+	if specEventSourceAllowed(ctx, fakeClient, agentConfig, &spoofedPolicyEvent, "hub2") {
+		t.Fatal("expected spoofed policy source to be rejected")
+	}
+	if !specEventSourceAllowed(ctx, fakeClient, agentConfig, &deployingEvent, "hub2") {
+		t.Fatal("expected registered migration deploying source to be allowed")
+	}
+	if !specEventSourceAllowed(ctx, fakeClient, agentConfig, &haResourcesEvent, "hub2") {
+		t.Fatal("expected active hub HA resource event to be allowed on standby hub")
+	}
+	if !specEventSourceAllowed(ctx, fakeClient, agentConfig, &haConfigEvent, "hub2") {
+		t.Fatal("expected HA config event addressed to leaf hub to be allowed")
+	}
+
+	spoofedHAEvent := utils.ToCloudEvent(constants.HubHAResourcesMsgKey, "spoofed-hub", "hub2", nil)
+	if specEventSourceAllowed(ctx, fakeClient, agentConfig, &spoofedHAEvent, "hub2") {
+		t.Fatal("expected spoofed HA resource source to be rejected")
+	}
+
+	activeHubConfig := &configs.AgentConfig{LeafHubName: "hub2"}
+	activeHubConfig.SetHubRole(constants.GHHubRoleActive)
+	if specEventSourceAllowed(ctx, fakeClient, activeHubConfig, &haResourcesEvent, "hub2") {
+		t.Fatal("expected HA resource event to be rejected on active hub")
+	}
+
+	standbyWithPeer := &configs.AgentConfig{LeafHubName: "hub2"}
+	standbyWithPeer.SetHubRole(constants.GHHubRoleStandby)
+	standbyWithPeer.SetStandbyHub("hub1")
+	selfSourcedHAConfig := utils.ToCloudEvent(constants.HAConfigMsgKey, "hub2", "hub2", nil)
+	if specEventSourceAllowed(ctx, fakeClient, standbyWithPeer, &selfSourcedHAConfig, "hub2") {
+		t.Fatal("expected HA config event with source equal to subject to be rejected")
+	}
+
+	unexpectedStandbyHAConfig := utils.ToCloudEvent(constants.HAConfigMsgKey, "hub3", "hub2", nil)
+	if specEventSourceAllowed(ctx, fakeClient, standbyWithPeer, &unexpectedStandbyHAConfig, "hub2") {
+		t.Fatal("expected HA config event from unexpected standby hub to be rejected")
+	}
+}
+
+func TestSpecEventSourceAllowed_NilInputs(t *testing.T) {
+	ctx := context.Background()
+	agentConfig := &configs.AgentConfig{LeafHubName: "hub2"}
+
+	if specEventSourceAllowed(ctx, nil, agentConfig, nil, "hub2") {
+		t.Fatal("expected nil event to be rejected")
+	}
+	if specEventSourceAllowed(ctx, nil, nil, &cloudevents.Event{}, "hub2") {
+		t.Fatal("expected nil agent config to be rejected")
+	}
+}
+
+func TestHubHAResourceSourceAllowed(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clusterv1.Install(scheme)
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(activeHubManagedCluster("hub1")).
+		Build()
+	ctx := context.Background()
+
+	standby := &configs.AgentConfig{LeafHubName: "hub2"}
+	standby.SetHubRole(constants.GHHubRoleStandby)
+
+	if !hubHAResourceSourceAllowed(ctx, fakeClient, standby, "hub1", "hub2") {
+		t.Fatal("expected peer active hub source to be allowed")
+	}
+	if hubHAResourceSourceAllowed(ctx, fakeClient, standby, "spoofed-hub", "hub2") {
+		t.Fatal("expected unexpected leaf hub source to be rejected")
+	}
+	if hubHAResourceSourceAllowed(ctx, fakeClient, standby, "", "hub2") {
+		t.Fatal("expected empty source to be rejected")
+	}
+	if hubHAResourceSourceAllowed(ctx, fakeClient, standby, constants.CloudEventGlobalHubClusterName, "hub2") {
+		t.Fatal("expected global-hub source to be rejected for HA resources")
+	}
+	if hubHAResourceSourceAllowed(ctx, fakeClient, standby, "hub2", "hub2") {
+		t.Fatal("expected self source to be rejected")
+	}
+	if hubHAResourceSourceAllowed(ctx, fakeClient, standby, "hub1", "hub3") {
+		t.Fatal("expected subject mismatch to be rejected")
+	}
+
+	active := &configs.AgentConfig{LeafHubName: "hub2"}
+	active.SetHubRole(constants.GHHubRoleActive)
+	if hubHAResourceSourceAllowed(ctx, fakeClient, active, "hub1", "hub2") {
+		t.Fatal("expected active hub role to reject HA resource events")
+	}
+
+	clientWithoutActiveHub := fake.NewClientBuilder().WithScheme(scheme).Build()
+	if hubHAResourceSourceAllowed(ctx, clientWithoutActiveHub, standby, "hub1", "hub2") {
+		t.Fatal("expected missing active hub label to reject HA resource events")
+	}
+}
+
+func TestExpectedActiveHubName(t *testing.T) {
+	ctx := context.Background()
+
+	if name, ok := expectedActiveHubName(ctx, nil); ok || name != "" {
+		t.Fatal("expected nil client to fail lookup")
+	}
+
+	scheme := runtime.NewScheme()
+	_ = clusterv1.Install(scheme)
+	clientWithoutScheme := fake.NewClientBuilder().WithScheme(runtime.NewScheme()).Build()
+	if _, ok := expectedActiveHubName(ctx, clientWithoutScheme); ok {
+		t.Fatal("expected list failure without cluster scheme")
+	}
+
+	clientWithoutActiveHub := fake.NewClientBuilder().WithScheme(scheme).Build()
+	if _, ok := expectedActiveHubName(ctx, clientWithoutActiveHub); ok {
+		t.Fatal("expected missing active hub to fail lookup")
+	}
+
+	multipleActiveHubs := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(activeHubManagedCluster("hub1"), activeHubManagedCluster("hub2")).
+		Build()
+	if _, ok := expectedActiveHubName(ctx, multipleActiveHubs); ok {
+		t.Fatal("expected multiple active hubs to fail lookup")
+	}
+
+	singleActiveHub := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(activeHubManagedCluster("hub1")).
+		Build()
+	name, ok := expectedActiveHubName(ctx, singleActiveHub)
+	if !ok || name != "hub1" {
+		t.Fatalf("expected active hub hub1, got name=%q ok=%v", name, ok)
+	}
+}
+
+func TestSpecEventSourceAllowed_GlobalHubSourceBypassesTypeChecks(t *testing.T) {
+	ctx := context.Background()
+	agentConfig := &configs.AgentConfig{LeafHubName: "hub2"}
+
+	unknownType := utils.ToCloudEvent("UnknownType", constants.CloudEventGlobalHubClusterName, "hub2", nil)
+	if !specEventSourceAllowed(ctx, nil, agentConfig, &unknownType, "hub2") {
+		t.Fatal("expected global-hub source to be allowed regardless of event type")
+	}
+}
+
+func TestHaConfigSourceAllowed(t *testing.T) {
+	cfg := &configs.AgentConfig{LeafHubName: "hub2"}
+	cfg.SetStandbyHub("hub1")
+
+	if !haConfigSourceAllowed(cfg, constants.CloudEventGlobalHubClusterName, "hub2") {
+		t.Fatal("expected manager global-hub HA config source to be allowed")
+	}
+	if !haConfigSourceAllowed(cfg, "hub1", "hub2") {
+		t.Fatal("expected configured standby hub source to be allowed")
+	}
+	if haConfigSourceAllowed(cfg, "hub3", "hub2") {
+		t.Fatal("expected unexpected standby hub source to be rejected")
+	}
+	if haConfigSourceAllowed(cfg, "", "hub2") {
+		t.Fatal("expected empty source to be rejected")
+	}
+	if haConfigSourceAllowed(cfg, "hub2", "hub3") {
+		t.Fatal("expected subject mismatch to be rejected")
+	}
+
+	cfgWithoutPeer := &configs.AgentConfig{LeafHubName: "hub2"}
+	if !haConfigSourceAllowed(cfgWithoutPeer, "any-peer", "hub2") {
+		t.Fatal("expected peer source to be allowed when standby hub is not configured")
+	}
+}

--- a/agent/pkg/spec/spec.go
+++ b/agent/pkg/spec/spec.go
@@ -17,9 +17,15 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 )
 
+var specCtrlStarted = false
+
 func AddToManager(context context.Context, mgr ctrl.Manager, transportClient transport.TransportClient,
 	agentConfig *configs.AgentConfig,
 ) error {
+	if specCtrlStarted {
+		return nil
+	}
+
 	log := logger.DefaultZapLogger()
 	if transportClient.GetConsumer() == nil {
 		return fmt.Errorf("the consumer is not initialized")
@@ -32,6 +38,9 @@ func AddToManager(context context.Context, mgr ctrl.Manager, transportClient tra
 	dispatcher, err := AddGenericDispatcher(mgr, transportClient.GetConsumer(), agentConfig)
 	if err != nil {
 		return fmt.Errorf("failed to add bundle dispatcher to runtime manager: %w", err)
+	}
+	if dispatcher == nil {
+		return fmt.Errorf("bundle dispatcher is not initialized")
 	}
 
 	// register single migration syncer that routes internally by payload
@@ -64,5 +73,6 @@ func AddToManager(context context.Context, mgr ctrl.Manager, transportClient tra
 		hubha.NewHAConfigSyncer(mgr.GetClient(), agentConfig))
 
 	log.Info("added the spec controllers to manager")
+	specCtrlStarted = true
 	return nil
 }

--- a/manager/pkg/migration/migration_controller.go
+++ b/manager/pkg/migration/migration_controller.go
@@ -261,6 +261,7 @@ func (m *ClusterMigrationController) sendEventToTargetHub(ctx context.Context,
 	log.Debugf("%s is %v", migration.Spec.To, isLocalCluster)
 
 	managedClusterMigrationToEvent := &migrationbundle.MigrationTargetBundle{
+		FromHub:                   migration.Spec.From,
 		ManagedClusters:           managedClusters,
 		RollbackStage:             rollbackStage,
 		ManagedServiceAccountName: migration.Name,

--- a/manager/pkg/migration/migration_initializing.go
+++ b/manager/pkg/migration/migration_initializing.go
@@ -89,7 +89,8 @@ func (m *ClusterMigrationController) initializing(ctx context.Context,
 	// Important: Registration must occur only after autoApprove is successfully set.
 	// Thinking - Ensure that autoApprove is properly configured before proceeding.
 	if !GetStarted(string(mcm.GetUID()), mcm.Spec.To, migrationv1alpha1.PhaseInitializing) {
-		if err := m.sendEventToTargetHub(ctx, mcm, migrationv1alpha1.PhaseInitializing, nil, ""); err != nil {
+		if err := m.sendEventToTargetHub(ctx, mcm, migrationv1alpha1.PhaseInitializing,
+			GetClusterList(string(mcm.GetUID())), ""); err != nil {
 			condition.Message = err.Error()
 			condition.Reason = ConditionReasonError
 			return false, err

--- a/manager/pkg/status/conflator/conflation_manager.go
+++ b/manager/pkg/status/conflator/conflation_manager.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/statistics"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport/config"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport/identity"
 )
 
 // ConflationManager implements conflation units management.
@@ -61,13 +62,25 @@ func (cm *ConflationManager) Insert(evt *cloudevents.Event) {
 		fmt.Print(evt)
 		return
 	}
+	leafHubName, ok := identity.LeafHubForStatusEvent(evt)
+	if !ok {
+		cm.log.Warnw(
+			"dropping event due to untrusted source",
+			"type", enum.ShortenEventType(evt.Type()),
+			"source", evt.Source(),
+			"authedhub", evt.Extensions()[identity.ExtensionAuthedHub],
+		)
+		return
+	}
+	evt.SetSource(leafHubName)
+
 	// metadata
 	conflationMetadata := metadata.NewThresholdMetadata(config.GetKafkaOwnerIdentity(), 3, evt)
 	if conflationMetadata == nil {
 		return
 	}
 
-	cm.getConflationUnit(evt.Source()).insert(evt, conflationMetadata)
+	cm.getConflationUnit(leafHubName).insert(evt, conflationMetadata)
 }
 
 // GetTransportMetadatas provides collections of the CU's bundle transport-metadata.

--- a/manager/pkg/status/conflator/conflation_manager_test.go
+++ b/manager/pkg/status/conflator/conflation_manager_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright Contributors to the Open Cluster Management project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conflator
+
+import (
+	"context"
+	"testing"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+
+	eventversion "github.com/stolostron/multicluster-global-hub/pkg/bundle/version"
+	"github.com/stolostron/multicluster-global-hub/pkg/enum"
+	"github.com/stolostron/multicluster-global-hub/pkg/statistics"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport/identity"
+)
+
+func newTestConflationManager() *ConflationManager {
+	return NewConflationManager(statistics.NewStatistics(&statistics.StatisticsConfig{
+		LogInterval: "1m",
+	}), nil)
+}
+
+func TestConflationManagerInsertRejectsSpoofedSource(t *testing.T) {
+	cm := newTestConflationManager()
+	eventType := string(enum.ManagedClusterType)
+	cm.Register(NewConflationRegistration(
+		HubClusterHeartbeatPriority,
+		enum.CompleteStateMode,
+		eventType,
+		func(context.Context, *cloudevents.Event) error { return nil },
+	))
+
+	evt := cloudevents.NewEvent()
+	evt.SetType(eventType)
+	evt.SetSource("victim-hub")
+	identity.SetAuthedHub(&evt, "writer-hub")
+
+	cm.Insert(&evt)
+
+	if _, found := cm.conflationUnits["victim-hub"]; found {
+		t.Fatal("spoofed event must not create a conflation unit for victim-hub")
+	}
+	if _, found := cm.conflationUnits["writer-hub"]; found {
+		t.Fatal("spoofed event must be dropped before conflation unit creation")
+	}
+}
+
+func TestConflationManagerInsertUsesAuthedHub(t *testing.T) {
+	cm := newTestConflationManager()
+	eventType := string(enum.ManagedClusterType)
+	cm.Register(NewConflationRegistration(
+		HubClusterHeartbeatPriority,
+		enum.CompleteStateMode,
+		eventType,
+		func(context.Context, *cloudevents.Event) error { return nil },
+	))
+
+	evt := cloudevents.NewEvent()
+	evt.SetType(eventType)
+	evt.SetSource("hub-a")
+	evt.SetExtension(eventversion.ExtVersion, "0.1")
+	identity.SetAuthedHub(&evt, "hub-a")
+
+	cm.Insert(&evt)
+
+	if _, found := cm.conflationUnits["hub-a"]; !found {
+		t.Fatal("expected conflation unit for hub-a")
+	}
+	if evt.Source() != "hub-a" {
+		t.Fatalf("event source = %q, want hub-a", evt.Source())
+	}
+}

--- a/manager/pkg/status/conflator/workerpool/worker.go
+++ b/manager/pkg/status/conflator/workerpool/worker.go
@@ -44,19 +44,20 @@ func (worker *Worker) RunAsync(job *conflator.ConflationJob) {
 
 func (worker *Worker) start(ctx context.Context) {
 	log.Infow("started worker", "WorkerID", worker.workerID)
+	defer close(worker.jobsQueue)
+
 	for {
-		// add worker into the dbWorkerPool to mark this worker as available.
-		// this is done in each iteration after the worker finished handling a job (or at startup),
-		// for receiving a new job to handle.
-		worker.workers <- worker
-		worker.statistics.SetNumberOfAvailableDBWorkers(len(worker.workers))
+		select {
+		case <-ctx.Done():
+			return
+		case worker.workers <- worker:
+			worker.statistics.SetNumberOfAvailableDBWorkers(len(worker.workers))
+		}
 
 		select {
-		case <-ctx.Done(): // we have received a signal to stop
-			close(worker.jobsQueue)
+		case <-ctx.Done():
 			return
-
-		case job := <-worker.jobsQueue: // DBWorker received a job request.
+		case job := <-worker.jobsQueue:
 			worker.handleJob(ctx, job)
 		}
 	}

--- a/manager/pkg/status/conflator/workerpool/worker_pool.go
+++ b/manager/pkg/status/conflator/workerpool/worker_pool.go
@@ -52,8 +52,6 @@ func (pool *DBWorkerPool) Start(ctx context.Context) error {
 
 	<-ctx.Done() // blocking wait until getting context cancel event
 
-	close(pool.workers)
-
 	return nil
 }
 

--- a/pkg/bundle/migration/managedcluster_migration.go
+++ b/pkg/bundle/migration/managedcluster_migration.go
@@ -39,6 +39,7 @@ type MigrationSourceBundle struct {
 type MigrationTargetBundle struct {
 	MigrationId                           string   `json:"-"` // populated from extension at receiver side
 	Stage                                 string   `json:"-"` // populated from extension at receiver side
+	FromHub                               string   `json:"fromHub,omitempty"`
 	ManagedServiceAccountName             string   `json:"managedServiceAccountName"`
 	ManagedServiceAccountInstallNamespace string   `json:"installNamespace,omitempty"`
 	ManagedClusters                       []string `json:"managedClusters,omitempty"`

--- a/pkg/transport/consumer/generic_consumer.go
+++ b/pkg/transport/consumer/generic_consumer.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport/config"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport/identity"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport/utils"
 )
 
@@ -40,6 +41,7 @@ type GenericConsumer struct {
 	transportConfigChan  chan *transport.TransportInternalConfig
 	enableDatabaseOffset bool
 	isManager            bool
+	statusTopicPattern   string
 
 	// internal variables
 	eventChan chan *cloudevents.Event
@@ -161,6 +163,7 @@ func (c *GenericConsumer) Start(ctx context.Context) error {
 func (c *GenericConsumer) initClient(tranConfig *transport.TransportInternalConfig) (cloudevents.Client, error) {
 	topics := []string{tranConfig.KafkaCredential.SpecTopic}
 	if c.isManager {
+		c.statusTopicPattern = tranConfig.KafkaCredential.StatusTopic
 		topics = []string{tranConfig.KafkaCredential.StatusTopic}
 	}
 
@@ -223,14 +226,14 @@ func (c *GenericConsumer) receive(client cloudevents.Client, ctx context.Context
 
 		chunk, isChunk := c.assembler.messageChunk(event)
 		if !isChunk {
-			c.eventChan <- &event
+			c.publishReceivedEvent(&event)
 			return ceprotocol.ResultACK
 		}
 		if payload := c.assembler.assemble(chunk); payload != nil {
 			if err := event.SetData(cloudevents.ApplicationJSON, payload); err != nil {
 				log.Errorw("failed the set the assembled data to event", "error", err)
 			} else {
-				c.eventChan <- &event
+				c.publishReceivedEvent(&event)
 			}
 		}
 		return ceprotocol.ResultACK
@@ -240,6 +243,13 @@ func (c *GenericConsumer) receive(client cloudevents.Client, ctx context.Context
 	}
 	receivedMessage = false
 	return nil
+}
+
+func (c *GenericConsumer) publishReceivedEvent(event *cloudevents.Event) {
+	if c.isManager {
+		identity.EnrichManagerStatusEvent(event, c.statusTopicPattern)
+	}
+	c.eventChan <- event
 }
 
 func (c *GenericConsumer) EventChan() chan *cloudevents.Event {

--- a/pkg/transport/identity/identity.go
+++ b/pkg/transport/identity/identity.go
@@ -1,0 +1,148 @@
+/*
+Copyright Contributors to the Open Cluster Management project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package identity provides helpers to derive and validate hub identity from Kafka transport metadata.
+package identity
+
+import (
+	"strings"
+
+	kafka_confluent "github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	cetypes "github.com/cloudevents/sdk-go/v2/types"
+)
+
+const (
+	// ExtensionAuthedHub is the CloudEvent extension carrying the transport-derived hub name.
+	ExtensionAuthedHub = "authedhub"
+
+	kafkaUserSuffix = "-kafka-user"
+)
+
+// HubFromKafkaUser maps a KafkaUser / mTLS CN (e.g. "hub1-kafka-user") to a hub cluster name.
+func HubFromKafkaUser(kafkaUser string) string {
+	if !strings.HasSuffix(kafkaUser, kafkaUserSuffix) {
+		return ""
+	}
+
+	hub := strings.TrimSuffix(kafkaUser, kafkaUserSuffix)
+	if hub == "" {
+		return ""
+	}
+
+	return hub
+}
+
+// HubFromStatusTopic extracts the managed-hub name from a Kafka status topic.
+// statusTopicPattern is the configured template, e.g. "gh-status.*" or "^gh-status.*".
+// Returns ("", false) for shared topics without a per-hub suffix (e.g. BYO "gh-status").
+func HubFromStatusTopic(topic, statusTopicPattern string) (string, bool) {
+	pattern := strings.TrimPrefix(statusTopicPattern, "^")
+	if !strings.Contains(pattern, "*") {
+		return "", false
+	}
+
+	prefix := strings.ReplaceAll(pattern, "*", "")
+	if prefix == "" || !strings.HasPrefix(topic, prefix) {
+		return "", false
+	}
+
+	hub := strings.TrimPrefix(topic, prefix)
+	if hub == "" {
+		return "", false
+	}
+
+	return hub, true
+}
+
+// KafkaTopicFromEvent reads the Kafka topic name from CloudEvent Kafka extensions.
+func KafkaTopicFromEvent(evt *cloudevents.Event) (string, bool) {
+	if evt == nil {
+		return "", false
+	}
+
+	topic, err := cetypes.ToString(evt.Extensions()[kafka_confluent.KafkaTopicKey])
+	if err != nil || topic == "" {
+		return "", false
+	}
+
+	return topic, true
+}
+
+// SetAuthedHub attaches the transport-derived hub identity to the event.
+func SetAuthedHub(evt *cloudevents.Event, hub string) {
+	if evt == nil || hub == "" {
+		return
+	}
+	evt.SetExtension(ExtensionAuthedHub, hub)
+}
+
+// AuthedHub returns the transport-derived hub from the event extension.
+func AuthedHub(evt *cloudevents.Event) (string, bool) {
+	if evt == nil {
+		return "", false
+	}
+
+	hub, err := cetypes.ToString(evt.Extensions()[ExtensionAuthedHub])
+	if err != nil || hub == "" {
+		return "", false
+	}
+
+	return hub, true
+}
+
+// LeafHubForStatusEvent returns the trusted leaf-hub name for a manager status event.
+// When authedhub is present, evt.Source() must match it. When absent (e.g. chan transport
+// in tests), source is used as a fallback.
+func LeafHubForStatusEvent(evt *cloudevents.Event) (string, bool) {
+	if evt == nil {
+		return "", false
+	}
+
+	authedHub, hasAuthed := AuthedHub(evt)
+	if hasAuthed {
+		if evt.Source() != authedHub {
+			return "", false
+		}
+		return authedHub, true
+	}
+
+	if evt.Source() == "" {
+		return "", false
+	}
+
+	return evt.Source(), true
+}
+
+// EnrichManagerStatusEvent sets authedhub from the Kafka status topic when the pattern
+// contains a per-hub wildcard segment.
+func EnrichManagerStatusEvent(evt *cloudevents.Event, statusTopicPattern string) {
+	if evt == nil {
+		return
+	}
+
+	topic, ok := KafkaTopicFromEvent(evt)
+	if !ok {
+		return
+	}
+
+	hub, ok := HubFromStatusTopic(topic, statusTopicPattern)
+	if !ok {
+		return
+	}
+
+	SetAuthedHub(evt, hub)
+}

--- a/pkg/transport/identity/identity_test.go
+++ b/pkg/transport/identity/identity_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright Contributors to the Open Cluster Management project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package identity
+
+import (
+	"testing"
+
+	kafka_confluent "github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+)
+
+func TestHubFromKafkaUser(t *testing.T) {
+	if got := HubFromKafkaUser("hub1-kafka-user"); got != "hub1" {
+		t.Fatalf("HubFromKafkaUser() = %q, want hub1", got)
+	}
+	if got := HubFromKafkaUser("global-hub-kafka-user"); got != "global-hub" {
+		t.Fatalf("HubFromKafkaUser() = %q, want global-hub", got)
+	}
+	if got := HubFromKafkaUser("other-user"); got != "" {
+		t.Fatalf("HubFromKafkaUser() = %q, want empty for malformed principal", got)
+	}
+}
+
+func TestHubFromStatusTopic(t *testing.T) {
+	tests := []struct {
+		name    string
+		topic   string
+		pattern string
+		want    string
+		ok      bool
+	}{
+		{
+			name:    "per-hub topic",
+			topic:   "gh-status.hub-east",
+			pattern: "gh-status.*",
+			want:    "hub-east",
+			ok:      true,
+		},
+		{
+			name:    "regex subscription pattern",
+			topic:   "gh-status.hub-west",
+			pattern: "^gh-status.*",
+			want:    "hub-west",
+			ok:      true,
+		},
+		{
+			name:    "shared BYO topic",
+			topic:   "gh-status",
+			pattern: "gh-status",
+			want:    "",
+			ok:      false,
+		},
+		{
+			name:    "spoof attempt wrong topic prefix",
+			topic:   "gh-spec.hub-east",
+			pattern: "gh-status.*",
+			want:    "",
+			ok:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := HubFromStatusTopic(tt.topic, tt.pattern)
+			if ok != tt.ok || got != tt.want {
+				t.Fatalf("HubFromStatusTopic(%q, %q) = (%q, %v), want (%q, %v)",
+					tt.topic, tt.pattern, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}
+
+func TestLeafHubForStatusEvent(t *testing.T) {
+	t.Run("matching authed hub", func(t *testing.T) {
+		evt := cloudevents.NewEvent()
+		evt.SetSource("hub-a")
+		SetAuthedHub(&evt, "hub-a")
+
+		hub, ok := LeafHubForStatusEvent(&evt)
+		if !ok || hub != "hub-a" {
+			t.Fatalf("LeafHubForStatusEvent() = (%q, %v), want (hub-a, true)", hub, ok)
+		}
+	})
+
+	t.Run("spoofed source rejected", func(t *testing.T) {
+		evt := cloudevents.NewEvent()
+		evt.SetSource("hub-b")
+		SetAuthedHub(&evt, "hub-a")
+
+		if hub, ok := LeafHubForStatusEvent(&evt); ok || hub != "" {
+			t.Fatalf("LeafHubForStatusEvent() = (%q, %v), want rejection", hub, ok)
+		}
+	})
+
+	t.Run("nil event rejected", func(t *testing.T) {
+		if hub, ok := LeafHubForStatusEvent(nil); ok || hub != "" {
+			t.Fatalf("LeafHubForStatusEvent(nil) = (%q, %v), want rejection", hub, ok)
+		}
+	})
+
+	t.Run("fallback without authed hub", func(t *testing.T) {
+		evt := cloudevents.NewEvent()
+		evt.SetSource("hub-a")
+
+		hub, ok := LeafHubForStatusEvent(&evt)
+		if !ok || hub != "hub-a" {
+			t.Fatalf("LeafHubForStatusEvent() = (%q, %v), want (hub-a, true)", hub, ok)
+		}
+	})
+}
+
+func TestEnrichManagerStatusEvent(t *testing.T) {
+	t.Run("enriches from kafka topic", func(t *testing.T) {
+		evt := cloudevents.NewEvent()
+		evt.SetSource("hub-a")
+		evt.SetExtension(kafka_confluent.KafkaTopicKey, "gh-status.hub-a")
+
+		EnrichManagerStatusEvent(&evt, "^gh-status.*")
+
+		hub, ok := AuthedHub(&evt)
+		if !ok || hub != "hub-a" {
+			t.Fatalf("AuthedHub() = (%q, %v), want (hub-a, true)", hub, ok)
+		}
+	})
+
+	t.Run("nil event is no-op", func(t *testing.T) {
+		EnrichManagerStatusEvent(nil, "^gh-status.*")
+	})
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,15 +6,22 @@ sonar.exclusions=test/**,**/*.sql,**/*.yaml,**/*.py,**/*_test.go,**/*_generated*
 
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go
-sonar.test.exclusions=test/**,**/*_generated*.go,**/*_generated/**,**/vendor/**,samples/**,**/*.py
+sonar.test.exclusions=test/**,**/*_generated*.go,**/*_generated/**,**/vendor/**,samples/**,**/*.py,**/migration_to_syncer_test.go
 
 sonar.go.tests.reportPaths=report.json
 sonar.go.coverage.reportPaths=coverage.out
 sonar.externalIssuesReportPaths=gosec.json
 
 # ignore the long line go:s103 for kubebuilder labels and strimzi kafka naming
-sonar.issue.ignore.multicriteria=e1,e2
+# ignore legacy migration_to_syncer_test.go maintainability debt (pre-existing 4.4k-line file)
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5
 sonar.issue.ignore.multicriteria.e1.ruleKey=go:S103
 sonar.issue.ignore.multicriteria.e1.resourceKey=**/*controller.go
 sonar.issue.ignore.multicriteria.e2.ruleKey=go:S103
 sonar.issue.ignore.multicriteria.e2.resourceKey=**/*_transporter.go
+sonar.issue.ignore.multicriteria.e3.ruleKey=go:S104
+sonar.issue.ignore.multicriteria.e3.resourceKey=**/migration_to_syncer_test.go
+sonar.issue.ignore.multicriteria.e4.ruleKey=go:S103
+sonar.issue.ignore.multicriteria.e4.resourceKey=**/migration_to_syncer_test.go
+sonar.issue.ignore.multicriteria.e5.ruleKey=go:S134
+sonar.issue.ignore.multicriteria.e5.resourceKey=**/migration_to_syncer_test.go

--- a/test/Makefile
+++ b/test/Makefile
@@ -42,6 +42,7 @@ e2e-log/grafana:
 e2e-log/agent:
 	@export CLUSTER_NAME=hub1 COMPONENT=multicluster-global-hub-agent NAMESPACE=multicluster-global-hub-agent && ./test/script/e2e_log.sh
 	@export CLUSTER_NAME=hub2 COMPONENT=multicluster-global-hub-agent NAMESPACE=multicluster-global-hub-agent && ./test/script/e2e_log.sh
+	@export CLUSTER_NAME=global-hub COMPONENT=multicluster-global-hub-agent && ./test/script/e2e_log.sh
 
 integration-test: setup_envtest
 	KUBEBUILDER_ASSETS="$(shell ${TMP_BIN}/setup-envtest use --use-env -p path)" ${GO_TEST} `go list ./test/integration/...`

--- a/test/integration/agent/migration/migration_from_syncer_test.go
+++ b/test/integration/agent/migration/migration_from_syncer_test.go
@@ -60,7 +60,7 @@ var _ = Describe("MigrationFromSyncer", Ordered, func() {
 		)
 
 		namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: utils.GetDefaultNamespace()}}
-		Expect(runtimeClient.Create(testCtx, namespace)).Should(Succeed())
+		Expect(client.IgnoreAlreadyExists(runtimeClient.Create(testCtx, namespace))).Should(Succeed())
 
 		cluster := &clusterv1.ManagedCluster{
 			ObjectMeta: metav1.ObjectMeta{
@@ -116,7 +116,6 @@ var _ = Describe("MigrationFromSyncer", Ordered, func() {
 			&mchv1.MultiClusterHub{ObjectMeta: metav1.ObjectMeta{Name: "multiclusterhub"}},
 			&addonv1.KlusterletAddonConfig{ObjectMeta: metav1.ObjectMeta{Name: testClusterName, Namespace: testClusterName}},
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testClusterName}},
-			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: utils.GetDefaultNamespace()}},
 		}
 		// delete the configmap using the test's namespace (not global config which may have changed)
 		_ = runtimeClient.Delete(testCtx, &corev1.ConfigMap{
@@ -128,6 +127,7 @@ var _ = Describe("MigrationFromSyncer", Ordered, func() {
 		for _, resource := range resources {
 			_ = runtimeClient.Delete(testCtx, resource)
 		}
+		// Keep multicluster-global-hub namespace: MigrationToSyncer reuses it for shadow migration CRs.
 		testCtxCancel()
 	})
 

--- a/test/integration/agent/migration/migration_to_syncer_test.go
+++ b/test/integration/agent/migration/migration_to_syncer_test.go
@@ -49,7 +49,7 @@ var _ = Describe("MigrationToSyncer", Ordered, func() {
 		receivedEvents = []*cloudevents.Event{}
 		agentConfig := &configs.AgentConfig{
 			TransportConfig: transportConfig,
-			LeafHubName:     "hub1",
+			LeafHubName:     testToHub,
 			PodNamespace:    testMSANamespace, // Set PodNamespace for configmap operations
 		}
 		configs.SetAgentConfig(agentConfig)
@@ -97,11 +97,6 @@ var _ = Describe("MigrationToSyncer", Ordered, func() {
 
 		clusterNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testClusterName}}
 		Expect(runtimeClient.Create(testCtx, clusterNamespace)).Should(Succeed())
-
-		configs.SetAgentConfig(&configs.AgentConfig{
-			LeafHubName:  testToHub,
-			PodNamespace: testMSANamespace, // Set PodNamespace for configmap operations
-		})
 
 		// Delete any existing configmap to ensure clean state before each test suite
 		_ = runtimeClient.Delete(ctx, &corev1.ConfigMap{
@@ -160,7 +155,9 @@ var _ = Describe("MigrationToSyncer", Ordered, func() {
 			By("Creating migration event for validating stage with no existing clusters")
 			event := createMigrationToEvent(testMigrationID, migrationv1alpha1.PhaseValidating, testFromHub, testToHub)
 			event.DataEncoded, _ = json.Marshal(&migration.MigrationTargetBundle{
-				ManagedClusters: []string{"non-existing-cluster"},
+				FromHub:                   testFromHub,
+				ManagedServiceAccountName: testMSAName,
+				ManagedClusters:           []string{"non-existing-cluster"},
 			})
 
 			By("Processing the validating event")
@@ -187,7 +184,9 @@ var _ = Describe("MigrationToSyncer", Ordered, func() {
 			By("Resetting migration state back to testMigrationID for subsequent tests")
 			resetEvent := createMigrationToEvent(testMigrationID, migrationv1alpha1.PhaseValidating, testFromHub, testToHub)
 			resetEvent.DataEncoded, _ = json.Marshal(&migration.MigrationTargetBundle{
-				ManagedClusters: []string{"non-existing-cluster"},
+				FromHub:                   testFromHub,
+				ManagedServiceAccountName: testMSAName,
+				ManagedClusters:           []string{"non-existing-cluster"},
 			})
 			err = migrationSyncer.Sync(testCtx, resetEvent)
 			Expect(err).NotTo(HaveOccurred())
@@ -197,8 +196,10 @@ var _ = Describe("MigrationToSyncer", Ordered, func() {
 			By("Creating migration event for initializing stage")
 			event := createMigrationToEvent(testMigrationID, migrationv1alpha1.PhaseInitializing, testFromHub, testToHub)
 			event.DataEncoded, _ = json.Marshal(&migration.MigrationTargetBundle{
+				FromHub:                               testFromHub,
 				ManagedServiceAccountName:             testMSAName,
 				ManagedServiceAccountInstallNamespace: testMSANamespace,
+				ManagedClusters:                       []string{testClusterName},
 			})
 
 			By("Processing the migration event")
@@ -277,6 +278,25 @@ var _ = Describe("MigrationToSyncer", Ordered, func() {
 		})
 
 		It("should deploy migration resources successfully", func() {
+			By("Creating migration namespace and in-flight CR for deploying source validation")
+			ghNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: constants.GHDefaultNamespace}}
+			Expect(client.IgnoreAlreadyExists(runtimeClient.Create(testCtx, ghNamespace))).Should(Succeed())
+
+			migrationCR := &migrationv1alpha1.ManagedClusterMigration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testMigrationID,
+					Namespace: constants.GHDefaultNamespace,
+				},
+				Spec: migrationv1alpha1.ManagedClusterMigrationSpec{
+					From:                    testFromHub,
+					To:                      testToHub,
+					IncludedManagedClusters: []string{testClusterName},
+				},
+			}
+			Expect(runtimeClient.Create(testCtx, migrationCR)).Should(Succeed())
+			migrationCR.Status.Phase = migrationv1alpha1.PhaseDeploying
+			Expect(runtimeClient.Status().Update(testCtx, migrationCR)).Should(Succeed())
+
 			By("Creating test manifest work for the cluster")
 			manifestWork := &workv1.ManifestWork{
 				ObjectMeta: metav1.ObjectMeta{

--- a/test/integration/agent/spec/hubstatus_syncer_test.go
+++ b/test/integration/agent/spec/hubstatus_syncer_test.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -15,6 +16,34 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
+
+func waitForManagedClusters(names ...string) {
+	Eventually(func() error {
+		for _, name := range names {
+			mc := &clusterv1.ManagedCluster{}
+			if err := runtimeClient.Get(ctx, client.ObjectKey{Name: name}, mc); err != nil {
+				return err
+			}
+		}
+		return nil
+	}, 5*time.Second, 50*time.Millisecond).Should(Succeed())
+}
+
+func waitForManagedClustersDeleted(names ...string) {
+	Eventually(func() error {
+		for _, name := range names {
+			mc := &clusterv1.ManagedCluster{}
+			err := runtimeClient.Get(ctx, client.ObjectKey{Name: name}, mc)
+			if err == nil {
+				return fmt.Errorf("managed cluster %s still exists", name)
+			}
+			if !errors.IsNotFound(err) {
+				return err
+			}
+		}
+		return nil
+	}, 5*time.Second, 50*time.Millisecond).Should(Succeed())
+}
 
 var _ = Describe("HubStatusSyncer", func() {
 	var (
@@ -55,30 +84,32 @@ var _ = Describe("HubStatusSyncer", func() {
 			},
 		}
 		Expect(runtimeClient.Create(ctx, cluster3)).To(Succeed())
+		waitForManagedClusters(cluster1Name, cluster2Name, cluster3Name)
 	})
 
 	AfterEach(func() {
-		// Clean up test ManagedClusters
+		// Clean up test ManagedClusters and wait for deletion so the next spec gets fresh objects in cache.
 		cluster1 := &clusterv1.ManagedCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: cluster1Name,
 			},
 		}
-		_ = runtimeClient.Delete(ctx, cluster1)
+		Expect(runtimeClient.Delete(ctx, cluster1)).To(Succeed())
 
 		cluster2 := &clusterv1.ManagedCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: cluster2Name,
 			},
 		}
-		_ = runtimeClient.Delete(ctx, cluster2)
+		Expect(runtimeClient.Delete(ctx, cluster2)).To(Succeed())
 
 		cluster3 := &clusterv1.ManagedCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: cluster3Name,
 			},
 		}
-		_ = runtimeClient.Delete(ctx, cluster3)
+		Expect(runtimeClient.Delete(ctx, cluster3)).To(Succeed())
+		waitForManagedClustersDeleted(cluster1Name, cluster2Name, cluster3Name)
 	})
 
 	It("should update hubAcceptsClient when active hub goes inactive (failover)", func() {

--- a/test/integration/manager/status/status_identity_test.go
+++ b/test/integration/manager/status/status_identity_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright Contributors to the Open Cluster Management project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	kafka_confluent "github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gorm.io/gorm"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/bundle/generic"
+	eventversion "github.com/stolostron/multicluster-global-hub/pkg/bundle/version"
+	"github.com/stolostron/multicluster-global-hub/pkg/database"
+	"github.com/stolostron/multicluster-global-hub/pkg/database/models"
+	"github.com/stolostron/multicluster-global-hub/pkg/enum"
+)
+
+// go test ./test/integration/manager/status -ginkgo.focus "StatusEventIdentity"
+var _ = Describe("StatusEventIdentity", Ordered, func() {
+	const (
+		trustedHub = "identity-trusted-hub"
+		topicHub   = "identity-topic-only-hub"
+		victimHub  = "identity-victim-hub"
+	)
+
+	AfterEach(func() {
+		db := database.GetGorm()
+		Expect(db.Exec(
+			`DELETE FROM status.leaf_hub_heartbeats WHERE leaf_hub_name IN ($1, $2, $3)`,
+			trustedHub, topicHub, victimHub,
+		).Error).To(Succeed(), "failed to clean up identity test heartbeat rows")
+	})
+
+	It("accepts status events when CloudEvent source matches the Kafka status topic hub", func() {
+		version := eventversion.NewVersion()
+		version.Incr()
+		evt := ToKafkaStatusCloudEvent(
+			fmt.Sprintf("gh-status.%s", trustedHub),
+			trustedHub,
+			string(enum.HubClusterHeartbeatType),
+			version,
+			generic.GenericObjectBundle{},
+		)
+
+		Expect(producer.SendEvent(ctx, *evt)).To(Succeed(),
+			"trusted status event with matching topic and source should publish successfully")
+
+		Eventually(func() error {
+			var heartbeat models.LeafHubHeartbeat
+			err := database.GetGorm().Where("leaf_hub_name = ?", trustedHub).First(&heartbeat).Error
+			if err != nil {
+				return fmt.Errorf("expected heartbeat row for trusted hub %q: %w", trustedHub, err)
+			}
+			return nil
+		}, 30*time.Second, 100*time.Millisecond).Should(Succeed(),
+			"trusted status event should be persisted for the topic-derived hub name")
+	})
+
+	It("drops status events when CloudEvent source does not match the Kafka status topic hub", func() {
+		version := eventversion.NewVersion()
+		version.Incr()
+		evt := ToKafkaStatusCloudEvent(
+			fmt.Sprintf("gh-status.%s", topicHub),
+			victimHub,
+			string(enum.HubClusterHeartbeatType),
+			version,
+			generic.GenericObjectBundle{},
+		)
+
+		Expect(producer.SendEvent(ctx, *evt)).To(Succeed(),
+			"transport publish should succeed even when downstream identity validation will reject the event")
+
+		Consistently(func() error {
+			db := database.GetGorm()
+			for _, hub := range []string{topicHub, victimHub} {
+				var heartbeat models.LeafHubHeartbeat
+				err := db.Where("leaf_hub_name = ?", hub).First(&heartbeat).Error
+				if errors.Is(err, gorm.ErrRecordNotFound) {
+					continue
+				}
+				if err != nil {
+					return fmt.Errorf("query heartbeat for hub %q: %w", hub, err)
+				}
+				return fmt.Errorf("spoofed status event must not create heartbeat row for hub %q", hub)
+			}
+			return nil
+		}, 30*time.Second, 200*time.Millisecond).Should(Succeed(),
+			"spoofed status event must be dropped for both topic-derived and claimed hub names")
+	})
+})
+
+func ToKafkaStatusCloudEvent(kafkaTopic, source, eventType string, version *eventversion.Version, data interface{}) *cloudevents.Event {
+	evt := ToCloudEvent(source, eventType, version, data)
+	evt.SetExtension(kafka_confluent.KafkaTopicKey, kafkaTopic)
+	return evt
+}

--- a/test/integration/manager/status/suite_test.go
+++ b/test/integration/manager/status/suite_test.go
@@ -85,7 +85,7 @@ var _ = BeforeSuite(func() {
 			TransportType: string(transport.Chan),
 			KafkaCredential: &transport.KafkaConfig{
 				SpecTopic:   "spec",
-				StatusTopic: "event",
+				StatusTopic: "gh-status.*",
 			},
 		},
 		StatisticsConfig: &statistics.StatisticsConfig{

--- a/test/script/e2e_setup.sh
+++ b/test/script/e2e_setup.sh
@@ -35,9 +35,8 @@ echo -e "${YELLOW} creating clusters:${NC} $(($(date +%s) - start_time)) seconds
 start_time=$(date +%s)
 pids=()
 
-# async install olm
-enable_olm "$GH_NAME" 2>&1 &
-pids+=($!)
+# global-hub needs OLM before clusteradm init; do not race init_hub with enable_olm
+enable_olm "$GH_NAME" 2>&1
 
 init_hub "$GH_NAME" 2>&1 &
 pids+=($!)
@@ -45,9 +44,18 @@ for i in $(seq 1 "${MH_NUM}"); do
   init_hub "hub$i" 2>&1 &
   pids+=($!)
 done
+init_failed=0
 for pid in "${pids[@]}"; do
-  wait "$pid" || true
+  if ! wait "$pid"; then
+    echo -e "${RED}Hub init process $pid failed${NC}"
+    init_failed=1
+  fi
 done
+if [ $init_failed -eq 1 ]; then
+  echo -e "${RED}One or more hub init processes failed. Exiting...${NC}"
+  exit 1
+fi
+ensure_hub_join_token "$GH_NAME"
 
 # service-ca
 # it reports `CSV "packageserver" failed to reach phase succeeded` if create service ca before enable olm

--- a/test/script/e2e_setup.sh
+++ b/test/script/e2e_setup.sh
@@ -76,7 +76,7 @@ start_time=$(date +%s)
 # gobal-hub: hub1, hub2
 pids=()
 for i in $(seq 1 "${MH_NUM}"); do
-  bash "${CURRENT_DIR}"/ocm.sh "${GH_NAME}" "hub$i" HUB_INIT=false POLICY_INIT=false 2>&1 &
+  HUB_INIT=false POLICY_INIT=false bash "${CURRENT_DIR}"/ocm.sh "${GH_NAME}" "hub$i" 2>&1 &
   pid=$!
   pids+=($pid)
   echo "$pid" >>"$CONFIG_DIR/PID"
@@ -85,7 +85,7 @@ done
 # hub1: cluster1 | hub2: cluster1
 for i in $(seq 1 "${MH_NUM}"); do
   for j in $(seq 1 "${MC_NUM}"); do
-    bash "${CURRENT_DIR}"/ocm.sh "hub$i" "hub$i-cluster$j" HUB_INIT=false 2>&1 &
+    HUB_INIT=false bash "${CURRENT_DIR}"/ocm.sh "hub$i" "hub$i-cluster$j" 2>&1 &
     pid=$!
     pids+=($pid)
     echo "$pid" >>"$CONFIG_DIR/PID"

--- a/test/script/e2e_setup.sh
+++ b/test/script/e2e_setup.sh
@@ -118,6 +118,11 @@ fi
 
 echo -e "${YELLOW} installing ocm and policy:${NC} $(($(date +%s) - start_time)) seconds"
 
+# Local agent e2e installs the agent on the global hub cluster, whose cache
+# requires Policy CRDs even when POLICY_INIT=false for global-hub imports.
+echo -e "${YELLOW}Installing Policy CRDs on global hub for local agent e2e${NC}"
+install_policy_crds_on_hub "$GH_NAME"
+
 # Install managed-serviceaccount addon on global hub
 # This is required for migration functionality to create ServiceAccounts and collect tokens
 echo -e "${YELLOW}Installing managed-serviceaccount addon on global hub${NC}"

--- a/test/script/util.sh
+++ b/test/script/util.sh
@@ -224,15 +224,24 @@ ensure_cluster() {
   fi
 }
 
+ensure_hub_join_token() {
+  local hub=$1
+  dir="${CONFIG_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+  join_file="$dir/join-$hub"
+  if [ ! -s "$join_file" ]; then
+    echo -e "${CYAN} Refreshing join token for hub $hub${NC}"
+    mkdir -p "$dir"
+    clusteradm get token --context "$hub" | grep "clusteradm" >"$join_file"
+  fi
+}
+
 init_hub() {
   echo -e "${CYAN} Init Hub $1 ... $NC"
   clusteradm init --wait --context "$1" >/dev/null 2>&1 # not echo the senetive information
   kubectl wait deployment -n open-cluster-management cluster-manager --for condition=Available=True --timeout=200s --context "$1"
   kubectl wait deployment -n open-cluster-management-hub cluster-manager-registration-controller --for condition=Available=True --timeout=200s --context "$1"
   kubectl wait deployment -n open-cluster-management-hub cluster-manager-registration-webhook --for condition=Available=True --timeout=200s --context "$1"
-  dir="${CONFIG_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
-  join_file="$dir/join-$1"
-  clusteradm get token --context "$1" | grep "clusteradm" >"$join_file"
+  ensure_hub_join_token "$1"
 }
 
 init_managed() {
@@ -265,6 +274,7 @@ join_cluster() {
   local hub=$1 # hub name also as the context
   local cluster=$2
   echo -e "${CYAN} Import Cluster $2 to Hub $1 ... $NC"
+  ensure_hub_join_token "$hub"
   dir="${CONFIG_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
   join_file="$dir/join-$1"
   if [[ -z $(kubectl get mcl "$cluster" --context "$hub" --ignore-not-found) ]]; then

--- a/test/script/util.sh
+++ b/test/script/util.sh
@@ -278,6 +278,34 @@ join_cluster() {
   fi
 }
 
+# sync_grc_git_repo clones and checks out a GRC dependency under a file lock so
+# parallel e2e setup jobs do not corrupt shared working-tree checkouts.
+sync_grc_git_repo() {
+  local repo_name=$1
+  local repo_url=$2
+  local lock_file="${CURRENT_DIR}/.${repo_name}.lock"
+
+  (
+    flock -x 200
+    if [ ! -d "$repo_name" ]; then
+      echo "Cloning $repo_name repository..."
+      if ! git clone "$repo_url"; then
+        echo -e "${RED}Failed to clone $repo_name repository${NC}"
+        exit 1
+      fi
+    fi
+    cd "$repo_name" || exit 1
+    if ! git checkout "$GRC_VERSION" 2>/dev/null; then
+      echo -e "${RED}Failed to checkout $GRC_VERSION, fetching updates...${NC}"
+      if ! git fetch origin && git checkout "$GRC_VERSION"; then
+        echo -e "${RED}Failed to checkout $GRC_VERSION after fetch${NC}"
+        exit 1
+      fi
+    fi
+    cd "${CURRENT_DIR}" || exit 1
+  ) 200>"$lock_file"
+}
+
 init_policy() {
   echo -e "${CYAN} Init Policy $1:$2 $NC"
   local hub=$1
@@ -293,25 +321,7 @@ init_policy() {
   PROPAGATOR_GIT_HTTP_PATH="https://github.com/open-cluster-management-io/governance-policy-propagator.git"
   propagator="governance-policy-propagator"
 
-  # Clone repository if it doesn't exist
-  if [ ! -d $propagator ]; then
-    echo "Cloning $propagator repository..."
-    if ! git clone $PROPAGATOR_GIT_HTTP_PATH; then
-      echo -e "${RED}Failed to clone $propagator repository${NC}"
-      exit 1
-    fi
-  fi
-
-  # Always ensure we're on the correct version
-  cd $propagator || exit 1
-  if ! git checkout $GRC_VERSION 2>/dev/null; then
-    echo -e "${RED}Failed to checkout $GRC_VERSION, fetching updates...${NC}"
-    if ! git fetch origin && git checkout $GRC_VERSION; then
-      echo -e "${RED}Failed to checkout $GRC_VERSION after fetch${NC}"
-      exit 1
-    fi
-  fi
-  cd ../ || exit 1
+  sync_grc_git_repo "$propagator" "$PROPAGATOR_GIT_HTTP_PATH" || exit 1
 
   # Verify required CRD files exist
   required_crds=(
@@ -371,24 +381,7 @@ init_policy() {
   POLICY_ADDON_GIT_HTTP_PATH="https://github.com/open-cluster-management-io/governance-policy-framework-addon.git"
   policy_addon=governance-policy-framework-addon
 
-  # Clone repository if it doesn't exist
-  if [ ! -d $policy_addon ]; then
-    if ! git clone $POLICY_ADDON_GIT_HTTP_PATH; then
-      echo -e "${RED}Failed to clone $policy_addon repository${NC}"
-      exit 1
-    fi
-  fi
-
-  # Always ensure we're on the correct version
-  cd $policy_addon || exit 1
-  if ! git checkout $GRC_VERSION 2>/dev/null; then
-    echo -e "${RED}Failed to checkout $GRC_VERSION, fetching updates...${NC}"
-    if ! git fetch origin && git checkout $GRC_VERSION; then
-      echo -e "${RED}Failed to checkout $GRC_VERSION after fetch${NC}"
-      exit 1
-    fi
-  fi
-  cd ../ || exit 1
+  sync_grc_git_repo "$policy_addon" "$POLICY_ADDON_GIT_HTTP_PATH" || exit 1
 
   retry "(kubectl --context $cluster apply -f $policy_addon/deploy/operator.yaml -n $MANAGED_NAMESPACE) && (kubectl --context $cluster get deploy/$policy_addon -n $MANAGED_NAMESPACE)" 10
 
@@ -401,24 +394,7 @@ init_policy() {
   config_policy="config-policy-controller"
   CONFIG_POLICY_GIT_HTTP_PATH="https://github.com/open-cluster-management-io/config-policy-controller.git"
 
-  # Clone repository if it doesn't exist
-  if [ ! -d $config_policy ]; then
-    if ! git clone $CONFIG_POLICY_GIT_HTTP_PATH; then
-      echo -e "${RED}Failed to clone $config_policy repository${NC}"
-      exit 1
-    fi
-  fi
-
-  # Always ensure we're on the correct version
-  cd $config_policy || exit 1
-  if ! git checkout $GRC_VERSION 2>/dev/null; then
-    echo -e "${RED}Failed to checkout $GRC_VERSION, fetching updates...${NC}"
-    if ! git fetch origin && git checkout $GRC_VERSION; then
-      echo -e "${RED}Failed to checkout $GRC_VERSION after fetch${NC}"
-      exit 1
-    fi
-  fi
-  cd ../ || exit 1
+  sync_grc_git_repo "$config_policy" "$CONFIG_POLICY_GIT_HTTP_PATH" || exit 1
 
   kubectl --context "$cluster" apply -f ${config_policy}/deploy/crds/policy.open-cluster-management.io_configurationpolicies.yaml
   # kubectl --context "$cluster" apply -f ${GIT_PATH}/crds/policy.open-cluster-management.io_operatorpolicies.yaml

--- a/test/script/util.sh
+++ b/test/script/util.sh
@@ -306,16 +306,8 @@ sync_grc_git_repo() {
   ) 200>"$lock_file"
 }
 
-init_policy() {
-  echo -e "${CYAN} Init Policy $1:$2 $NC"
+install_policy_crds_on_hub() {
   local hub=$1
-  local cluster=$2
-
-  # create namespace fist
-  HUB_NAMESPACE="open-cluster-management"
-  kubectl create ns "${HUB_NAMESPACE}" --dry-run=client -o yaml | kubectl --context $hub apply -f -
-  MANAGED_NAMESPACE="open-cluster-management-agent-addon"
-  kubectl create ns "${MANAGED_NAMESPACE}" --dry-run=client -o yaml | kubectl --context "$cluster" apply -f -
 
   # Reference: https://open-cluster-management.io/getting-started/integration/policy-framework/
   PROPAGATOR_GIT_HTTP_PATH="https://github.com/open-cluster-management-io/governance-policy-propagator.git"
@@ -323,7 +315,6 @@ init_policy() {
 
   sync_grc_git_repo "$propagator" "$PROPAGATOR_GIT_HTTP_PATH" || exit 1
 
-  # Verify required CRD files exist
   required_crds=(
     "$propagator/deploy/crds/policy.open-cluster-management.io_policies.yaml"
     "$propagator/deploy/crds/policy.open-cluster-management.io_placementbindings.yaml"
@@ -339,13 +330,28 @@ init_policy() {
     fi
   done
 
+  kubectl --context "$hub" apply -f "$propagator/deploy/crds/policy.open-cluster-management.io_policies.yaml"
+  kubectl --context "$hub" apply -f "$propagator/deploy/crds/policy.open-cluster-management.io_placementbindings.yaml"
+  kubectl --context "$hub" apply -f "$propagator/deploy/crds/policy.open-cluster-management.io_policyautomations.yaml"
+  kubectl --context "$hub" apply -f "$propagator/deploy/crds/policy.open-cluster-management.io_policysets.yaml"
+}
+
+init_policy() {
+  echo -e "${CYAN} Init Policy $1:$2 $NC"
+  local hub=$1
+  local cluster=$2
+  propagator="governance-policy-propagator"
+
+  # create namespace fist
+  HUB_NAMESPACE="open-cluster-management"
+  kubectl create ns "${HUB_NAMESPACE}" --dry-run=client -o yaml | kubectl --context $hub apply -f -
+  MANAGED_NAMESPACE="open-cluster-management-agent-addon"
+  kubectl create ns "${MANAGED_NAMESPACE}" --dry-run=client -o yaml | kubectl --context "$cluster" apply -f -
+
+  install_policy_crds_on_hub "$hub" || exit 1
+
   # On hub
   if ! kubectl --context $hub get deploy -n "$HUB_NAMESPACE" | grep -q $propagator | grep -q Running; then
-    ## Apply the CRDs
-    kubectl --context $hub apply -f $propagator/deploy/crds/policy.open-cluster-management.io_policies.yaml
-    kubectl --context $hub apply -f $propagator/deploy/crds/policy.open-cluster-management.io_placementbindings.yaml
-    kubectl --context $hub apply -f $propagator/deploy/crds/policy.open-cluster-management.io_policyautomations.yaml
-    kubectl --context $hub apply -f $propagator/deploy/crds/policy.open-cluster-management.io_policysets.yaml
     # Deploy the policy-propagator
     kubectl --context $hub apply -f $propagator/deploy/operator.yaml -n ${HUB_NAMESPACE}
     sleep 2


### PR DESCRIPTION
Fixes: [ACM-34442](https://redhat.atlassian.net/browse/ACM-34442) [ACM-38860](https://redhat.atlassian.net/browse/ACM-38860)

## Summary

Backport **[ACM-34442](https://redhat.atlassian.net/browse/ACM-34442) phases 1–2** to **release-2.17** (Global Hub 1.8). Both commits cherry-pick cleanly from main with no adaptation required.

- **Phase 1:** [#2564](https://github.com/stolostron/multicluster-global-hub/pull/2564) — manager validates status hub identity from Kafka topic (`788e4903`)
- **Phase 2:** [#2623](https://github.com/stolostron/multicluster-global-hub/pull/2623) — agent spec source validation, migration syncer hardening, Hub HA defense-in-depth (`e2d0e308`)

This is a near 1:1 port: 2.17 already has `hubha/`, subject routing, migration CE extensions, and async dispatcher.

## Test plan

- [x] `go test ./agent/pkg/spec/... ./agent/pkg/spec/migration/... ./pkg/transport/identity/...`
- [ ] CI format / unit / integration on release-2.17

[ACM-34442]: https://redhat.atlassian.net/browse/ACM-34442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-34442]: https://redhat.atlassian.net/browse/ACM-34442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ACM-38860]: https://redhat.atlassian.net/browse/ACM-38860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ