### PR TITLE
chore: trigger Konflux rebuild for manager and operator globalhub-5-0

### DIFF
--- a/pkg/bundle/version/version.go
+++ b/pkg/bundle/version/version.go
@@ -131,3 +131,5 @@ func (v *Version) Reset() {
 func (v *Version) InitGen() bool {
 	return v.Generation == 0
 }
+
+// konflux-rebuild-touch


### PR DESCRIPTION
## Summary

- Touch `pkg/bundle/version/version.go` to trigger Konflux on-push for operator and manager on `release-5.0`
- Pre-flight blocked bundle stage: `gh-manager` and `gh-operator` unchanged vs `stage-publish-globalhub-5-0-0-20260730`

## Test plan

- [ ] Merge → operator/manager/agent on-push PipelineRuns succeed on Konflux
- [ ] MintMaker opens bundle nudge on operator-bundle
- [ ] Re-run pre-flight → all 5 operands CHANGED vs last success


Made with [Cursor](https://cursor.com)