### PR TITLE
chore: retrigger Konflux on-push for GH 5.0 operands

### DIFF
--- a/pkg/bundle/version/version.go
+++ b/pkg/bundle/version/version.go
@@ -1,3 +1,4 @@
+// Package version provides generation/value semantics for status bundle versioning.
 package version
 
 import (


### PR DESCRIPTION
## Summary
- #2684 empty commit did **not** trigger Konflux — PAC CEL on `release-5.0` requires path changes under `pkg/`, `operator/`, `manager/`, or `agent/` (empty commits are ignored)
- Add a package doc comment in `pkg/bundle/version/version.go` so **operator, manager, and agent** on-push PipelineRuns fire
- Rebuilds pending code already on `release-5.0` since Jul 23 (ACM-34442 transport #2624, HA fixes, etc.) → MintMaker bundle nudge → stage publish

## Why this is needed
| Commit | Konflux on-push? | Reason |
|--------|------------------|--------|
| `5ece935` (#2684) | No | Empty commit — CEL `pathChanged()` false |
| `349fb14` (#2624) | No | Konflux outage ~Jul 28–30 |
| This PR | Expected yes | `pkg/***` path change matches all three operand CEL rules |

## Test plan
- [ ] Merge to `release-5.0`
- [ ] Confirm Konflux checks: `multicluster-global-hub-{operator,manager,agent}-globalhub-5-0-on-push`
- [ ] Wait for MintMaker bundle nudge on `multicluster-global-hub-operator-bundle` `release-5.0`
- [ ] Merge bundle nudge → pre-flight gate → bundle stage release

Made with [Cursor](https://cursor.com)