### PR TITLE
ACM-34442 / ACM-38859: backport Phase 1-2 transport identity e2e tests to release-2.16 (GH 1.7)

### DIFF
--- a/pkg/transport/utils/utils.go
+++ b/pkg/transport/utils/utils.go
@@ -4,14 +4,22 @@ import (
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 )
 
+var sensitiveKafkaConfigKeys = map[string]struct{}{
+	"bootstrap.servers":   {},
+	"sasl.username":       {},
+	"sasl.password":       {},
+	"ssl.ca.pem":          {},
+	"ssl.certificate.pem": {},
+	"ssl.key.pem":         {},
+	"ssl.key.password":    {},
+}
+
 // FilterSensitiveKafkaConfig filters out sensitive data from Kafka ConfigMap for safe logging.
-// It replaces SSL certificate and key values with "[REDACTED]" to prevent exposure of
-// sensitive credentials in logs.
+// It replaces broker endpoints, credentials, and certificate/key values with "[REDACTED]".
 func FilterSensitiveKafkaConfig(configMap *kafka.ConfigMap) map[string]interface{} {
 	safeConfig := make(map[string]interface{})
 	for key, value := range *configMap {
-		// Exclude sensitive SSL/TLS certificate and key data
-		if key == "ssl.ca.pem" || key == "ssl.certificate.pem" || key == "ssl.key.pem" {
+		if _, sensitive := sensitiveKafkaConfigKeys[key]; sensitive {
 			safeConfig[key] = "[REDACTED]"
 		} else {
 			safeConfig[key] = value

--- a/pkg/transport/utils/utils_test.go
+++ b/pkg/transport/utils/utils_test.go
@@ -16,11 +16,11 @@ func TestFilterSensitiveKafkaConfig(t *testing.T) {
 		{
 			name: "No sensitive keys",
 			input: kafka.ConfigMap{
-				"bootstrap.servers": "localhost:9092",
+				"group.id":          "test-group",
 				"security.protocol": "SSL",
 			},
 			expected: map[string]interface{}{
-				"bootstrap.servers": "localhost:9092",
+				"group.id":          "test-group",
 				"security.protocol": "SSL",
 			},
 		},
@@ -31,12 +31,16 @@ func TestFilterSensitiveKafkaConfig(t *testing.T) {
 				"ssl.certificate.pem": "cert-data",
 				"ssl.key.pem":         "key-data",
 				"bootstrap.servers":   "localhost:9092",
+				"sasl.username":       "user",
+				"sasl.password":       "secret",
 			},
 			expected: map[string]interface{}{
 				"ssl.ca.pem":          "[REDACTED]",
 				"ssl.certificate.pem": "[REDACTED]",
 				"ssl.key.pem":         "[REDACTED]",
-				"bootstrap.servers":   "localhost:9092",
+				"bootstrap.servers":   "[REDACTED]",
+				"sasl.username":       "[REDACTED]",
+				"sasl.password":       "[REDACTED]",
 			},
 		},
 		{
@@ -47,7 +51,7 @@ func TestFilterSensitiveKafkaConfig(t *testing.T) {
 			},
 			expected: map[string]interface{}{
 				"ssl.ca.pem":        "[REDACTED]",
-				"bootstrap.servers": "localhost:9092",
+				"bootstrap.servers": "[REDACTED]",
 			},
 		},
 		{
@@ -60,9 +64,33 @@ func TestFilterSensitiveKafkaConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := FilterSensitiveKafkaConfig(&tt.input)
-			if !reflect.DeepEqual(result, tt.expected) {
-				t.Errorf("FilterSensitiveKafkaConfig() = %v, want %v", result, tt.expected)
-			}
+			assertFilteredKafkaConfig(t, result, tt.expected)
 		})
+	}
+}
+
+func assertFilteredKafkaConfig(t *testing.T, got, want map[string]interface{}) {
+	t.Helper()
+
+	for key, wantVal := range want {
+		gotVal, ok := got[key]
+		if !ok {
+			t.Errorf("missing key %q in filtered config", key)
+			continue
+		}
+		if reflect.DeepEqual(gotVal, wantVal) {
+			continue
+		}
+		if _, sensitive := sensitiveKafkaConfigKeys[key]; sensitive {
+			t.Errorf("key %q: expected redaction marker, got unexpected value", key)
+			continue
+		}
+		t.Errorf("key %q: got %v, want %v", key, gotVal, wantVal)
+	}
+
+	for key := range got {
+		if _, ok := want[key]; !ok {
+			t.Errorf("unexpected key %q in filtered config", key)
+		}
 	}
 }

--- a/test/Makefile
+++ b/test/Makefile
@@ -22,8 +22,9 @@ e2e-test-all: tidy vendor
 	sh ./test/script/e2e_clean_globalhub.sh
 	sh ./test/script/e2e_run_byo.sh -v $(VERBOSE)
 	sh ./test/script/e2e_run.sh -f "e2e-test-migration" -v $(VERBOSE)
+	sh ./test/script/e2e_run.sh -f "e2e-test-transport-identity" -v $(VERBOSE)
 
-e2e-test-cluster e2e-test-local-agent e2e-test-localpolicy e2e-test-grafana e2e-test-migration: tidy vendor
+e2e-test-cluster e2e-test-local-agent e2e-test-localpolicy e2e-test-grafana e2e-test-migration e2e-test-transport-identity: tidy vendor
 	./test/script/e2e_run.sh -f $@ -v $(VERBOSE)
 
 e2e-prow-tests: 

--- a/test/e2e/transport_identity_test.go
+++ b/test/e2e/transport_identity_test.go
@@ -1,0 +1,320 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package tests
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	kafka_confluent "github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gorm.io/gorm"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	migrationv1alpha1 "github.com/stolostron/multicluster-global-hub/operator/api/migration/v1alpha1"
+	"github.com/stolostron/multicluster-global-hub/pkg/bundle/generic"
+	migrationbundle "github.com/stolostron/multicluster-global-hub/pkg/bundle/migration"
+	eventversion "github.com/stolostron/multicluster-global-hub/pkg/bundle/version"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/database"
+	"github.com/stolostron/multicluster-global-hub/pkg/database/models"
+	"github.com/stolostron/multicluster-global-hub/pkg/enum"
+	pkgutils "github.com/stolostron/multicluster-global-hub/pkg/utils"
+	e2eutils "github.com/stolostron/multicluster-global-hub/test/e2e/utils"
+)
+
+const (
+	spoofVictimHubName     = "e2e-spoof-victim-hub"
+	spoofMigrationSource   = "e2e-spoof-migration-source"
+	spoofMigrationID       = "e2e-spoof-migration"
+	spoofMigrationNSPrefix = "e2e-spoof-migration-ns"
+)
+
+var _ = Describe("Transport Identity E2E", Label("e2e-test-transport-identity"), Ordered, func() {
+	var (
+		sourceHubName   string
+		targetHubName   string
+		targetHubClient client.Client
+	)
+
+	BeforeAll(func() {
+		Expect(len(managedHubNames)).To(BeNumerically(">=", 2),
+			"transport identity e2e requires two regional hubs (source and target)")
+		sourceHubName = managedHubNames[0]
+		targetHubName = managedHubNames[1]
+
+		var err error
+		targetHubClient, err = testClients.RuntimeClient(targetHubName, agentScheme)
+		Expect(err).NotTo(HaveOccurred(), "expected target hub %q kubeconfig to be valid", targetHubName)
+	})
+
+	Context("ACM-34442 Phase 1 - manager status identity from Kafka topic", func() {
+		var publisher *e2eutils.KafkaEventPublisher
+
+		BeforeEach(func() {
+			var err error
+			publisher, err = e2eutils.NewKafkaEventPublisher(ctx, globalHubClient, constants.GHDefaultNamespace)
+			Expect(err).NotTo(HaveOccurred(), "expected Kafka publisher from global hub transport-config secret")
+		})
+
+		AfterEach(func() {
+			for _, hub := range []string{spoofVictimHubName, sourceHubName} {
+				Expect(database.GetGorm().Exec(
+					`DELETE FROM status.leaf_hub_heartbeats WHERE leaf_hub_name = $1`,
+					hub,
+				).Error).To(Succeed(), "expected heartbeat cleanup for hub %q between tests", hub)
+			}
+		})
+
+		It("should drop status events when CloudEvent source does not match the Kafka status topic hub", func() {
+			statusTopic := publisher.StatusTopic(sourceHubName)
+			evt := statusCloudEvent(
+				statusTopic,
+				spoofVictimHubName,
+				string(enum.HubClusterHeartbeatType),
+				generic.GenericObjectBundle{},
+			)
+
+			Expect(publisher.SendToTopic(ctx, statusTopic, *evt)).To(Succeed(),
+				"expected spoofed status event to publish to Kafka for rejection testing")
+
+			Consistently(func() error {
+				for _, hub := range []string{sourceHubName, spoofVictimHubName} {
+					var heartbeat models.LeafHubHeartbeat
+					err := database.GetGorm().Where("leaf_hub_name = ?", hub).First(&heartbeat).Error
+					if errors.Is(err, gorm.ErrRecordNotFound) {
+						continue
+					}
+					if err != nil {
+						return fmt.Errorf("query heartbeat for hub %q: %w", hub, err)
+					}
+					if hub == spoofVictimHubName {
+						return fmt.Errorf("spoofed status event must not create heartbeat for hub %q", hub)
+					}
+				}
+				return nil
+			}, 45*time.Second, 500*time.Millisecond).Should(Succeed(),
+				"spoofed status heartbeat must not be persisted when CloudEvent source mismatches topic hub")
+		})
+
+		It("should accept status events when CloudEvent source matches the Kafka status topic hub", func() {
+			statusTopic := publisher.StatusTopic(sourceHubName)
+			evt := statusCloudEvent(
+				statusTopic,
+				sourceHubName,
+				string(enum.HubClusterHeartbeatType),
+				generic.GenericObjectBundle{},
+			)
+
+			Expect(publisher.SendToTopic(ctx, statusTopic, *evt)).To(Succeed(),
+				"expected trusted status event to publish to Kafka")
+
+			Eventually(func() error {
+				var heartbeat models.LeafHubHeartbeat
+				err := database.GetGorm().Where("leaf_hub_name = ?", sourceHubName).First(&heartbeat).Error
+				if err != nil {
+					return fmt.Errorf("expected heartbeat row for trusted hub %q: %w", sourceHubName, err)
+				}
+				return nil
+			}, 45*time.Second, 500*time.Millisecond).Should(Succeed(),
+				"trusted status heartbeat must be persisted when CloudEvent source matches topic hub")
+		})
+	})
+
+	Context("ACM-34442 Phase 2 - agent spec source validation", func() {
+		var (
+			publisher        *e2eutils.KafkaEventPublisher
+			spoofMigrationNS string
+		)
+
+		BeforeEach(func() {
+			spoofMigrationNS = fmt.Sprintf("%s-%d", spoofMigrationNSPrefix, time.Now().UnixNano())
+
+			var err error
+			publisher, err = e2eutils.NewKafkaEventPublisher(ctx, globalHubClient, constants.GHDefaultNamespace)
+			Expect(err).NotTo(HaveOccurred(), "expected Kafka publisher from global hub transport-config secret")
+		})
+
+		AfterEach(func() {
+			deleteNamespaceAndWait(targetHubClient, spoofMigrationNS)
+		})
+
+		It("should drop migration deploying events when no in-flight migration is recorded on the target hub", func() {
+			migrationID := fmt.Sprintf("%s-no-state-%d", spoofMigrationID, time.Now().UnixNano())
+			evt := migrationDeployingEvent(
+				sourceHubName,
+				targetHubName,
+				spoofMigrationNS,
+				migrationID,
+			)
+			Expect(publisher.SendToTopic(ctx, publisher.SpecTopic(), evt)).To(Succeed(),
+				"expected migration event to publish to Kafka for rejection testing")
+
+			Consistently(func() error {
+				ns := &corev1.Namespace{}
+				err := targetHubClient.Get(ctx, types.NamespacedName{Name: spoofMigrationNS}, ns)
+				if err == nil {
+					return fmt.Errorf("namespace %q must not be created without in-flight migration state", spoofMigrationNS)
+				}
+				if client.IgnoreNotFound(err) != nil {
+					return err
+				}
+				return nil
+			}, 45*time.Second, 500*time.Millisecond).Should(Succeed(),
+				"migration deploying event must not create resources without in-flight migration state")
+		})
+
+		It("should drop migration deploying events from an untrusted source hub", func() {
+			migrationID := fmt.Sprintf("%s-untrusted-%d", spoofMigrationID, time.Now().UnixNano())
+			seedClusterName := fmt.Sprintf("e2e-transport-id-seed-%d", time.Now().UnixNano())
+			seedMSAName := fmt.Sprintf("e2e-transport-id-msa-%d", time.Now().UnixNano())
+
+			seedInFlightMigrationState(
+				publisher,
+				sourceHubName,
+				targetHubName,
+				migrationID,
+				seedMSAName,
+				seedClusterName,
+			)
+
+			probeNS := fmt.Sprintf("%s-probe-%d", spoofMigrationNSPrefix, time.Now().UnixNano())
+			waitForTrustedMigrationDeploy(
+				publisher,
+				targetHubClient,
+				sourceHubName,
+				targetHubName,
+				probeNS,
+				migrationID,
+			)
+			deleteNamespaceAndWait(targetHubClient, probeNS)
+
+			evt := migrationDeployingEvent(
+				spoofMigrationSource,
+				targetHubName,
+				spoofMigrationNS,
+				migrationID,
+			)
+			Expect(publisher.SendToTopic(ctx, publisher.SpecTopic(), evt)).To(Succeed(),
+				"expected spoofed migration event to publish to Kafka for rejection testing")
+
+			Consistently(func() error {
+				ns := &corev1.Namespace{}
+				err := targetHubClient.Get(ctx, types.NamespacedName{Name: spoofMigrationNS}, ns)
+				if err == nil {
+					return fmt.Errorf("namespace %q must not be created from spoofed migration source", spoofMigrationNS)
+				}
+				if client.IgnoreNotFound(err) != nil {
+					return err
+				}
+				return nil
+			}, 45*time.Second, 500*time.Millisecond).Should(Succeed(),
+				"spoofed migration deploying event must not create resources when in-flight migration is registered for a different source hub")
+		})
+	})
+})
+
+func statusCloudEvent(kafkaTopic, source, eventType string, data interface{}) *cloudevents.Event {
+	version := eventversion.NewVersion()
+	version.Incr()
+	evt := cloudevents.NewEvent()
+	evt.SetSource(source)
+	evt.SetType(eventType)
+	evt.SetExtension(eventversion.ExtVersion, version.String())
+	_ = evt.SetData(cloudevents.ApplicationJSON, data)
+	evt.SetExtension(kafka_confluent.KafkaTopicKey, kafkaTopic)
+	return &evt
+}
+
+func migrationDeployingEvent(sourceHub, targetHub, resourceName, migrationID string) cloudevents.Event {
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: resourceName}}
+	unstructuredNS, err := runtime.DefaultUnstructuredConverter.ToUnstructured(ns)
+	Expect(err).NotTo(HaveOccurred(), "expected namespace object conversion for migration bundle")
+	obj := unstructured.Unstructured{Object: unstructuredNS}
+	obj.SetKind("Namespace")
+	obj.SetAPIVersion("v1")
+
+	bundle := migrationbundle.MigrationResourceBundle{
+		MigrationId: migrationID,
+		MigrationClusterResources: []migrationbundle.MigrationClusterResource{
+			{
+				ClusterName:  resourceName,
+				ResourceList: []unstructured.Unstructured{obj},
+			},
+		},
+	}
+
+	evt := pkgutils.ToCloudEvent(constants.MigrationTargetMsgKey, sourceHub, targetHub, bundle)
+	evt.SetExtension(migrationbundle.ExtTotalClusters, 1)
+	evt.SetTime(time.Now())
+	return evt
+}
+
+func migrationValidatingEvent(
+	sourceHub, targetHub, migrationID, managedServiceAccountName, clusterName string,
+) cloudevents.Event {
+	bundle := migrationbundle.MigrationTargetBundle{
+		MigrationId:               migrationID,
+		Stage:                     migrationv1alpha1.PhaseValidating,
+		FromHub:                   sourceHub,
+		ManagedServiceAccountName: managedServiceAccountName,
+		ManagedClusters:           []string{clusterName},
+	}
+
+	evt := pkgutils.ToCloudEvent(constants.MigrationTargetMsgKey, constants.CloudEventGlobalHubClusterName, targetHub, bundle)
+	evt.SetTime(time.Now())
+	return evt
+}
+
+func seedInFlightMigrationState(
+	publisher *e2eutils.KafkaEventPublisher,
+	sourceHub, targetHub, migrationID, managedServiceAccountName, clusterName string,
+) {
+	evt := migrationValidatingEvent(sourceHub, targetHub, migrationID, managedServiceAccountName, clusterName)
+	Expect(publisher.SendToTopic(ctx, publisher.SpecTopic(), evt)).To(Succeed(),
+		"expected validating migration event to seed in-flight migration state on target hub agent")
+}
+
+func waitForTrustedMigrationDeploy(
+	publisher *e2eutils.KafkaEventPublisher,
+	targetClient client.Client,
+	sourceHub, targetHub, probeNamespace, migrationID string,
+) {
+	Eventually(func() error {
+		evt := migrationDeployingEvent(sourceHub, targetHub, probeNamespace, migrationID)
+		if err := publisher.SendToTopic(ctx, publisher.SpecTopic(), evt); err != nil {
+			return fmt.Errorf("publish trusted migration deploying probe event: %w", err)
+		}
+
+		ns := &corev1.Namespace{}
+		err := targetClient.Get(ctx, types.NamespacedName{Name: probeNamespace}, ns)
+		if err != nil {
+			return fmt.Errorf("wait for trusted migration deploy to create namespace %q: %w", probeNamespace, err)
+		}
+		return nil
+	}, 45*time.Second, 500*time.Millisecond).Should(Succeed(),
+		"trusted migration deploying event must succeed once in-flight migration state is registered for the source hub")
+}
+
+func deleteNamespaceAndWait(targetClient client.Client, namespaceName string) {
+	err := targetClient.Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespaceName}})
+	if err != nil && !apierrors.IsNotFound(err) {
+		Expect(err).NotTo(HaveOccurred(), "expected to delete namespace %q during test cleanup", namespaceName)
+	}
+
+	Eventually(func() bool {
+		err := targetClient.Get(ctx, types.NamespacedName{Name: namespaceName}, &corev1.Namespace{})
+		return client.IgnoreNotFound(err) == nil && err != nil
+	}, 30*time.Second, 500*time.Millisecond).Should(BeTrue(),
+		"expected namespace %q to be fully removed before next test", namespaceName)
+}

