### PR TITLE
fix: harden transport offset migration integration test

### DIFF
--- a/test/integration/manager/status/transport_offset_test.go
+++ b/test/integration/manager/status/transport_offset_test.go
@@ -96,18 +96,25 @@ var _ = Describe("TransportOffsetPersistence", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(oldCount).To(Equal(int64(0)), "old format records should be deleted")
 
-			// Verify new records exist with correct format
-			var newRecords []models.Transport
-			err = db.Find(&newRecords).Error
-			Expect(err).NotTo(HaveOccurred())
-			Expect(newRecords).To(HaveLen(3))
-
-			// Verify each new record has topic@partition format
+			// Verify migrated records exist with correct format. Query only expected
+			// names — the suite-wide manager committer may insert unrelated offsets
+			// (e.g. "@0" from events with empty topic) while this test runs.
 			expectedNames := map[string]bool{
 				"old-topic-1@0": false,
 				"old-topic-2@1": false,
 				"old-topic-3@2": false,
 			}
+			expectedNameList := make([]string, 0, len(expectedNames))
+			for name := range expectedNames {
+				expectedNameList = append(expectedNameList, name)
+			}
+
+			var newRecords []models.Transport
+			err = db.Where("name IN ?", expectedNameList).Find(&newRecords).Error
+			Expect(err).NotTo(HaveOccurred())
+			Expect(newRecords).To(HaveLen(3))
+
+			// Verify each new record has topic@partition format
 
 			for _, record := range newRecords {
 				_, exists := expectedNames[record.Name]


### PR DESCRIPTION
## Summary

- `TransportOffsetPersistence` migration test queried **all** `status.transport` rows and expected exactly 3
- The suite-wide manager committer (started in `BeforeSuite`) can insert unrelated offsets in parallel — e.g. spurious `@0` with empty topic from events that fail topic parsing
- Flaked on #2689 integration (`len:4` instead of `len:3`); unrelated to Phase 1-3 or that PR's pkg comment change
- Fix: query only the three expected migrated names (`old-topic-*@*`), same pattern as the multi-partition test below

## Test plan

- [ ] `ci/prow/test-integration` passes
- [ ] Unblocks #2689 once merged (or merge this first)

Related: #2689

Made with Cursor

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved migration test validation by checking only the expected migrated transport records.
  * Prevented unrelated records from affecting migration count assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->