### PR TITLE
ACM-34442 / ACM-38863: backport Phase 1-2 transport identity e2e tests to release-2.15 (GH 1.6)

### DIFF
--- a/pkg/transport/utils/utils.go
+++ b/pkg/transport/utils/utils.go
@@ -2,14 +2,22 @@ package utils
 
 import "github.com/confluentinc/confluent-kafka-go/v2/kafka"
 
+var sensitiveKafkaConfigKeys = map[string]struct{}{
+	"bootstrap.servers":   {},
+	"sasl.username":       {},
+	"sasl.password":       {},
+	"ssl.ca.pem":          {},
+	"ssl.certificate.pem": {},
+	"ssl.key.pem":         {},
+	"ssl.key.password":    {},
+}
+
 // FilterSensitiveKafkaConfig filters out sensitive data from Kafka ConfigMap for safe logging.
-// It replaces SSL certificate and key values with "[REDACTED]" to prevent exposure of
-// sensitive credentials in logs.
+// It replaces broker endpoints, credentials, and certificate/key values with "[REDACTED]".
 func FilterSensitiveKafkaConfig(configMap *kafka.ConfigMap) map[string]interface{} {
 	safeConfig := make(map[string]interface{})
 	for key, value := range *configMap {
-		// Exclude sensitive SSL/TLS certificate and key data
-		if key == "ssl.ca.pem" || key == "ssl.certificate.pem" || key == "ssl.key.pem" {
+		if _, sensitive := sensitiveKafkaConfigKeys[key]; sensitive {
 			safeConfig[key] = "[REDACTED]"
 		} else {
 			safeConfig[key] = value

--- a/pkg/transport/utils/utils_test.go
+++ b/pkg/transport/utils/utils_test.go
@@ -16,11 +16,11 @@ func TestFilterSensitiveKafkaConfig(t *testing.T) {
 		{
 			name: "No sensitive keys",
 			input: kafka.ConfigMap{
-				"bootstrap.servers": "localhost:9092",
+				"group.id":          "test-group",
 				"security.protocol": "SSL",
 			},
 			expected: map[string]interface{}{
-				"bootstrap.servers": "localhost:9092",
+				"group.id":          "test-group",
 				"security.protocol": "SSL",
 			},
 		},
@@ -31,12 +31,16 @@ func TestFilterSensitiveKafkaConfig(t *testing.T) {
 				"ssl.certificate.pem": "cert-data",
 				"ssl.key.pem":         "key-data",
 				"bootstrap.servers":   "localhost:9092",
+				"sasl.username":       "user",
+				"sasl.password":       "secret",
 			},
 			expected: map[string]interface{}{
 				"ssl.ca.pem":          "[REDACTED]",
 				"ssl.certificate.pem": "[REDACTED]",
 				"ssl.key.pem":         "[REDACTED]",
-				"bootstrap.servers":   "localhost:9092",
+				"bootstrap.servers":   "[REDACTED]",
+				"sasl.username":       "[REDACTED]",
+				"sasl.password":       "[REDACTED]",
 			},
 		},
 		{
@@ -47,7 +51,7 @@ func TestFilterSensitiveKafkaConfig(t *testing.T) {
 			},
 			expected: map[string]interface{}{
 				"ssl.ca.pem":        "[REDACTED]",
-				"bootstrap.servers": "localhost:9092",
+				"bootstrap.servers": "[REDACTED]",
 			},
 		},
 		{
@@ -60,9 +64,33 @@ func TestFilterSensitiveKafkaConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := FilterSensitiveKafkaConfig(&tt.input)
-			if !reflect.DeepEqual(result, tt.expected) {
-				t.Errorf("FilterSensitiveKafkaConfig() = %v, want %v", result, tt.expected)
-			}
+			assertFilteredKafkaConfig(t, result, tt.expected)
 		})
+	}
+}
+
+func assertFilteredKafkaConfig(t *testing.T, got, want map[string]interface{}) {
+	t.Helper()
+
+	for key, wantVal := range want {
+		gotVal, ok := got[key]
+		if !ok {
+			t.Errorf("missing key %q in filtered config", key)
+			continue
+		}
+		if reflect.DeepEqual(gotVal, wantVal) {
+			continue
+		}
+		if _, sensitive := sensitiveKafkaConfigKeys[key]; sensitive {
+			t.Errorf("key %q: expected redaction marker, got unexpected value", key)
+			continue
+		}
+		t.Errorf("key %q: got %v, want %v", key, gotVal, wantVal)
+	}
+
+	for key := range got {
+		if _, ok := want[key]; !ok {
+			t.Errorf("unexpected key %q in filtered config", key)
+		}
 	}
 }

--- a/test/Makefile
+++ b/test/Makefile
@@ -18,6 +18,7 @@ e2e-test-all: tidy vendor
 	sh ./test/script/e2e_run.sh -f "e2e-test-localpolicy,e2e-tests-backup,e2e-test-grafana,e2e-test-local-agent" -v $(VERBOSE)
 	sh ./test/script/e2e_run.sh -f "e2e-test-prune" -v $(VERBOSE)
 	sh ./test/script/e2e_clean_globalhub.sh
+	sh ./test/script/e2e_run_byo.sh -v $(VERBOSE)
 	sh ./test/script/e2e_run.sh -f "e2e-test-transport-identity" -v $(VERBOSE)
 
 e2e-test-cluster e2e-test-local-agent e2e-test-localpolicy e2e-test-grafana e2e-test-transport-identity: tidy vendor

--- a/test/Makefile
+++ b/test/Makefile
@@ -18,8 +18,8 @@ e2e-test-all: tidy vendor
 	sh ./test/script/e2e_run.sh -f "e2e-test-localpolicy,e2e-tests-backup,e2e-test-grafana,e2e-test-local-agent" -v $(VERBOSE)
 	sh ./test/script/e2e_run.sh -f "e2e-test-prune" -v $(VERBOSE)
 	sh ./test/script/e2e_clean_globalhub.sh
+	sh ./test/script/e2e_run.sh -f "e2e-test-transport-identity" -v $(VERBOSE)
 	sh ./test/script/e2e_run_byo.sh -v $(VERBOSE)
-	ISBYO=true sh ./test/script/e2e_run.sh -n mgh -f "e2e-test-transport-identity" -v $(VERBOSE)
 
 e2e-test-cluster e2e-test-local-agent e2e-test-localpolicy e2e-test-grafana e2e-test-transport-identity: tidy vendor
 	./test/script/e2e_run.sh -f $@ -v $(VERBOSE)

--- a/test/Makefile
+++ b/test/Makefile
@@ -41,7 +41,7 @@ e2e-log/agent:
 	@export CLUSTER_NAME=hub2 COMPONENT=multicluster-global-hub-agent NAMESPACE=multicluster-global-hub-agent && ./test/script/e2e_log.sh
 
 integration-test: setup_envtest
-	KUBEBUILDER_ASSETS="$(shell ${TMP_BIN}/setup-envtest use --use-env -p path)" ${GO_TEST} `go list ./test/integration/...`
+	KUBEBUILDER_ASSETS="$(shell ${TMP_BIN}/setup-envtest use --use-env -p path)" ${GO_TEST} -p 1 `go list ./test/integration/...`
 
 integration-test/agent: setup_envtest
 	KUBEBUILDER_ASSETS="$(shell ${TMP_BIN}/setup-envtest use --use-env -p path)" ${GO_TEST} `go list ./test/integration/agent/...`

--- a/test/Makefile
+++ b/test/Makefile
@@ -19,7 +19,7 @@ e2e-test-all: tidy vendor
 	sh ./test/script/e2e_run.sh -f "e2e-test-prune" -v $(VERBOSE)
 	sh ./test/script/e2e_clean_globalhub.sh
 	sh ./test/script/e2e_run_byo.sh -v $(VERBOSE)
-	sh ./test/script/e2e_run.sh -f "e2e-test-transport-identity" -v $(VERBOSE)
+	ISBYO=true sh ./test/script/e2e_run.sh -f "e2e-test-transport-identity" -v $(VERBOSE)
 
 e2e-test-cluster e2e-test-local-agent e2e-test-localpolicy e2e-test-grafana e2e-test-transport-identity: tidy vendor
 	./test/script/e2e_run.sh -f $@ -v $(VERBOSE)

--- a/test/Makefile
+++ b/test/Makefile
@@ -19,7 +19,7 @@ e2e-test-all: tidy vendor
 	sh ./test/script/e2e_run.sh -f "e2e-test-prune" -v $(VERBOSE)
 	sh ./test/script/e2e_clean_globalhub.sh
 	sh ./test/script/e2e_run_byo.sh -v $(VERBOSE)
-	ISBYO=true sh ./test/script/e2e_run.sh -f "e2e-test-transport-identity" -v $(VERBOSE)
+	ISBYO=true sh ./test/script/e2e_run.sh -n mgh -f "e2e-test-transport-identity" -v $(VERBOSE)
 
 e2e-test-cluster e2e-test-local-agent e2e-test-localpolicy e2e-test-grafana e2e-test-transport-identity: tidy vendor
 	./test/script/e2e_run.sh -f $@ -v $(VERBOSE)

--- a/test/Makefile
+++ b/test/Makefile
@@ -18,8 +18,9 @@ e2e-test-all: tidy vendor
 	sh ./test/script/e2e_run.sh -f "e2e-test-localpolicy,e2e-tests-backup,e2e-test-grafana,e2e-test-local-agent" -v $(VERBOSE)
 	sh ./test/script/e2e_run.sh -f "e2e-test-prune" -v $(VERBOSE)
 	sh ./test/script/e2e_clean_globalhub.sh
+	sh ./test/script/e2e_run.sh -f "e2e-test-transport-identity" -v $(VERBOSE)
 
-e2e-test-cluster e2e-test-local-agent e2e-test-localpolicy e2e-test-grafana: tidy vendor
+e2e-test-cluster e2e-test-local-agent e2e-test-localpolicy e2e-test-grafana e2e-test-transport-identity: tidy vendor
 	./test/script/e2e_run.sh -f $@ -v $(VERBOSE)
 
 e2e-prow-tests: 

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -143,15 +143,20 @@ var _ = BeforeSuite(func() {
 	}
 
 	if isPrune != "true" {
-		// valid the clients
-		deployClient := testClients.KubeClient().AppsV1().Deployments(testOptions.GlobalHub.Namespace)
-		_, err := deployClient.List(ctx, metav1.ListOptions{Limit: 2})
-		Expect(err).ShouldNot(HaveOccurred())
-		// Expect(len(deployList.Items) > 0).To(BeTrue())
-		// valid the global hub cluster apiserver
-		healthy, err := testClients.KubeClient().Discovery().RESTClient().Get().AbsPath("/healthz").DoRaw(ctx)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(string(healthy)).To(Equal("ok"))
+		Eventually(func() error {
+			deployClient := testClients.KubeClient().AppsV1().Deployments(testOptions.GlobalHub.Namespace)
+			if _, err := deployClient.List(ctx, metav1.ListOptions{Limit: 2}); err != nil {
+				return err
+			}
+			healthy, err := testClients.KubeClient().Discovery().RESTClient().Get().AbsPath("/healthz").DoRaw(ctx)
+			if err != nil {
+				return err
+			}
+			if string(healthy) != "ok" {
+				return fmt.Errorf("healthz returned %q", string(healthy))
+			}
+			return nil
+		}, 3*time.Minute, 5*time.Second).Should(Succeed())
 
 		if isGlobalHubDeployed() {
 			klog.Infof("Global hub already deployed, skipping deployGlobalHub")

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -322,10 +322,22 @@ func deployGlobalHub() {
 	Expect(err).NotTo(HaveOccurred())
 
 	By("Removing stale e2e nonk8s NodePort service if present")
-	err = testClients.KubeClient().CoreV1().Services(testOptions.GlobalHub.Namespace).Delete(ctx,
-		"multicluster-global-hub-manager-nonk8s-service", metav1.DeleteOptions{})
-	if err != nil && !errors.IsNotFound(err) {
-		Expect(err).NotTo(HaveOccurred())
+	// nodePort 30080 is cluster-scoped; transport-identity may leave the service in the default GH ns while BYO deploys to mgh.
+	nonk8sServiceNamespaces := []string{testOptions.GlobalHub.Namespace, commonconstants.GHDefaultNamespace}
+	seenNamespaces := map[string]struct{}{}
+	for _, ns := range nonk8sServiceNamespaces {
+		if ns == "" {
+			continue
+		}
+		if _, exists := seenNamespaces[ns]; exists {
+			continue
+		}
+		seenNamespaces[ns] = struct{}{}
+		err = testClients.KubeClient().CoreV1().Services(ns).Delete(ctx,
+			"multicluster-global-hub-manager-nonk8s-service", metav1.DeleteOptions{})
+		if err != nil && !errors.IsNotFound(err) {
+			Expect(err).NotTo(HaveOccurred())
+		}
 	}
 
 	Expect(utils.Apply(testClients, testOptions,

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -325,6 +325,13 @@ func deployGlobalHub() {
 	}
 	Expect(err).NotTo(HaveOccurred())
 
+	By("Removing stale e2e nonk8s NodePort service if present")
+	err = testClients.KubeClient().CoreV1().Services(testOptions.GlobalHub.Namespace).Delete(ctx,
+		"multicluster-global-hub-manager-nonk8s-service", metav1.DeleteOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		Expect(err).NotTo(HaveOccurred())
+	}
+
 	Expect(utils.Apply(testClients, testOptions,
 		utils.RenderOptions{Namespace: testOptions.GlobalHub.Namespace, KustomizationPath: fmt.Sprintf("%s/test/manifest/resources", rootDir)})).NotTo(HaveOccurred())
 	Expect(utils.Apply(testClients, testOptions,

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -153,15 +153,6 @@ var _ = BeforeSuite(func() {
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(string(healthy)).To(Equal("ok"))
 
-		if isBYO != "true" {
-			_, byoErr := testClients.KubeClient().CoreV1().Secrets(testOptions.GlobalHub.Namespace).
-				Get(ctx, "multicluster-global-hub-storage", metav1.GetOptions{})
-			if byoErr == nil {
-				isBYO = "true"
-				klog.Infof("Detected BYO postgres from multicluster-global-hub-storage secret")
-			}
-		}
-
 		if isGlobalHubDeployed() {
 			klog.Infof("Global hub already deployed, skipping deployGlobalHub")
 			operatorconfig.SetMGHNamespacedName(types.NamespacedName{

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -152,8 +152,26 @@ var _ = BeforeSuite(func() {
 		healthy, err := testClients.KubeClient().Discovery().RESTClient().Get().AbsPath("/healthz").DoRaw(ctx)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(string(healthy)).To(Equal("ok"))
-		By("Deploy the global hub")
-		deployGlobalHub()
+
+		if isBYO != "true" {
+			_, byoErr := testClients.KubeClient().CoreV1().Secrets(testOptions.GlobalHub.Namespace).
+				Get(ctx, "multicluster-global-hub-storage", metav1.GetOptions{})
+			if byoErr == nil {
+				isBYO = "true"
+				klog.Infof("Detected BYO postgres from multicluster-global-hub-storage secret")
+			}
+		}
+
+		if isGlobalHubDeployed() {
+			klog.Infof("Global hub already deployed, skipping deployGlobalHub")
+			operatorconfig.SetMGHNamespacedName(types.NamespacedName{
+				Namespace: testOptions.GlobalHub.Namespace,
+				Name:      MghName,
+			})
+		} else {
+			By("Deploy the global hub")
+			deployGlobalHub()
+		}
 		waitGlobalhubReadyAndLeaseUpdated()
 		By("Init postgres connection")
 		if isBYO == "true" {
@@ -271,6 +289,15 @@ func findRootDir(dir string) (string, error) {
 
 		dir = filepath.Dir(dir)
 	}
+}
+
+func isGlobalHubDeployed() bool {
+	mgh := &v1alpha4.MulticlusterGlobalHub{}
+	err := globalHubClient.Get(ctx, types.NamespacedName{
+		Name:      MghName,
+		Namespace: testOptions.GlobalHub.Namespace,
+	}, mgh)
+	return err == nil
 }
 
 func deployGlobalHub() {

--- a/test/e2e/transport_identity_test.go
+++ b/test/e2e/transport_identity_test.go
@@ -1,0 +1,319 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package tests
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	kafka_confluent "github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gorm.io/gorm"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	migrationv1alpha1 "github.com/stolostron/multicluster-global-hub/operator/api/migration/v1alpha1"
+	"github.com/stolostron/multicluster-global-hub/pkg/bundle/generic"
+	migrationbundle "github.com/stolostron/multicluster-global-hub/pkg/bundle/migration"
+	eventversion "github.com/stolostron/multicluster-global-hub/pkg/bundle/version"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/database"
+	"github.com/stolostron/multicluster-global-hub/pkg/database/models"
+	"github.com/stolostron/multicluster-global-hub/pkg/enum"
+	pkgutils "github.com/stolostron/multicluster-global-hub/pkg/utils"
+	e2eutils "github.com/stolostron/multicluster-global-hub/test/e2e/utils"
+)
+
+const (
+	spoofVictimHubName     = "e2e-spoof-victim-hub"
+	spoofMigrationSource   = "e2e-spoof-migration-source"
+	spoofMigrationID       = "e2e-spoof-migration"
+	spoofMigrationNSPrefix = "e2e-spoof-migration-ns"
+)
+
+var _ = Describe("Transport Identity E2E", Label("e2e-test-transport-identity"), Ordered, func() {
+	var (
+		sourceHubName   string
+		targetHubName   string
+		targetHubClient client.Client
+	)
+
+	BeforeAll(func() {
+		Expect(len(managedHubNames)).To(BeNumerically(">=", 2),
+			"transport identity e2e requires two regional hubs (source and target)")
+		sourceHubName = managedHubNames[0]
+		targetHubName = managedHubNames[1]
+
+		var err error
+		targetHubClient, err = testClients.RuntimeClient(targetHubName, agentScheme)
+		Expect(err).NotTo(HaveOccurred(), "expected target hub %q kubeconfig to be valid", targetHubName)
+	})
+
+	Context("ACM-34442 Phase 1 - manager status identity from Kafka topic", func() {
+		var publisher *e2eutils.KafkaEventPublisher
+
+		BeforeEach(func() {
+			var err error
+			publisher, err = e2eutils.NewKafkaEventPublisher(ctx, globalHubClient, constants.GHDefaultNamespace)
+			Expect(err).NotTo(HaveOccurred(), "expected Kafka publisher from global hub transport-config secret")
+		})
+
+		AfterEach(func() {
+			for _, hub := range []string{spoofVictimHubName, sourceHubName} {
+				Expect(database.GetGorm().Exec(
+					`DELETE FROM status.leaf_hub_heartbeats WHERE leaf_hub_name = $1`,
+					hub,
+				).Error).To(Succeed(), "expected heartbeat cleanup for hub %q between tests", hub)
+			}
+		})
+
+		It("should drop status events when CloudEvent source does not match the Kafka status topic hub", func() {
+			statusTopic := publisher.StatusTopic(sourceHubName)
+			evt := statusCloudEvent(
+				statusTopic,
+				spoofVictimHubName,
+				string(enum.HubClusterHeartbeatType),
+				generic.GenericObjectBundle{},
+			)
+
+			Expect(publisher.SendToTopic(ctx, statusTopic, *evt)).To(Succeed(),
+				"expected spoofed status event to publish to Kafka for rejection testing")
+
+			Consistently(func() error {
+				for _, hub := range []string{sourceHubName, spoofVictimHubName} {
+					var heartbeat models.LeafHubHeartbeat
+					err := database.GetGorm().Where("leaf_hub_name = ?", hub).First(&heartbeat).Error
+					if errors.Is(err, gorm.ErrRecordNotFound) {
+						continue
+					}
+					if err != nil {
+						return fmt.Errorf("query heartbeat for hub %q: %w", hub, err)
+					}
+					if hub == spoofVictimHubName {
+						return fmt.Errorf("spoofed status event must not create heartbeat for hub %q", hub)
+					}
+				}
+				return nil
+			}, 45*time.Second, 500*time.Millisecond).Should(Succeed(),
+				"spoofed status heartbeat must not be persisted when CloudEvent source mismatches topic hub")
+		})
+
+		It("should accept status events when CloudEvent source matches the Kafka status topic hub", func() {
+			statusTopic := publisher.StatusTopic(sourceHubName)
+			evt := statusCloudEvent(
+				statusTopic,
+				sourceHubName,
+				string(enum.HubClusterHeartbeatType),
+				generic.GenericObjectBundle{},
+			)
+
+			Expect(publisher.SendToTopic(ctx, statusTopic, *evt)).To(Succeed(),
+				"expected trusted status event to publish to Kafka")
+
+			Eventually(func() error {
+				var heartbeat models.LeafHubHeartbeat
+				err := database.GetGorm().Where("leaf_hub_name = ?", sourceHubName).First(&heartbeat).Error
+				if err != nil {
+					return fmt.Errorf("expected heartbeat row for trusted hub %q: %w", sourceHubName, err)
+				}
+				return nil
+			}, 45*time.Second, 500*time.Millisecond).Should(Succeed(),
+				"trusted status heartbeat must be persisted when CloudEvent source matches topic hub")
+		})
+	})
+
+	Context("ACM-34442 Phase 2 - agent spec source validation", func() {
+		var (
+			publisher        *e2eutils.KafkaEventPublisher
+			spoofMigrationNS string
+		)
+
+		BeforeEach(func() {
+			spoofMigrationNS = fmt.Sprintf("%s-%d", spoofMigrationNSPrefix, time.Now().UnixNano())
+
+			var err error
+			publisher, err = e2eutils.NewKafkaEventPublisher(ctx, globalHubClient, constants.GHDefaultNamespace)
+			Expect(err).NotTo(HaveOccurred(), "expected Kafka publisher from global hub transport-config secret")
+		})
+
+		AfterEach(func() {
+			deleteNamespaceAndWait(targetHubClient, spoofMigrationNS)
+		})
+
+		It("should drop migration deploying events when no in-flight migration is recorded on the target hub", func() {
+			migrationID := fmt.Sprintf("%s-no-state-%d", spoofMigrationID, time.Now().UnixNano())
+			evt := migrationDeployingEvent(
+				sourceHubName,
+				targetHubName,
+				spoofMigrationNS,
+				migrationID,
+			)
+			Expect(publisher.SendToTopic(ctx, publisher.SpecTopic(), evt)).To(Succeed(),
+				"expected migration event to publish to Kafka for rejection testing")
+
+			Consistently(func() error {
+				ns := &corev1.Namespace{}
+				err := targetHubClient.Get(ctx, types.NamespacedName{Name: spoofMigrationNS}, ns)
+				if err == nil {
+					return fmt.Errorf("namespace %q must not be created without in-flight migration state", spoofMigrationNS)
+				}
+				if client.IgnoreNotFound(err) != nil {
+					return err
+				}
+				return nil
+			}, 45*time.Second, 500*time.Millisecond).Should(Succeed(),
+				"migration deploying event must not create resources without in-flight migration state")
+		})
+
+		It("should drop migration deploying events from an untrusted source hub", func() {
+			migrationID := fmt.Sprintf("%s-untrusted-%d", spoofMigrationID, time.Now().UnixNano())
+			seedClusterName := fmt.Sprintf("e2e-transport-id-seed-%d", time.Now().UnixNano())
+			seedMSAName := fmt.Sprintf("e2e-transport-id-msa-%d", time.Now().UnixNano())
+
+			seedInFlightMigrationState(
+				publisher,
+				sourceHubName,
+				targetHubName,
+				migrationID,
+				seedMSAName,
+				seedClusterName,
+			)
+
+			probeNS := fmt.Sprintf("%s-probe-%d", spoofMigrationNSPrefix, time.Now().UnixNano())
+			waitForTrustedMigrationDeploy(
+				publisher,
+				targetHubClient,
+				sourceHubName,
+				targetHubName,
+				probeNS,
+				migrationID,
+			)
+			deleteNamespaceAndWait(targetHubClient, probeNS)
+
+			evt := migrationDeployingEvent(
+				spoofMigrationSource,
+				targetHubName,
+				spoofMigrationNS,
+				migrationID,
+			)
+			Expect(publisher.SendToTopic(ctx, publisher.SpecTopic(), evt)).To(Succeed(),
+				"expected spoofed migration event to publish to Kafka for rejection testing")
+
+			Consistently(func() error {
+				ns := &corev1.Namespace{}
+				err := targetHubClient.Get(ctx, types.NamespacedName{Name: spoofMigrationNS}, ns)
+				if err == nil {
+					return fmt.Errorf("namespace %q must not be created from spoofed migration source", spoofMigrationNS)
+				}
+				if client.IgnoreNotFound(err) != nil {
+					return err
+				}
+				return nil
+			}, 45*time.Second, 500*time.Millisecond).Should(Succeed(),
+				"spoofed migration deploying event must not create resources when in-flight migration is registered for a different source hub")
+		})
+	})
+})
+
+func statusCloudEvent(kafkaTopic, source, eventType string, data interface{}) *cloudevents.Event {
+	version := eventversion.NewVersion()
+	version.Incr()
+	evt := cloudevents.NewEvent()
+	evt.SetSource(source)
+	evt.SetType(eventType)
+	evt.SetExtension(eventversion.ExtVersion, version.String())
+	_ = evt.SetData(cloudevents.ApplicationJSON, data)
+	evt.SetExtension(kafka_confluent.KafkaTopicKey, kafkaTopic)
+	return &evt
+}
+
+func migrationDeployingEvent(sourceHub, targetHub, resourceName, migrationID string) cloudevents.Event {
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: resourceName}}
+	unstructuredNS, err := runtime.DefaultUnstructuredConverter.ToUnstructured(ns)
+	Expect(err).NotTo(HaveOccurred(), "expected namespace object conversion for migration bundle")
+	obj := unstructured.Unstructured{Object: unstructuredNS}
+	obj.SetKind("Namespace")
+	obj.SetAPIVersion("v1")
+
+	bundle := migrationbundle.MigrationResourceBundle{
+		MigrationId: migrationID,
+		MigrationClusterResources: []migrationbundle.MigrationClusterResource{
+			{
+				ClusterName: resourceName,
+				ResouceList: []unstructured.Unstructured{obj},
+			},
+		},
+	}
+
+	evt := pkgutils.ToCloudEvent(constants.MigrationTargetMsgKey, sourceHub, targetHub, bundle)
+	evt.SetTime(time.Now())
+	return evt
+}
+
+func migrationValidatingEvent(
+	sourceHub, targetHub, migrationID, managedServiceAccountName, clusterName string,
+) cloudevents.Event {
+	bundle := migrationbundle.MigrationTargetBundle{
+		MigrationId:               migrationID,
+		Stage:                     migrationv1alpha1.PhaseValidating,
+		FromHub:                   sourceHub,
+		ManagedServiceAccountName: managedServiceAccountName,
+		ManagedClusters:           []string{clusterName},
+	}
+
+	evt := pkgutils.ToCloudEvent(constants.MigrationTargetMsgKey, constants.CloudEventGlobalHubClusterName, targetHub, bundle)
+	evt.SetTime(time.Now())
+	return evt
+}
+
+func seedInFlightMigrationState(
+	publisher *e2eutils.KafkaEventPublisher,
+	sourceHub, targetHub, migrationID, managedServiceAccountName, clusterName string,
+) {
+	evt := migrationValidatingEvent(sourceHub, targetHub, migrationID, managedServiceAccountName, clusterName)
+	Expect(publisher.SendToTopic(ctx, publisher.SpecTopic(), evt)).To(Succeed(),
+		"expected validating migration event to seed in-flight migration state on target hub agent")
+}
+
+func waitForTrustedMigrationDeploy(
+	publisher *e2eutils.KafkaEventPublisher,
+	targetClient client.Client,
+	sourceHub, targetHub, probeNamespace, migrationID string,
+) {
+	Eventually(func() error {
+		evt := migrationDeployingEvent(sourceHub, targetHub, probeNamespace, migrationID)
+		if err := publisher.SendToTopic(ctx, publisher.SpecTopic(), evt); err != nil {
+			return fmt.Errorf("publish trusted migration deploying probe event: %w", err)
+		}
+
+		ns := &corev1.Namespace{}
+		err := targetClient.Get(ctx, types.NamespacedName{Name: probeNamespace}, ns)
+		if err != nil {
+			return fmt.Errorf("wait for trusted migration deploy to create namespace %q: %w", probeNamespace, err)
+		}
+		return nil
+	}, 45*time.Second, 500*time.Millisecond).Should(Succeed(),
+		"trusted migration deploying event must succeed once in-flight migration state is registered for the source hub")
+}
+
+func deleteNamespaceAndWait(targetClient client.Client, namespaceName string) {
+	err := targetClient.Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespaceName}})
+	if err != nil && !apierrors.IsNotFound(err) {
+		Expect(err).NotTo(HaveOccurred(), "expected to delete namespace %q during test cleanup", namespaceName)
+	}
+
+	Eventually(func() bool {
+		err := targetClient.Get(ctx, types.NamespacedName{Name: namespaceName}, &corev1.Namespace{})
+		return client.IgnoreNotFound(err) == nil && err != nil
+	}, 30*time.Second, 500*time.Millisecond).Should(BeTrue(),
+		"expected namespace %q to be fully removed before next test", namespaceName)
+}

--- a/test/e2e/utils/kafka_producer.go
+++ b/test/e2e/utils/kafka_producer.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package utils
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	cecontext "github.com/cloudevents/sdk-go/v2/context"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	operatorconfig "github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport"
+	transportconfig "github.com/stolostron/multicluster-global-hub/pkg/transport/config"
+	genericproducer "github.com/stolostron/multicluster-global-hub/pkg/transport/producer"
+)
+
+// KafkaEventPublisher sends CloudEvents to Kafka using transport credentials from a cluster secret.
+type KafkaEventPublisher struct {
+	producer    transport.Producer
+	kafkaConfig *transport.KafkaConfig
+}
+
+// NewKafkaEventPublisher loads transport-config from namespace and builds a producer.
+func NewKafkaEventPublisher(ctx context.Context, c client.Client, namespace string) (*KafkaEventPublisher, error) {
+	secret := &corev1.Secret{}
+	if err := c.Get(ctx, types.NamespacedName{
+		Name:      constants.GHTransportConfigSecret,
+		Namespace: namespace,
+	}, secret); err != nil {
+		return nil, fmt.Errorf("get transport secret in namespace %s: %w", namespace, err)
+	}
+
+	kafkaConfig, err := transportconfig.GetKafkaCredentialBySecret(secret, c)
+	if err != nil {
+		return nil, fmt.Errorf("parse kafka credentials: %w", err)
+	}
+
+	transportConfig := &transport.TransportInternalConfig{
+		TransportType:   string(transport.Kafka),
+		KafkaCredential: kafkaConfig,
+	}
+
+	producer, err := genericproducer.NewGenericProducer(transportConfig, kafkaConfig.SpecTopic, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create kafka producer: %w", err)
+	}
+
+	return &KafkaEventPublisher{
+		producer:    producer,
+		kafkaConfig: kafkaConfig,
+	}, nil
+}
+
+// SendToTopic publishes evt to the given Kafka topic.
+func (p *KafkaEventPublisher) SendToTopic(ctx context.Context, topic string, evt cloudevents.Event) error {
+	return p.producer.SendEvent(cecontext.WithTopic(ctx, topic), evt)
+}
+
+// SpecTopic returns the configured spec topic (typically gh-spec).
+func (p *KafkaEventPublisher) SpecTopic() string {
+	return p.kafkaConfig.SpecTopic
+}
+
+// StatusTopic returns the status topic for hubName (per-hub topic or credential override).
+func (p *KafkaEventPublisher) StatusTopic(hubName string) string {
+	if p.kafkaConfig.StatusTopic != "" && !strings.Contains(p.kafkaConfig.StatusTopic, "*") {
+		return p.kafkaConfig.StatusTopic
+	}
+	return operatorconfig.GetStatusTopic(hubName)
+}

--- a/test/integration/agent/controller/version_clusterclaim_test.go
+++ b/test/integration/agent/controller/version_clusterclaim_test.go
@@ -58,8 +58,7 @@ var _ = Describe("claim controllers", Ordered, func() {
 			}, clusterClaim)
 		}, 3*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
 		Expect(clusterClaim.Spec.Value).Should(Equal(
-			constants.HubInstalledByUser,
-		))
+			constants.HubInstalledByUser))
 	})
 
 	It("clusterClaim testing clusterManager and mch are not installed", func() {
@@ -85,20 +84,27 @@ var _ = Describe("claim controllers", Ordered, func() {
 			}
 			return fmt.Errorf("the claim(%s) expect %s, but got %s", constants.HubClusterClaimName,
 				constants.HubNotInstalled, clusterClaim.Spec.Value)
-		}, 10*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
+		}, 3*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
 	})
 
 	It("clusterclaim testing", func() {
 		By("Create MCH instance to trigger reconciliation")
-		Expect(mgr.GetClient().Create(ctx, &mchv1.MultiClusterHub{
+		mch := &mchv1.MultiClusterHub{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "multiclusterhub",
 				Namespace: "default",
 			},
 			Spec: mchv1.MultiClusterHubSpec{},
-		})).NotTo(HaveOccurred())
+		}
+		Eventually(func() error {
+			err := mgr.GetClient().Create(ctx, mch)
+			if errors.IsAlreadyExists(err) {
+				return nil
+			}
+			return err
+		}, 30*time.Second, 500*time.Millisecond).Should(Succeed())
 
-		mch := &mchv1.MultiClusterHub{}
+		mch = &mchv1.MultiClusterHub{}
 		Eventually(func() bool {
 			err := mgr.GetClient().Get(ctx, types.NamespacedName{
 				Name:      "multiclusterhub",
@@ -139,8 +145,7 @@ var _ = Describe("claim controllers", Ordered, func() {
 			return true
 		}, 1*time.Second, 100*time.Millisecond).Should(BeTrue())
 		Expect(clusterClaim.Spec.Value).Should(Equal(
-			constants.HubInstalledByUser,
-		))
+			constants.HubInstalledByUser))
 
 		By("Expect clusterClaim version to be updated")
 		mch.Status = mchv1.MultiClusterHubStatus{CurrentVersion: "2.7.0"}
@@ -165,12 +170,8 @@ var _ = Describe("claim controllers", Ordered, func() {
 			err := mgr.GetClient().Get(ctx, types.NamespacedName{
 				Name: constants.VersionClusterClaimName,
 			}, newClusterClaim)
-			if _, err := fmt.Fprintf(GinkgoWriter, "the old ClusterClaim: %v\n", clusterClaim); err != nil {
-				panic(err)
-			}
-			if _, err := fmt.Fprintf(GinkgoWriter, "the new ClusterClaim: %v\n", newClusterClaim); err != nil {
-				panic(err)
-			}
+			fmt.Fprintf(GinkgoWriter, "the old ClusterClaim: %v\n", clusterClaim)
+			fmt.Fprintf(GinkgoWriter, "the new ClusterClaim: %v\n", newClusterClaim)
 			return err == nil && clusterClaim.GetResourceVersion() != newClusterClaim.GetResourceVersion()
 		}, 1*time.Second, 100*time.Millisecond).Should(BeTrue())
 
@@ -191,8 +192,7 @@ var _ = Describe("claim controllers", Ordered, func() {
 			return true
 		}, 1*time.Second, 100*time.Millisecond).Should(BeTrue())
 		Expect(clusterClaim.Spec.Value).Should(Equal(
-			constants.HubInstalledByUser,
-		))
+			constants.HubInstalledByUser))
 	})
 })
 
@@ -248,19 +248,4 @@ func cleanup(ctx context.Context, client client.Client) {
 		}
 		return err
 	}, 1*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
-
-	for _, claimName := range []string{"test", "test2"} {
-		Eventually(func() error {
-			err := client.Delete(ctx, &clustersv1alpha1.ClusterClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: claimName,
-				},
-				Spec: clustersv1alpha1.ClusterClaimSpec{},
-			})
-			if errors.IsNotFound(err) {
-				return nil
-			}
-			return err
-		}, 1*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
-	}
 }