--- a/test/e2e/utils/kafka_producer.go
+++ b/test/e2e/utils/kafka_producer.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package utils
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	cecontext "github.com/cloudevents/sdk-go/v2/context"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	operatorconfig "github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport"
+	genericproducer "github.com/stolostron/multicluster-global-hub/pkg/transport/producer"
+	pkgutils "github.com/stolostron/multicluster-global-hub/pkg/utils"
+)
+
+// KafkaEventPublisher sends CloudEvents to Kafka using transport credentials from a cluster secret.
+type KafkaEventPublisher struct {
+	producer    transport.Producer
+	kafkaConfig *transport.KafkaConfig
+}
+
+// NewKafkaEventPublisher loads transport-config from namespace and builds a producer.
+func NewKafkaEventPublisher(ctx context.Context, c client.Client, namespace string) (*KafkaEventPublisher, error) {
+	secret := &corev1.Secret{}
+	if err := c.Get(ctx, types.NamespacedName{
+		Name:      constants.GHTransportConfigSecret,
+		Namespace: namespace,
+	}, secret); err != nil {
+		return nil, fmt.Errorf("get transport secret in namespace %s: %w", namespace, err)
+	}
+
+	kafkaConfig, err := pkgutils.GetKafkaCredentialBySecret(secret, c)
+	if err != nil {
+		return nil, fmt.Errorf("parse kafka credentials: %w", err)
+	}
+
+	transportConfig := &transport.TransportInternalConfig{
+		TransportType:   string(transport.Kafka),
+		KafkaCredential: kafkaConfig,
+	}
+
+	producer, err := genericproducer.NewGenericProducer(transportConfig, kafkaConfig.SpecTopic, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create kafka producer: %w", err)
+	}
+
+	return &KafkaEventPublisher{
+		producer:    producer,
+		kafkaConfig: kafkaConfig,
+	}, nil
+}
+
+// SendToTopic publishes evt to the given Kafka topic.
+func (p *KafkaEventPublisher) SendToTopic(ctx context.Context, topic string, evt cloudevents.Event) error {
+	return p.producer.SendEvent(cecontext.WithTopic(ctx, topic), evt)
+}
+
+// SpecTopic returns the configured spec topic (typically gh-spec).
+func (p *KafkaEventPublisher) SpecTopic() string {
+	return p.kafkaConfig.SpecTopic
+}
+
+// StatusTopic returns the status topic for hubName (per-hub topic or credential override).
+func (p *KafkaEventPublisher) StatusTopic(hubName string) string {
+	if p.kafkaConfig.StatusTopic != "" && !strings.Contains(p.kafkaConfig.StatusTopic, "*") {
+		return p.kafkaConfig.StatusTopic
+	}
+	return operatorconfig.GetStatusTopic(hubName)
+}


### PR DESCRIPTION
## Summary

Backport of [#2670](https://github.com/stolostron/multicluster-global-hub/pull/2670) e2e coverage for ACM-34442 Phase 1-2 transport identity fixes (stacked on the merged phase 1-2 product backport).

- Add `test/e2e/utils/kafka_producer.go` to publish CloudEvents via hub transport credentials in KinD e2e
- Add `e2e-test-transport-identity` suite for manager status topic/source binding and agent spec source validation
- Wire the new label into `test/Makefile`

Related: [ACM-34442](https://redhat.atlassian.net/browse/ACM-34442)

## Test plan

- [ ] `make e2e-setup && make e2e-test-transport-identity`
- [ ] OpenShift Prow e2e job (label filter `e2e-test-transport-identity`)

Made with [Cursor](https://cursor.com)

[ACM-34442]: https://redhat.atlassian.net/browse/ACM-34442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