### PR TITLE
ACM-34442: e2e tests for Phase 3 gh-migration topic

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -24,8 +24,9 @@ e2e-test-all: tidy vendor
 	sh ./test/script/e2e_run.sh -f "e2e-test-migration" -v $(VERBOSE)
 	sh ./test/script/e2e_run.sh -f "e2e-test-hubha" -v $(VERBOSE)
 	sh ./test/script/e2e_run.sh -f "e2e-test-transport-identity" -v $(VERBOSE)
+	sh ./test/script/e2e_run.sh -f "e2e-test-transport-migration-topic" -v $(VERBOSE)
 
-e2e-test-cluster e2e-test-local-agent e2e-test-localpolicy e2e-test-grafana e2e-test-migration e2e-test-hubha e2e-test-transport-identity: tidy vendor
+e2e-test-cluster e2e-test-local-agent e2e-test-localpolicy e2e-test-grafana e2e-test-migration e2e-test-hubha e2e-test-transport-identity e2e-test-transport-migration-topic: tidy vendor
 	./test/script/e2e_run.sh -f $@ -v $(VERBOSE)
 
 e2e-prow-tests: 

--- a/test/e2e/hubha_test.go
+++ b/test/e2e/hubha_test.go
@@ -1066,6 +1066,9 @@ var _ = Describe("Hub HA Sync", Label("e2e-test-hubha"), Ordered, func() {
 					return activeHubClient.Update(ctx, activeCluster)
 				}, 1*time.Minute, 5*time.Second).Should(Succeed())
 
+				By("Waiting for ManagedCluster resourceVersion to stabilize after update")
+				waitForManagedClusterStable(ctx, activeHubClient, testClusterName, 10*time.Second)
+
 				By("Verifying update is synced with hubAcceptsClient still false")
 				Eventually(func() error {
 					standbyCluster := &clusterv1.ManagedCluster{}
@@ -1090,7 +1093,7 @@ var _ = Describe("Hub HA Sync", Label("e2e-test-hubha"), Ordered, func() {
 
 					klog.Infof("ManagedCluster %s update synced correctly with hubAcceptsClient=false maintained", testClusterName)
 					return nil
-				}, hubHASyncWait+30*time.Second, 5*time.Second).Should(Succeed())
+				}, 2*time.Minute, 5*time.Second).Should(Succeed())
 			})
 		})
 	})

--- a/test/e2e/transport_migration_topic_test.go
+++ b/test/e2e/transport_migration_topic_test.go
@@ -54,7 +54,9 @@ var _ = Describe("Transport Migration Topic E2E", Label("e2e-test-transport-migr
 				}, topic)
 			}, 2*time.Minute, 5*time.Second).Should(Succeed(),
 				"expected gh-migration KafkaTopic to be provisioned in the global hub namespace")
-			Expect(topic.Spec.Partitions).To(BeNumerically(">", 0),
+			Expect(topic.Spec.Partitions).NotTo(BeNil(),
+				"gh-migration topic must define partitions in spec")
+			Expect(int(*topic.Spec.Partitions)).To(BeNumerically(">", 0),
 				"gh-migration topic must have at least one partition")
 		})
 

