### PR TITLE
chore: backport Konflux pkg touch from release-5.0 to main

### DIFF
--- a/pkg/bundle/version/version.go
+++ b/pkg/bundle/version/version.go
@@ -1,3 +1,4 @@
+// Package version provides generation/value semantics for status bundle versioning.
 package version
 
 import (


### PR DESCRIPTION
## Summary

Backport the `pkg/bundle/version/version.go` comment from #2685 (merged to `release-5.0` only) onto `main` so `main` and `release-5.0` stay aligned after sync PR #2688.

Root cause: Konflux retrigger PRs #2684/#2685 targeted `release-5.0` instead of `main`, breaking main → release-5.0 ffwd.

## Test plan

- [ ] CI passes
- [ ] Merge before or with #2688 so compare shows minimal drift

Related: #2688

Made with Cursor

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added package documentation describing the purpose of the version component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->