--- a/test/integration/agent/controller/version_clusterclaim_test.go
+++ b/test/integration/agent/controller/version_clusterclaim_test.go
@@ -170,8 +170,12 @@ var _ = Describe("claim controllers", Ordered, func() {
 			err := mgr.GetClient().Get(ctx, types.NamespacedName{
 				Name: constants.VersionClusterClaimName,
 			}, newClusterClaim)
-			fmt.Fprintf(GinkgoWriter, "the old ClusterClaim: %v\n", clusterClaim)
-			fmt.Fprintf(GinkgoWriter, "the new ClusterClaim: %v\n", newClusterClaim)
+			if _, err := fmt.Fprintf(GinkgoWriter, "the old ClusterClaim: %v\n", clusterClaim); err != nil {
+				panic(err)
+			}
+			if _, err := fmt.Fprintf(GinkgoWriter, "the new ClusterClaim: %v\n", newClusterClaim); err != nil {
+				panic(err)
+			}
 			return err == nil && clusterClaim.GetResourceVersion() != newClusterClaim.GetResourceVersion()
 		}, 1*time.Second, 100*time.Millisecond).Should(BeTrue())
 

--- a/test/integration/agent/status/clustergroupupgrade_event_test.go
+++ b/test/integration/agent/status/clustergroupupgrade_event_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	cloudevents "github.com/cloudevents/sdk-go/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -54,10 +55,11 @@ var _ = Describe("ClusterGroupUpgradeEventEmitter", Ordered, func() {
 
 		Eventually(func() error {
 			key := string(enum.ClusterGroupUpgradesEventType)
-			receivedEvent, ok := receivedEvents[key]
+			val, ok := receivedEvents.Load(key)
 			if !ok {
 				return fmt.Errorf("not get the event: %s", key)
 			}
+			receivedEvent := val.(*cloudevents.Event)
 			fmt.Println(">>>>>>>>>>>>>>>>>>> cgu event", receivedEvent)
 			outEvents := event.ClusterGroupUpgradeEventBundle{}
 			err = json.Unmarshal(receivedEvent.Data(), &outEvents)

--- a/test/integration/agent/status/localpolicy_event_test.go
+++ b/test/integration/agent/status/localpolicy_event_test.go
@@ -111,7 +111,7 @@ var _ = Describe("LocalPolicyEventEmitter", Ordered, func() {
 			},
 		}
 
-		name := strings.Replace(string(enum.LocalRootPolicyEventType), enum.EventTypePrefix, "", -1)
+		name := strings.ReplaceAll(string(enum.LocalRootPolicyEventType), enum.EventTypePrefix, "")
 		filter.DeltaDuration = 0
 		now := time.Now().Add(2 * time.Second)
 		filter.CacheTime(name, now)

--- a/test/integration/agent/status/localpolicy_event_test.go
+++ b/test/integration/agent/status/localpolicy_event_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	cloudevents "github.com/cloudevents/sdk-go/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -64,10 +65,11 @@ var _ = Describe("LocalPolicyEventEmitter", Ordered, func() {
 
 		Eventually(func() error {
 			key := string(enum.LocalRootPolicyEventType)
-			receivedEvent, ok := receivedEvents[key]
+			val, ok := receivedEvents.Load(key)
 			if !ok {
 				return fmt.Errorf("not get the event: %s", key)
 			}
+			receivedEvent := val.(*cloudevents.Event)
 			fmt.Println(">>>>>>>>>>>>>>>>>>> root policy event1", receivedEvent)
 			outEvents := []event.RootPolicyEvent{}
 			err := json.Unmarshal(receivedEvent.Data(), &outEvents)
@@ -109,15 +111,12 @@ var _ = Describe("LocalPolicyEventEmitter", Ordered, func() {
 			},
 		}
 
-		// update the cache with the expired event
-		name := strings.ReplaceAll(string(enum.LocalRootPolicyEventType), enum.EventTypePrefix, "")
-		filter.DeltaDuration = 0 // set the delta buffer into 0
-		filter.CacheSyncInterval = 1
-		now := time.Now().Add(2 * time.Second) // the next 2 seconds events will be considered as expired
+		name := strings.Replace(string(enum.LocalRootPolicyEventType), enum.EventTypePrefix, "", -1)
+		filter.DeltaDuration = 0
+		now := time.Now().Add(2 * time.Second)
 		filter.CacheTime(name, now)
 
 		Expect(runtimeClient.Create(ctx, expiredEvent)).NotTo(HaveOccurred())
-
 		time.Sleep(3 * time.Second)
 
 		By("Create a new event")
@@ -141,10 +140,11 @@ var _ = Describe("LocalPolicyEventEmitter", Ordered, func() {
 
 		Eventually(func() error {
 			key := string(enum.LocalRootPolicyEventType)
-			receivedEvent, ok := receivedEvents[key]
+			val, ok := receivedEvents.Load(key)
 			if !ok {
 				return fmt.Errorf("not get the event: %s", key)
 			}
+			receivedEvent := val.(*cloudevents.Event)
 			outEvents := []event.RootPolicyEvent{}
 			err := json.Unmarshal(receivedEvent.Data(), &outEvents)
 			if err != nil {
@@ -195,7 +195,7 @@ var _ = Describe("LocalPolicyEventEmitter", Ordered, func() {
 		cluster.Status = clusterv1.ManagedClusterStatus{
 			ClusterClaims: []clusterv1.ManagedClusterClaim{
 				{
-					Name:  constants.ClusterIdClaimName,
+					Name:  "id.k8s.io",
 					Value: "3f406177-34b2-4852-88dd-ff2809680336",
 				},
 			},
@@ -241,10 +241,11 @@ var _ = Describe("LocalPolicyEventEmitter", Ordered, func() {
 
 		Eventually(func() error {
 			key := string(enum.LocalReplicatedPolicyEventType)
-			receivedEvent, ok := receivedEvents[key]
+			val, ok := receivedEvents.Load(key)
 			if !ok {
 				return fmt.Errorf("not get the event: %s", key)
 			}
+			receivedEvent := val.(*cloudevents.Event)
 			fmt.Println(">>>>>>>>>>>>>>>>>>> replicated policy event", receivedEvent)
 			outEvents := []event.ReplicatedPolicyEvent{}
 			err = json.Unmarshal(receivedEvent.Data(), &outEvents)

--- a/test/integration/agent/status/localpolicy_test.go
+++ b/test/integration/agent/status/localpolicy_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	cloudevents "github.com/cloudevents/sdk-go/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -40,10 +41,12 @@ var _ = Describe("LocalPolicyEmitters", Ordered, func() {
 		By("Check the local policy spec can be read from cloudevents consumer")
 		fmt.Println("============================ create policy -> policy spec event: disabled")
 		Eventually(func() error {
-			evt := receivedEvents[string(enum.LocalPolicySpecType)]
-			if evt == nil {
-				return fmt.Errorf("not get the event: %s", string(enum.LocalPolicySpecType))
+			key := string(enum.LocalPolicySpecType)
+			val, ok := receivedEvents.Load(key)
+			if !ok {
+				return fmt.Errorf("not get the event: %s", key)
 			}
+			evt := val.(*cloudevents.Event)
 			fmt.Println(evt)
 			bundle := &generic.GenericBundle[policyv1.Policy]{}
 			err := evt.DataAs(bundle)
@@ -72,10 +75,12 @@ var _ = Describe("LocalPolicyEmitters", Ordered, func() {
 		By("Check the local policy spec can be read from cloudevents consumer")
 		fmt.Println("============================ update policy -> policy spec event: enabled")
 		Eventually(func() error {
-			evt := receivedEvents[string(enum.LocalPolicySpecType)]
-			if evt == nil {
-				return fmt.Errorf("not get the event: %s", string(enum.LocalPolicySpecType))
+			key := string(enum.LocalPolicySpecType)
+			val, ok := receivedEvents.Load(key)
+			if !ok {
+				return fmt.Errorf("not get the event: %s", key)
 			}
+			evt := val.(*cloudevents.Event)
 			bundle := generic.GenericBundle[policyv1.Policy]{}
 			err := evt.DataAs(&bundle)
 			if err != nil {
@@ -109,9 +114,9 @@ var _ = Describe("LocalPolicyEmitters", Ordered, func() {
 
 		By("Check the compliance can be read from cloudevents consumer")
 		Eventually(func() error {
-			evt := receivedEvents[string(enum.LocalComplianceType)]
-			if evt == nil {
-				return fmt.Errorf("not get the event: %s", string(enum.LocalComplianceType))
+			key := string(enum.LocalComplianceType)
+			if _, ok := receivedEvents.Load(key); !ok {
+				return fmt.Errorf("not get the event: %s", key)
 			}
 			return nil
 		}, 10*time.Second, 100*time.Millisecond).Should(Succeed())
@@ -133,9 +138,9 @@ var _ = Describe("LocalPolicyEmitters", Ordered, func() {
 
 		By("Check the complete compliance can be read from cloudevents consumer")
 		Eventually(func() error {
-			evt := receivedEvents[string(enum.LocalCompleteComplianceType)]
-			if evt == nil {
-				return fmt.Errorf("not get the event: %s", string(enum.LocalCompleteComplianceType))
+			key := string(enum.LocalCompleteComplianceType)
+			if _, ok := receivedEvents.Load(key); !ok {
+				return fmt.Errorf("not get the event: %s", key)
 			}
 			return nil
 		}, 10*time.Second, 100*time.Millisecond).Should(Succeed())
@@ -208,9 +213,9 @@ var _ = Describe("LocalPolicyEmitters", Ordered, func() {
 
 		By("Check the local replicated policy event can be read from cloudevents consumer")
 		Eventually(func() error {
-			evt := receivedEvents[string(enum.LocalReplicatedPolicyEventType)]
-			if evt == nil {
-				return fmt.Errorf("not get the event: %s", string(enum.LocalReplicatedPolicyEventType))
+			key := string(enum.LocalReplicatedPolicyEventType)
+			if _, ok := receivedEvents.Load(key); !ok {
+				return fmt.Errorf("not get the event: %s", key)
 			}
 			return nil
 		}, 10*time.Second, 100*time.Millisecond).Should(Succeed())

--- a/test/integration/agent/status/managedcluster_event_test.go
+++ b/test/integration/agent/status/managedcluster_event_test.go
@@ -5,23 +5,22 @@ import (
 	"fmt"
 	"time"
 
+	cloudevents "github.com/cloudevents/sdk-go/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/stolostron/multicluster-global-hub/pkg/bundle/event"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
-	"github.com/stolostron/multicluster-global-hub/pkg/database/models"
 	"github.com/stolostron/multicluster-global-hub/pkg/enum"
 )
 
 // go test ./test/integration/agent/status -v -ginkgo.focus "ManagedClusterEventEmitter"
 var _ = Describe("ManagedClusterEventEmitter", Ordered, func() {
-	It("should pass the managed cluster event in batch mode", func() {
+	It("should pass the managed cluster event", func() {
 		By("Create namespace and cluster for managed cluster event")
 		err := runtimeClient.Create(ctx, &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
@@ -42,93 +41,42 @@ var _ = Describe("ManagedClusterEventEmitter", Ordered, func() {
 		cluster.Status = clusterv1.ManagedClusterStatus{
 			ClusterClaims: []clusterv1.ManagedClusterClaim{
 				{
-					Name:  constants.ClusterIdClaimName,
+					Name:  "id.k8s.io",
 					Value: "4f406177-34b2-4852-88dd-ff2809680444",
 				},
 			},
 		}
 		Expect(runtimeClient.Status().Update(ctx, cluster)).Should(Succeed())
 
-		By("Wait for the managed cluster")
-		Eventually(func() error {
-			// wait for managed cluster
-			return runtimeClient.Get(ctx, types.NamespacedName{Name: "cluster2"}, &clusterv1.ManagedCluster{})
-		}, 3*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
-
-		By("Create multiple cluster events to test batch mode")
-		events := []*corev1.Event{
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "cluster2.event.17cd34e8c8b27fdd",
-					Namespace: "cluster2",
-				},
-				InvolvedObject: corev1.ObjectReference{
-					Kind:      constants.ManagedClusterKind,
-					Namespace: "cluster2",
-					Name:      cluster.Name,
-				},
-				Reason:              "AvailableUnknown",
-				Message:             "The managed cluster (cluster2) cannot connect to the hub cluster.",
-				ReportingController: "registration-controller",
-				ReportingInstance:   "registration-controller-cluster-manager-registration-controller-6794cf54d9-j7lgm",
-				Type:                "Warning",
+		By("Create the cluster event after the clusterId is ready")
+		evt := &corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster2.event.17cd34e8c8b27fdd",
+				Namespace: "cluster2",
 			},
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "cluster2.event.28cd34e8c8b27fee",
-					Namespace: "cluster2",
-				},
-				InvolvedObject: corev1.ObjectReference{
-					Kind:      constants.ManagedClusterKind,
-					Namespace: "cluster2",
-					Name:      cluster.Name,
-				},
-				Reason:              "Available",
-				Message:             "The managed cluster (cluster2) is now available.",
-				ReportingController: "registration-controller",
-				ReportingInstance:   "registration-controller-cluster-manager-registration-controller-6794cf54d9-j7lgm",
-				Type:                "Normal",
+			InvolvedObject: corev1.ObjectReference{
+				Kind: constants.ManagedClusterKind,
+				// TODO: the cluster namespace should be empty! but if not set the namespace,
+				// it will throw the error: involvedObject.namespace: Invalid value: "": does not match event.namespace
+				Namespace: "cluster2",
+				Name:      cluster.Name,
 			},
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "cluster2.event.39cd34e8c8b27fff",
-					Namespace: "cluster2",
-				},
-				InvolvedObject: corev1.ObjectReference{
-					Kind:      constants.ManagedClusterKind,
-					Namespace: "cluster2",
-					Name:      cluster.Name,
-				},
-				Reason:              "Updated",
-				Message:             "The managed cluster (cluster2) status updated.",
-				ReportingController: "registration-controller",
-				ReportingInstance:   "registration-controller-cluster-manager-registration-controller-6794cf54d9-j7lgm",
-				Type:                "Normal",
-			},
+			Reason:              "AvailableUnknown",
+			Message:             "The managed cluster (cluster2) cannot connect to the hub cluster.",
+			ReportingController: "registration-controller",
+			ReportingInstance:   "registration-controller-cluster-manager-registration-controller-6794cf54d9-j7lgm",
+			Type:                "Warning",
 		}
-
-		for _, evt := range events {
-			Expect(runtimeClient.Create(ctx, evt)).NotTo(HaveOccurred())
-		}
+		Expect(runtimeClient.Create(ctx, evt)).NotTo(HaveOccurred())
 
 		Eventually(func() error {
-			// wait for managed cluster
 			key := string(enum.ManagedClusterEventType)
-			receivedEvent, ok := receivedEvents[key]
+			val, ok := receivedEvents.Load(key)
 			if !ok {
 				return fmt.Errorf("not get the event: %s", key)
 			}
-			// fmt.Println(">>>>>>>>>>>>>>>>>>> managed cluster event", receivedEvent)
-
-			// Verify it's sent in batch mode
-			sendMode, ok := receivedEvent.Extensions()[constants.CloudEventExtensionSendMode]
-			if !ok {
-				return fmt.Errorf("missing send mode extension")
-			}
-			if sendMode != string(constants.EventSendModeBatch) {
-				return fmt.Errorf("expected batch mode, got %s", sendMode)
-			}
-
+			receivedEvent := val.(*cloudevents.Event)
+			fmt.Println(">>>>>>>>>>>>>>>>>>> managed cluster event", receivedEvent)
 			outEvents := event.ManagedClusterEventBundle{}
 			err = json.Unmarshal(receivedEvent.Data(), &outEvents)
 			if err != nil {
@@ -138,134 +86,9 @@ var _ = Describe("ManagedClusterEventEmitter", Ordered, func() {
 				return fmt.Errorf("got an empty event payload %s", key)
 			}
 
-			// In batch mode, we expect all events to be bundled together
-			if len(outEvents) < 3 {
-				return fmt.Errorf("expected at least 3 events in batch, got %d", len(outEvents))
+			if outEvents[0].EventName != evt.Name {
+				return fmt.Errorf("want %v, but got %v", evt, outEvents[0])
 			}
-
-			// Verify that all created events are present
-			eventNames := make(map[string]bool)
-			for _, evt := range outEvents {
-				eventNames[evt.EventName] = true
-			}
-
-			expectedNames := []string{
-				"cluster2.event.17cd34e8c8b27fdd",
-				"cluster2.event.28cd34e8c8b27fee",
-				"cluster2.event.39cd34e8c8b27fff",
-			}
-
-			for _, expectedName := range expectedNames {
-				if !eventNames[expectedName] {
-					return fmt.Errorf("expected event %s not found in batch", expectedName)
-				}
-			}
-			return nil
-		}, 30*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
-	})
-
-	It("should pass managed cluster event in single mode", func() {
-		By("Set agent config to single mode")
-		originalEventMode := agentConfig.EventMode
-		agentConfig.EventMode = string(constants.EventSendModeSingle)
-		defer func() {
-			agentConfig.EventMode = originalEventMode
-		}()
-
-		By("Create namespace and cluster for single mode test")
-		err := runtimeClient.Create(ctx, &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "cluster-single",
-			},
-		}, &client.CreateOptions{})
-		Expect(err).Should(Succeed())
-
-		By("Create the cluster")
-		cluster := &clusterv1.ManagedCluster{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "cluster-single",
-			},
-		}
-		Expect(runtimeClient.Create(ctx, cluster, &client.CreateOptions{})).Should(Succeed())
-
-		By("Claim the clusterId")
-		cluster.Status = clusterv1.ManagedClusterStatus{
-			ClusterClaims: []clusterv1.ManagedClusterClaim{
-				{
-					Name:  constants.ClusterIdClaimName,
-					Value: "6f406177-34b2-4852-88dd-ff2809680666",
-				},
-			},
-		}
-		Expect(runtimeClient.Status().Update(ctx, cluster)).Should(Succeed())
-
-		By("Wait for the managed cluster")
-		Eventually(func() error {
-			return runtimeClient.Get(ctx, types.NamespacedName{Name: "cluster-single"}, &clusterv1.ManagedCluster{})
-		}, 3*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
-
-		By("Clear previous received events to avoid interference")
-		delete(receivedEvents, string(enum.ManagedClusterEventType))
-
-		By("Create a single cluster event to test single mode sending")
-		evt := &corev1.Event{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "cluster-single.event.single-test",
-				Namespace: "cluster-single",
-			},
-			InvolvedObject: corev1.ObjectReference{
-				Kind:      constants.ManagedClusterKind,
-				Namespace: "cluster-single",
-				Name:      cluster.Name,
-			},
-			Reason:              "SingleModeTest",
-			Message:             "Testing single mode event sending",
-			ReportingController: "test-controller",
-			ReportingInstance:   "test-instance",
-			Type:                "Normal",
-		}
-		Expect(runtimeClient.Create(ctx, evt)).NotTo(HaveOccurred())
-
-		Eventually(func() error {
-			key := string(enum.ManagedClusterEventType)
-			receivedEvent, ok := receivedEvents[key]
-			if !ok {
-				return fmt.Errorf("not get the event: %s", key)
-			}
-			fmt.Println(">>>>>>>>>>>>>>>>>>> managed cluster event (single mode)", receivedEvent)
-
-			// Verify it's sent in single mode
-			sendMode, ok := receivedEvent.Extensions()[constants.CloudEventExtensionSendMode]
-			if !ok {
-				return fmt.Errorf("missing send mode extension")
-			}
-			if sendMode != string(constants.EventSendModeSingle) {
-				return fmt.Errorf("expected single mode, got %s", sendMode)
-			}
-
-			// In single mode, the payload should be a single ManagedClusterEvent, not an array
-			var singleEvent models.ManagedClusterEvent
-			err = json.Unmarshal(receivedEvent.Data(), &singleEvent)
-			if err != nil {
-				// If unmarshaling as single event fails, try as array to provide better error message
-				var eventArray event.ManagedClusterEventBundle
-				if arrayErr := json.Unmarshal(receivedEvent.Data(), &eventArray); arrayErr == nil {
-					return fmt.Errorf("received event array in single mode, expected single event")
-				}
-				return fmt.Errorf("failed to unmarshal event data: %v", err)
-			}
-
-			// Verify the single event data
-			if singleEvent.EventName != evt.Name {
-				return fmt.Errorf("event name mismatch: expected %s, got %s", evt.Name, singleEvent.EventName)
-			}
-			if singleEvent.ClusterName != cluster.Name {
-				return fmt.Errorf("cluster name mismatch: expected %s, got %s", cluster.Name, singleEvent.ClusterName)
-			}
-			if singleEvent.Reason != evt.Reason {
-				return fmt.Errorf("reason mismatch: expected %s, got %s", evt.Reason, singleEvent.Reason)
-			}
-
 			return nil
 		}, 30*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
 	})

--- a/test/integration/agent/status/suite_test.go
+++ b/test/integration/agent/status/suite_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
-	cloudevents "github.com/cloudevents/sdk-go/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -20,21 +20,24 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/configs"
-	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/generic"
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/syncers/apps"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/syncers/configmap"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/syncers/events"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/syncers/managedcluster"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/syncers/managedhub"
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/syncers/placement"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/syncers/policies"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
-	"github.com/stolostron/multicluster-global-hub/pkg/enum"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 	genericconsumer "github.com/stolostron/multicluster-global-hub/pkg/transport/consumer"
 	genericproducer "github.com/stolostron/multicluster-global-hub/pkg/transport/producer"
 )
 
 const (
+	PolicyTopic         = "Policy"
+	PlacementTopic      = "Placement"
 	ManagedClusterTopic = "ManagedCluster"
+	ApplicationTopic    = "Application"
 	HeartBeatTopic      = "HeartBeat"
 	HubClusterInfoTopic = "HubCluster"
 	EventTopic          = "Event"
@@ -48,8 +51,7 @@ var (
 	leafHubName    = "hub1"
 	runtimeClient  client.Client
 	chanTransport  *ChanTransport
-	receivedEvents map[string]*cloudevents.Event
-	agentConfig    *configs.AgentConfig
+	receivedEvents *sync.Map
 )
 
 func TestControllers(t *testing.T) {
@@ -74,12 +76,12 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
-	agentConfig = &configs.AgentConfig{
-		PodNamespace: constants.GHAgentNamespace,
-		LeafHubName:  leafHubName,
+	agentConfig := &configs.AgentConfig{
+		LeafHubName: leafHubName,
 		TransportConfig: &transport.TransportInternalConfig{
 			CommitterInterval: 1 * time.Second,
 			TransportType:     string(transport.Chan),
+			IsManager:         false,
 			KafkaCredential: &transport.KafkaConfig{
 				SpecTopic:   "spec",
 				StatusTopic: "event",
@@ -88,8 +90,8 @@ var _ = BeforeSuite(func() {
 		EnableGlobalResource: true,
 	}
 	configs.SetAgentConfig(agentConfig)
-	configmap.SetInterval(configmap.GetSyncKey(enum.HubClusterHeartbeatType), 2*time.Second)
-	configmap.SetInterval(configmap.GetSyncKey(enum.HubClusterInfoType), 2*time.Second)
+	configmap.SetInterval(configmap.HubClusterHeartBeatIntervalKey, 2*time.Second)
+	configmap.SetInterval(configmap.HubClusterInfoIntervalKey, 2*time.Second)
 
 	By("Create controller-runtime manager")
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
@@ -120,29 +122,27 @@ var _ = BeforeSuite(func() {
 
 	By("Create cloudevents transport")
 	chanTransport, err = NewChanTransport(mgr, agentConfig.TransportConfig, []string{
+		PolicyTopic,
+		PlacementTopic,
 		ManagedClusterTopic,
+		ApplicationTopic,
 		HeartBeatTopic,
 		HubClusterInfoTopic,
 		EventTopic,
 	})
 	Expect(err).To(Succeed())
-	By("Start the manager")
-	go func() {
-		defer GinkgoRecover()
-		Expect(mgr.Start(ctx)).ToNot(HaveOccurred(), "failed to run manager")
-	}()
 
-	By("Waiting for the manager to be ready")
-	Expect(mgr.GetCache().WaitForCacheSync(ctx)).To(BeTrue())
 	By("Add syncers")
-	// start periodic syncer
-	periodicSyncer, err := generic.AddPeriodicSyncer(mgr)
-	Expect(err).Should(Succeed())
-
 	// policy
-	err = policies.LaunchPolicySyncer(ctx, mgr, agentConfig, chanTransport.Producer(EventTopic))
+	err = policies.LaunchPolicySyncer(ctx, mgr, agentConfig, chanTransport.Producer(PolicyTopic))
 	Expect(err).To(Succeed())
-	err = policies.AddPolicySyncer(ctx, mgr, chanTransport.Producer(EventTopic), periodicSyncer, agentConfig)
+
+	// placement
+	err = placement.LaunchPlacementRuleSyncer(ctx, mgr, agentConfig, chanTransport.Producer(PlacementTopic))
+	Expect(err).To(Succeed())
+	err = placement.LaunchPlacementSyncer(ctx, mgr, agentConfig, chanTransport.Producer(PlacementTopic))
+	Expect(err).To(Succeed())
+	err = placement.LaunchPlacementDecisionSyncer(ctx, mgr, agentConfig, chanTransport.Producer(PlacementTopic))
 	Expect(err).To(Succeed())
 
 	// hubcluster info
@@ -154,13 +154,17 @@ var _ = BeforeSuite(func() {
 	Expect(err).Should(Succeed())
 
 	// managed cluster
-	err = managedcluster.AddManagedClusterSyncer(ctx, mgr, chanTransport.Producer(ManagedClusterTopic), periodicSyncer)
+	err = managedcluster.LaunchManagedClusterSyncer(ctx, mgr, agentConfig, chanTransport.Producer(ManagedClusterTopic))
+	Expect(err).To(Succeed())
+
+	// application
+	err = apps.LaunchSubscriptionReportSyncer(ctx, mgr, agentConfig, chanTransport.Producer(ApplicationTopic))
 	Expect(err).To(Succeed())
 
 	// event
-	err = events.AddEventSyncer(ctx, mgr, chanTransport.Producer(EventTopic), periodicSyncer)
+	err = events.LaunchEventSyncer(ctx, mgr, agentConfig, chanTransport.Producer(EventTopic))
 	Expect(err).To(Succeed())
-	receivedEvents = make(map[string]*cloudevents.Event)
+	receivedEvents = &sync.Map{}
 	go func() {
 		for {
 			select {
@@ -169,26 +173,38 @@ var _ = BeforeSuite(func() {
 					fmt.Println("event channel closed, exiting...")
 					return
 				}
-				fmt.Println("========== received event: ", evt.Type())
-				receivedEvents[evt.Type()] = evt
+				receivedEvents.Store(evt.Type(), evt)
 			case <-ctx.Done():
 				fmt.Println("context canceled, exiting...")
 				return
 			}
 		}
 	}()
+
+	By("Start the manager")
+	go func() {
+		defer GinkgoRecover()
+		Expect(mgr.Start(ctx)).ToNot(HaveOccurred(), "failed to run manager")
+	}()
+
+	By("Waiting for the manager to be ready")
+	Expect(mgr.GetCache().WaitForCacheSync(ctx)).To(BeTrue())
 })
 
 var _ = AfterSuite(func() {
-	cancel()
+	if cancel != nil {
+		cancel()
+	}
 
 	By("Tearing down the test environment")
-	err := testenv.Stop()
-	// https://github.com/kubernetes-sigs/controller-runtime/issues/1571
-	// Set 4 with random
-	if err != nil {
-		time.Sleep(4 * time.Second)
-		Expect(testenv.Stop()).NotTo(HaveOccurred())
+	if testenv != nil {
+		err := testenv.Stop()
+		// https://github.com/kubernetes-sigs/controller-runtime/issues/1571
+		// Set 4 with random
+		if err != nil {
+			time.Sleep(4 * time.Second)
+			_ = testenv.Stop()
+		}
 	}
 })
 
@@ -216,9 +232,10 @@ func NewChanTransport(mgr ctrl.Manager, transConfig *transport.TransportInternal
 	for _, topic := range topics {
 
 		// mock the consumer in manager
+		transConfig.IsManager = true
 		transConfig.EnableDatabaseOffset = false
 		transConfig.KafkaCredential.StatusTopic = topic
-		consumer, err := genericconsumer.NewGenericConsumer(transConfig, []string{topic})
+		consumer, err := genericconsumer.NewGenericConsumer(transConfig)
 		if err != nil {
 			return trans, err
 		}
@@ -230,7 +247,8 @@ func NewChanTransport(mgr ctrl.Manager, transConfig *transport.TransportInternal
 		Expect(err).NotTo(HaveOccurred())
 
 		// mock the producer in agent
-		producer, err := genericproducer.NewGenericProducer(transConfig, topic, nil)
+		transConfig.IsManager = false
+		producer, err := genericproducer.NewGenericProducer(transConfig)
 		if err != nil {
 			return trans, err
 		}

--- a/test/integration/agent/status/suite_test.go
+++ b/test/integration/agent/status/suite_test.go
@@ -20,24 +20,21 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/configs"
-	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/syncers/apps"
+	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/generic"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/syncers/configmap"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/syncers/events"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/syncers/managedcluster"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/syncers/managedhub"
-	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/syncers/placement"
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/status/syncers/policies"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/enum"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 	genericconsumer "github.com/stolostron/multicluster-global-hub/pkg/transport/consumer"
 	genericproducer "github.com/stolostron/multicluster-global-hub/pkg/transport/producer"
 )
 
 const (
-	PolicyTopic         = "Policy"
-	PlacementTopic      = "Placement"
 	ManagedClusterTopic = "ManagedCluster"
-	ApplicationTopic    = "Application"
 	HeartBeatTopic      = "HeartBeat"
 	HubClusterInfoTopic = "HubCluster"
 	EventTopic          = "Event"
@@ -83,7 +80,6 @@ var _ = BeforeSuite(func() {
 		TransportConfig: &transport.TransportInternalConfig{
 			CommitterInterval: 1 * time.Second,
 			TransportType:     string(transport.Chan),
-			IsManager:         false,
 			KafkaCredential: &transport.KafkaConfig{
 				SpecTopic:   "spec",
 				StatusTopic: "event",
@@ -92,8 +88,8 @@ var _ = BeforeSuite(func() {
 		EnableGlobalResource: true,
 	}
 	configs.SetAgentConfig(agentConfig)
-	configmap.SetInterval(configmap.HubClusterHeartBeatIntervalKey, 2*time.Second)
-	configmap.SetInterval(configmap.HubClusterInfoIntervalKey, 2*time.Second)
+	configmap.SetInterval(configmap.GetSyncKey(enum.HubClusterHeartbeatType), 2*time.Second)
+	configmap.SetInterval(configmap.GetSyncKey(enum.HubClusterInfoType), 2*time.Second)
 
 	By("Create controller-runtime manager")
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
@@ -124,27 +120,29 @@ var _ = BeforeSuite(func() {
 
 	By("Create cloudevents transport")
 	chanTransport, err = NewChanTransport(mgr, agentConfig.TransportConfig, []string{
-		PolicyTopic,
-		PlacementTopic,
 		ManagedClusterTopic,
-		ApplicationTopic,
 		HeartBeatTopic,
 		HubClusterInfoTopic,
 		EventTopic,
 	})
 	Expect(err).To(Succeed())
+	By("Start the manager")
+	go func() {
+		defer GinkgoRecover()
+		Expect(mgr.Start(ctx)).ToNot(HaveOccurred(), "failed to run manager")
+	}()
 
+	By("Waiting for the manager to be ready")
+	Expect(mgr.GetCache().WaitForCacheSync(ctx)).To(BeTrue())
 	By("Add syncers")
-	// policy
-	err = policies.LaunchPolicySyncer(ctx, mgr, agentConfig, chanTransport.Producer(PolicyTopic))
-	Expect(err).To(Succeed())
+	// start periodic syncer
+	periodicSyncer, err := generic.AddPeriodicSyncer(mgr)
+	Expect(err).Should(Succeed())
 
-	// placement
-	err = placement.LaunchPlacementRuleSyncer(ctx, mgr, agentConfig, chanTransport.Producer(PlacementTopic))
+	// policy
+	err = policies.LaunchPolicySyncer(ctx, mgr, agentConfig, chanTransport.Producer(EventTopic))
 	Expect(err).To(Succeed())
-	err = placement.LaunchPlacementSyncer(ctx, mgr, agentConfig, chanTransport.Producer(PlacementTopic))
-	Expect(err).To(Succeed())
-	err = placement.LaunchPlacementDecisionSyncer(ctx, mgr, agentConfig, chanTransport.Producer(PlacementTopic))
+	err = policies.AddPolicySyncer(ctx, mgr, chanTransport.Producer(EventTopic), periodicSyncer, agentConfig)
 	Expect(err).To(Succeed())
 
 	// hubcluster info
@@ -156,15 +154,11 @@ var _ = BeforeSuite(func() {
 	Expect(err).Should(Succeed())
 
 	// managed cluster
-	err = managedcluster.LaunchManagedClusterSyncer(ctx, mgr, agentConfig, chanTransport.Producer(ManagedClusterTopic))
-	Expect(err).To(Succeed())
-
-	// application
-	err = apps.LaunchSubscriptionReportSyncer(ctx, mgr, agentConfig, chanTransport.Producer(ApplicationTopic))
+	err = managedcluster.AddManagedClusterSyncer(ctx, mgr, chanTransport.Producer(ManagedClusterTopic), periodicSyncer)
 	Expect(err).To(Succeed())
 
 	// event
-	err = events.LaunchEventSyncer(ctx, mgr, agentConfig, chanTransport.Producer(EventTopic))
+	err = events.AddEventSyncer(ctx, mgr, chanTransport.Producer(EventTopic), periodicSyncer)
 	Expect(err).To(Succeed())
 	receivedEvents = &sync.Map{}
 	go func() {
@@ -175,6 +169,7 @@ var _ = BeforeSuite(func() {
 					fmt.Println("event channel closed, exiting...")
 					return
 				}
+				fmt.Println("========== received event: ", evt.Type())
 				receivedEvents.Store(evt.Type(), evt)
 			case <-ctx.Done():
 				fmt.Println("context canceled, exiting...")
@@ -182,15 +177,6 @@ var _ = BeforeSuite(func() {
 			}
 		}
 	}()
-
-	By("Start the manager")
-	go func() {
-		defer GinkgoRecover()
-		Expect(mgr.Start(ctx)).ToNot(HaveOccurred(), "failed to run manager")
-	}()
-
-	By("Waiting for the manager to be ready")
-	Expect(mgr.GetCache().WaitForCacheSync(ctx)).To(BeTrue())
 })
 
 var _ = AfterSuite(func() {
@@ -234,10 +220,9 @@ func NewChanTransport(mgr ctrl.Manager, transConfig *transport.TransportInternal
 	for _, topic := range topics {
 
 		// mock the consumer in manager
-		transConfig.IsManager = true
 		transConfig.EnableDatabaseOffset = false
 		transConfig.KafkaCredential.StatusTopic = topic
-		consumer, err := genericconsumer.NewGenericConsumer(transConfig)
+		consumer, err := genericconsumer.NewGenericConsumer(transConfig, []string{topic})
 		if err != nil {
 			return trans, err
 		}
@@ -249,8 +234,7 @@ func NewChanTransport(mgr ctrl.Manager, transConfig *transport.TransportInternal
 		Expect(err).NotTo(HaveOccurred())
 
 		// mock the producer in agent
-		transConfig.IsManager = false
-		producer, err := genericproducer.NewGenericProducer(transConfig)
+		producer, err := genericproducer.NewGenericProducer(transConfig, topic, nil)
 		if err != nil {
 			return trans, err
 		}

--- a/test/integration/agent/status/suite_test.go
+++ b/test/integration/agent/status/suite_test.go
@@ -52,6 +52,7 @@ var (
 	runtimeClient  client.Client
 	chanTransport  *ChanTransport
 	receivedEvents *sync.Map
+	agentConfig    *configs.AgentConfig
 )
 
 func TestControllers(t *testing.T) {
@@ -76,8 +77,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
-	agentConfig := &configs.AgentConfig{
-		LeafHubName: leafHubName,
+	agentConfig = &configs.AgentConfig{
+		PodNamespace: constants.GHAgentNamespace,
+		LeafHubName:  leafHubName,
 		TransportConfig: &transport.TransportInternalConfig{
 			CommitterInterval: 1 * time.Second,
 			TransportType:     string(transport.Chan),

--- a/test/integration/manager/controller/backup_test.go
+++ b/test/integration/manager/controller/backup_test.go
@@ -76,8 +76,8 @@ var _ = Describe("backup pvc", Ordered, func() {
 		Expect(err).Should(Succeed())
 
 		backupReconciler = controllers.NewBackupPVCReconciler(mgr, database.GetConn())
-		err = backupReconciler.SetupWithManager(mgr)
-		Expect(err).NotTo(HaveOccurred())
+		// Tests invoke Reconcile directly; registering with the manager causes duplicate
+		// reconciles on PVC updates and flakes the volsync simulation in test 3.
 		Expect(mgr.GetClient().Create(ctx, postgresPvc)).NotTo(HaveOccurred())
 		Expect(mgr.GetClient().Create(ctx, mchObj)).Should(Succeed())
 	})
@@ -146,47 +146,47 @@ var _ = Describe("backup pvc", Ordered, func() {
 			}
 			return err
 		}, timeout, interval).Should(Succeed())
+
+		reconcileDone := make(chan error, 1)
 		go func() {
-			for {
-				err := mgr.GetClient().Get(ctx, types.NamespacedName{
+			_, err := backupReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
 					Namespace: pvcNamespace,
 					Name:      pvcName,
-				}, postgresPvc)
-				Expect(err).NotTo(HaveOccurred())
-				if len(postgresPvc.Annotations[constants.BackupPvcLatestCopyTrigger]) > 5 {
-					return
-				}
-				Eventually(func() error {
-					postgresPvc := &corev1.PersistentVolumeClaim{}
-					err := mgr.GetClient().Get(ctx, types.NamespacedName{
-						Namespace: pvcNamespace,
-						Name:      pvcName,
-					}, postgresPvc)
-					if err != nil {
-						return err
-					}
-
-					utils.MergeAnnotations(postgresPvc, map[string]string{
-						constants.BackupPvcLatestCopyTrigger: postgresPvc.Annotations[constants.BackupPvcCopyTrigger],
-						constants.BackupPvcLatestCopyStatus:  constants.BackupPvcCompletedTrigger,
-					})
-
-					err = mgr.GetClient().Update(ctx, postgresPvc)
-					if err != nil {
-						return err
-					}
-					return err
-				}, timeout, interval).Should(Succeed())
-				time.Sleep(time.Second * 1)
-			}
+				},
+			})
+			reconcileDone <- err
 		}()
-		_, err := backupReconciler.Reconcile(ctx, reconcile.Request{
-			NamespacedName: types.NamespacedName{
+
+		// Simulate volsync on the main goroutine while Reconcile polls for completion.
+		Eventually(func() error {
+			postgresPvc := &corev1.PersistentVolumeClaim{}
+			err := mgr.GetClient().Get(ctx, types.NamespacedName{
 				Namespace: pvcNamespace,
 				Name:      pvcName,
-			},
-		})
-		Expect(err).NotTo(HaveOccurred())
+			}, postgresPvc)
+			if err != nil {
+				return err
+			}
+
+			copyTrigger := postgresPvc.Annotations[constants.BackupPvcCopyTrigger]
+			if copyTrigger == "" || copyTrigger == "now" {
+				return fmt.Errorf("waiting for reconciler copy trigger")
+			}
+			if utils.HasItem(postgresPvc.GetAnnotations(), constants.BackupPvcLatestCopyStatus, constants.BackupPvcCompletedTrigger) &&
+				utils.HasItem(postgresPvc.GetAnnotations(), constants.BackupPvcLatestCopyTrigger, copyTrigger) {
+				return nil
+			}
+
+			utils.MergeAnnotations(postgresPvc, map[string]string{
+				constants.BackupPvcLatestCopyTrigger: copyTrigger,
+				constants.BackupPvcLatestCopyStatus:  constants.BackupPvcCompletedTrigger,
+			})
+
+			return mgr.GetClient().Update(ctx, postgresPvc)
+		}, 2*time.Minute, interval).Should(Succeed())
+
+		Eventually(reconcileDone, 2*time.Minute, interval).Should(Receive(BeNil()))
 	})
 
 	It("disable mch and pvc do not need backup", func() {

--- a/test/integration/manager/webhook/admission_handler_test.go
+++ b/test/integration/manager/webhook/admission_handler_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Multicluster hub manager webhook", func() {
 					return false
 				}
 				return placement.Annotations == nil
-			}, 1*time.Second, 5*time.Second).Should(BeTrue())
+			}, 30*time.Second, 100*time.Millisecond).Should(BeTrue())
 		})
 
 		It("Should set global-hub as scheduler name for the placementrule", func() {
@@ -81,7 +81,7 @@ var _ = Describe("Multicluster hub manager webhook", func() {
 					return false
 				}
 				return placementrule.Spec.SchedulerName == constants.GlobalHubSchedulerName
-			}, 1*time.Second, 5*time.Second).Should(BeTrue())
+			}, 30*time.Second, 100*time.Millisecond).Should(BeTrue())
 		})
 
 		It("Should not set global-hub as scheduler name for the placementrule", func() {
@@ -103,7 +103,7 @@ var _ = Describe("Multicluster hub manager webhook", func() {
 					return false
 				}
 				return placementrule.Spec.SchedulerName != constants.GlobalHubSchedulerName
-			}, 1*time.Second, 5*time.Second).Should(BeTrue())
+			}, 30*time.Second, 100*time.Millisecond).Should(BeTrue())
 		})
 	})
 })

--- a/test/integration/operator/controllers/suite_test.go
+++ b/test/integration/operator/controllers/suite_test.go
@@ -86,9 +86,10 @@ var _ = BeforeSuite(func() {
 		"ServiceAccount,MutatingAdmissionWebhook,ValidatingAdmissionWebhook")
 
 	var err error
-	// cfg is defined in this file globally.
-	cfg, err = testEnv.Start()
-	Expect(err).NotTo(HaveOccurred())
+	Eventually(func() error {
+		cfg, err = testEnv.Start()
+		return err
+	}, 3*time.Minute, 5*time.Second).Should(Succeed())
 	Expect(cfg).NotTo(BeNil())
 
 	// create test postgres
@@ -131,15 +132,21 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	cancel()
-	Expect(testPostgres.Stop()).To(Succeed())
+	if cancel != nil {
+		cancel()
+	}
+	if testPostgres != nil {
+		Expect(testPostgres.Stop()).To(Succeed())
+	}
 	By("tearing down the test environment")
-	err := testEnv.Stop()
-	// https://github.com/kubernetes-sigs/controller-runtime/issues/1571
-	// Set 4 with random
-	if err != nil {
-		time.Sleep(4 * time.Second)
-		Expect(testEnv.Stop()).To(Succeed())
+	if testEnv != nil {
+		err := testEnv.Stop()
+		// https://github.com/kubernetes-sigs/controller-runtime/issues/1571
+		// Set 4 with random
+		if err != nil {
+			time.Sleep(4 * time.Second)
+			_ = testEnv.Stop()
+		}
 	}
 })
 

--- a/test/script/e2e_clean_globalhub.sh
+++ b/test/script/e2e_clean_globalhub.sh
@@ -67,3 +67,6 @@ wait_cmd "kubectl delete crd kafkanodepools.kafka.strimzi.io --ignore-not-found=
 wait_cmd "kubectl delete crd kafkatopics.kafka.strimzi.io --ignore-not-found=true"
 wait_cmd "kubectl delete crd kafkausers.kafka.strimzi.io --ignore-not-found=true"
 
+echo "Recreate namespace for subsequent e2e runs"
+kubectl get namespace "$GH_NAMESPACE" >/dev/null 2>&1 || kubectl create namespace "$GH_NAMESPACE"
+

--- a/test/script/e2e_clean_globalhub.sh
+++ b/test/script/e2e_clean_globalhub.sh
@@ -55,6 +55,9 @@ if [[ ! -z $(kubectl get kafka -n "$GH_NAMESPACE" --ignore-not-found=true) ]]; t
   exit 1
 fi
 
+echo "Delete e2e nonk8s NodePort service"
+kubectl delete service multicluster-global-hub-manager-nonk8s-service -n "$GH_NAMESPACE" --ignore-not-found=true
+
 cd operator
 make undeploy
 

--- a/test/script/e2e_run.sh
+++ b/test/script/e2e_run.sh
@@ -105,6 +105,13 @@ export CGO_ENABLED=1
 export GLOBAL_HUB_NODE_IP=${global_hub_node_ip}
 
 # set log level to debug
+kubectl apply --kubeconfig "$GH_KUBECONFIG" -f - <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${GH_NAMESPACE}
+EOF
+
 cat <<EOF | kubectl apply --kubeconfig $GH_KUBECONFIG -n $GH_NAMESPACE -f -
 apiVersion: v1
 kind: ConfigMap

--- a/test/script/e2e_run_byo.sh
+++ b/test/script/e2e_run_byo.sh
@@ -82,6 +82,11 @@ kubectl create secret generic "$transport_secret" -n "$target_namespace" --kubec
   --from-file=client.key="$CURRENT_DIR"/config/kafka-client-key.pem
 echo "transport secret is ready in $target_namespace namespace!"
 
+# nodePort 30080 is cluster-scoped; transport-identity leaves the nonk8s service in multicluster-global-hub.
+echo "Delete stale nonk8s NodePort service from built-in GH namespace"
+kubectl delete service multicluster-global-hub-manager-nonk8s-service -n multicluster-global-hub \
+  --kubeconfig "$GH_KUBECONFIG" --ignore-not-found=true
+
 ## run e2e
 bash "$CURRENT_DIR/e2e_run.sh" -n $target_namespace -f "e2e-test-localpolicy,e2e-test-grafana,e2e-test-local-agent"
 

--- a/test/script/e2e_run_byo.sh
+++ b/test/script/e2e_run_byo.sh
@@ -15,6 +15,10 @@ POSTGRES_KUBECONFIG="${CONFIG_DIR}/hub1"
 
 export ISBYO="true"
 
+# transport-identity runs in multicluster-global-hub before BYO; undeploy it so
+# cluster-scoped operator RBAC and nodePort 30080 are free for the mgh deploy.
+bash "$CURRENT_DIR/e2e_clean_globalhub.sh"
+
 target_namespace=${TARGET_NAMESPACE:-"mgh"}
 export NAMESPACE="$target_namespace"
 


### PR DESCRIPTION
## Summary

Backport of [#2670](https://github.com/stolostron/multicluster-global-hub/pull/2670) e2e coverage for ACM-34442 Phase 1-2 transport identity fixes (stacked on the merged phase 1-2 product backport).

- Add `test/e2e/utils/kafka_producer.go` to publish CloudEvents via hub transport credentials in KinD e2e
- Add `e2e-test-transport-identity` suite for manager status topic/source binding and agent spec source validation
- Wire the new label into `test/Makefile`

Related: [ACM-34442](https://redhat.atlassian.net/browse/ACM-34442)

## Test plan

- [ ] `make e2e-setup && make e2e-test-transport-identity`
- [ ] OpenShift Prow e2e job (label filter `e2e-test-transport-identity`)

Made with [Cursor](https://cursor.com)

[ACM-34442]: https://redhat.atlassian.net/browse/ACM-34442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