--- a/test/e2e/transport_migration_topic_test.go
+++ b/test/e2e/transport_migration_topic_test.go
@@ -34,7 +34,8 @@ var _ = Describe("Transport Migration Topic E2E", Label("e2e-test-transport-migr
 			"transport migration topic e2e requires two regional hubs (source and target)")
 		sourceHubName = managedHubNames[0]
 		targetHubName = managedHubNames[1]
-		migrationTopic = operatorconfig.GetMigrationTopic()
+		// Operator in-process topic config is not initialized in the e2e test binary.
+		migrationTopic = operatorconfig.DEFAULT_MIGRATION_TOPIC
 
 		var err error
 		sourceHubClient, err = testClients.RuntimeClient(sourceHubName, agentScheme)

--- a/test/e2e/transport_migration_topic_test.go
+++ b/test/e2e/transport_migration_topic_test.go
@@ -1,0 +1,158 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package tests
+
+import (
+	"fmt"
+	"time"
+
+	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+
+	operatorconfig "github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport"
+	e2eutils "github.com/stolostron/multicluster-global-hub/test/e2e/utils"
+)
+
+var _ = Describe("Transport Migration Topic E2E", Label("e2e-test-transport-migration-topic"), Ordered, func() {
+	var (
+		sourceHubName   string
+		targetHubName   string
+		sourceHubClient client.Client
+		targetHubClient client.Client
+		migrationTopic  string
+	)
+
+	BeforeAll(func() {
+		Expect(len(managedHubNames)).To(BeNumerically(">=", 2),
+			"transport migration topic e2e requires two regional hubs (source and target)")
+		sourceHubName = managedHubNames[0]
+		targetHubName = managedHubNames[1]
+		migrationTopic = operatorconfig.GetMigrationTopic()
+
+		var err error
+		sourceHubClient, err = testClients.RuntimeClient(sourceHubName, agentScheme)
+		Expect(err).NotTo(HaveOccurred(), "expected source hub %q kubeconfig to be valid", sourceHubName)
+		targetHubClient, err = testClients.RuntimeClient(targetHubName, agentScheme)
+		Expect(err).NotTo(HaveOccurred(), "expected target hub %q kubeconfig to be valid", targetHubName)
+	})
+
+	Context("ACM-34442 Phase 3 - dedicated gh-migration topic", func() {
+		It("should provision the gh-migration KafkaTopic in the global hub namespace", func() {
+			topic := &kafkav1beta2.KafkaTopic{}
+			Eventually(func() error {
+				return globalHubClient.Get(ctx, types.NamespacedName{
+					Name:      migrationTopic,
+					Namespace: testOptions.GlobalHub.Namespace,
+				}, topic)
+			}, 2*time.Minute, 5*time.Second).Should(Succeed(),
+				"expected gh-migration KafkaTopic to be provisioned in the global hub namespace")
+			Expect(topic.Spec.Partitions).To(BeNumerically(">", 0),
+				"gh-migration topic must have at least one partition")
+		})
+
+		It("should include the migration topic in managed hub transport credentials", func() {
+			secret := &corev1.Secret{}
+			Expect(sourceHubClient.Get(ctx, types.NamespacedName{
+				Name:      constants.GHTransportSecretName,
+				Namespace: constants.GHAgentNamespace,
+			}, secret)).To(Succeed(), "expected transport secret on managed hub agent namespace")
+
+			kafkaYAML, ok := secret.Data["kafka.yaml"]
+			Expect(ok).To(BeTrue(), "transport secret must contain kafka.yaml")
+
+			kafkaConfig := &transport.KafkaConfig{}
+			Expect(yaml.Unmarshal(kafkaYAML, kafkaConfig)).To(Succeed(),
+				"expected kafka.yaml in transport secret to unmarshal")
+			Expect(kafkaConfig.MigrationTopic).To(Equal(migrationTopic),
+				"managed hub transport credentials must include the gh-migration topic")
+		})
+	})
+
+	Context("Migration deploying over gh-migration", func() {
+		var (
+			publisher        *e2eutils.KafkaEventPublisher
+			trustedMigration string
+			spoofMigrationNS string
+		)
+
+		BeforeEach(func() {
+			trustedMigration = fmt.Sprintf("%s-trusted-%d", spoofMigrationNSPrefix, time.Now().UnixNano())
+			spoofMigrationNS = fmt.Sprintf("%s-spoof-%d", spoofMigrationNSPrefix, time.Now().UnixNano())
+
+			var err error
+			publisher, err = e2eutils.NewKafkaEventPublisher(ctx, globalHubClient, constants.GHDefaultNamespace)
+			Expect(err).NotTo(HaveOccurred(), "expected Kafka publisher from global hub transport-config secret")
+		})
+
+		AfterEach(func() {
+			deleteNamespaceAndWait(targetHubClient, trustedMigration)
+			deleteNamespaceAndWait(targetHubClient, spoofMigrationNS)
+		})
+
+		It("should apply deploying migration resources received on gh-migration from the registered source hub", func() {
+			migrationID := fmt.Sprintf("%s-trusted-%d", spoofMigrationID, time.Now().UnixNano())
+			seedClusterName := fmt.Sprintf("e2e-migration-topic-seed-%d", time.Now().UnixNano())
+			seedMSAName := fmt.Sprintf("e2e-migration-topic-msa-%d", time.Now().UnixNano())
+
+			seedInFlightMigrationState(
+				publisher,
+				sourceHubName,
+				targetHubName,
+				migrationID,
+				seedMSAName,
+				seedClusterName,
+			)
+
+			evt := migrationDeployingEvent(sourceHubName, targetHubName, trustedMigration, migrationID)
+			Expect(publisher.SendToTopic(ctx, publisher.MigrationTopic(), evt)).To(Succeed(),
+				"expected trusted migration deploying event to publish on gh-migration")
+
+			Eventually(func() error {
+				ns := &corev1.Namespace{}
+				return targetHubClient.Get(ctx, types.NamespacedName{Name: trustedMigration}, ns)
+			}, 2*time.Minute, 2*time.Second).Should(Succeed(),
+				"trusted migration deploying event on gh-migration must create target resources")
+		})
+
+		It("should drop migration deploying events on gh-migration from an untrusted source hub", func() {
+			migrationID := fmt.Sprintf("%s-untrusted-%d", spoofMigrationID, time.Now().UnixNano())
+			seedClusterName := fmt.Sprintf("e2e-migration-topic-spoof-seed-%d", time.Now().UnixNano())
+			seedMSAName := fmt.Sprintf("e2e-migration-topic-spoof-msa-%d", time.Now().UnixNano())
+
+			seedInFlightMigrationState(
+				publisher,
+				sourceHubName,
+				targetHubName,
+				migrationID,
+				seedMSAName,
+				seedClusterName,
+			)
+
+			evt := migrationDeployingEvent(spoofMigrationSource, targetHubName, spoofMigrationNS, migrationID)
+			Expect(publisher.SendToTopic(ctx, publisher.MigrationTopic(), evt)).To(Succeed(),
+				"expected spoofed migration event to publish on gh-migration for rejection testing")
+
+			Consistently(func() error {
+				ns := &corev1.Namespace{}
+				err := targetHubClient.Get(ctx, types.NamespacedName{Name: spoofMigrationNS}, ns)
+				if err == nil {
+					return fmt.Errorf("namespace %q must not be created from spoofed migration source on %s",
+						spoofMigrationNS, migrationTopic)
+				}
+				if client.IgnoreNotFound(err) != nil {
+					return err
+				}
+				return nil
+			}, 45*time.Second, 500*time.Millisecond).Should(Succeed(),
+				"spoofed migration deploying event on gh-migration must not create resources")
+		})
+	})
+})

--- a/test/e2e/transport_migration_topic_test.go
+++ b/test/e2e/transport_migration_topic_test.go
@@ -13,11 +13,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/kustomize/kyaml/yaml"
 
 	operatorconfig "github.com/stolostron/multicluster-global-hub/operator/pkg/config"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
-	"github.com/stolostron/multicluster-global-hub/pkg/transport"
+	pkgutils "github.com/stolostron/multicluster-global-hub/pkg/utils"
 	e2eutils "github.com/stolostron/multicluster-global-hub/test/e2e/utils"
 )
 
@@ -59,19 +58,25 @@ var _ = Describe("Transport Migration Topic E2E", Label("e2e-test-transport-migr
 		})
 
 		It("should include the migration topic in managed hub transport credentials", func() {
-			secret := &corev1.Secret{}
-			Expect(sourceHubClient.Get(ctx, types.NamespacedName{
-				Name:      constants.GHTransportSecretName,
-				Namespace: constants.GHAgentNamespace,
-			}, secret)).To(Succeed(), "expected transport secret on managed hub agent namespace")
+			Eventually(func() error {
+				secret := &corev1.Secret{}
+				if err := sourceHubClient.Get(ctx, types.NamespacedName{
+					Name:      constants.GHTransportSecretName,
+					Namespace: constants.GHAgentNamespace,
+				}, secret); err != nil {
+					return fmt.Errorf("get transport secret on managed hub agent namespace: %w", err)
+				}
 
-			kafkaYAML, ok := secret.Data["kafka.yaml"]
-			Expect(ok).To(BeTrue(), "transport secret must contain kafka.yaml")
-
-			kafkaConfig := &transport.KafkaConfig{}
-			Expect(yaml.Unmarshal(kafkaYAML, kafkaConfig)).To(Succeed(),
-				"expected kafka.yaml in transport secret to unmarshal")
-			Expect(kafkaConfig.MigrationTopic).To(Equal(migrationTopic),
+				kafkaConfig, err := pkgutils.GetKafkaCredentialBySecret(secret, sourceHubClient)
+				if err != nil {
+					return fmt.Errorf("parse transport secret kafka credentials: %w", err)
+				}
+				if kafkaConfig.MigrationTopic != migrationTopic {
+					return fmt.Errorf("managed hub transport credentials migration topic = %q, want %q",
+						kafkaConfig.MigrationTopic, migrationTopic)
+				}
+				return nil
+			}, 2*time.Minute, 5*time.Second).Should(Succeed(),
 				"managed hub transport credentials must include the gh-migration topic")
 		})
 	})

--- a/test/e2e/transport_migration_topic_test.go
+++ b/test/e2e/transport_migration_topic_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Transport Migration Topic E2E", Label("e2e-test-transport-migr
 			Eventually(func() error {
 				secret := &corev1.Secret{}
 				if err := sourceHubClient.Get(ctx, types.NamespacedName{
-					Name:      constants.GHTransportSecretName,
+					Name:      constants.GHTransportConfigSecret,
 					Namespace: constants.GHAgentNamespace,
 				}, secret); err != nil {
 					return fmt.Errorf("get transport secret on managed hub agent namespace: %w", err)

--- a/test/e2e/utils/kafka_producer.go
+++ b/test/e2e/utils/kafka_producer.go
@@ -68,6 +68,14 @@ func (p *KafkaEventPublisher) SpecTopic() string {
 	return p.kafkaConfig.SpecTopic
 }
 
+// MigrationTopic returns the configured migration topic (typically gh-migration).
+func (p *KafkaEventPublisher) MigrationTopic() string {
+	if p.kafkaConfig.MigrationTopic != "" {
+		return p.kafkaConfig.MigrationTopic
+	}
+	return operatorconfig.GetMigrationTopic()
+}
+
 // StatusTopic returns the status topic for hubName (per-hub topic or credential override).
 func (p *KafkaEventPublisher) StatusTopic(hubName string) string {
 	if p.kafkaConfig.StatusTopic != "" && !strings.Contains(p.kafkaConfig.StatusTopic, "*") {

--- a/test/integration/manager/controller/backup_test.go
+++ b/test/integration/manager/controller/backup_test.go
@@ -76,8 +76,8 @@ var _ = Describe("backup pvc", Ordered, func() {
 		Expect(err).Should(Succeed())
 
 		backupReconciler = controllers.NewBackupPVCReconciler(mgr, database.GetConn())
-		err = backupReconciler.SetupWithManager(mgr)
-		Expect(err).NotTo(HaveOccurred())
+		// Tests invoke Reconcile directly; registering with the manager causes duplicate
+		// reconciles on PVC updates and flakes the volsync simulation in test 3.
 		Expect(mgr.GetClient().Create(ctx, postgresPvc)).NotTo(HaveOccurred())
 		Expect(mgr.GetClient().Create(ctx, mchObj)).Should(Succeed())
 	})
@@ -146,42 +146,47 @@ var _ = Describe("backup pvc", Ordered, func() {
 			}
 			return err
 		}, timeout, interval).Should(Succeed())
+
+		reconcileDone := make(chan error, 1)
 		go func() {
-			// Simulate volsync: wait for the reconciler to stamp CopyTrigger, then mark backup complete.
-			Eventually(func() error {
-				postgresPvc := &corev1.PersistentVolumeClaim{}
-				err := mgr.GetClient().Get(ctx, types.NamespacedName{
+			_, err := backupReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
 					Namespace: pvcNamespace,
 					Name:      pvcName,
-				}, postgresPvc)
-				if err != nil {
-					return err
-				}
-
-				copyTrigger := postgresPvc.Annotations[constants.BackupPvcCopyTrigger]
-				if copyTrigger == "" || copyTrigger == "now" {
-					return fmt.Errorf("waiting for reconciler copy trigger")
-				}
-				if utils.HasItem(postgresPvc.GetAnnotations(), constants.BackupPvcLatestCopyStatus, constants.BackupPvcCompletedTrigger) &&
-					utils.HasItem(postgresPvc.GetAnnotations(), constants.BackupPvcLatestCopyTrigger, copyTrigger) {
-					return nil
-				}
-
-				utils.MergeAnnotations(postgresPvc, map[string]string{
-					constants.BackupPvcLatestCopyTrigger: copyTrigger,
-					constants.BackupPvcLatestCopyStatus:  constants.BackupPvcCompletedTrigger,
-				})
-
-				return mgr.GetClient().Update(ctx, postgresPvc)
-			}, 2*time.Minute, interval).Should(Succeed())
+				},
+			})
+			reconcileDone <- err
 		}()
-		_, err := backupReconciler.Reconcile(ctx, reconcile.Request{
-			NamespacedName: types.NamespacedName{
+
+		// Simulate volsync on the main goroutine while Reconcile polls for completion.
+		Eventually(func() error {
+			postgresPvc := &corev1.PersistentVolumeClaim{}
+			err := mgr.GetClient().Get(ctx, types.NamespacedName{
 				Namespace: pvcNamespace,
 				Name:      pvcName,
-			},
-		})
-		Expect(err).NotTo(HaveOccurred())
+			}, postgresPvc)
+			if err != nil {
+				return err
+			}
+
+			copyTrigger := postgresPvc.Annotations[constants.BackupPvcCopyTrigger]
+			if copyTrigger == "" || copyTrigger == "now" {
+				return fmt.Errorf("waiting for reconciler copy trigger")
+			}
+			if utils.HasItem(postgresPvc.GetAnnotations(), constants.BackupPvcLatestCopyStatus, constants.BackupPvcCompletedTrigger) &&
+				utils.HasItem(postgresPvc.GetAnnotations(), constants.BackupPvcLatestCopyTrigger, copyTrigger) {
+				return nil
+			}
+
+			utils.MergeAnnotations(postgresPvc, map[string]string{
+				constants.BackupPvcLatestCopyTrigger: copyTrigger,
+				constants.BackupPvcLatestCopyStatus:  constants.BackupPvcCompletedTrigger,
+			})
+
+			return mgr.GetClient().Update(ctx, postgresPvc)
+		}, 2*time.Minute, interval).Should(Succeed())
+
+		Eventually(reconcileDone, 2*time.Minute, interval).Should(Receive(BeNil()))
 	})
 
 	It("disable mch and pvc do not need backup", func() {


### PR DESCRIPTION
## Summary
- Extends the ACM-34442 transport identity e2e helpers with `MigrationTopic()` support
- Adds `e2e-test-transport-migration-topic` suite for Phase 3 (`gh-migration` topic provisioning, credential wiring, trusted deploying delivery, spoof rejection)
- Includes Phase 1–2 e2e helpers this suite builds on (same commits as #2670; reconcile when that PR merges)


## Test plan
- [ ] `make e2e-setup && make e2e-test-transport-migration-topic`
- [ ] `make e2e-test-transport-identity`

### Coverage

| Fix | E2e assertion |
|-----|---------------|
| Phase 3 — gh-migration topic | KafkaTopic CR exists; hub transport secret includes `topic.migration` |
| Phase 3 — deploying path | Registered source-hub deploying bundle on `gh-migration` creates target resources |
| Phase 3 — defense in depth | Spoofed source on `gh-migration` is still dropped |


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Added a new end-to-end suite that verifies the migration topic is provisioned with partitions and that its value is reflected in managed hub transport credentials.
  * Added coverage for migration deployment events: trusted sources create target resources, while untrusted/spoofed sources do not.
  * Improved hub update testing by waiting for managed cluster stabilization and extending verification timeout.

* **Chores**
  * Updated end-to-end runs to include the new transport migration topic suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->