### PR TITLE
ACM-38862: gh-migration transport backport to release-2.14 (GH 1.5)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -47,8 +47,10 @@ jobs:
           # clone multicluster-global-hub-operator-bundle repo
           git clone https://github.com/stolostron/multicluster-global-hub-operator-bundle.git -b release-1.5
 
-          # compare the bundle dir
-          diff -I 'createdAt' -ruN operator/bundle multicluster-global-hub-operator-bundle/bundle
+          # compare the bundle dir (exclude accidental CSV backup copy in operator-bundle repo)
+          diff -I 'createdAt' -ruN \
+            --exclude="multicluster-global-hub-operator.clusterserviceversion.yaml''" \
+            operator/bundle multicluster-global-hub-operator-bundle/bundle
 
   scorecard-test:
     name: bundle scorecard test

--- a/agent/pkg/spec/syncers/migration_from_syncer.go
+++ b/agent/pkg/spec/syncers/migration_from_syncer.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	cecontext "github.com/cloudevents/sdk-go/v2/context"
@@ -20,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -31,6 +33,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/enum"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
+	genericproducer "github.com/stolostron/multicluster-global-hub/pkg/transport/producer"
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
@@ -446,13 +449,47 @@ func (s *migrationSourceSyncer) SendMigrationResources(ctx context.Context,
 	}
 
 	e := utils.ToCloudEvent(constants.MigrationTargetMsgKey, fromHub, toHub, payloadBytes)
-	if err := s.transportClient.GetProducer().SendEvent(
-		cecontext.WithTopic(ctx, s.transportConfig.KafkaCredential.SpecTopic), e); err != nil {
+	topicCtx := cecontext.WithTopic(ctx, s.transportConfig.KafkaCredential.GetMigrationTopic())
+	const migrationPublishDeliveryTimeout = 30 * time.Second
+	err = wait.ExponentialBackoff(wait.Backoff{
+		Duration: 5 * time.Second,
+		Factor:   1.0,
+		Steps:    6,
+	}, func() (bool, error) {
+		sendErr := s.sendMigrationEventWithDelivery(topicCtx, e, migrationPublishDeliveryTimeout)
+		if sendErr == nil {
+			return true, nil
+		}
+		if !isMigrationTopicAuthorizationError(sendErr) {
+			return false, sendErr
+		}
+		return false, nil
+	})
+	if err != nil {
 		return fmt.Errorf("failed to send event(%s) from %s to %s: %v",
 			constants.MigrationTargetMsgKey, fromHub, toHub, err)
 	}
 	log.Info("deploying the resources into the target hub cluster")
 	return nil
+}
+
+func (s *migrationSourceSyncer) sendMigrationEventWithDelivery(
+	ctx context.Context, evt cloudevents.Event, timeout time.Duration,
+) error {
+	producer := s.transportClient.GetProducer()
+	if gp, ok := producer.(*genericproducer.GenericProducer); ok {
+		return gp.SendEventWithDeliveryConfirmation(ctx, evt, timeout)
+	}
+	return producer.SendEvent(ctx, evt)
+}
+
+func isMigrationTopicAuthorizationError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "Topic authorization failed") ||
+		strings.Contains(msg, "Broker: Topic authorization failed")
 }
 
 func (s *migrationSourceSyncer) addResources(ctx context.Context, resources []string,

--- a/agent/pkg/spec/syncers/migration_from_syncer_test.go
+++ b/agent/pkg/spec/syncers/migration_from_syncer_test.go
@@ -6,8 +6,10 @@ package syncers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	klusterletv1alpha1 "github.com/stolostron/cluster-lifecycle-api/klusterletconfig/v1alpha1"
@@ -394,13 +396,44 @@ func TestGenerateKlusterletConfig(t *testing.T) {
 
 type ProducerMock struct {
 	sentEvent *cloudevents.Event
+	sendErr   error
 }
 
 func (m *ProducerMock) SendEvent(ctx context.Context, evt cloudevents.Event) error {
 	m.sentEvent = &evt
-	return nil
+	return m.sendErr
 }
 
 func (m *ProducerMock) Reconnect(config *transport.TransportInternalConfig, topic string) error {
 	return nil
+}
+
+type mockMigrationTransportClient struct {
+	producer transport.Producer
+}
+
+func (m *mockMigrationTransportClient) GetProducer() transport.Producer { return m.producer }
+
+func (m *mockMigrationTransportClient) GetConsumer() transport.Consumer { return nil }
+
+func (m *mockMigrationTransportClient) GetRequester() transport.Requester { return nil }
+
+func TestIsMigrationTopicAuthorizationError(t *testing.T) {
+	assert.False(t, isMigrationTopicAuthorizationError(nil))
+	assert.False(t, isMigrationTopicAuthorizationError(errors.New("connection refused")))
+	assert.True(t, isMigrationTopicAuthorizationError(errors.New("Topic authorization failed")))
+	assert.True(t, isMigrationTopicAuthorizationError(errors.New("Broker: Topic authorization failed")))
+}
+
+func TestSendMigrationEventWithDelivery_usesProducerSendEvent(t *testing.T) {
+	producer := &ProducerMock{}
+	syncer := &migrationSourceSyncer{
+		transportClient: &mockMigrationTransportClient{producer: producer},
+	}
+
+	evt := cloudevents.NewEvent()
+	evt.SetID("test-id")
+	err := syncer.sendMigrationEventWithDelivery(context.Background(), evt, time.Second)
+	assert.NoError(t, err)
+	assert.NotNil(t, producer.sentEvent)
 }

--- a/manager/pkg/migration/migration_deploying.go
+++ b/manager/pkg/migration/migration_deploying.go
@@ -3,6 +3,7 @@ package migration
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,6 +15,10 @@ const (
 	conditionReasonResourcesNotDeployed = "ResourcesNotDeployed"
 	conditionReasonResourcesDeployed    = "ResourcesDeployed"
 	conditionReasonResourcesDeploying   = "ResourcesDeploying"
+
+	// migrationDeployingACLPropagationWait allows Strimzi to propagate gh-migration
+	// Write ACLs from KafkaUser to brokers before source-hub agents publish bundles.
+	migrationDeployingACLPropagationWait = 45 * time.Second
 )
 
 // Migrating - deploying:
@@ -57,6 +62,25 @@ func (m *ClusterMigrationController) deploying(ctx context.Context,
 	sourceHubToClusters := GetSourceClusters(string(mcm.GetUID()))
 	if sourceHubToClusters == nil {
 		return false, fmt.Errorf("not initialized the source clusters for migrationId: %s", string(mcm.GetUID()))
+	}
+
+	migrationID := string(mcm.GetUID())
+	if !GetStarted(migrationID, mcm.Spec.From, migrationv1alpha1.PhaseDeploying) &&
+		!GetStarted(migrationID, mcm.Spec.To, migrationv1alpha1.PhaseDeploying) {
+		readyTime, scheduled := GetDeployingACLReadyTime(migrationID)
+		if !scheduled {
+			SetDeployingACLReadyTime(migrationID, time.Now().Add(migrationDeployingACLPropagationWait))
+			condMessage = "Waiting for migration transport ACL to be provisioned"
+			condStatus = metav1.ConditionFalse
+			condReason = conditionReasonResourcesDeploying
+			return true, nil
+		}
+		if time.Now().Before(readyTime) {
+			condMessage = "Waiting for migration transport ACL to propagate"
+			condStatus = metav1.ConditionFalse
+			condReason = conditionReasonResourcesDeploying
+			return true, nil
+		}
 	}
 
 	for fromHub, clusters := range sourceHubToClusters {

--- a/manager/pkg/migration/migration_deploying_test.go
+++ b/manager/pkg/migration/migration_deploying_test.go
@@ -1,0 +1,122 @@
+package migration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/stolostron/multicluster-global-hub/operator/api/migration/v1alpha1"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport"
+)
+
+type deployingProducerMock struct{}
+
+func (deployingProducerMock) SendEvent(_ context.Context, _ cloudevents.Event) error { return nil }
+
+func (deployingProducerMock) Reconnect(_ *transport.TransportInternalConfig, _ string) error {
+	return nil
+}
+
+func TestDeployingWaitsForACLPropagation(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+
+	migrationUID := types.UID("deploying-acl-uid")
+	mcm := &v1alpha1.ManagedClusterMigration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-migration",
+			Namespace:         "default",
+			UID:               migrationUID,
+			CreationTimestamp: metav1.Time{Time: time.Now()},
+		},
+		Spec: v1alpha1.ManagedClusterMigrationSpec{
+			From: "source-hub",
+			To:   "dest-hub",
+		},
+		Status: v1alpha1.ManagedClusterMigrationStatus{
+			Phase: v1alpha1.PhaseDeploying,
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(mcm).
+		WithStatusSubresource(mcm).
+		Build()
+
+	ctrl := &ClusterMigrationController{
+		Client:   fakeClient,
+		Producer: deployingProducerMock{},
+	}
+
+	migrationID := string(migrationUID)
+	AddMigrationStatus(migrationID)
+	AddSourceClusters(migrationID, map[string][]string{"source-hub": {"cluster1"}})
+	t.Cleanup(func() { RemoveMigrationStatus(migrationID) })
+
+	requeue, err := ctrl.deploying(context.Background(), mcm.DeepCopy())
+	assert.NoError(t, err)
+	assert.True(t, requeue)
+
+	_, scheduled := GetDeployingACLReadyTime(migrationID)
+	assert.True(t, scheduled)
+
+	requeue, err = ctrl.deploying(context.Background(), mcm.DeepCopy())
+	assert.NoError(t, err)
+	assert.True(t, requeue)
+}
+
+func TestDeployingProceedsAfterACLReadyTime(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+
+	migrationUID := types.UID("deploying-ready-uid")
+	mcm := &v1alpha1.ManagedClusterMigration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-migration",
+			Namespace:         "default",
+			UID:               migrationUID,
+			CreationTimestamp: metav1.Time{Time: time.Now()},
+		},
+		Spec: v1alpha1.ManagedClusterMigrationSpec{
+			From: "source-hub",
+			To:   "dest-hub",
+		},
+		Status: v1alpha1.ManagedClusterMigrationStatus{
+			Phase: v1alpha1.PhaseDeploying,
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(mcm).
+		WithStatusSubresource(mcm).
+		Build()
+
+	ctrl := &ClusterMigrationController{
+		Client:   fakeClient,
+		Producer: deployingProducerMock{},
+	}
+
+	migrationID := string(migrationUID)
+	AddMigrationStatus(migrationID)
+	AddSourceClusters(migrationID, map[string][]string{"source-hub": {"cluster1"}})
+	SetDeployingACLReadyTime(migrationID, time.Now().Add(-time.Minute))
+	t.Cleanup(func() { RemoveMigrationStatus(migrationID) })
+
+	requeue, err := ctrl.deploying(context.Background(), mcm.DeepCopy())
+	assert.NoError(t, err)
+	assert.True(t, requeue)
+	assert.True(t, GetStarted(migrationID, "source-hub", v1alpha1.PhaseDeploying))
+}

--- a/manager/pkg/migration/migration_eventstatus.go
+++ b/manager/pkg/migration/migration_eventstatus.go
@@ -3,6 +3,7 @@ package migration
 import (
 	"fmt"
 	"sync"
+	"time"
 )
 
 var (
@@ -11,8 +12,9 @@ var (
 )
 
 type MigrationStatus struct {
-	Progress map[string]*MigrationProgress // key: hub-phase
-	Clusters map[string][]string           // key: source hub -> clusters
+	Progress              map[string]*MigrationProgress // key: hub-phase
+	Clusters              map[string][]string           // key: source hub -> clusters
+	deployingACLReadyTime time.Time                     // zero until set; deploy after this instant
 }
 
 type MigrationProgress struct {
@@ -110,6 +112,25 @@ func SetErrorMessage(migrationId, hub, phase, errMessage string) {
 	if p := getProgress(migrationId, hub, phase); p != nil {
 		p.error = errMessage
 	}
+}
+
+// SetDeployingACLReadyTime records when hub agents may publish to gh-migration.
+func SetDeployingACLReadyTime(migrationId string, readyTime time.Time) {
+	mu.Lock()
+	defer mu.Unlock()
+	if status := getMigrationStatus(migrationId); status != nil {
+		status.deployingACLReadyTime = readyTime
+	}
+}
+
+// GetDeployingACLReadyTime returns the earliest time Deploying hub events may start.
+func GetDeployingACLReadyTime(migrationId string) (time.Time, bool) {
+	mu.RLock()
+	defer mu.RUnlock()
+	if status := getMigrationStatus(migrationId); status != nil {
+		return status.deployingACLReadyTime, !status.deployingACLReadyTime.IsZero()
+	}
+	return time.Time{}, false
 }
 
 // GetStarted returns true if the status of the given stage is started for the hub cluster

--- a/manager/pkg/migration/migration_eventstatus_test.go
+++ b/manager/pkg/migration/migration_eventstatus_test.go
@@ -2,6 +2,7 @@ package migration
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -40,4 +41,38 @@ func TestMigrationEventProgress(t *testing.T) {
 	assert.Empty(t, GetErrorMessage(migrateId, "target-cluster", migrationv1alpha1.PhaseValidating))
 	SetErrorMessage(migrateId, "target-cluster", migrationv1alpha1.PhaseValidating, "failed to validate")
 	assert.NotEmpty(t, GetErrorMessage(migrateId, "target-cluster", migrationv1alpha1.PhaseValidating))
+}
+
+func TestDeployingACLReadyTime(t *testing.T) {
+	migrateId := "acl-ready-migration"
+	t.Cleanup(func() { RemoveMigrationStatus(migrateId) })
+
+	_, ok := GetDeployingACLReadyTime(migrateId)
+	assert.False(t, ok)
+
+	AddMigrationStatus(migrateId)
+	_, ok = GetDeployingACLReadyTime(migrateId)
+	assert.False(t, ok)
+
+	readyTime := time.Now().Add(45 * time.Second)
+	SetDeployingACLReadyTime(migrateId, readyTime)
+
+	got, ok := GetDeployingACLReadyTime(migrateId)
+	assert.True(t, ok)
+	assert.Equal(t, readyTime, got)
+}
+
+func TestAddSourceClustersAndRemoveMigrationStatus(t *testing.T) {
+	migrateId := "source-clusters-migration"
+	t.Cleanup(func() { RemoveMigrationStatus(migrateId) })
+
+	AddMigrationStatus(migrateId)
+	clusters := map[string][]string{"hub1": {"cluster1", "cluster2"}}
+	AddSourceClusters(migrateId, clusters)
+	assert.Equal(t, clusters, GetSourceClusters(migrateId))
+
+	RemoveMigrationStatus(migrateId)
+	assert.Nil(t, GetSourceClusters(migrateId))
+	_, ok := GetDeployingACLReadyTime(migrateId)
+	assert.False(t, ok)
 }

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.5.6
+VERSION ?= 1.5.7
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -41,7 +41,7 @@ metadata:
     categories: Integration & Delivery,OpenShift Optional
     certified: "false"
     containerImage: quay.io/stolostron/multicluster-global-hub-operator:latest
-    createdAt: "2025-12-09T06:56:17Z"
+    createdAt: "2025-08-18T08:30:32Z"
     description: Manages the installation and upgrade of the Multicluster Global Hub.
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -70,7 +70,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: multicluster-global-hub-operator.v1.5.6
+  name: multicluster-global-hub-operator.v1.5.7
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1140,5 +1140,5 @@ spec:
   provider:
     name: Red Hat, Inc
     url: https://github.com/stolostron/multicluster-global-hub
-  replaces: multicluster-global-hub-operator.v1.5.5
-  version: 1.5.6
+  replaces: multicluster-global-hub-operator.v1.5.6
+  version: 1.5.7

--- a/operator/config/manifests/bases/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -240,5 +240,5 @@ spec:
   provider:
     name: Red Hat, Inc
     url: https://github.com/stolostron/multicluster-global-hub
-  replaces: multicluster-global-hub-operator.v1.5.5
+  replaces: multicluster-global-hub-operator.v1.5.6
   version: 0.0.1

--- a/operator/pkg/config/transport_config.go
+++ b/operator/pkg/config/transport_config.go
@@ -21,6 +21,7 @@ import (
 
 const (
 	DEFAULT_SPEC_TOPIC          = "gh-spec"
+	DEFAULT_MIGRATION_TOPIC     = "gh-migration"
 	DEFAULT_STATUS_TOPIC        = "gh-status.*"
 	DEFAULT_SHARED_STATUS_TOPIC = "gh-status"
 )
@@ -32,6 +33,7 @@ var (
 	enableInventory       = false
 	isBYOKafka            = false
 	specTopic             = ""
+	migrationTopic        = ""
 	statusTopic           = ""
 	kafkaResourceReady    = false
 	acmResourceReady      = false
@@ -39,7 +41,6 @@ var (
 	kafkaClientCACert     []byte
 	inventoryClientCAKey  []byte
 	inventoryClientCACert []byte
-	inventoryConn         *transport.RestfulConfig
 )
 
 func SetTransporterConn(conn *transport.KafkaConfig) bool {
@@ -107,11 +108,18 @@ func SetTransportConfig(ctx context.Context, runtimeClient client.Client, mgh *v
 	// set the topic
 	specTopic = mgh.Spec.DataLayerSpec.Kafka.KafkaTopics.SpecTopic
 	statusTopic = mgh.Spec.DataLayerSpec.Kafka.KafkaTopics.StatusTopic
+	migrationTopic = DEFAULT_MIGRATION_TOPIC
+	if specTopic == "" {
+		specTopic = DEFAULT_SPEC_TOPIC
+	}
+	if statusTopic == "" {
+		statusTopic = DEFAULT_STATUS_TOPIC
+	}
 	if !isValidKafkaTopicName(specTopic) {
 		return fmt.Errorf("the specTopic is invalid: %s", specTopic)
 	}
 	if !isValidKafkaTopicName(statusTopic) {
-		return fmt.Errorf("the specTopic is invalid: %s", statusTopic)
+		return fmt.Errorf("the statusTopic is invalid: %s", statusTopic)
 	}
 
 	// BYO Case:
@@ -158,9 +166,13 @@ func GetSpecTopic() string {
 	return specTopic
 }
 
+func GetMigrationTopic() string {
+	return migrationTopic
+}
+
 // GetStatusTopic return the status topic with clusterName, like 'gh-status.<clusterName>'
 func GetStatusTopic(clusterName string) string {
-	return strings.Replace(statusTopic, "*", clusterName, -1)
+	return strings.ReplaceAll(statusTopic, "*", clusterName)
 }
 
 // GetRawStatusTopic return the validated statusTopic from mgh CR
@@ -198,6 +210,10 @@ func SetKafkaType(ctx context.Context, runtimeClient client.Client, namespace st
 
 func SetBYOKafka(byoKafka bool) {
 	isBYOKafka = byoKafka
+}
+
+func SetMigrationTopic(topic string) {
+	migrationTopic = topic
 }
 
 func IsBYOKafka() bool {
@@ -297,4 +313,8 @@ func GetConsumerGroupID(prefix, clusterName string) string {
 		consumerGroupID = prefix + clusterName
 	}
 	return strings.ReplaceAll(consumerGroupID, "-", "_")
+}
+
+func GetManagerConsumerGroupID(mgh *v1alpha4.MulticlusterGlobalHub) string {
+	return GetConsumerGroupID(mgh.Spec.DataLayerSpec.Kafka.ConsumerGroupPrefix, constants.CloudEventGlobalHubClusterName)
 }

--- a/operator/pkg/config/transport_config_test.go
+++ b/operator/pkg/config/transport_config_test.go
@@ -1,37 +1,29 @@
 package config
 
-import (
-	"fmt"
-	"testing"
-)
+import "testing"
 
-// TestIsValidKafkaTopicName tests the isValidKafkaTopicName function.
-func TestIsValidKafkaTopicName(t *testing.T) {
-	// Define test cases
-	testCases := []struct {
-		name     string
-		input    string
-		expected bool
-	}{
-		{"Valid topic with letters and numbers", "validTopic1", true},
-		{"Valid topic with underscore", "valid_topic-2", true},
-		{"Valid topic with dot", "valid.topic.3", true},
-		{"Invalid topic with space", "invalid topic", false},
-		{"Invalid topic with invalid character", "invalidTopic$", false},
-		{"Empty topic name", "", false},
-		{"Invalid name .", ".", false},
-		{"Invalid name ..", "..", false},
-		{"Valid topic with asterisk", "validTopic*", true},
-		{"Invalid topic with asterisk not at the end", "invalidTopic*extra", false},
+func TestGetMigrationTopic(t *testing.T) {
+	original := migrationTopic
+	t.Cleanup(func() { migrationTopic = original })
+
+	migrationTopic = "gh-migration"
+	if got := GetMigrationTopic(); got != "gh-migration" {
+		t.Fatalf("GetMigrationTopic() = %q, want gh-migration", got)
 	}
+}
 
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			result := isValidKafkaTopicName(testCase.input)
-			if result != testCase.expected {
-				fmt.Println("len", len(testCase.input))
-				t.Errorf("isValidKafkaTopicName(%q) = %v; expected %v", testCase.input, result, testCase.expected)
-			}
-		})
+func TestGetKafkaUserName(t *testing.T) {
+	if got := GetKafkaUserName("hub1"); got != "hub1-kafka-user" {
+		t.Fatalf("GetKafkaUserName() = %q, want hub1-kafka-user", got)
+	}
+}
+
+func TestSetMigrationTopic(t *testing.T) {
+	original := migrationTopic
+	t.Cleanup(func() { migrationTopic = original })
+
+	SetMigrationTopic("custom-migration")
+	if got := GetMigrationTopic(); got != "custom-migration" {
+		t.Fatalf("SetMigrationTopic() = %q, want custom-migration", got)
 	}
 }

--- a/operator/pkg/controllers/manager/manager_reconciler.go
+++ b/operator/pkg/controllers/manager/manager_reconciler.go
@@ -290,11 +290,15 @@ func (r *ManagerReconciler) Reconcile(ctx context.Context,
 	}
 
 	if isMiddlewareUpdated(kafkaConfig, storageConn) {
-		log.Infof("restarting manager pod")
-		err = commonutils.RestartPod(ctx, r.kubeClient, mgh.Namespace, constants.ManagerDeploymentName)
-		if err != nil {
-			reconcileErr = fmt.Errorf("failed to restart manager pod: %w", err)
-			return ctrl.Result{}, reconcileErr
+		if r.kubeClient == nil {
+			log.Infof("skip restarting manager pod: kube client is not configured")
+		} else {
+			log.Infof("restarting manager pod")
+			err = commonutils.RestartPod(ctx, r.kubeClient, mgh.Namespace, constants.ManagerDeploymentName)
+			if err != nil {
+				reconcileErr = fmt.Errorf("failed to restart manager pod: %w", err)
+				return ctrl.Result{}, reconcileErr
+			}
 		}
 	}
 	electionConfig, err := config.GetElectionConfig()

--- a/operator/pkg/controllers/transporter/migration_acl_reconciler.go
+++ b/operator/pkg/controllers/transporter/migration_acl_reconciler.go
@@ -1,0 +1,193 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transporter
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	migrationv1alpha1 "github.com/stolostron/multicluster-global-hub/operator/api/migration/v1alpha1"
+	operatorv1alpha4 "github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/transporter/protocol"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
+)
+
+var migrationACLLog = logger.DefaultZapLogger()
+
+// +kubebuilder:rbac:groups=global-hub.open-cluster-management.io,resources=managedclustermigrations,verbs=get;list
+// +kubebuilder:rbac:groups=global-hub.open-cluster-management.io,resources=managedclustermigrations,verbs=watch
+// +kubebuilder:rbac:groups=kafka.strimzi.io,resources=kafkausers,verbs=get;update;list;watch
+
+type MigrationACLReconciler struct {
+	mgr ctrl.Manager
+	client.Client
+}
+
+func (r *MigrationACLReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	if config.IsBYOKafka() {
+		return ctrl.Result{}, nil
+	}
+
+	mgh, err := config.GetMulticlusterGlobalHub(ctx, r.Client)
+	if err != nil || mgh == nil || config.IsPaused(mgh) {
+		return ctrl.Result{}, err
+	}
+
+	migration := &migrationv1alpha1.ManagedClusterMigration{}
+	if err := r.Get(ctx, req.NamespacedName, migration); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Migration was deleted; re-sync all managed hub KafkaUsers so revoked ACLs
+			// are cleaned up even though the trigger object's Spec.From is gone.
+			return ctrl.Result{}, r.syncAllMigrationWriteACLs(ctx, mgh, req.Namespace)
+		}
+		return ctrl.Result{}, err
+	}
+
+	if err := r.syncMigrationWriteACLs(ctx, mgh, req.Namespace, migration.Spec.From); err != nil {
+		return ctrl.Result{}, err
+	}
+	if migration.Status.Phase == migrationv1alpha1.PhaseDeploying {
+		migrationACLLog.Infow("synced migration write ACLs",
+			"migration", req.Name, "fromHub", migration.Spec.From, "phase", migration.Status.Phase)
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *MigrationACLReconciler) syncMigrationWriteACLs(
+	ctx context.Context,
+	mgh *operatorv1alpha4.MulticlusterGlobalHub,
+	namespace string,
+	triggerFromHub string,
+) error {
+	list := &migrationv1alpha1.ManagedClusterMigrationList{}
+	if err := r.List(ctx, list, client.InNamespace(namespace)); err != nil {
+		return fmt.Errorf("failed to list ManagedClusterMigration resources: %w", err)
+	}
+
+	needed := deployingSourceHubs(list)
+	hubsToSync := hubsToSyncForMigration(triggerFromHub, needed)
+	for _, fromHub := range hubsToSync {
+		_, grant := needed[fromHub]
+		if err := protocol.SyncMigrationWriteACL(r.mgr, mgh, fromHub, grant, protocol.WithContext(ctx)); err != nil {
+			return fmt.Errorf("failed to sync migration write ACL for hub %q: %w", fromHub, err)
+		}
+	}
+	return nil
+}
+
+func (r *MigrationACLReconciler) syncAllMigrationWriteACLs(
+	ctx context.Context,
+	mgh *operatorv1alpha4.MulticlusterGlobalHub,
+	namespace string,
+) error {
+	list := &migrationv1alpha1.ManagedClusterMigrationList{}
+	if err := r.List(ctx, list, client.InNamespace(namespace)); err != nil {
+		return fmt.Errorf("failed to list ManagedClusterMigration resources: %w", err)
+	}
+	needed := deployingSourceHubs(list)
+
+	kafkaUsers := &kafkav1beta2.KafkaUserList{}
+	if err := r.List(ctx, kafkaUsers, client.InNamespace(namespace)); err != nil {
+		return fmt.Errorf("failed to list KafkaUser resources: %w", err)
+	}
+
+	for i := range kafkaUsers.Items {
+		fromHub, ok := managedHubFromKafkaUser(&kafkaUsers.Items[i])
+		if !ok {
+			continue
+		}
+		_, grant := needed[fromHub]
+		if err := protocol.SyncMigrationWriteACL(r.mgr, mgh, fromHub, grant, protocol.WithContext(ctx)); err != nil {
+			return fmt.Errorf("failed to sync migration write ACL for hub %q: %w", fromHub, err)
+		}
+	}
+	return nil
+}
+
+func deployingSourceHubs(list *migrationv1alpha1.ManagedClusterMigrationList) map[string]struct{} {
+	needed := make(map[string]struct{})
+	for i := range list.Items {
+		addDeployingSourceHub(needed, &list.Items[i])
+	}
+	return needed
+}
+
+func addDeployingSourceHub(needed map[string]struct{}, mcm *migrationv1alpha1.ManagedClusterMigration) {
+	if mcm == nil || mcm.DeletionTimestamp != nil {
+		return
+	}
+	if mcm.Status.Phase == migrationv1alpha1.PhaseDeploying {
+		needed[mcm.Spec.From] = struct{}{}
+	}
+}
+
+func hubsToSyncForMigration(fromHub string, needed map[string]struct{}) []string {
+	hubs := sets.NewString()
+	if fromHub != "" {
+		hubs.Insert(fromHub)
+	}
+	for hub := range needed {
+		hubs.Insert(hub)
+	}
+	return hubs.UnsortedList()
+}
+
+func managedHubFromKafkaUser(user *kafkav1beta2.KafkaUser) (string, bool) {
+	if user.Name == protocol.DefaultGlobalHubKafkaUserName {
+		return "", false
+	}
+	if !strings.HasSuffix(user.Name, "-kafka-user") {
+		return "", false
+	}
+	fromHub := strings.TrimSuffix(user.Name, "-kafka-user")
+	if fromHub == constants.LocalClusterName || fromHub == config.GetLocalClusterName() {
+		return "", false
+	}
+	return fromHub, true
+}
+
+func (r *MigrationACLReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("migration-transport-acl").
+		For(&migrationv1alpha1.ManagedClusterMigration{}).
+		Complete(r)
+}
+
+func setupMigrationACLReconciler(mgr ctrl.Manager) error {
+	if migrationACLControllerStarted {
+		return nil
+	}
+	reconciler := &MigrationACLReconciler{
+		mgr:    mgr,
+		Client: mgr.GetClient(),
+	}
+	if err := reconciler.SetupWithManager(mgr); err != nil {
+		return err
+	}
+	migrationACLControllerStarted = true
+	return nil
+}
+
+var migrationACLControllerStarted bool

--- a/operator/pkg/controllers/transporter/migration_acl_reconciler_test.go
+++ b/operator/pkg/controllers/transporter/migration_acl_reconciler_test.go
@@ -1,0 +1,412 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transporter
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	crconfig "sigs.k8s.io/controller-runtime/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	migrationv1alpha1 "github.com/stolostron/multicluster-global-hub/operator/api/migration/v1alpha1"
+	operatorv1alpha4 "github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
+	operatorconfig "github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/transporter/protocol"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
+)
+
+func TestDeployingSourceHubs(t *testing.T) {
+	t.Parallel()
+
+	list := &migrationv1alpha1.ManagedClusterMigrationList{
+		Items: []migrationv1alpha1.ManagedClusterMigration{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "active"},
+				Spec:       migrationv1alpha1.ManagedClusterMigrationSpec{From: "hub1"},
+				Status:     migrationv1alpha1.ManagedClusterMigrationStatus{Phase: migrationv1alpha1.PhaseDeploying},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "done"},
+				Spec:       migrationv1alpha1.ManagedClusterMigrationSpec{From: "hub2"},
+				Status:     migrationv1alpha1.ManagedClusterMigrationStatus{Phase: migrationv1alpha1.PhaseCompleted},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "deleted",
+					DeletionTimestamp: &metav1.Time{Time: metav1.Now().Time},
+				},
+				Spec:   migrationv1alpha1.ManagedClusterMigrationSpec{From: "hub3"},
+				Status: migrationv1alpha1.ManagedClusterMigrationStatus{Phase: migrationv1alpha1.PhaseDeploying},
+			},
+		},
+	}
+
+	got := deployingSourceHubs(list)
+	if len(got) != 1 {
+		t.Fatalf("deployingSourceHubs() len = %d, want 1", len(got))
+	}
+	if _, ok := got["hub1"]; !ok {
+		t.Fatalf("deployingSourceHubs() = %#v, want hub1 only", got)
+	}
+}
+
+func TestHubsToSyncForMigration(t *testing.T) {
+	t.Parallel()
+
+	needed := map[string]struct{}{
+		"hub1": {},
+		"hub2": {},
+	}
+	got := hubsToSyncForMigration("hub3", needed)
+	if len(got) != 3 {
+		t.Fatalf("hubsToSyncForMigration() len = %d, want 3", len(got))
+	}
+}
+
+func TestManagedHubFromKafkaUser(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		user    *kafkav1beta2.KafkaUser
+		wantHub string
+		wantOK  bool
+	}{
+		{
+			name:    "managed hub user",
+			user:    &kafkav1beta2.KafkaUser{ObjectMeta: metav1.ObjectMeta{Name: "hub1-kafka-user"}},
+			wantHub: "hub1",
+			wantOK:  true,
+		},
+		{
+			name:   "global hub user skipped",
+			user:   &kafkav1beta2.KafkaUser{ObjectMeta: metav1.ObjectMeta{Name: protocol.DefaultGlobalHubKafkaUserName}},
+			wantOK: false,
+		},
+		{
+			name:   "non kafka-user skipped",
+			user:   &kafkav1beta2.KafkaUser{ObjectMeta: metav1.ObjectMeta{Name: "other-user"}},
+			wantOK: false,
+		},
+		{
+			name:   "local cluster skipped",
+			user:   &kafkav1beta2.KafkaUser{ObjectMeta: metav1.ObjectMeta{Name: constants.LocalClusterName + "-kafka-user"}},
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotHub, gotOK := managedHubFromKafkaUser(tt.user)
+			if gotHub != tt.wantHub || gotOK != tt.wantOK {
+				t.Fatalf("managedHubFromKafkaUser() = (%q, %v), want (%q, %v)", gotHub, gotOK, tt.wantHub, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestMigrationACLReconcilerReconcileSkipsBYO(t *testing.T) {
+	originalBYO := operatorconfig.IsBYOKafka()
+	t.Cleanup(func() { operatorconfig.SetBYOKafka(originalBYO) })
+	operatorconfig.SetBYOKafka(true)
+
+	reconciler := &MigrationACLReconciler{}
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: clientObjectKey("test-ns", "migration-1"),
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() BYO skip error = %v", err)
+	}
+}
+
+func TestMigrationACLReconcilerReconcileNotFound(t *testing.T) {
+	originalBYO := operatorconfig.IsBYOKafka()
+	t.Cleanup(func() { operatorconfig.SetBYOKafka(originalBYO) })
+	operatorconfig.SetBYOKafka(false)
+	operatorconfig.SetMigrationTopic("gh-migration")
+
+	scheme := runtime.NewScheme()
+	if err := operatorv1alpha4.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(MulticlusterGlobalHub) error = %v", err)
+	}
+	if err := migrationv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(ManagedClusterMigration) error = %v", err)
+	}
+	if err := kafkav1beta2.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(KafkaUser) error = %v", err)
+	}
+
+	mgh := &operatorv1alpha4.MulticlusterGlobalHub{
+		ObjectMeta: metav1.ObjectMeta{Name: "mgh", Namespace: "test-ns"},
+	}
+	kafkaUser := &kafkav1beta2.KafkaUser{
+		ObjectMeta: metav1.ObjectMeta{Name: "hub1-kafka-user", Namespace: "test-ns"},
+		Spec: &kafkav1beta2.KafkaUserSpec{
+			Authorization: simpleKafkaUserAuthorization(
+				utils.WriteTopicACL("gh-migration"),
+			),
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(mgh, kafkaUser).
+		Build()
+
+	reconciler := &MigrationACLReconciler{
+		mgr:    &migrationACLReconcilerMockManager{client: fakeClient},
+		Client: fakeClient,
+	}
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: clientObjectKey("test-ns", "missing"),
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() missing migration should succeed, got %v", err)
+	}
+
+	updated := &kafkav1beta2.KafkaUser{}
+	if err := fakeClient.Get(context.Background(), client.ObjectKeyFromObject(kafkaUser), updated); err != nil {
+		t.Fatalf("get updated kafka user: %v", err)
+	}
+	if updated.Spec.Authorization != nil {
+		for _, acl := range updated.Spec.Authorization.Acls {
+			if utils.GenerateACLKey(acl) == utils.GenerateACLKey(utils.WriteTopicACL("gh-migration")) {
+				t.Fatal("expected migration write ACL to be revoked after migration deletion")
+			}
+		}
+	}
+}
+
+func TestMigrationACLReconcilerReconcileDeployingGrantsACL(t *testing.T) {
+	originalBYO := operatorconfig.IsBYOKafka()
+	t.Cleanup(func() { operatorconfig.SetBYOKafka(originalBYO) })
+	operatorconfig.SetBYOKafka(false)
+	operatorconfig.SetMigrationTopic("gh-migration")
+
+	_, fakeClient, _, kafkaUser := newMigrationACLReconcilerFixtures(t)
+	migration := &migrationv1alpha1.ManagedClusterMigration{
+		ObjectMeta: metav1.ObjectMeta{Name: "migration-1", Namespace: "test-ns"},
+		Spec:       migrationv1alpha1.ManagedClusterMigrationSpec{From: "hub1", To: "hub2"},
+		Status:     migrationv1alpha1.ManagedClusterMigrationStatus{Phase: migrationv1alpha1.PhaseDeploying},
+	}
+	if err := fakeClient.Create(context.Background(), migration); err != nil {
+		t.Fatalf("create migration: %v", err)
+	}
+
+	reconciler := &MigrationACLReconciler{
+		mgr:    &migrationACLReconcilerMockManager{client: fakeClient},
+		Client: fakeClient,
+	}
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: clientObjectKey("test-ns", "migration-1"),
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() deploying migration error = %v", err)
+	}
+
+	updated := &kafkav1beta2.KafkaUser{}
+	if err := fakeClient.Get(context.Background(), client.ObjectKeyFromObject(kafkaUser), updated); err != nil {
+		t.Fatalf("get updated kafka user: %v", err)
+	}
+	wantKey := utils.GenerateACLKey(utils.WriteTopicACL("gh-migration"))
+	found := false
+	for _, acl := range updated.Spec.Authorization.Acls {
+		if utils.GenerateACLKey(acl) == wantKey {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected migration write ACL to be granted for deploying migration")
+	}
+}
+
+func TestMigrationACLReconcilerReconcileCompletedRevokesACL(t *testing.T) {
+	originalBYO := operatorconfig.IsBYOKafka()
+	t.Cleanup(func() { operatorconfig.SetBYOKafka(originalBYO) })
+	operatorconfig.SetBYOKafka(false)
+	operatorconfig.SetMigrationTopic("gh-migration")
+
+	scheme, fakeClient, _, kafkaUser := newMigrationACLReconcilerFixtures(t)
+	_ = scheme
+	kafkaUser.Spec.Authorization.Acls = []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
+		utils.WriteTopicACL("gh-migration"),
+	}
+	if err := fakeClient.Update(context.Background(), kafkaUser); err != nil {
+		t.Fatalf("update kafka user with migration ACL: %v", err)
+	}
+
+	migration := &migrationv1alpha1.ManagedClusterMigration{
+		ObjectMeta: metav1.ObjectMeta{Name: "migration-1", Namespace: "test-ns"},
+		Spec:       migrationv1alpha1.ManagedClusterMigrationSpec{From: "hub1", To: "hub2"},
+		Status:     migrationv1alpha1.ManagedClusterMigrationStatus{Phase: migrationv1alpha1.PhaseCompleted},
+	}
+	if err := fakeClient.Create(context.Background(), migration); err != nil {
+		t.Fatalf("create migration: %v", err)
+	}
+
+	reconciler := &MigrationACLReconciler{
+		mgr:    &migrationACLReconcilerMockManager{client: fakeClient},
+		Client: fakeClient,
+	}
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: clientObjectKey("test-ns", "migration-1"),
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() completed migration error = %v", err)
+	}
+
+	updated := &kafkav1beta2.KafkaUser{}
+	if err := fakeClient.Get(context.Background(), client.ObjectKeyFromObject(kafkaUser), updated); err != nil {
+		t.Fatalf("get updated kafka user: %v", err)
+	}
+	if updated.Spec.Authorization != nil {
+		for _, acl := range updated.Spec.Authorization.Acls {
+			if utils.GenerateACLKey(acl) == utils.GenerateACLKey(utils.WriteTopicACL("gh-migration")) {
+				t.Fatal("expected migration write ACL to be revoked after migration completed")
+			}
+		}
+	}
+}
+
+func TestMigrationACLReconcilerReconcileSkipsPausedMGH(t *testing.T) {
+	originalBYO := operatorconfig.IsBYOKafka()
+	t.Cleanup(func() { operatorconfig.SetBYOKafka(originalBYO) })
+	operatorconfig.SetBYOKafka(false)
+
+	_, fakeClient, mgh, _ := newMigrationACLReconcilerFixtures(t)
+	mgh.Annotations = map[string]string{"mgh-pause": "true"}
+	if err := fakeClient.Update(context.Background(), mgh); err != nil {
+		t.Fatalf("update paused mgh: %v", err)
+	}
+
+	reconciler := &MigrationACLReconciler{
+		mgr:    &migrationACLReconcilerMockManager{client: fakeClient},
+		Client: fakeClient,
+	}
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: clientObjectKey("test-ns", "migration-1"),
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() paused mgh should succeed, got %v", err)
+	}
+}
+
+func newMigrationACLReconcilerFixtures(
+	t *testing.T,
+) (*runtime.Scheme, client.Client, *operatorv1alpha4.MulticlusterGlobalHub, *kafkav1beta2.KafkaUser) {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	if err := operatorv1alpha4.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(MulticlusterGlobalHub) error = %v", err)
+	}
+	if err := migrationv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(ManagedClusterMigration) error = %v", err)
+	}
+	if err := kafkav1beta2.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(KafkaUser) error = %v", err)
+	}
+
+	mgh := &operatorv1alpha4.MulticlusterGlobalHub{
+		ObjectMeta: metav1.ObjectMeta{Name: "mgh", Namespace: "test-ns"},
+	}
+	kafkaUser := &kafkav1beta2.KafkaUser{
+		ObjectMeta: metav1.ObjectMeta{Name: "hub1-kafka-user", Namespace: "test-ns"},
+		Spec: &kafkav1beta2.KafkaUserSpec{
+			Authorization: simpleKafkaUserAuthorization(
+				utils.ReadTopicACL("gh-spec", false),
+			),
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(mgh, kafkaUser).
+		Build()
+
+	return scheme, fakeClient, mgh, kafkaUser
+}
+
+type migrationACLReconcilerMockManager struct {
+	client client.Client
+}
+
+func (m *migrationACLReconcilerMockManager) Add(manager.Runnable) error { return nil }
+func (m *migrationACLReconcilerMockManager) GetClient() client.Client   { return m.client }
+func (m *migrationACLReconcilerMockManager) GetScheme() *runtime.Scheme { return nil }
+func (m *migrationACLReconcilerMockManager) GetFieldIndexer() client.FieldIndexer {
+	return nil
+}
+func (m *migrationACLReconcilerMockManager) GetCache() cache.Cache { return nil }
+func (m *migrationACLReconcilerMockManager) GetEventRecorderFor(string) record.EventRecorder {
+	return nil
+}
+func (m *migrationACLReconcilerMockManager) GetRESTMapper() meta.RESTMapper { return nil }
+func (m *migrationACLReconcilerMockManager) GetAPIReader() client.Reader    { return nil }
+func (m *migrationACLReconcilerMockManager) Start(context.Context) error    { return nil }
+func (m *migrationACLReconcilerMockManager) GetWebhookServer() webhook.Server {
+	return nil
+}
+func (m *migrationACLReconcilerMockManager) GetLogger() logr.Logger { return logr.Discard() }
+func (m *migrationACLReconcilerMockManager) GetControllerOptions() crconfig.Controller {
+	return crconfig.Controller{}
+}
+func (m *migrationACLReconcilerMockManager) Elected() <-chan struct{} { return nil }
+func (m *migrationACLReconcilerMockManager) AddHealthzCheck(string, healthz.Checker) error {
+	return nil
+}
+
+func (m *migrationACLReconcilerMockManager) AddReadyzCheck(string, healthz.Checker) error {
+	return nil
+}
+func (m *migrationACLReconcilerMockManager) GetHTTPClient() *http.Client { return nil }
+func (m *migrationACLReconcilerMockManager) AddMetricsServerExtraHandler(string, http.Handler) error {
+	return nil
+}
+func (m *migrationACLReconcilerMockManager) GetConfig() *rest.Config { return nil }
+
+var _ ctrl.Manager = (*migrationACLReconcilerMockManager)(nil)
+
+func clientObjectKey(namespace, name string) types.NamespacedName {
+	return types.NamespacedName{Namespace: namespace, Name: name}
+}
+
+func simpleKafkaUserAuthorization(
+	acls ...kafkav1beta2.KafkaUserSpecAuthorizationAclsElem,
+) *kafkav1beta2.KafkaUserSpecAuthorization {
+	return &kafkav1beta2.KafkaUserSpecAuthorization{
+		Type: kafkav1beta2.KafkaUserSpecAuthorizationTypeSimple,
+		Acls: acls,
+	}
+}

--- a/operator/pkg/controllers/transporter/protocol/byo_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/byo_transporter.go
@@ -51,8 +51,9 @@ func (s *BYOTransporter) EnsureUser(clusterName string) (string, error) {
 
 func (s *BYOTransporter) EnsureTopic(clusterName string) (*transport.ClusterTopic, error) {
 	return &transport.ClusterTopic{
-		SpecTopic:   config.GetSpecTopic(),
-		StatusTopic: config.GetStatusTopic(clusterName),
+		SpecTopic:      config.GetSpecTopic(),
+		MigrationTopic: config.GetMigrationTopic(),
+		StatusTopic:    config.GetStatusTopic(clusterName),
 	}, nil
 }
 
@@ -80,16 +81,21 @@ func (s *BYOTransporter) GetConnCredential(clusterName string) (*transport.Kafka
 		return nil, fmt.Errorf("failed to get mgh: %w", err)
 	}
 
+	if mgh == nil {
+		return nil, fmt.Errorf("multicluster global hub instance not found")
+	}
+
 	return &transport.KafkaConfig{
 		ClusterID:       string(kafkaSecret.Data[filepath.Join("bootstrap_server")]),
 		BootstrapServer: string(kafkaSecret.Data[filepath.Join("bootstrap_server")]),
 		ConsumerGroupID: config.GetConsumerGroupID(mgh.Spec.DataLayerSpec.Kafka.ConsumerGroupPrefix, clusterName),
 
 		// for the byo case, the status topic isn't change by the clusterName
-		StatusTopic: config.GetStatusTopic(""),
-		SpecTopic:   config.GetSpecTopic(),
-		CACert:      base64.StdEncoding.EncodeToString(kafkaSecret.Data[filepath.Join("ca.crt")]),
-		ClientCert:  base64.StdEncoding.EncodeToString(kafkaSecret.Data[filepath.Join("client.crt")]),
-		ClientKey:   base64.StdEncoding.EncodeToString(kafkaSecret.Data[filepath.Join("client.key")]),
+		StatusTopic:    config.GetStatusTopic(""),
+		SpecTopic:      config.GetSpecTopic(),
+		MigrationTopic: config.GetMigrationTopic(),
+		CACert:         base64.StdEncoding.EncodeToString(kafkaSecret.Data[filepath.Join("ca.crt")]),
+		ClientCert:     base64.StdEncoding.EncodeToString(kafkaSecret.Data[filepath.Join("client.crt")]),
+		ClientKey:      base64.StdEncoding.EncodeToString(kafkaSecret.Data[filepath.Join("client.key")]),
 	}, nil
 }

--- a/operator/pkg/controllers/transporter/protocol/manifests/global-hub-kafka-topic.yaml
+++ b/operator/pkg/controllers/transporter/protocol/manifests/global-hub-kafka-topic.yaml
@@ -3,6 +3,22 @@ kind: KafkaTopic
 metadata:
   labels:
     strimzi.io/cluster: {{.KafkaCluster}}
+  name: {{.MigrationTopic}}
+  namespace: {{.Namespace}}
+spec:
+  config:
+    cleanup.policy: compact,delete
+    retention.ms: "86400000"
+    retention.bytes: "1073741824"
+  partitions: {{.TopicPartition}}
+  replicas: {{.TopicReplicas}}
+
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  labels:
+    strimzi.io/cluster: {{.KafkaCluster}}
   name: {{.StatusPlaceholderTopic}}
   namespace: {{.Namespace}}
 spec:

--- a/operator/pkg/controllers/transporter/protocol/manifests/global-hub-kafka-user.yaml
+++ b/operator/pkg/controllers/transporter/protocol/manifests/global-hub-kafka-user.yaml
@@ -28,6 +28,15 @@ spec:
       operations:
       - Describe
       - Read
+      - Write
+      resource:
+        name: {{.MigrationTopic}}
+        patternType: literal
+        type: topic
+    - host: '*'
+      operations:
+      - Describe
+      - Read
       resource:
         name: {{.StatusTopic}}
         patternType: {{.StatusTopicPattern}}

--- a/operator/pkg/controllers/transporter/protocol/migration_acl.go
+++ b/operator/pkg/controllers/transporter/protocol/migration_acl.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protocol
+
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	operatorv1alpha4 "github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
+)
+
+// SyncMigrationWriteACL grants or revokes Write on the migration topic for a source hub.
+func SyncMigrationWriteACL(
+	mgr ctrl.Manager,
+	mgh *operatorv1alpha4.MulticlusterGlobalHub,
+	fromHub string,
+	grant bool,
+	opts ...KafkaOption,
+) error {
+	trans := NewStrimziTransporter(mgr, mgh, opts...)
+	return trans.SyncMigrationWriteACL(fromHub, grant)
+}

--- a/operator/pkg/controllers/transporter/protocol/migration_acl_test.go
+++ b/operator/pkg/controllers/transporter/protocol/migration_acl_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protocol
+
+import (
+	"context"
+	"testing"
+
+	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	operatorv1alpha4 "github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
+	operatorconfig "github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
+)
+
+func TestSyncMigrationWriteACLWrapper(t *testing.T) {
+	operatorconfig.SetMigrationTopic("gh-migration")
+
+	scheme := runtime.NewScheme()
+	if err := kafkav1beta2.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+
+	kafkaUser := &kafkav1beta2.KafkaUser{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hub1-kafka-user",
+			Namespace: "test-ns",
+		},
+		Spec: &kafkav1beta2.KafkaUserSpec{
+			Authorization: &kafkav1beta2.KafkaUserSpecAuthorization{
+				Type: kafkav1beta2.KafkaUserSpecAuthorizationTypeSimple,
+				Acls: []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
+					utils.ReadTopicACL("gh-spec", false),
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(kafkaUser).
+		Build()
+
+	mgh := &operatorv1alpha4.MulticlusterGlobalHub{
+		ObjectMeta: metav1.ObjectMeta{Name: "mgh", Namespace: "test-ns"},
+	}
+
+	mgr := &migrationACLMockManager{client: fakeClient}
+	if err := SyncMigrationWriteACL(mgr, mgh, "hub1", true, WithContext(context.Background())); err != nil {
+		t.Fatalf("SyncMigrationWriteACL() grant error = %v", err)
+	}
+
+	updated := &kafkav1beta2.KafkaUser{}
+	if err := fakeClient.Get(context.Background(), client.ObjectKeyFromObject(kafkaUser), updated); err != nil {
+		t.Fatalf("get updated kafka user: %v", err)
+	}
+	if len(updated.Spec.Authorization.Acls) != 2 {
+		t.Fatalf("expected read and write ACLs after grant, got %d", len(updated.Spec.Authorization.Acls))
+	}
+	wantKey := utils.GenerateACLKey(utils.WriteTopicACL("gh-migration"))
+	foundWrite := false
+	for _, acl := range updated.Spec.Authorization.Acls {
+		if utils.GenerateACLKey(acl) == wantKey {
+			foundWrite = true
+			break
+		}
+	}
+	if !foundWrite {
+		t.Fatal("expected migration topic write ACL")
+	}
+}

--- a/operator/pkg/controllers/transporter/protocol/migration_acl_test.go
+++ b/operator/pkg/controllers/transporter/protocol/migration_acl_test.go
@@ -85,4 +85,20 @@ func TestSyncMigrationWriteACLWrapper(t *testing.T) {
 	if !foundWrite {
 		t.Fatal("expected migration topic write ACL")
 	}
+
+	if err := SyncMigrationWriteACL(mgr, mgh, "hub1", false, WithContext(context.Background())); err != nil {
+		t.Fatalf("SyncMigrationWriteACL() revoke error = %v", err)
+	}
+
+	if err := fakeClient.Get(context.Background(), client.ObjectKeyFromObject(kafkaUser), updated); err != nil {
+		t.Fatalf("get updated kafka user after revoke: %v", err)
+	}
+	if len(updated.Spec.Authorization.Acls) != 1 {
+		t.Fatalf("expected only read ACL after revoke, got %d", len(updated.Spec.Authorization.Acls))
+	}
+	for _, acl := range updated.Spec.Authorization.Acls {
+		if utils.GenerateACLKey(acl) == wantKey {
+			t.Fatal("expected migration topic write ACL to be revoked")
+		}
+	}
 }

--- a/operator/pkg/controllers/transporter/protocol/strimzi_migration_acl.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_migration_acl.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protocol
+
+import (
+	"fmt"
+
+	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
+)
+
+func migrationWriteACLKey(topic string) string {
+	return utils.GenerateACLKey(utils.WriteTopicACL(topic))
+}
+
+func (k *strimziTransporter) hasMigrationWriteACL(acls []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem) bool {
+	key := migrationWriteACLKey(config.GetMigrationTopic())
+	for _, acl := range acls {
+		if utils.GenerateACLKey(acl) == key {
+			return true
+		}
+	}
+	return false
+}
+
+// SyncMigrationWriteACL grants or revokes Write on the migration topic for a source hub.
+func (k *strimziTransporter) SyncMigrationWriteACL(fromHub string, grant bool) error {
+	if fromHub == "" {
+		return nil
+	}
+
+	userName := config.GetKafkaUserName(fromHub)
+	kafkaUser := &kafkav1beta2.KafkaUser{}
+	err := k.manager.GetClient().Get(k.ctx, types.NamespacedName{
+		Name:      userName,
+		Namespace: k.kafkaClusterNamespace,
+	}, kafkaUser)
+	if errors.IsNotFound(err) {
+		if !grant {
+			return nil
+		}
+		return fmt.Errorf("kafka user %s not found for migration write ACL", userName)
+	}
+	if err != nil {
+		return err
+	}
+
+	migrationTopic := config.GetMigrationTopic()
+	desiredWriteACL := utils.WriteTopicACL(migrationTopic)
+
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latestKafkaUser := &kafkav1beta2.KafkaUser{}
+		if err := k.manager.GetClient().Get(k.ctx, types.NamespacedName{
+			Name:      userName,
+			Namespace: k.kafkaClusterNamespace,
+		}, latestKafkaUser); err != nil {
+			return err
+		}
+
+		currentACLs := currentKafkaUserACLs(latestKafkaUser)
+		if k.hasMigrationWriteACL(currentACLs) == grant {
+			return nil
+		}
+
+		updatedACLs := make([]kafkav1beta2.KafkaUserSpecAuthorizationAclsElem, 0, len(currentACLs))
+		for _, acl := range currentACLs {
+			if utils.GenerateACLKey(acl) == migrationWriteACLKey(migrationTopic) {
+				continue
+			}
+			updatedACLs = append(updatedACLs, acl)
+		}
+		if grant {
+			updatedACLs = append(updatedACLs, desiredWriteACL)
+		}
+
+		if len(updatedACLs) == 0 {
+			latestKafkaUser.Spec.Authorization = nil
+		} else {
+			if latestKafkaUser.Spec.Authorization == nil {
+				latestKafkaUser.Spec.Authorization = &kafkav1beta2.KafkaUserSpecAuthorization{
+					Type: kafkav1beta2.KafkaUserSpecAuthorizationTypeSimple,
+				}
+			}
+			if latestKafkaUser.Spec.Authorization.Type == "" {
+				latestKafkaUser.Spec.Authorization.Type = kafkav1beta2.KafkaUserSpecAuthorizationTypeSimple
+			}
+			latestKafkaUser.Spec.Authorization.Acls = updatedACLs
+		}
+		return k.manager.GetClient().Update(k.ctx, latestKafkaUser)
+	})
+}
+
+func currentKafkaUserACLs(kafkaUser *kafkav1beta2.KafkaUser) []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem {
+	if kafkaUser == nil || kafkaUser.Spec == nil || kafkaUser.Spec.Authorization == nil {
+		return nil
+	}
+	return kafkaUser.Spec.Authorization.Acls
+}

--- a/operator/pkg/controllers/transporter/protocol/strimzi_migration_acl_test.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_migration_acl_test.go
@@ -1,0 +1,275 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protocol
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	operatorconfig "github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
+)
+
+type migrationACLMockManager struct {
+	client client.Client
+}
+
+func (m *migrationACLMockManager) Add(manager.Runnable) error { return nil }
+func (m *migrationACLMockManager) GetClient() client.Client   { return m.client }
+func (m *migrationACLMockManager) GetScheme() *runtime.Scheme {
+	return nil
+}
+func (m *migrationACLMockManager) GetFieldIndexer() client.FieldIndexer { return nil }
+func (m *migrationACLMockManager) GetCache() cache.Cache                { return nil }
+func (m *migrationACLMockManager) GetEventRecorderFor(string) record.EventRecorder {
+	return nil
+}
+func (m *migrationACLMockManager) GetRESTMapper() meta.RESTMapper { return nil }
+func (m *migrationACLMockManager) GetAPIReader() client.Reader    { return nil }
+func (m *migrationACLMockManager) Start(context.Context) error    { return nil }
+func (m *migrationACLMockManager) GetWebhookServer() webhook.Server {
+	return nil
+}
+func (m *migrationACLMockManager) GetLogger() logr.Logger { return logr.Discard() }
+func (m *migrationACLMockManager) GetControllerOptions() config.Controller {
+	return config.Controller{}
+}
+func (m *migrationACLMockManager) Elected() <-chan struct{} { return nil }
+func (m *migrationACLMockManager) AddHealthzCheck(string, healthz.Checker) error {
+	return nil
+}
+
+func (m *migrationACLMockManager) AddReadyzCheck(string, healthz.Checker) error {
+	return nil
+}
+func (m *migrationACLMockManager) GetHTTPClient() *http.Client { return nil }
+func (m *migrationACLMockManager) AddMetricsServerExtraHandler(string, http.Handler) error {
+	return nil
+}
+func (m *migrationACLMockManager) GetConfig() *rest.Config { return nil }
+
+func TestMigrationWriteACLKey(t *testing.T) {
+	t.Parallel()
+
+	key := migrationWriteACLKey("gh-migration")
+	want := utils.GenerateACLKey(utils.WriteTopicACL("gh-migration"))
+	if key != want {
+		t.Fatalf("migrationWriteACLKey() = %q, want %q", key, want)
+	}
+}
+
+func TestHasMigrationWriteACL(t *testing.T) {
+	t.Parallel()
+
+	operatorconfig.SetMigrationTopic("gh-migration")
+	transporter := &strimziTransporter{}
+	withACL := []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
+		utils.WriteTopicACL("gh-migration"),
+	}
+	if !transporter.hasMigrationWriteACL(withACL) {
+		t.Fatal("expected migration write ACL to be present")
+	}
+	if transporter.hasMigrationWriteACL(nil) {
+		t.Fatal("expected nil ACL list to return false")
+	}
+}
+
+func TestCurrentKafkaUserACLs(t *testing.T) {
+	t.Parallel()
+
+	if got := currentKafkaUserACLs(&kafkav1beta2.KafkaUser{}); got != nil {
+		t.Fatalf("expected nil ACLs for missing spec, got %#v", got)
+	}
+	if got := currentKafkaUserACLs(nil); got != nil {
+		t.Fatalf("expected nil ACLs for nil user, got %#v", got)
+	}
+
+	acl := utils.WriteTopicACL("gh-migration")
+	user := &kafkav1beta2.KafkaUser{
+		Spec: &kafkav1beta2.KafkaUserSpec{
+			Authorization: &kafkav1beta2.KafkaUserSpecAuthorization{
+				Acls: []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{acl},
+			},
+		},
+	}
+	got := currentKafkaUserACLs(user)
+	if len(got) != 1 {
+		t.Fatalf("expected one ACL, got %d", len(got))
+	}
+}
+
+func TestSyncMigrationWriteACLSkipsEmptyHub(t *testing.T) {
+	t.Parallel()
+
+	transporter := &strimziTransporter{}
+	if err := transporter.SyncMigrationWriteACL("", true); err != nil {
+		t.Fatalf("SyncMigrationWriteACL with empty hub should succeed, got %v", err)
+	}
+}
+
+func TestSyncMigrationWriteACLGrantAndRevoke(t *testing.T) {
+	operatorconfig.SetMigrationTopic("gh-migration")
+
+	scheme := runtime.NewScheme()
+	if err := kafkav1beta2.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+
+	kafkaUser := &kafkav1beta2.KafkaUser{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hub1-kafka-user",
+			Namespace: "test-ns",
+		},
+		Spec: &kafkav1beta2.KafkaUserSpec{
+			Authorization: &kafkav1beta2.KafkaUserSpecAuthorization{
+				Type: kafkav1beta2.KafkaUserSpecAuthorizationTypeSimple,
+				Acls: []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
+					utils.ReadTopicACL("gh-spec", false),
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(kafkaUser).
+		Build()
+
+	transporter := &strimziTransporter{
+		ctx:                   context.Background(),
+		kafkaClusterNamespace: "test-ns",
+		manager:               &migrationACLMockManager{client: fakeClient},
+	}
+
+	if err := transporter.SyncMigrationWriteACL("hub1", true); err != nil {
+		t.Fatalf("grant migration write ACL: %v", err)
+	}
+
+	updated := &kafkav1beta2.KafkaUser{}
+	if err := fakeClient.Get(context.Background(), client.ObjectKeyFromObject(kafkaUser), updated); err != nil {
+		t.Fatalf("get updated kafka user: %v", err)
+	}
+	if !transporter.hasMigrationWriteACL(updated.Spec.Authorization.Acls) {
+		t.Fatal("expected migration write ACL to be granted")
+	}
+
+	if err := transporter.SyncMigrationWriteACL("hub1", false); err != nil {
+		t.Fatalf("revoke migration write ACL: %v", err)
+	}
+	if err := fakeClient.Get(context.Background(), client.ObjectKeyFromObject(kafkaUser), updated); err != nil {
+		t.Fatalf("get updated kafka user after revoke: %v", err)
+	}
+	if transporter.hasMigrationWriteACL(updated.Spec.Authorization.Acls) {
+		t.Fatal("expected migration write ACL to be revoked")
+	}
+}
+
+func TestSyncMigrationWriteACLNotFoundWhenGranting(t *testing.T) {
+	operatorconfig.SetMigrationTopic("gh-migration")
+
+	scheme := runtime.NewScheme()
+	if err := kafkav1beta2.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+
+	transporter := &strimziTransporter{
+		ctx:                   context.Background(),
+		kafkaClusterNamespace: "test-ns",
+		manager:               &migrationACLMockManager{client: fake.NewClientBuilder().WithScheme(scheme).Build()},
+	}
+
+	if err := transporter.SyncMigrationWriteACL("hub1", true); err == nil {
+		t.Fatal("expected error when kafka user is missing during grant")
+	}
+}
+
+func TestSyncMigrationWriteACLNotFoundWhenRevoking(t *testing.T) {
+	operatorconfig.SetMigrationTopic("gh-migration")
+
+	scheme := runtime.NewScheme()
+	if err := kafkav1beta2.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+
+	transporter := &strimziTransporter{
+		ctx:                   context.Background(),
+		kafkaClusterNamespace: "test-ns",
+		manager:               &migrationACLMockManager{client: fake.NewClientBuilder().WithScheme(scheme).Build()},
+	}
+
+	if err := transporter.SyncMigrationWriteACL("hub1", false); err != nil {
+		t.Fatalf("revoke on missing kafka user should succeed, got %v", err)
+	}
+}
+
+func TestSyncMigrationWriteACLInitializesNilAuthorization(t *testing.T) {
+	operatorconfig.SetMigrationTopic("gh-migration")
+
+	scheme := runtime.NewScheme()
+	if err := kafkav1beta2.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+
+	kafkaUser := &kafkav1beta2.KafkaUser{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hub1-kafka-user",
+			Namespace: "test-ns",
+		},
+		Spec: &kafkav1beta2.KafkaUserSpec{},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(kafkaUser).
+		Build()
+
+	transporter := &strimziTransporter{
+		ctx:                   context.Background(),
+		kafkaClusterNamespace: "test-ns",
+		manager:               &migrationACLMockManager{client: fakeClient},
+	}
+
+	if err := transporter.SyncMigrationWriteACL("hub1", true); err != nil {
+		t.Fatalf("grant migration write ACL with nil authorization: %v", err)
+	}
+
+	updated := &kafkav1beta2.KafkaUser{}
+	if err := fakeClient.Get(context.Background(), client.ObjectKeyFromObject(kafkaUser), updated); err != nil {
+		t.Fatalf("get updated kafka user: %v", err)
+	}
+	if updated.Spec.Authorization == nil || len(updated.Spec.Authorization.Acls) != 1 {
+		t.Fatal("expected authorization block with migration write ACL")
+	}
+}
+
+var _ ctrl.Manager = (*migrationACLMockManager)(nil)

--- a/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 
 	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
@@ -20,6 +21,7 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/restmapper"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -48,25 +50,25 @@ const (
 	DefaultCatalogSourceNamespace = "openshift-marketplace"
 
 	// subscription - production
-	DefaultAMQChannel        = "amq-streams-2.9.x"
+	DefaultAMQChannel        = "amq-streams-3.0.x"
 	DefaultAMQPackageName    = "amq-streams"
 	DefaultCatalogSourceName = "redhat-operators"
 
 	// subscription - community
-	CommunityChannel           = "strimzi-0.45.x"
+	CommunityChannel           = "strimzi-0.48.x"
 	CommunityPackageName       = "strimzi-kafka-operator"
 	CommunityCatalogSourceName = "community-operators"
 )
 
 var (
-	DefaultAMQKafkaVersion         = "3.9.0"
+	DefaultAMQKafkaVersion         = "4.0.0"
 	KafkaStorageIdentifier   int32 = 0
 	KafkaStorageDeleteClaim        = false
 	DefaultPartition         int32 = 1
 	DefaultPartitionReplicas int32 = 3
 	// kafka metrics constants
-	KakfaMetricsConfigmapName   = "kafka-metrics"
-	KafkaMetricsConfigmapKeyRef = "kafka-metrics-config.yml"
+	KafkaMetricsConfigMapName   = "kafka-metrics"
+	KafkaMetricsConfigMapKeyRef = "kafka-metrics-config.yml"
 )
 
 // install the strimzi kafka cluster by operator
@@ -127,6 +129,7 @@ func NewStrimziTransporter(mgr ctrl.Manager, mgh *operatorv1alpha4.MulticlusterG
 	}
 
 	transporter.mgh = mgh
+	transporter.manager = mgr
 	transporter.kafkaClusterNamespace = mgh.Namespace
 	// apply options
 	for _, opt := range opts {
@@ -165,15 +168,13 @@ func (k *strimziTransporter) getCurrentReplicas() (int32, error) {
 		Name:      "kraft",
 		Namespace: k.mgh.Namespace,
 	}, existingKafkaNodepool)
-	log.Debugf("existing kafkaNodepool: %v, err:%v", existingKafkaNodepool, err)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return k.topicPartitionReplicas, nil
 		}
 		return k.topicPartitionReplicas, err
 	}
-
-	log.Debugf("existing kafkaNodepool: %v", existingKafkaNodepool.Spec.Replicas)
+	log.Debugf("existing kafkaNodepool replicas: %s", existingKafkaNodepool.Spec.Replicas)
 	return existingKafkaNodepool.Spec.Replicas, nil
 }
 
@@ -246,8 +247,8 @@ func (k *strimziTransporter) renderKafkaResources(mgh *operatorv1alpha4.Multiclu
 	statusPlaceholderTopic := config.GetRawStatusTopic()
 	topicPattern := kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypeLiteral
 	if strings.Contains(config.GetRawStatusTopic(), "*") {
-		statusTopic = strings.Replace(config.GetRawStatusTopic(), "*", "", -1)
-		statusPlaceholderTopic = strings.Replace(config.GetRawStatusTopic(), "*", "global-hub", -1)
+		statusTopic = strings.ReplaceAll(config.GetRawStatusTopic(), "*", "")
+		statusPlaceholderTopic = strings.ReplaceAll(config.GetRawStatusTopic(), "*", "global-hub")
 		topicPattern = kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypePrefix
 	}
 	topicReplicas := k.topicPartitionReplicas
@@ -262,6 +263,7 @@ func (k *strimziTransporter) renderKafkaResources(mgh *operatorv1alpha4.Multiclu
 				KafkaCluster           string
 				GlobalHubKafkaUser     string
 				SpecTopic              string
+				MigrationTopic         string
 				StatusTopic            string
 				StatusTopicPattern     string
 				StatusPlaceholderTopic string
@@ -277,6 +279,7 @@ func (k *strimziTransporter) renderKafkaResources(mgh *operatorv1alpha4.Multiclu
 				KafkaCluster:           KafkaClusterName,
 				GlobalHubKafkaUser:     DefaultGlobalHubKafkaUserName,
 				SpecTopic:              config.GetSpecTopic(),
+				MigrationTopic:         config.GetMigrationTopic(),
 				StatusTopic:            statusTopic,
 				StatusTopicPattern:     string(topicPattern),
 				StatusPlaceholderTopic: statusPlaceholderTopic,
@@ -352,6 +355,11 @@ func (k *strimziTransporter) EnsureUser(clusterName string) (string, error) {
 			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
 			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite,
 		}),
+		// consume migration deploying bundles from the dedicated migration topic
+		utils.GetTopicACL(clusterTopic.MigrationTopic, []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+		}),
 		// report status into gh: allow the current hub to write messages to the specific status topic
 		utils.GetTopicACL(clusterTopic.StatusTopic, []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
 			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite,
@@ -372,20 +380,34 @@ func (k *strimziTransporter) EnsureUser(clusterName string) (string, error) {
 		return "", err
 	}
 
-	updatedKafkaUser := &kafkav1beta2.KafkaUser{}
-	err = operatorutils.MergeObjects(kafkaUser, desiredKafkaUser, updatedKafkaUser)
-	if err != nil {
-		return "", err
-	}
-	// combine the acls of kafkaUser and the acls of desiredKafkaUser
-	updatedKafkaUser.Spec.Authorization.Acls = combineACLs(kafkaUser.Spec.Authorization.Acls,
-		desiredKafkaUser.Spec.Authorization.Acls)
-
-	if !equality.Semantic.DeepDerivative(updatedKafkaUser.Spec, kafkaUser.Spec) {
-		log.Infof("update the kafkaUser: %s", userName)
-		if err = k.manager.GetClient().Update(k.ctx, updatedKafkaUser); err != nil {
-			return "", err
+	// Retry logic to handle concurrent updates with exponential backoff
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		// Get the latest version of the KafkaUser
+		latestKafkaUser := &kafkav1beta2.KafkaUser{}
+		if err := k.manager.GetClient().Get(k.ctx, types.NamespacedName{
+			Name:      userName,
+			Namespace: k.kafkaClusterNamespace,
+		}, latestKafkaUser); err != nil {
+			return err
 		}
+
+		updatedKafkaUser := &kafkav1beta2.KafkaUser{}
+		if err := operatorutils.MergeObjects(latestKafkaUser, desiredKafkaUser, updatedKafkaUser); err != nil {
+			return err
+		}
+		// combine the acls of kafkaUser and the acls of desiredKafkaUser
+		updatedKafkaUser.Spec.Authorization.Acls = combineACLs(latestKafkaUser.Spec.Authorization.Acls,
+			desiredKafkaUser.Spec.Authorization.Acls)
+
+		if !equality.Semantic.DeepDerivative(updatedKafkaUser.Spec, latestKafkaUser.Spec) {
+			log.Infof("update the kafkaUser: %s", userName)
+			return k.manager.GetClient().Update(k.ctx, updatedKafkaUser)
+		}
+		return nil
+	})
+
+	if retryErr != nil {
+		return "", retryErr
 	}
 	return userName, nil
 }
@@ -410,13 +432,20 @@ func combineACLs(kafkaUserAcls []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem
 	for _, acl := range aclMap {
 		mergedAcls = append(mergedAcls, acl)
 	}
+
+	// Sort ACLs to ensure consistent ordering for comparison
+	// This prevents unnecessary updates when ACLs are functionally identical but ordered differently
+	sort.Slice(mergedAcls, func(i, j int) bool {
+		return utils.GenerateACLKey(mergedAcls[i]) < utils.GenerateACLKey(mergedAcls[j])
+	})
+
 	return mergedAcls
 }
 
 func (k *strimziTransporter) EnsureTopic(clusterName string) (*transport.ClusterTopic, error) {
 	clusterTopic := k.getClusterTopic(clusterName)
 
-	topicNames := []string{clusterTopic.SpecTopic, clusterTopic.StatusTopic}
+	topicNames := []string{clusterTopic.SpecTopic, clusterTopic.MigrationTopic, clusterTopic.StatusTopic}
 	for _, topicName := range topicNames {
 		if err := k.ensureTopic(topicName, nil); err != nil {
 			return nil, err
@@ -503,8 +532,9 @@ func (k *strimziTransporter) Prune(clusterName string) error {
 
 func (k *strimziTransporter) getClusterTopic(clusterName string) *transport.ClusterTopic {
 	topic := &transport.ClusterTopic{
-		SpecTopic:   config.GetSpecTopic(),
-		StatusTopic: config.GetStatusTopic(clusterName),
+		SpecTopic:      config.GetSpecTopic(),
+		MigrationTopic: config.GetMigrationTopic(),
+		StatusTopic:    config.GetStatusTopic(clusterName),
 	}
 	return topic
 }
@@ -524,6 +554,7 @@ func (k *strimziTransporter) GetConnCredential(clusterName string) (*transport.K
 	// topics
 	credential.StatusTopic = config.GetStatusTopic(clusterName)
 	credential.SpecTopic = config.GetSpecTopic()
+	credential.MigrationTopic = config.GetMigrationTopic()
 
 	// consumer group id
 	credential.ConsumerGroupID = config.GetConsumerGroupID(k.mgh.Spec.DataLayerSpec.Kafka.ConsumerGroupPrefix,
@@ -655,7 +686,7 @@ func (k *strimziTransporter) kafkaClusterReady() (KafkaStatus, error) {
 
 	kafkaStatus := KafkaStatus{
 		kafkaReady:   false,
-		kakfaReason:  "KafkaNotReady",
+		kafkaReason:  "KafkaNotReady",
 		kafkaMessage: "Wait kafka cluster ready",
 	}
 
@@ -693,7 +724,7 @@ func (k *strimziTransporter) kafkaClusterReady() (KafkaStatus, error) {
 				return kafkaStatus, nil
 			}
 			kafkaStatus.kafkaMessage = *condition.Message
-			kafkaStatus.kakfaReason = *condition.Reason
+			kafkaStatus.kafkaReason = *condition.Reason
 			return kafkaStatus, nil
 		}
 	}
@@ -838,14 +869,13 @@ func (k *strimziTransporter) newKafkaCluster(mgh *operatorv1alpha4.MulticlusterG
 func (k *strimziTransporter) setMetricsConfig(mgh *operatorv1alpha4.MulticlusterGlobalHub,
 	kafkaCluster *kafkav1beta2.Kafka,
 ) {
-	kafkaMetricsConfig := &kafkav1beta2.KafkaSpecKafkaMetricsConfig{}
 	if mgh.Spec.EnableMetrics {
-		kafkaMetricsConfig = &kafkav1beta2.KafkaSpecKafkaMetricsConfig{
+		kafkaMetricsConfig := &kafkav1beta2.KafkaSpecKafkaMetricsConfig{
 			Type: kafkav1beta2.KafkaSpecKafkaMetricsConfigTypeJmxPrometheusExporter,
 			ValueFrom: kafkav1beta2.KafkaSpecKafkaMetricsConfigValueFrom{
 				ConfigMapKeyRef: &kafkav1beta2.KafkaSpecKafkaMetricsConfigValueFromConfigMapKeyRef{
-					Name: &KakfaMetricsConfigmapName,
-					Key:  &KafkaMetricsConfigmapKeyRef,
+					Name: &KafkaMetricsConfigMapName,
+					Key:  &KafkaMetricsConfigMapKeyRef,
 				},
 			},
 		}

--- a/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
@@ -686,7 +686,7 @@ func (k *strimziTransporter) kafkaClusterReady() (KafkaStatus, error) {
 
 	kafkaStatus := KafkaStatus{
 		kafkaReady:   false,
-		kafkaReason:  "KafkaNotReady",
+		kakfaReason:  "KafkaNotReady",
 		kafkaMessage: "Wait kafka cluster ready",
 	}
 
@@ -724,7 +724,7 @@ func (k *strimziTransporter) kafkaClusterReady() (KafkaStatus, error) {
 				return kafkaStatus, nil
 			}
 			kafkaStatus.kafkaMessage = *condition.Message
-			kafkaStatus.kafkaReason = *condition.Reason
+			kafkaStatus.kakfaReason = *condition.Reason
 			return kafkaStatus, nil
 		}
 	}

--- a/operator/pkg/controllers/transporter/protocol/strimzi_transporter_test.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_transporter_test.go
@@ -136,7 +136,7 @@ func TestNewKafkaCluster(t *testing.T) {
                     "memory": "128Mi"
                 }
             },
-            "version": "3.9.0"
+            "version": "4.0.0"
         }
     }
 }`,
@@ -207,7 +207,7 @@ func TestNewKafkaCluster(t *testing.T) {
                     "memory": "128Mi"
                 }
             },
-            "version": "3.9.0"
+            "version": "4.0.0"
         }
     }
 }`,
@@ -292,7 +292,7 @@ func TestNewKafkaCluster(t *testing.T) {
                     "memory": "128Mi"
                 }
             },
-            "version": "3.9.0"
+            "version": "4.0.0"
         }
     }
 }`,

--- a/operator/pkg/controllers/transporter/transport_reconciler.go
+++ b/operator/pkg/controllers/transporter/transport_reconciler.go
@@ -52,6 +52,11 @@ func (c *TransportReconciler) IsResourceRemoved() bool {
 
 func StartController(controllerOption config.ControllerOption) (config.ControllerInterface, error) {
 	if transportReconciler != nil {
+		if !migrationACLControllerStarted {
+			if err := migrationACLReconcilerSetup(controllerOption.Manager); err != nil {
+				return nil, err
+			}
+		}
 		return transportReconciler, nil
 	}
 	log.Info("start transport controller")
@@ -62,9 +67,14 @@ func StartController(controllerOption config.ControllerOption) (config.Controlle
 		transportReconciler = nil
 		return nil, err
 	}
+	if err := migrationACLReconcilerSetup(controllerOption.Manager); err != nil {
+		return nil, err
+	}
 	log.Infof("inited transport controller")
 	return transportReconciler, nil
 }
+
+var migrationACLReconcilerSetup = setupMigrationACLReconciler
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *TransportReconciler) SetupWithManager(mgr ctrl.Manager) error {
@@ -74,18 +84,6 @@ func (r *TransportReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&corev1.Secret{},
 			&handler.EnqueueRequestForObject{}, builder.WithPredicates(secretPred)).
 		Complete(r)
-}
-
-var mghPred = predicate.Funcs{
-	CreateFunc: func(e event.CreateEvent) bool {
-		return true
-	},
-	UpdateFunc: func(e event.UpdateEvent) bool {
-		return true
-	},
-	DeleteFunc: func(e event.DeleteEvent) bool {
-		return false
-	},
 }
 
 var secretPred = predicate.Funcs{
@@ -145,7 +143,8 @@ func (r *TransportReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			return
 		}
 
-		err = config.UpdateMGHComponent(ctx, r.GetClient(),
+		err = config.UpdateMGHComponent(
+			ctx, r.GetClient(),
 			getTransportComponentStatus(reconcileErr),
 			updateConn,
 		)

--- a/operator/pkg/controllers/transporter/transport_reconciler_test.go
+++ b/operator/pkg/controllers/transporter/transport_reconciler_test.go
@@ -1,0 +1,348 @@
+package transporter
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	crconfig "sigs.k8s.io/controller-runtime/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	migrationv1alpha1 "github.com/stolostron/multicluster-global-hub/operator/api/migration/v1alpha1"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/transporter/protocol"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
+)
+
+var errMigrationACLSetup = errors.New("migration ACL controller registration failed")
+
+// Predicate Tests - These test critical watch logic for Kafka-related resources
+
+const (
+	testSecretName      = "some-secret"
+	strimziClusterLabel = "strimzi.io/cluster"
+	strimziKindLabel    = "strimzi.io/kind"
+	strimziKindUser     = "KafkaUser"
+)
+
+// assertPredicateAllEvents asserts Create, Update, and Delete predicate results for the same expected value.
+func assertPredicateAllEvents(t *testing.T, pred predicate.Funcs, obj client.Object, want bool) {
+	t.Helper()
+	assert.Equal(t, want, pred.Create(event.CreateEvent{Object: obj}), "CreateFunc")
+	assert.Equal(t, want, pred.Update(event.UpdateEvent{ObjectNew: obj}), "UpdateFunc")
+	assert.Equal(t, want, pred.Delete(event.DeleteEvent{Object: obj}), "DeleteFunc")
+}
+
+func TestSecretPredicate(t *testing.T) {
+	tests := []struct {
+		name     string
+		obj      *corev1.Secret
+		wantBool bool
+	}{
+		{
+			name: "transport secret should match",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.GHTransportSecretName,
+					Namespace: utils.GetDefaultNamespace(),
+				},
+			},
+			wantBool: true,
+		},
+		{
+			name: "kafka user secret with strimzi labels should match",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kafka-user-secret",
+					Namespace: utils.GetDefaultNamespace(),
+					Labels: map[string]string{
+						strimziClusterLabel: protocol.KafkaClusterName,
+						strimziKindLabel:    strimziKindUser,
+					},
+				},
+			},
+			wantBool: true,
+		},
+		{
+			name: "kafka secret with wrong cluster name should not match",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kafka-user-secret",
+					Namespace: utils.GetDefaultNamespace(),
+					Labels: map[string]string{
+						strimziClusterLabel: "wrong-cluster",
+						strimziKindLabel:    strimziKindUser,
+					},
+				},
+			},
+			wantBool: false,
+		},
+		{
+			name: "kafka secret with wrong kind should not match",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kafka-secret",
+					Namespace: utils.GetDefaultNamespace(),
+					Labels: map[string]string{
+						strimziClusterLabel: protocol.KafkaClusterName,
+						strimziKindLabel:    "Kafka",
+					},
+				},
+			},
+			wantBool: false,
+		},
+		{
+			name: "other secret should not match",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "other-secret",
+					Namespace: utils.GetDefaultNamespace(),
+				},
+			},
+			wantBool: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertPredicateAllEvents(t, secretPred, tt.obj, tt.wantBool)
+		})
+	}
+}
+
+func TestSecretCond(t *testing.T) {
+	tests := []struct {
+		name     string
+		obj      *corev1.Secret
+		expected bool
+	}{
+		{
+			name: "transport secret name matches",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: constants.GHTransportSecretName,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "kafka user secret with both labels matches",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: testSecretName,
+					Labels: map[string]string{
+						strimziClusterLabel: protocol.KafkaClusterName,
+						strimziKindLabel:    strimziKindUser,
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "kafka secret with only cluster label does not match",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: testSecretName,
+					Labels: map[string]string{
+						strimziClusterLabel: protocol.KafkaClusterName,
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "kafka secret with only kind label does not match",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: testSecretName,
+					Labels: map[string]string{
+						strimziKindLabel: strimziKindUser,
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "other secret does not match",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "other-secret",
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := secretCond(tt.obj)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// State Management Tests
+
+func TestTransportReconcilerIsResourceRemoved(t *testing.T) {
+	r := &TransportReconciler{}
+
+	// Test with default state (should be true initially)
+	originalState := isResourceRemoved
+	defer func() {
+		isResourceRemoved = originalState
+	}()
+
+	// Test when isResourceRemoved is true
+	isResourceRemoved = true
+	result := r.IsResourceRemoved()
+	assert.True(t, result)
+
+	// Test when isResourceRemoved is false
+	isResourceRemoved = false
+	result = r.IsResourceRemoved()
+	assert.False(t, result)
+}
+
+func TestStartControllerSingleton(t *testing.T) {
+	// Save and restore the singleton so we don't affect other tests.
+	original := transportReconciler
+	originalMigrationACL := migrationACLControllerStarted
+	t.Cleanup(func() {
+		transportReconciler = original
+		migrationACLControllerStarted = originalMigrationACL
+	})
+
+	existing := &TransportReconciler{}
+	transportReconciler = existing
+	migrationACLControllerStarted = true
+
+	// Second call must return the pre-existing instance without error.
+	controller, err := StartController(config.ControllerOption{})
+	assert.NoError(t, err, "StartController should succeed when transport singleton is already initialized")
+	assert.Equal(t, existing, controller, "StartController should reuse the existing transport controller instance")
+}
+
+func TestStartControllerRetriesMigrationACLSetup(t *testing.T) {
+	originalTransport := transportReconciler
+	originalMigrationACL := migrationACLControllerStarted
+	originalSetup := migrationACLReconcilerSetup
+	t.Cleanup(func() {
+		transportReconciler = originalTransport
+		migrationACLControllerStarted = originalMigrationACL
+		migrationACLReconcilerSetup = originalSetup
+	})
+
+	scheme := runtime.NewScheme()
+	if err := migrationv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(ManagedClusterMigration) error = %v", err)
+	}
+	mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{migrationv1alpha1.GroupVersion})
+	mapper.Add(migrationv1alpha1.GroupVersion.WithKind("ManagedClusterMigration"), meta.RESTScopeNamespace)
+
+	transportReconciler = &TransportReconciler{}
+	migrationACLControllerStarted = false
+	migrationACLReconcilerSetup = func(ctrl.Manager) error { return errMigrationACLSetup }
+
+	mgr := &migrationACLSetupFailManager{
+		client:     fake.NewClientBuilder().WithScheme(scheme).Build(),
+		scheme:     scheme,
+		restMapper: mapper,
+	}
+
+	controller, err := StartController(config.ControllerOption{Manager: mgr})
+	assert.ErrorIs(t, err, errMigrationACLSetup, "StartController should return migration ACL setup error")
+	assert.Nil(t, controller, "StartController should not return a controller when migration ACL setup fails")
+	assert.False(
+		t,
+		migrationACLControllerStarted,
+		"migration ACL controller must not be marked started after setup failure",
+	)
+}
+
+type migrationACLSetupFailManager struct {
+	client     client.Client
+	scheme     *runtime.Scheme
+	restMapper meta.RESTMapper
+	addErr     error
+}
+
+func (m *migrationACLSetupFailManager) Add(manager.Runnable) error { return m.addErr }
+func (m *migrationACLSetupFailManager) GetClient() client.Client   { return m.client }
+func (m *migrationACLSetupFailManager) GetScheme() *runtime.Scheme { return m.scheme }
+func (m *migrationACLSetupFailManager) GetFieldIndexer() client.FieldIndexer {
+	return nil
+}
+func (m *migrationACLSetupFailManager) GetCache() cache.Cache { return nil }
+func (m *migrationACLSetupFailManager) GetEventRecorderFor(string) record.EventRecorder {
+	return nil
+}
+func (m *migrationACLSetupFailManager) GetRESTMapper() meta.RESTMapper { return m.restMapper }
+func (m *migrationACLSetupFailManager) GetAPIReader() client.Reader    { return m.client }
+func (m *migrationACLSetupFailManager) Start(context.Context) error    { return nil }
+func (m *migrationACLSetupFailManager) GetWebhookServer() webhook.Server {
+	return nil
+}
+func (m *migrationACLSetupFailManager) GetLogger() logr.Logger { return logr.Discard() }
+func (m *migrationACLSetupFailManager) GetControllerOptions() crconfig.Controller {
+	return crconfig.Controller{}
+}
+func (m *migrationACLSetupFailManager) Elected() <-chan struct{} { return nil }
+func (m *migrationACLSetupFailManager) AddHealthzCheck(string, healthz.Checker) error {
+	return nil
+}
+
+func (m *migrationACLSetupFailManager) AddReadyzCheck(string, healthz.Checker) error {
+	return nil
+}
+func (m *migrationACLSetupFailManager) GetHTTPClient() *http.Client { return nil }
+func (m *migrationACLSetupFailManager) AddMetricsServerExtraHandler(string, http.Handler) error {
+	return nil
+}
+func (m *migrationACLSetupFailManager) GetConfig() *rest.Config { return nil }
+
+var _ ctrl.Manager = (*migrationACLSetupFailManager)(nil)
+
+func TestAMigrationACLReconcilerSetupSuccess(t *testing.T) {
+	original := migrationACLControllerStarted
+	migrationACLControllerStarted = false
+	t.Cleanup(func() { migrationACLControllerStarted = original })
+
+	scheme := runtime.NewScheme()
+	if err := migrationv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(ManagedClusterMigration) error = %v", err)
+	}
+	mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{migrationv1alpha1.GroupVersion})
+	mapper.Add(migrationv1alpha1.GroupVersion.WithKind("ManagedClusterMigration"), meta.RESTScopeNamespace)
+
+	mgr := &migrationACLSetupFailManager{
+		client:     fake.NewClientBuilder().WithScheme(scheme).Build(),
+		scheme:     scheme,
+		restMapper: mapper,
+	}
+
+	if err := setupMigrationACLReconciler(mgr); err != nil {
+		t.Fatalf("setupMigrationACLReconciler() error = %v", err)
+	}
+	if !migrationACLControllerStarted {
+		t.Fatal("expected migration ACL controller to be marked started")
+	}
+}

--- a/pkg/transport/consumer/generic_consumer.go
+++ b/pkg/transport/consumer/generic_consumer.go
@@ -7,9 +7,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math"
 	"strings"
-	"time"
+	"sync"
 
 	kafka_confluent "github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -18,221 +17,158 @@ import (
 	ceprotocol "github.com/cloudevents/sdk-go/v2/protocol"
 	"github.com/cloudevents/sdk-go/v2/protocol/gochan"
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
-	"k8s.io/apimachinery/pkg/util/wait"
+	"go.uber.org/zap"
 
-	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/database"
 	"github.com/stolostron/multicluster-global-hub/pkg/database/models"
-	"github.com/stolostron/multicluster-global-hub/pkg/enum"
 	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport/config"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport/identity"
-	"github.com/stolostron/multicluster-global-hub/pkg/transport/utils"
 )
 
-const (
-	defaultStableThreshold = 1 * time.Minute
-)
+var transportID string
 
 type GenericConsumer struct {
-	// transportConfigChan receives transport config to trigger consumer reconnection.
-	// This avoids race conditions by passing config explicitly instead of sharing a pointer.
-	transportConfigChan  chan *transport.TransportInternalConfig
+	log                  *zap.SugaredLogger
+	assembler            *messageAssembler
+	eventChan            chan *cloudevents.Event
 	enableDatabaseOffset bool
+	clusterID            string
 	isManager            bool
 	statusTopicPattern   string
 
-	// internal variables
-	eventChan chan *cloudevents.Event
-	assembler *messageAssembler
+	consumerCtx    context.Context
+	consumerCancel context.CancelFunc
+	client         cloudevents.Client
+	kafkaConsumer  *kafka.Consumer
 
-	// backoff for reconnection with exponential backoff
-	// Note: Only accessed from Start() goroutine, no mutex needed
-	backoff wait.Backoff
-
-	// topicMetadataRefreshInterval reflects the topic.metadata.refresh.interval.ms and
-	// metadata.max.age.ms settings in the consumer config.
-	// the default value is 5 mins in Kafka, we set it to 1 min in order to quickly
-	// respond to topic changes for the global hub manager only.
-	// the global hub manager consumes from topics created dynamically when importing the managed cluster.
-	topicMetadataRefreshInterval int
+	mutex sync.Mutex
 }
 
-func NewGenericConsumer(isManager bool, enableDatabaseOffset bool) (*GenericConsumer, error) {
-	c := &GenericConsumer{
-		transportConfigChan:  make(chan *transport.TransportInternalConfig, 1),
-		isManager:            isManager,
-		enableDatabaseOffset: enableDatabaseOffset,
+type GenericConsumeOption func(*GenericConsumer) error
 
-		eventChan: make(chan *cloudevents.Event),
-		assembler: newMessageAssembler(),
-		backoff:   newBackoff(),
+func EnableDatabaseOffset(enableOffset bool) GenericConsumeOption {
+	return func(c *GenericConsumer) error {
+		c.enableDatabaseOffset = enableOffset
+		return nil
 	}
-	if isManager {
-		c.topicMetadataRefreshInterval = constants.TopicMetadataRefreshInterval
+}
+
+func NewGenericConsumer(tranConfig *transport.TransportInternalConfig, topics []string,
+	opts ...GenericConsumeOption,
+) (*GenericConsumer, error) {
+	c := &GenericConsumer{
+		log:                  logger.ZapLogger(fmt.Sprintf("%s-consumer", tranConfig.TransportType)),
+		eventChan:            make(chan *cloudevents.Event),
+		assembler:            newMessageAssembler(),
+		enableDatabaseOffset: tranConfig.EnableDatabaseOffset,
+	}
+	if err := c.initClient(tranConfig, topics); err != nil {
+		return nil, err
+	}
+	if err := c.applyOptions(opts...); err != nil {
+		return nil, err
 	}
 	return c, nil
 }
 
-// newBackoff creates a new backoff configuration
-func newBackoff() wait.Backoff {
-	return wait.Backoff{
-		Duration: 1 * time.Second,
-		Factor:   2.0,
-		Jitter:   0.1,
-		Steps:    math.MaxInt32,
-		Cap:      30 * time.Second,
-	}
-}
-
-// resetBackoff resets the backoff to initial state.
-// Note: Not thread-safe. Only call from tests or within getBackoffDuration (which holds the lock).
-func (c *GenericConsumer) resetBackoff() {
-	c.backoff = newBackoff()
-}
-
-// getBackoffDuration returns the current backoff duration using wait.Backoff.Step()
-// Note: Only called from Start() goroutine, no synchronization needed.
-func (c *GenericConsumer) getBackoffDuration(lastTime time.Time) time.Duration {
-	// if connection was stable (ran > threshold), reset backoff
-	if time.Since(lastTime) > defaultStableThreshold {
-		log.Infof("connection was stable, resetting backoff")
-		c.resetBackoff()
-	}
-	return c.backoff.Step()
-}
-
-// Start runs the consumer loop independently from the reconcile loop.
-// It reconnects when receiving new transport config via the transportConfigChan.
-// Returns error to trigger graceful shutdown if client initialization fails.
-func (c *GenericConsumer) Start(ctx context.Context) error {
-	var consumerCtx context.Context
-	var consumerCancel context.CancelFunc
-	for {
-		select {
-		case <-ctx.Done():
-			if consumerCancel != nil {
-				consumerCancel()
-			}
-			log.Infof("context done, stop the consumer")
-			return nil
-
-		case transportConfig := <-c.transportConfigChan:
-			// 1. cancel the previous consumer receiver if exists
-			if consumerCancel != nil {
-				consumerCancel()
-			}
-
-			// 2. init the cloudevents client with the new transport config
-			client, err := c.initClient(transportConfig)
-			if err != nil {
-				// return error to trigger graceful shutdown via controller-runtime manager
-				return fmt.Errorf("failed to init transport client: %w", err)
-			}
-
-			// 4. create new context and start receiving events in a goroutine
-			consumerCtx, consumerCancel = context.WithCancel(ctx)
-			go func(ctx context.Context, config *transport.TransportInternalConfig) {
-				consumerGroupId := config.KafkaCredential.ConsumerGroupID
-				log.Infof("start receiving events: %s", consumerGroupId)
-				startTime := time.Now()
-				if err := c.receive(client, ctx); err != nil {
-					log.Infof("receiver cancelled, skip reconnect (consumerGroupId=%s)", consumerGroupId)
-				}
-				log.Infof("stop receiving events: %s", consumerGroupId)
-
-				// only reconnect if receiver exited unexpectedly (not cancelled by new signal)
-				if ctx.Err() == context.Canceled {
-					log.Infof("receiver cancelled, skip reconnection for the current group id: %s", consumerGroupId)
-					return
-				}
-
-				// backoff before reconnect to avoid rapid retry loops
-				backoff := c.getBackoffDuration(startTime)
-				log.Infof("receiver exited unexpectedly, reconnect in %v (consumerGroupId=%s)", backoff, consumerGroupId)
-				time.Sleep(backoff)
-				// resend the current config to trigger reconnection
-				c.transportConfigChan <- config
-			}(consumerCtx, transportConfig)
-		}
-	}
+func (c *GenericConsumer) KafkaConsumer() *kafka.Consumer {
+	return c.kafkaConsumer
 }
 
 // initClient will init the consumer identity, clientProtocol, client
-func (c *GenericConsumer) initClient(tranConfig *transport.TransportInternalConfig) (cloudevents.Client, error) {
-	var topics []string
-	if c.isManager {
-		c.statusTopicPattern = tranConfig.KafkaCredential.StatusTopic
-		topics = []string{tranConfig.KafkaCredential.StatusTopic}
-	} else {
-		topics = []string{tranConfig.KafkaCredential.SpecTopic}
-		if migrationTopic := tranConfig.KafkaCredential.GetMigrationTopic(); migrationTopic != "" &&
-			migrationTopic != tranConfig.KafkaCredential.SpecTopic {
-			topics = append(topics, migrationTopic)
-		}
-	}
-
+func (c *GenericConsumer) initClient(tranConfig *transport.TransportInternalConfig, topics []string) error {
 	var err error
 	var clientProtocol interface{}
 
+	c.clusterID = tranConfig.KafkaCredential.ClusterID
+	c.isManager = len(topics) > 0 && topics[0] == tranConfig.KafkaCredential.StatusTopic
+	if c.isManager {
+		c.statusTopicPattern = tranConfig.KafkaCredential.StatusTopic
+	}
+
 	switch tranConfig.TransportType {
 	case string(transport.Kafka):
-		log.Info("transport consumer with cloudevents-kafka receiver")
-		_, clientProtocol, err = getConfluentReceiverProtocol(tranConfig,
-			topics, c.topicMetadataRefreshInterval)
-		if err != nil {
-			return nil, err
-		}
-	case string(transport.Chan):
-		log.Info("transport consumer with go chan receiver")
-		if tranConfig.Extends == nil {
-			tranConfig.Extends = make(map[string]interface{})
-		}
-		primaryTopic := topics[0]
-		if _, found := tranConfig.Extends[primaryTopic]; !found {
-			tranConfig.Extends[primaryTopic] = gochan.New()
-		}
-		primaryChan := tranConfig.Extends[primaryTopic]
-		for _, topic := range topics[1:] {
-			tranConfig.Extends[topic] = primaryChan
-		}
-		clientProtocol = primaryChan
-	default:
-		return nil, fmt.Errorf("transport-type - %s is not a valid option", tranConfig.TransportType)
-	}
-
-	client, err := cloudevents.NewClient(clientProtocol, client.WithPollGoroutines(1))
-	if err != nil {
-		return nil, err
-	}
-
-	return client, nil
-}
-
-func (c *GenericConsumer) receive(client cloudevents.Client, ctx context.Context) error {
-	receiveContext := cectx.WithLogger(ctx, logger.ZapLogger("cloudevents"))
-	if c.enableDatabaseOffset {
-		offsets, err := getInitOffset(config.GetKafkaOwnerIdentity())
+		c.log.Info("transport consumer with cloudevents-kafka receiver")
+		c.kafkaConsumer, clientProtocol, err = getConfluentReceiverProtocol(tranConfig, topics)
 		if err != nil {
 			return err
 		}
-		log.Infow("init consumer with database offsets", "offsets", offsets)
-		if len(offsets) > 0 {
-			receiveContext = kafka_confluent.WithTopicPartitionOffsets(receiveContext, offsets)
+	case string(transport.Chan):
+		c.log.Info("transport consumer with go chan receiver")
+		if tranConfig.Extends == nil {
+			tranConfig.Extends = make(map[string]interface{})
+		}
+		topic := topics[0]
+		if _, found := tranConfig.Extends[topic]; !found {
+			tranConfig.Extends[topic] = gochan.New()
+		}
+		clientProtocol = tranConfig.Extends[topic]
+	default:
+		return fmt.Errorf("transport-type - %s is not a valid option", tranConfig.TransportType)
+	}
+
+	c.client, err = cloudevents.NewClient(clientProtocol, client.WithPollGoroutines(1))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *GenericConsumer) applyOptions(opts ...GenericConsumeOption) error {
+	for _, fn := range opts {
+		if err := fn(c); err != nil {
+			return err
 		}
 	}
-	// each time the consumer starts, it will only log the first message
-	receivedMessage := false
-	err := client.StartReceiver(receiveContext, func(ctx context.Context, event cloudevents.Event) ceprotocol.Result {
-		log.Debugw("received message", "event.Source", event.Source(), "event.Type", enum.ShortenEventType(event.Type()))
+	return nil
+}
 
-		if !receivedMessage {
-			receivedMessage = true
-			log.Infow("received message", "topic", event.Extensions()[kafka_confluent.KafkaTopicKey],
-				"partition", event.Extensions()[kafka_confluent.KafkaPartitionKey],
-				"offset", event.Extensions()[kafka_confluent.KafkaOffsetKey])
+func (c *GenericConsumer) Reconnect(ctx context.Context,
+	tranConfig *transport.TransportInternalConfig, topics []string,
+) error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	err := c.initClient(tranConfig, topics)
+	if err != nil {
+		return err
+	}
+
+	// close the previous consumer
+	if c.consumerCancel != nil {
+		c.consumerCancel()
+	}
+	c.consumerCtx, c.consumerCancel = context.WithCancel(ctx)
+	consumerGroupId := tranConfig.KafkaCredential.ConsumerGroupID
+	go func() {
+		c.log.Infof("reconnect consumer: %s", consumerGroupId)
+		if err := c.Start(c.consumerCtx); err != nil {
+			c.log.Warnf("stop the consumer(%s): %v", consumerGroupId, err)
 		}
+		c.log.Infof("consumer stopped: %s", consumerGroupId)
+	}()
+	return nil
+}
+
+func (c *GenericConsumer) Start(ctx context.Context) error {
+	receiveContext := cectx.WithLogger(ctx, logger.ZapLogger("cloudevents"))
+	if c.enableDatabaseOffset {
+		offsets, err := getInitOffset(c.clusterID)
+		if err != nil {
+			return err
+		}
+		c.log.Infow("init consumer", "offsets", offsets)
+		if len(offsets) > 0 {
+			receiveContext = kafka_confluent.WithTopicPartitionOffsets(ctx, offsets)
+		}
+	}
+
+	c.consumerCtx, c.consumerCancel = context.WithCancel(receiveContext)
+	err := c.client.StartReceiver(c.consumerCtx, func(ctx context.Context, event cloudevents.Event) ceprotocol.Result {
+		c.log.Debugw("received message", "event.Source", event.Source(), "event.Type", event.Type())
 
 		chunk, isChunk := c.assembler.messageChunk(event)
 		if !isChunk {
@@ -241,7 +177,7 @@ func (c *GenericConsumer) receive(client cloudevents.Client, ctx context.Context
 		}
 		if payload := c.assembler.assemble(chunk); payload != nil {
 			if err := event.SetData(cloudevents.ApplicationJSON, payload); err != nil {
-				log.Errorw("failed the set the assembled data to event", "error", err)
+				c.log.Errorw("failed the set the assembled data to event", "error", err)
 			} else {
 				c.publishReceivedEvent(&event)
 			}
@@ -251,7 +187,6 @@ func (c *GenericConsumer) receive(client cloudevents.Client, ctx context.Context
 	if err != nil {
 		return fmt.Errorf("consumer receiver stopped with error: %w", err)
 	}
-	receivedMessage = false
 	return nil
 }
 
@@ -266,15 +201,10 @@ func (c *GenericConsumer) EventChan() chan *cloudevents.Event {
 	return c.eventChan
 }
 
-func (c *GenericConsumer) ConfigChan() chan *transport.TransportInternalConfig {
-	return c.transportConfigChan
-}
-
 func getInitOffset(kafkaClusterIdentity string) ([]kafka.TopicPartition, error) {
 	db := database.GetGorm()
 	var positions []models.Transport
-	// TODO: clean the expired offset, maybe consider to delete the record when detach the managed hub
-	err := db.
+	err := db.Where("name ~ ?", "^status*").
 		Where("payload->>'ownerIdentity' <> ? AND payload->>'ownerIdentity' = ?", "", kafkaClusterIdentity).
 		Find(&positions).Error
 	if err != nil {
@@ -301,31 +231,14 @@ func getInitOffset(kafkaClusterIdentity string) ([]kafka.TopicPartition, error) 
 	return offsetToStart, nil
 }
 
-// func getSaramaReceiverProtocol(transportConfig *transport.TransportConfig) (interface{}, error) {
-// 	saramaConfig, err := config.GetSaramaConfig(transportConfig.KafkaConfig)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	// if set this to false, it will consume message from beginning when restart the client
-// 	saramaConfig.Consumer.Offsets.AutoCommit.Enable = true
-// 	saramaConfig.Consumer.Offsets.Initial = sarama.OffsetOldest
-// 	// set the consumer groupId = clientId
-// 	return kafka_sarama.NewConsumer([]string{transportConfig.KafkaConfig.BootstrapServer}, saramaConfig,
-// 		transportConfig.KafkaConfig.ConsumerConfig.ConsumerID,
-// 		transportConfig.KafkaConfig.ConsumerConfig.ConsumerTopic)
-// }
-
-func getConfluentReceiverProtocol(transportConfig *transport.TransportInternalConfig,
-	topics []string, topicMetadataRefreshInterval int) (
+func getConfluentReceiverProtocol(transportConfig *transport.TransportInternalConfig, topics []string) (
 	*kafka.Consumer, interface{}, error,
 ) {
 	configMap, err := config.GetConfluentConfigMapByKafkaCredential(transportConfig.KafkaCredential,
-		transportConfig.KafkaCredential.ConsumerGroupID, topicMetadataRefreshInterval)
+		transportConfig.KafkaCredential.ConsumerGroupID)
 	if err != nil {
 		return nil, nil, err
 	}
-	log.Debugw("the configurations applied to the Kafka consumer", "configMap",
-		utils.FilterSensitiveKafkaConfig(configMap))
 
 	consumer, err := kafka.NewConsumer(configMap)
 	if err != nil {
@@ -338,4 +251,8 @@ func getConfluentReceiverProtocol(transportConfig *transport.TransportInternalCo
 		return nil, nil, err
 	}
 	return consumer, protocol, nil
+}
+
+func TransportID() string {
+	return transportID
 }

--- a/pkg/transport/consumer/generic_consumer.go
+++ b/pkg/transport/consumer/generic_consumer.go
@@ -7,8 +7,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"strings"
-	"sync"
+	"time"
 
 	kafka_confluent "github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -17,158 +18,221 @@ import (
 	ceprotocol "github.com/cloudevents/sdk-go/v2/protocol"
 	"github.com/cloudevents/sdk-go/v2/protocol/gochan"
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
-	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/util/wait"
 
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/database"
 	"github.com/stolostron/multicluster-global-hub/pkg/database/models"
+	"github.com/stolostron/multicluster-global-hub/pkg/enum"
 	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport/config"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport/identity"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport/utils"
 )
 
-var transportID string
+const (
+	defaultStableThreshold = 1 * time.Minute
+)
 
 type GenericConsumer struct {
-	log                  *zap.SugaredLogger
-	assembler            *messageAssembler
-	eventChan            chan *cloudevents.Event
+	// transportConfigChan receives transport config to trigger consumer reconnection.
+	// This avoids race conditions by passing config explicitly instead of sharing a pointer.
+	transportConfigChan  chan *transport.TransportInternalConfig
 	enableDatabaseOffset bool
-	clusterID            string
 	isManager            bool
 	statusTopicPattern   string
 
-	consumerCtx    context.Context
-	consumerCancel context.CancelFunc
-	client         cloudevents.Client
-	kafkaConsumer  *kafka.Consumer
+	// internal variables
+	eventChan chan *cloudevents.Event
+	assembler *messageAssembler
 
-	mutex sync.Mutex
+	// backoff for reconnection with exponential backoff
+	// Note: Only accessed from Start() goroutine, no mutex needed
+	backoff wait.Backoff
+
+	// topicMetadataRefreshInterval reflects the topic.metadata.refresh.interval.ms and
+	// metadata.max.age.ms settings in the consumer config.
+	// the default value is 5 mins in Kafka, we set it to 1 min in order to quickly
+	// respond to topic changes for the global hub manager only.
+	// the global hub manager consumes from topics created dynamically when importing the managed cluster.
+	topicMetadataRefreshInterval int
 }
 
-type GenericConsumeOption func(*GenericConsumer) error
-
-func EnableDatabaseOffset(enableOffset bool) GenericConsumeOption {
-	return func(c *GenericConsumer) error {
-		c.enableDatabaseOffset = enableOffset
-		return nil
-	}
-}
-
-func NewGenericConsumer(tranConfig *transport.TransportInternalConfig, topics []string,
-	opts ...GenericConsumeOption,
-) (*GenericConsumer, error) {
+func NewGenericConsumer(isManager bool, enableDatabaseOffset bool) (*GenericConsumer, error) {
 	c := &GenericConsumer{
-		log:                  logger.ZapLogger(fmt.Sprintf("%s-consumer", tranConfig.TransportType)),
-		eventChan:            make(chan *cloudevents.Event),
-		assembler:            newMessageAssembler(),
-		enableDatabaseOffset: tranConfig.EnableDatabaseOffset,
+		transportConfigChan:  make(chan *transport.TransportInternalConfig, 1),
+		isManager:            isManager,
+		enableDatabaseOffset: enableDatabaseOffset,
+
+		eventChan: make(chan *cloudevents.Event),
+		assembler: newMessageAssembler(),
+		backoff:   newBackoff(),
 	}
-	if err := c.initClient(tranConfig, topics); err != nil {
-		return nil, err
-	}
-	if err := c.applyOptions(opts...); err != nil {
-		return nil, err
+	if isManager {
+		c.topicMetadataRefreshInterval = constants.TopicMetadataRefreshInterval
 	}
 	return c, nil
 }
 
-func (c *GenericConsumer) KafkaConsumer() *kafka.Consumer {
-	return c.kafkaConsumer
+// newBackoff creates a new backoff configuration
+func newBackoff() wait.Backoff {
+	return wait.Backoff{
+		Duration: 1 * time.Second,
+		Factor:   2.0,
+		Jitter:   0.1,
+		Steps:    math.MaxInt32,
+		Cap:      30 * time.Second,
+	}
+}
+
+// resetBackoff resets the backoff to initial state.
+// Note: Not thread-safe. Only call from tests or within getBackoffDuration (which holds the lock).
+func (c *GenericConsumer) resetBackoff() {
+	c.backoff = newBackoff()
+}
+
+// getBackoffDuration returns the current backoff duration using wait.Backoff.Step()
+// Note: Only called from Start() goroutine, no synchronization needed.
+func (c *GenericConsumer) getBackoffDuration(lastTime time.Time) time.Duration {
+	// if connection was stable (ran > threshold), reset backoff
+	if time.Since(lastTime) > defaultStableThreshold {
+		log.Infof("connection was stable, resetting backoff")
+		c.resetBackoff()
+	}
+	return c.backoff.Step()
+}
+
+// Start runs the consumer loop independently from the reconcile loop.
+// It reconnects when receiving new transport config via the transportConfigChan.
+// Returns error to trigger graceful shutdown if client initialization fails.
+func (c *GenericConsumer) Start(ctx context.Context) error {
+	var consumerCtx context.Context
+	var consumerCancel context.CancelFunc
+	for {
+		select {
+		case <-ctx.Done():
+			if consumerCancel != nil {
+				consumerCancel()
+			}
+			log.Infof("context done, stop the consumer")
+			return nil
+
+		case transportConfig := <-c.transportConfigChan:
+			// 1. cancel the previous consumer receiver if exists
+			if consumerCancel != nil {
+				consumerCancel()
+			}
+
+			// 2. init the cloudevents client with the new transport config
+			client, err := c.initClient(transportConfig)
+			if err != nil {
+				// return error to trigger graceful shutdown via controller-runtime manager
+				return fmt.Errorf("failed to init transport client: %w", err)
+			}
+
+			// 4. create new context and start receiving events in a goroutine
+			consumerCtx, consumerCancel = context.WithCancel(ctx)
+			go func(ctx context.Context, config *transport.TransportInternalConfig) {
+				consumerGroupId := config.KafkaCredential.ConsumerGroupID
+				log.Infof("start receiving events: %s", consumerGroupId)
+				startTime := time.Now()
+				if err := c.receive(client, ctx); err != nil {
+					log.Infof("receiver cancelled, skip reconnect (consumerGroupId=%s)", consumerGroupId)
+				}
+				log.Infof("stop receiving events: %s", consumerGroupId)
+
+				// only reconnect if receiver exited unexpectedly (not cancelled by new signal)
+				if ctx.Err() == context.Canceled {
+					log.Infof("receiver cancelled, skip reconnection for the current group id: %s", consumerGroupId)
+					return
+				}
+
+				// backoff before reconnect to avoid rapid retry loops
+				backoff := c.getBackoffDuration(startTime)
+				log.Infof("receiver exited unexpectedly, reconnect in %v (consumerGroupId=%s)", backoff, consumerGroupId)
+				time.Sleep(backoff)
+				// resend the current config to trigger reconnection
+				c.transportConfigChan <- config
+			}(consumerCtx, transportConfig)
+		}
+	}
 }
 
 // initClient will init the consumer identity, clientProtocol, client
-func (c *GenericConsumer) initClient(tranConfig *transport.TransportInternalConfig, topics []string) error {
+func (c *GenericConsumer) initClient(tranConfig *transport.TransportInternalConfig) (cloudevents.Client, error) {
+	var topics []string
+	if c.isManager {
+		c.statusTopicPattern = tranConfig.KafkaCredential.StatusTopic
+		topics = []string{tranConfig.KafkaCredential.StatusTopic}
+	} else {
+		topics = []string{tranConfig.KafkaCredential.SpecTopic}
+		if migrationTopic := tranConfig.KafkaCredential.GetMigrationTopic(); migrationTopic != "" &&
+			migrationTopic != tranConfig.KafkaCredential.SpecTopic {
+			topics = append(topics, migrationTopic)
+		}
+	}
+
 	var err error
 	var clientProtocol interface{}
 
-	c.clusterID = tranConfig.KafkaCredential.ClusterID
-	c.isManager = len(topics) > 0 && topics[0] == tranConfig.KafkaCredential.StatusTopic
-	if c.isManager {
-		c.statusTopicPattern = tranConfig.KafkaCredential.StatusTopic
-	}
-
 	switch tranConfig.TransportType {
 	case string(transport.Kafka):
-		c.log.Info("transport consumer with cloudevents-kafka receiver")
-		c.kafkaConsumer, clientProtocol, err = getConfluentReceiverProtocol(tranConfig, topics)
+		log.Info("transport consumer with cloudevents-kafka receiver")
+		_, clientProtocol, err = getConfluentReceiverProtocol(tranConfig,
+			topics, c.topicMetadataRefreshInterval)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	case string(transport.Chan):
-		c.log.Info("transport consumer with go chan receiver")
+		log.Info("transport consumer with go chan receiver")
 		if tranConfig.Extends == nil {
 			tranConfig.Extends = make(map[string]interface{})
 		}
-		topic := topics[0]
-		if _, found := tranConfig.Extends[topic]; !found {
-			tranConfig.Extends[topic] = gochan.New()
+		primaryTopic := topics[0]
+		if _, found := tranConfig.Extends[primaryTopic]; !found {
+			tranConfig.Extends[primaryTopic] = gochan.New()
 		}
-		clientProtocol = tranConfig.Extends[topic]
+		primaryChan := tranConfig.Extends[primaryTopic]
+		for _, topic := range topics[1:] {
+			tranConfig.Extends[topic] = primaryChan
+		}
+		clientProtocol = primaryChan
 	default:
-		return fmt.Errorf("transport-type - %s is not a valid option", tranConfig.TransportType)
+		return nil, fmt.Errorf("transport-type - %s is not a valid option", tranConfig.TransportType)
 	}
 
-	c.client, err = cloudevents.NewClient(clientProtocol, client.WithPollGoroutines(1))
+	client, err := cloudevents.NewClient(clientProtocol, client.WithPollGoroutines(1))
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	return client, nil
 }
 
-func (c *GenericConsumer) applyOptions(opts ...GenericConsumeOption) error {
-	for _, fn := range opts {
-		if err := fn(c); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (c *GenericConsumer) Reconnect(ctx context.Context,
-	tranConfig *transport.TransportInternalConfig, topics []string,
-) error {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
-	err := c.initClient(tranConfig, topics)
-	if err != nil {
-		return err
-	}
-
-	// close the previous consumer
-	if c.consumerCancel != nil {
-		c.consumerCancel()
-	}
-	c.consumerCtx, c.consumerCancel = context.WithCancel(ctx)
-	consumerGroupId := tranConfig.KafkaCredential.ConsumerGroupID
-	go func() {
-		c.log.Infof("reconnect consumer: %s", consumerGroupId)
-		if err := c.Start(c.consumerCtx); err != nil {
-			c.log.Warnf("stop the consumer(%s): %v", consumerGroupId, err)
-		}
-		c.log.Infof("consumer stopped: %s", consumerGroupId)
-	}()
-	return nil
-}
-
-func (c *GenericConsumer) Start(ctx context.Context) error {
+func (c *GenericConsumer) receive(client cloudevents.Client, ctx context.Context) error {
 	receiveContext := cectx.WithLogger(ctx, logger.ZapLogger("cloudevents"))
 	if c.enableDatabaseOffset {
-		offsets, err := getInitOffset(c.clusterID)
+		offsets, err := getInitOffset(config.GetKafkaOwnerIdentity())
 		if err != nil {
 			return err
 		}
-		c.log.Infow("init consumer", "offsets", offsets)
+		log.Infow("init consumer with database offsets", "offsets", offsets)
 		if len(offsets) > 0 {
-			receiveContext = kafka_confluent.WithTopicPartitionOffsets(ctx, offsets)
+			receiveContext = kafka_confluent.WithTopicPartitionOffsets(receiveContext, offsets)
 		}
 	}
+	// each time the consumer starts, it will only log the first message
+	receivedMessage := false
+	err := client.StartReceiver(receiveContext, func(ctx context.Context, event cloudevents.Event) ceprotocol.Result {
+		log.Debugw("received message", "event.Source", event.Source(), "event.Type", enum.ShortenEventType(event.Type()))
 
-	c.consumerCtx, c.consumerCancel = context.WithCancel(receiveContext)
-	err := c.client.StartReceiver(c.consumerCtx, func(ctx context.Context, event cloudevents.Event) ceprotocol.Result {
-		c.log.Debugw("received message", "event.Source", event.Source(), "event.Type", event.Type())
+		if !receivedMessage {
+			receivedMessage = true
+			log.Infow("received message", "topic", event.Extensions()[kafka_confluent.KafkaTopicKey],
+				"partition", event.Extensions()[kafka_confluent.KafkaPartitionKey],
+				"offset", event.Extensions()[kafka_confluent.KafkaOffsetKey])
+		}
 
 		chunk, isChunk := c.assembler.messageChunk(event)
 		if !isChunk {
@@ -177,7 +241,7 @@ func (c *GenericConsumer) Start(ctx context.Context) error {
 		}
 		if payload := c.assembler.assemble(chunk); payload != nil {
 			if err := event.SetData(cloudevents.ApplicationJSON, payload); err != nil {
-				c.log.Errorw("failed the set the assembled data to event", "error", err)
+				log.Errorw("failed the set the assembled data to event", "error", err)
 			} else {
 				c.publishReceivedEvent(&event)
 			}
@@ -187,6 +251,7 @@ func (c *GenericConsumer) Start(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("consumer receiver stopped with error: %w", err)
 	}
+	receivedMessage = false
 	return nil
 }
 
@@ -201,10 +266,15 @@ func (c *GenericConsumer) EventChan() chan *cloudevents.Event {
 	return c.eventChan
 }
 
+func (c *GenericConsumer) ConfigChan() chan *transport.TransportInternalConfig {
+	return c.transportConfigChan
+}
+
 func getInitOffset(kafkaClusterIdentity string) ([]kafka.TopicPartition, error) {
 	db := database.GetGorm()
 	var positions []models.Transport
-	err := db.Where("name ~ ?", "^status*").
+	// TODO: clean the expired offset, maybe consider to delete the record when detach the managed hub
+	err := db.
 		Where("payload->>'ownerIdentity' <> ? AND payload->>'ownerIdentity' = ?", "", kafkaClusterIdentity).
 		Find(&positions).Error
 	if err != nil {
@@ -231,14 +301,31 @@ func getInitOffset(kafkaClusterIdentity string) ([]kafka.TopicPartition, error) 
 	return offsetToStart, nil
 }
 
-func getConfluentReceiverProtocol(transportConfig *transport.TransportInternalConfig, topics []string) (
+// func getSaramaReceiverProtocol(transportConfig *transport.TransportConfig) (interface{}, error) {
+// 	saramaConfig, err := config.GetSaramaConfig(transportConfig.KafkaConfig)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	// if set this to false, it will consume message from beginning when restart the client
+// 	saramaConfig.Consumer.Offsets.AutoCommit.Enable = true
+// 	saramaConfig.Consumer.Offsets.Initial = sarama.OffsetOldest
+// 	// set the consumer groupId = clientId
+// 	return kafka_sarama.NewConsumer([]string{transportConfig.KafkaConfig.BootstrapServer}, saramaConfig,
+// 		transportConfig.KafkaConfig.ConsumerConfig.ConsumerID,
+// 		transportConfig.KafkaConfig.ConsumerConfig.ConsumerTopic)
+// }
+
+func getConfluentReceiverProtocol(transportConfig *transport.TransportInternalConfig,
+	topics []string, topicMetadataRefreshInterval int) (
 	*kafka.Consumer, interface{}, error,
 ) {
 	configMap, err := config.GetConfluentConfigMapByKafkaCredential(transportConfig.KafkaCredential,
-		transportConfig.KafkaCredential.ConsumerGroupID)
+		transportConfig.KafkaCredential.ConsumerGroupID, topicMetadataRefreshInterval)
 	if err != nil {
 		return nil, nil, err
 	}
+	log.Debugw("the configurations applied to the Kafka consumer", "configMap",
+		utils.FilterSensitiveKafkaConfig(configMap))
 
 	consumer, err := kafka.NewConsumer(configMap)
 	if err != nil {
@@ -251,8 +338,4 @@ func getConfluentReceiverProtocol(transportConfig *transport.TransportInternalCo
 		return nil, nil, err
 	}
 	return consumer, protocol, nil
-}
-
-func TransportID() string {
-	return transportID
 }

--- a/pkg/transport/consumer/generic_consumer_test.go
+++ b/pkg/transport/consumer/generic_consumer_test.go
@@ -1,12 +1,12 @@
 package consumer
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
-	"time"
 
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	"github.com/stretchr/testify/assert"
 	"gorm.io/gorm/clause"
 
@@ -17,15 +17,21 @@ import (
 )
 
 func TestGenerateConsumer(t *testing.T) {
-	consumer, err := NewGenericConsumer(true, false)
+	mockKafkaCluster, err := kafka.NewMockCluster(1)
 	if err != nil {
+		t.Errorf("failed to init mock kafka cluster - %v", err)
+	}
+	transportConfig := &transport.TransportInternalConfig{
+		TransportType: "kafka",
+		KafkaCredential: &transport.KafkaConfig{
+			BootstrapServer: mockKafkaCluster.BootstrapServers(),
+			SpecTopic:       "test-topic",
+			ConsumerGroupID: "test-consumer",
+		},
+	}
+	_, err = NewGenericConsumer(transportConfig, []string{transportConfig.KafkaCredential.SpecTopic})
+	if err != nil && !strings.Contains(err.Error(), "client has run out of available brokers") {
 		t.Errorf("failed to generate consumer - %v", err)
-	}
-	if consumer == nil {
-		t.Fatal("consumer should not be nil")
-	}
-	if consumer.eventChan == nil {
-		t.Fatal("eventChan should be initialized")
 	}
 }
 
@@ -38,12 +44,10 @@ func TestGetInitOffset(t *testing.T) {
 	databaseTransports := []models.Transport{}
 
 	kafkaClusterIdentity := "clusterID"
-	deprecatedTransport := generateTransport(kafkaClusterIdentity, "status.hub6", 9)
-	deprecatedTransport.UpdatedAt = time.Now().AddDate(0, 0, -8)
 	databaseTransports = append(databaseTransports, generateTransport(kafkaClusterIdentity, "status.hub1", 12))
 	databaseTransports = append(databaseTransports, generateTransport(kafkaClusterIdentity, "status.hub2", 11))
 	databaseTransports = append(databaseTransports, generateTransport(kafkaClusterIdentity, "status", 9))
-	databaseTransports = append(databaseTransports, deprecatedTransport)
+	databaseTransports = append(databaseTransports, generateTransport(kafkaClusterIdentity, "spec", 9))
 	databaseTransports = append(databaseTransports, generateTransport("", "status.hub3", 8))
 	databaseTransports = append(databaseTransports, generateTransport("another", "status.hub4", 7))
 
@@ -58,9 +62,12 @@ func TestGetInitOffset(t *testing.T) {
 	count := 0
 	for _, offset := range offsets {
 		fmt.Println(*offset.Topic, offset.Partition, offset.Offset)
+		if *offset.Topic == "spec" {
+			t.Fatalf("the topic %s shouldn't be selected", "spec")
+		}
 		count++
 	}
-	assert.Equal(t, 4, count)
+	assert.Equal(t, 3, count)
 }
 
 func generateTransport(ownerIdentity string, topic string, offset int64) models.Transport {
@@ -74,293 +81,4 @@ func generateTransport(ownerIdentity string, topic string, offset int64) models.
 		Name:    topic,
 		Payload: payload,
 	}
-}
-
-func TestNewBackoff(t *testing.T) {
-	backoff := newBackoff()
-
-	assert.Equal(t, 1*time.Second, backoff.Duration, "initial duration should be 1 second")
-	assert.Equal(t, 2.0, backoff.Factor, "factor should be 2.0")
-	assert.Equal(t, 0.1, backoff.Jitter, "jitter should be 0.1")
-	assert.Equal(t, 30*time.Second, backoff.Cap, "cap should be 30 seconds")
-}
-
-func TestResetBackoff(t *testing.T) {
-	consumer, err := NewGenericConsumer(true, false)
-	assert.NoError(t, err)
-
-	// Step the backoff multiple times to increase duration
-	_ = consumer.backoff.Step()
-	_ = consumer.backoff.Step()
-	_ = consumer.backoff.Step()
-
-	// Reset the backoff
-	consumer.resetBackoff()
-
-	// Verify backoff is reset to initial state
-	assert.Equal(t, 1*time.Second, consumer.backoff.Duration, "duration should be reset to 1 second")
-}
-
-func TestGetBackoffDuration(t *testing.T) {
-	consumer, err := NewGenericConsumer(false, false)
-	assert.NoError(t, err)
-
-	t.Run("exponential backoff increases duration", func(t *testing.T) {
-		// Reset to ensure clean state
-		consumer.resetBackoff()
-
-		// First call should return around 1s (with some jitter)
-		d1 := consumer.getBackoffDuration(time.Now())
-		assert.True(t, d1 >= 900*time.Millisecond && d1 <= 1100*time.Millisecond,
-			"first backoff should be around 1s, got %v", d1)
-
-		// Second call should return around 2s (with some jitter)
-		d2 := consumer.getBackoffDuration(time.Now())
-		assert.True(t, d2 >= 1800*time.Millisecond && d2 <= 2200*time.Millisecond,
-			"second backoff should be around 2s, got %v", d2)
-
-		// Third call should return around 4s (with some jitter)
-		d3 := consumer.getBackoffDuration(time.Now())
-		assert.True(t, d3 >= 3600*time.Millisecond && d3 <= 4400*time.Millisecond,
-			"third backoff should be around 4s, got %v", d3)
-	})
-
-	t.Run("backoff resets after stable connection", func(t *testing.T) {
-		consumer.resetBackoff()
-
-		// Step multiple times to increase backoff
-		_ = consumer.getBackoffDuration(time.Now())
-		_ = consumer.getBackoffDuration(time.Now())
-		_ = consumer.getBackoffDuration(time.Now())
-
-		// Simulate stable connection (started more than 1 minute ago)
-		stableStartTime := time.Now().Add(-2 * time.Minute)
-
-		// This should reset the backoff because connection was stable
-		d := consumer.getBackoffDuration(stableStartTime)
-
-		// After reset, duration should be around 1s again
-		assert.True(t, d >= 900*time.Millisecond && d <= 1100*time.Millisecond,
-			"backoff should reset to around 1s after stable connection, got %v", d)
-	})
-
-	t.Run("backoff caps at 30 seconds", func(t *testing.T) {
-		consumer.resetBackoff()
-
-		// Step many times to hit the cap
-		var lastDuration time.Duration
-		for range 10 {
-			lastDuration = consumer.getBackoffDuration(time.Now())
-		}
-
-		// Should be capped at 30 seconds (with some jitter)
-		assert.True(t, lastDuration <= 33*time.Second,
-			"backoff should be capped at around 30s, got %v", lastDuration)
-	})
-}
-
-func TestNewGenericConsumerForAgent(t *testing.T) {
-	// Test creating consumer for agent (isManager=false)
-	consumer, err := NewGenericConsumer(false, false)
-	assert.NoError(t, err)
-	assert.NotNil(t, consumer)
-	assert.NotNil(t, consumer.eventChan)
-	assert.NotNil(t, consumer.assembler)
-	assert.Equal(t, false, consumer.isManager)
-	assert.Equal(t, 0, consumer.topicMetadataRefreshInterval)
-}
-
-func TestNewGenericConsumerForManager(t *testing.T) {
-	// Test creating consumer for manager (isManager=true)
-	consumer, err := NewGenericConsumer(true, true)
-	assert.NoError(t, err)
-	assert.NotNil(t, consumer)
-	assert.Equal(t, true, consumer.isManager)
-	assert.Equal(t, true, consumer.enableDatabaseOffset)
-	assert.NotEqual(t, 0, consumer.topicMetadataRefreshInterval)
-}
-
-func TestEventChan(t *testing.T) {
-	consumer, err := NewGenericConsumer(true, false)
-	assert.NoError(t, err)
-
-	// EventChan should return the same channel
-	ch := consumer.EventChan()
-	assert.NotNil(t, ch)
-	assert.Equal(t, consumer.eventChan, ch)
-}
-
-func TestInitClientWithChanTransport(t *testing.T) {
-	t.Run("init client for agent with Chan transport", func(t *testing.T) {
-		consumer, err := NewGenericConsumer(false, false)
-		assert.NoError(t, err)
-
-		config := &transport.TransportInternalConfig{
-			TransportType: string(transport.Chan),
-			KafkaCredential: &transport.KafkaConfig{
-				SpecTopic:   "spec-topic",
-				StatusTopic: "status-topic",
-			},
-			Extends: make(map[string]any),
-		}
-
-		client, err := consumer.initClient(config)
-		assert.NoError(t, err)
-		assert.NotNil(t, client)
-		// Verify the topic channel was created in Extends
-		assert.NotNil(t, config.Extends["spec-topic"])
-	})
-
-	t.Run("init client for manager with Chan transport", func(t *testing.T) {
-		consumer, err := NewGenericConsumer(true, false)
-		assert.NoError(t, err)
-
-		config := &transport.TransportInternalConfig{
-			TransportType: string(transport.Chan),
-			KafkaCredential: &transport.KafkaConfig{
-				SpecTopic:   "spec-topic",
-				StatusTopic: "status-topic",
-			},
-			Extends: make(map[string]any),
-		}
-
-		client, err := consumer.initClient(config)
-		assert.NoError(t, err)
-		assert.NotNil(t, client)
-		// Manager consumes from status topic
-		assert.NotNil(t, config.Extends["status-topic"])
-	})
-
-	t.Run("init client with nil Extends creates new map", func(t *testing.T) {
-		consumer, err := NewGenericConsumer(false, false)
-		assert.NoError(t, err)
-
-		config := &transport.TransportInternalConfig{
-			TransportType: string(transport.Chan),
-			KafkaCredential: &transport.KafkaConfig{
-				SpecTopic:   "spec-topic",
-				StatusTopic: "status-topic",
-			},
-			Extends: nil, // nil Extends
-		}
-
-		client, err := consumer.initClient(config)
-		assert.NoError(t, err)
-		assert.NotNil(t, client)
-		assert.NotNil(t, config.Extends)
-	})
-
-	t.Run("init client aliases migration topic to spec topic for Chan transport", func(t *testing.T) {
-		consumer, err := NewGenericConsumer(false, false)
-		assert.NoError(t, err)
-
-		config := &transport.TransportInternalConfig{
-			TransportType: string(transport.Chan),
-			KafkaCredential: &transport.KafkaConfig{
-				SpecTopic:      "gh-spec",
-				MigrationTopic: "gh-migration",
-			},
-			Extends: make(map[string]any),
-		}
-
-		client, err := consumer.initClient(config)
-		assert.NoError(t, err)
-		assert.NotNil(t, client)
-		assert.NotNil(t, config.Extends["gh-spec"])
-		assert.Equal(t, config.Extends["gh-spec"], config.Extends["gh-migration"])
-	})
-
-	t.Run("init client skips migration topic when same as spec topic", func(t *testing.T) {
-		consumer, err := NewGenericConsumer(false, false)
-		assert.NoError(t, err)
-
-		config := &transport.TransportInternalConfig{
-			TransportType: string(transport.Chan),
-			KafkaCredential: &transport.KafkaConfig{
-				SpecTopic:      "gh-spec",
-				MigrationTopic: "gh-spec",
-			},
-			Extends: make(map[string]any),
-		}
-
-		client, err := consumer.initClient(config)
-		assert.NoError(t, err)
-		assert.NotNil(t, client)
-		assert.NotNil(t, config.Extends["gh-spec"])
-		assert.Len(t, config.Extends, 1)
-	})
-
-	t.Run("init client with invalid transport type", func(t *testing.T) {
-		consumer, err := NewGenericConsumer(false, false)
-		assert.NoError(t, err)
-
-		config := &transport.TransportInternalConfig{
-			TransportType: "invalid",
-			KafkaCredential: &transport.KafkaConfig{
-				SpecTopic:   "spec-topic",
-				StatusTopic: "status-topic",
-			},
-		}
-
-		client, err := consumer.initClient(config)
-		assert.Error(t, err)
-		assert.Nil(t, client)
-		assert.Contains(t, err.Error(), "is not a valid option")
-	})
-}
-
-func TestStartWithChanTransport(t *testing.T) {
-	t.Run("start with context cancellation", func(t *testing.T) {
-		consumer, err := NewGenericConsumer(false, false)
-		assert.NoError(t, err)
-
-		ctx, cancel := context.WithCancel(context.Background())
-
-		startErr := make(chan error, 1)
-		go func() {
-			startErr <- consumer.Start(ctx)
-		}()
-
-		// Cancel immediately
-		cancel()
-
-		select {
-		case err := <-startErr:
-			assert.NoError(t, err)
-		case <-time.After(2 * time.Second):
-			t.Fatal("Start did not return after context cancellation")
-		}
-	})
-
-	t.Run("start with invalid transport type returns error", func(t *testing.T) {
-		consumer, err := NewGenericConsumer(false, false)
-		assert.NoError(t, err)
-
-		config := &transport.TransportInternalConfig{
-			TransportType: "invalid-type",
-			KafkaCredential: &transport.KafkaConfig{
-				SpecTopic:   "spec-topic",
-				StatusTopic: "status-topic",
-			},
-		}
-
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
-		startErr := make(chan error, 1)
-		go func() {
-			startErr <- consumer.Start(ctx)
-		}()
-
-		// Send invalid config via consumer's ConfigChan
-		consumer.ConfigChan() <- config
-
-		select {
-		case err := <-startErr:
-			assert.Error(t, err)
-			assert.Contains(t, err.Error(), "failed to init transport client")
-		case <-time.After(2 * time.Second):
-			t.Fatal("Start did not return error for invalid transport type")
-		}
-	})
 }

--- a/pkg/transport/consumer/generic_consumer_test.go
+++ b/pkg/transport/consumer/generic_consumer_test.go
@@ -1,12 +1,12 @@
 package consumer
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"testing"
+	"time"
 
-	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	"github.com/stretchr/testify/assert"
 	"gorm.io/gorm/clause"
 
@@ -17,21 +17,15 @@ import (
 )
 
 func TestGenerateConsumer(t *testing.T) {
-	mockKafkaCluster, err := kafka.NewMockCluster(1)
+	consumer, err := NewGenericConsumer(true, false)
 	if err != nil {
-		t.Errorf("failed to init mock kafka cluster - %v", err)
-	}
-	transportConfig := &transport.TransportInternalConfig{
-		TransportType: "kafka",
-		KafkaCredential: &transport.KafkaConfig{
-			BootstrapServer: mockKafkaCluster.BootstrapServers(),
-			SpecTopic:       "test-topic",
-			ConsumerGroupID: "test-consumer",
-		},
-	}
-	_, err = NewGenericConsumer(transportConfig, []string{transportConfig.KafkaCredential.SpecTopic})
-	if err != nil && !strings.Contains(err.Error(), "client has run out of available brokers") {
 		t.Errorf("failed to generate consumer - %v", err)
+	}
+	if consumer == nil {
+		t.Fatal("consumer should not be nil")
+	}
+	if consumer.eventChan == nil {
+		t.Fatal("eventChan should be initialized")
 	}
 }
 
@@ -44,10 +38,12 @@ func TestGetInitOffset(t *testing.T) {
 	databaseTransports := []models.Transport{}
 
 	kafkaClusterIdentity := "clusterID"
+	deprecatedTransport := generateTransport(kafkaClusterIdentity, "status.hub6", 9)
+	deprecatedTransport.UpdatedAt = time.Now().AddDate(0, 0, -8)
 	databaseTransports = append(databaseTransports, generateTransport(kafkaClusterIdentity, "status.hub1", 12))
 	databaseTransports = append(databaseTransports, generateTransport(kafkaClusterIdentity, "status.hub2", 11))
 	databaseTransports = append(databaseTransports, generateTransport(kafkaClusterIdentity, "status", 9))
-	databaseTransports = append(databaseTransports, generateTransport(kafkaClusterIdentity, "spec", 9))
+	databaseTransports = append(databaseTransports, deprecatedTransport)
 	databaseTransports = append(databaseTransports, generateTransport("", "status.hub3", 8))
 	databaseTransports = append(databaseTransports, generateTransport("another", "status.hub4", 7))
 
@@ -62,12 +58,9 @@ func TestGetInitOffset(t *testing.T) {
 	count := 0
 	for _, offset := range offsets {
 		fmt.Println(*offset.Topic, offset.Partition, offset.Offset)
-		if *offset.Topic == "spec" {
-			t.Fatalf("the topic %s shouldn't be selected", "spec")
-		}
 		count++
 	}
-	assert.Equal(t, 3, count)
+	assert.Equal(t, 4, count)
 }
 
 func generateTransport(ownerIdentity string, topic string, offset int64) models.Transport {
@@ -81,4 +74,293 @@ func generateTransport(ownerIdentity string, topic string, offset int64) models.
 		Name:    topic,
 		Payload: payload,
 	}
+}
+
+func TestNewBackoff(t *testing.T) {
+	backoff := newBackoff()
+
+	assert.Equal(t, 1*time.Second, backoff.Duration, "initial duration should be 1 second")
+	assert.Equal(t, 2.0, backoff.Factor, "factor should be 2.0")
+	assert.Equal(t, 0.1, backoff.Jitter, "jitter should be 0.1")
+	assert.Equal(t, 30*time.Second, backoff.Cap, "cap should be 30 seconds")
+}
+
+func TestResetBackoff(t *testing.T) {
+	consumer, err := NewGenericConsumer(true, false)
+	assert.NoError(t, err)
+
+	// Step the backoff multiple times to increase duration
+	_ = consumer.backoff.Step()
+	_ = consumer.backoff.Step()
+	_ = consumer.backoff.Step()
+
+	// Reset the backoff
+	consumer.resetBackoff()
+
+	// Verify backoff is reset to initial state
+	assert.Equal(t, 1*time.Second, consumer.backoff.Duration, "duration should be reset to 1 second")
+}
+
+func TestGetBackoffDuration(t *testing.T) {
+	consumer, err := NewGenericConsumer(false, false)
+	assert.NoError(t, err)
+
+	t.Run("exponential backoff increases duration", func(t *testing.T) {
+		// Reset to ensure clean state
+		consumer.resetBackoff()
+
+		// First call should return around 1s (with some jitter)
+		d1 := consumer.getBackoffDuration(time.Now())
+		assert.True(t, d1 >= 900*time.Millisecond && d1 <= 1100*time.Millisecond,
+			"first backoff should be around 1s, got %v", d1)
+
+		// Second call should return around 2s (with some jitter)
+		d2 := consumer.getBackoffDuration(time.Now())
+		assert.True(t, d2 >= 1800*time.Millisecond && d2 <= 2200*time.Millisecond,
+			"second backoff should be around 2s, got %v", d2)
+
+		// Third call should return around 4s (with some jitter)
+		d3 := consumer.getBackoffDuration(time.Now())
+		assert.True(t, d3 >= 3600*time.Millisecond && d3 <= 4400*time.Millisecond,
+			"third backoff should be around 4s, got %v", d3)
+	})
+
+	t.Run("backoff resets after stable connection", func(t *testing.T) {
+		consumer.resetBackoff()
+
+		// Step multiple times to increase backoff
+		_ = consumer.getBackoffDuration(time.Now())
+		_ = consumer.getBackoffDuration(time.Now())
+		_ = consumer.getBackoffDuration(time.Now())
+
+		// Simulate stable connection (started more than 1 minute ago)
+		stableStartTime := time.Now().Add(-2 * time.Minute)
+
+		// This should reset the backoff because connection was stable
+		d := consumer.getBackoffDuration(stableStartTime)
+
+		// After reset, duration should be around 1s again
+		assert.True(t, d >= 900*time.Millisecond && d <= 1100*time.Millisecond,
+			"backoff should reset to around 1s after stable connection, got %v", d)
+	})
+
+	t.Run("backoff caps at 30 seconds", func(t *testing.T) {
+		consumer.resetBackoff()
+
+		// Step many times to hit the cap
+		var lastDuration time.Duration
+		for range 10 {
+			lastDuration = consumer.getBackoffDuration(time.Now())
+		}
+
+		// Should be capped at 30 seconds (with some jitter)
+		assert.True(t, lastDuration <= 33*time.Second,
+			"backoff should be capped at around 30s, got %v", lastDuration)
+	})
+}
+
+func TestNewGenericConsumerForAgent(t *testing.T) {
+	// Test creating consumer for agent (isManager=false)
+	consumer, err := NewGenericConsumer(false, false)
+	assert.NoError(t, err)
+	assert.NotNil(t, consumer)
+	assert.NotNil(t, consumer.eventChan)
+	assert.NotNil(t, consumer.assembler)
+	assert.Equal(t, false, consumer.isManager)
+	assert.Equal(t, 0, consumer.topicMetadataRefreshInterval)
+}
+
+func TestNewGenericConsumerForManager(t *testing.T) {
+	// Test creating consumer for manager (isManager=true)
+	consumer, err := NewGenericConsumer(true, true)
+	assert.NoError(t, err)
+	assert.NotNil(t, consumer)
+	assert.Equal(t, true, consumer.isManager)
+	assert.Equal(t, true, consumer.enableDatabaseOffset)
+	assert.NotEqual(t, 0, consumer.topicMetadataRefreshInterval)
+}
+
+func TestEventChan(t *testing.T) {
+	consumer, err := NewGenericConsumer(true, false)
+	assert.NoError(t, err)
+
+	// EventChan should return the same channel
+	ch := consumer.EventChan()
+	assert.NotNil(t, ch)
+	assert.Equal(t, consumer.eventChan, ch)
+}
+
+func TestInitClientWithChanTransport(t *testing.T) {
+	t.Run("init client for agent with Chan transport", func(t *testing.T) {
+		consumer, err := NewGenericConsumer(false, false)
+		assert.NoError(t, err)
+
+		config := &transport.TransportInternalConfig{
+			TransportType: string(transport.Chan),
+			KafkaCredential: &transport.KafkaConfig{
+				SpecTopic:   "spec-topic",
+				StatusTopic: "status-topic",
+			},
+			Extends: make(map[string]any),
+		}
+
+		client, err := consumer.initClient(config)
+		assert.NoError(t, err)
+		assert.NotNil(t, client)
+		// Verify the topic channel was created in Extends
+		assert.NotNil(t, config.Extends["spec-topic"])
+	})
+
+	t.Run("init client for manager with Chan transport", func(t *testing.T) {
+		consumer, err := NewGenericConsumer(true, false)
+		assert.NoError(t, err)
+
+		config := &transport.TransportInternalConfig{
+			TransportType: string(transport.Chan),
+			KafkaCredential: &transport.KafkaConfig{
+				SpecTopic:   "spec-topic",
+				StatusTopic: "status-topic",
+			},
+			Extends: make(map[string]any),
+		}
+
+		client, err := consumer.initClient(config)
+		assert.NoError(t, err)
+		assert.NotNil(t, client)
+		// Manager consumes from status topic
+		assert.NotNil(t, config.Extends["status-topic"])
+	})
+
+	t.Run("init client with nil Extends creates new map", func(t *testing.T) {
+		consumer, err := NewGenericConsumer(false, false)
+		assert.NoError(t, err)
+
+		config := &transport.TransportInternalConfig{
+			TransportType: string(transport.Chan),
+			KafkaCredential: &transport.KafkaConfig{
+				SpecTopic:   "spec-topic",
+				StatusTopic: "status-topic",
+			},
+			Extends: nil, // nil Extends
+		}
+
+		client, err := consumer.initClient(config)
+		assert.NoError(t, err)
+		assert.NotNil(t, client)
+		assert.NotNil(t, config.Extends)
+	})
+
+	t.Run("init client aliases migration topic to spec topic for Chan transport", func(t *testing.T) {
+		consumer, err := NewGenericConsumer(false, false)
+		assert.NoError(t, err)
+
+		config := &transport.TransportInternalConfig{
+			TransportType: string(transport.Chan),
+			KafkaCredential: &transport.KafkaConfig{
+				SpecTopic:      "gh-spec",
+				MigrationTopic: "gh-migration",
+			},
+			Extends: make(map[string]any),
+		}
+
+		client, err := consumer.initClient(config)
+		assert.NoError(t, err)
+		assert.NotNil(t, client)
+		assert.NotNil(t, config.Extends["gh-spec"])
+		assert.Equal(t, config.Extends["gh-spec"], config.Extends["gh-migration"])
+	})
+
+	t.Run("init client skips migration topic when same as spec topic", func(t *testing.T) {
+		consumer, err := NewGenericConsumer(false, false)
+		assert.NoError(t, err)
+
+		config := &transport.TransportInternalConfig{
+			TransportType: string(transport.Chan),
+			KafkaCredential: &transport.KafkaConfig{
+				SpecTopic:      "gh-spec",
+				MigrationTopic: "gh-spec",
+			},
+			Extends: make(map[string]any),
+		}
+
+		client, err := consumer.initClient(config)
+		assert.NoError(t, err)
+		assert.NotNil(t, client)
+		assert.NotNil(t, config.Extends["gh-spec"])
+		assert.Len(t, config.Extends, 1)
+	})
+
+	t.Run("init client with invalid transport type", func(t *testing.T) {
+		consumer, err := NewGenericConsumer(false, false)
+		assert.NoError(t, err)
+
+		config := &transport.TransportInternalConfig{
+			TransportType: "invalid",
+			KafkaCredential: &transport.KafkaConfig{
+				SpecTopic:   "spec-topic",
+				StatusTopic: "status-topic",
+			},
+		}
+
+		client, err := consumer.initClient(config)
+		assert.Error(t, err)
+		assert.Nil(t, client)
+		assert.Contains(t, err.Error(), "is not a valid option")
+	})
+}
+
+func TestStartWithChanTransport(t *testing.T) {
+	t.Run("start with context cancellation", func(t *testing.T) {
+		consumer, err := NewGenericConsumer(false, false)
+		assert.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		startErr := make(chan error, 1)
+		go func() {
+			startErr <- consumer.Start(ctx)
+		}()
+
+		// Cancel immediately
+		cancel()
+
+		select {
+		case err := <-startErr:
+			assert.NoError(t, err)
+		case <-time.After(2 * time.Second):
+			t.Fatal("Start did not return after context cancellation")
+		}
+	})
+
+	t.Run("start with invalid transport type returns error", func(t *testing.T) {
+		consumer, err := NewGenericConsumer(false, false)
+		assert.NoError(t, err)
+
+		config := &transport.TransportInternalConfig{
+			TransportType: "invalid-type",
+			KafkaCredential: &transport.KafkaConfig{
+				SpecTopic:   "spec-topic",
+				StatusTopic: "status-topic",
+			},
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		startErr := make(chan error, 1)
+		go func() {
+			startErr <- consumer.Start(ctx)
+		}()
+
+		// Send invalid config via consumer's ConfigChan
+		consumer.ConfigChan() <- config
+
+		select {
+		case err := <-startErr:
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "failed to init transport client")
+		case <-time.After(2 * time.Second):
+			t.Fatal("Start did not return error for invalid transport type")
+		}
+	})
 }

--- a/pkg/transport/controller/controller.go
+++ b/pkg/transport/controller/controller.go
@@ -198,6 +198,10 @@ func (c *TransportCtrl) ReconcileConsumer(ctx context.Context) error {
 		c.consumerTopics = []string{c.transportConfig.KafkaCredential.StatusTopic}
 	} else {
 		c.consumerTopics = []string{c.transportConfig.KafkaCredential.SpecTopic}
+		if migrationTopic := c.transportConfig.KafkaCredential.GetMigrationTopic(); migrationTopic != "" &&
+			migrationTopic != c.transportConfig.KafkaCredential.SpecTopic {
+			c.consumerTopics = append(c.consumerTopics, migrationTopic)
+		}
 	}
 
 	consumerGroupID := c.transportConfig.KafkaCredential.ConsumerGroupID

--- a/pkg/transport/kafka_config.go
+++ b/pkg/transport/kafka_config.go
@@ -8,6 +8,7 @@ type KafkaConfig struct {
 	BootstrapServer  string `yaml:"bootstrap.server"`
 	StatusTopic      string `yaml:"topic.status,omitempty"`
 	SpecTopic        string `yaml:"topic.spec,omitempty"`
+	MigrationTopic   string `yaml:"topic.migration,omitempty"`
 	ClusterID        string `yaml:"cluster.id,omitempty"`
 	CACert           string `yaml:"ca.crt,omitempty"`
 	ClientCert       string `yaml:"client.crt,omitempty"`
@@ -38,6 +39,7 @@ func (k *KafkaConfig) DeepCopy() *KafkaConfig {
 		BootstrapServer:  k.BootstrapServer,
 		StatusTopic:      k.StatusTopic,
 		SpecTopic:        k.SpecTopic,
+		MigrationTopic:   k.MigrationTopic,
 		ClusterID:        k.ClusterID,
 		ConsumerGroupID:  k.ConsumerGroupID,
 		CACert:           k.CACert,
@@ -78,4 +80,16 @@ func (k *KafkaConfig) GetCASecretName() string {
 
 func (k *KafkaConfig) GetClientSecretName() string {
 	return k.ClientSecretName
+}
+
+// GetMigrationTopic returns the dedicated migration topic, falling back to the spec topic
+// when the credential has not yet been refreshed (upgrade window).
+func (k *KafkaConfig) GetMigrationTopic() string {
+	if k == nil {
+		return ""
+	}
+	if k.MigrationTopic != "" {
+		return k.MigrationTopic
+	}
+	return k.SpecTopic
 }

--- a/pkg/transport/kafka_config_test.go
+++ b/pkg/transport/kafka_config_test.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2023 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package transport
+
+import "testing"
+
+func TestKafkaConfigGetMigrationTopic(t *testing.T) {
+	cfg := &KafkaConfig{
+		SpecTopic:      "gh-spec",
+		MigrationTopic: "gh-migration",
+	}
+	if got := cfg.GetMigrationTopic(); got != "gh-migration" {
+		t.Fatalf("GetMigrationTopic() = %q, want gh-migration", got)
+	}
+
+	fallback := &KafkaConfig{SpecTopic: "gh-spec"}
+	if got := fallback.GetMigrationTopic(); got != "gh-spec" {
+		t.Fatalf("GetMigrationTopic() fallback = %q, want gh-spec", got)
+	}
+
+	var nilCfg *KafkaConfig
+	if got := nilCfg.GetMigrationTopic(); got != "" {
+		t.Fatalf("GetMigrationTopic() nil = %q, want empty string", got)
+	}
+}

--- a/pkg/transport/producer/generic_producer.go
+++ b/pkg/transport/producer/generic_producer.go
@@ -17,6 +17,7 @@ import (
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	"go.uber.org/zap"
 
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport/config"
@@ -52,7 +53,7 @@ func NewGenericProducer(transportConfig *transport.TransportInternalConfig, topi
 ) (*GenericProducer, error) {
 	genericProducer := &GenericProducer{
 		log:               logger.ZapLogger(fmt.Sprintf("%s-producer", transportConfig.TransportType)),
-		messageSizeLimit:  config.MaxSizeToChunk,
+		messageSizeLimit:  constants.KafkaClientMessageMaxBytes,
 		eventErrorHandler: eventErrorHandler,
 	}
 	err := genericProducer.initClient(transportConfig, topic)
@@ -384,7 +385,7 @@ func (p *GenericProducer) SetDataLimit(size int) {
 func getConfluentSenderProtocol(logger *zap.SugaredLogger, kafkaCredentail *transport.KafkaConfig,
 	defaultTopic string,
 ) (*kafka.Producer, *kafka_confluent.Protocol, error) {
-	configMap, err := config.GetConfluentConfigMapByKafkaCredential(kafkaCredentail, "", 0)
+	configMap, err := config.GetConfluentConfigMapByKafkaCredential(kafkaCredentail, "")
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/transport/producer/generic_producer.go
+++ b/pkg/transport/producer/generic_producer.go
@@ -6,6 +6,7 @@ package producer
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	kafka_confluent "github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2"
@@ -16,19 +17,34 @@ import (
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	"go.uber.org/zap"
 
-	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport/config"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport/utils"
 )
 
 type GenericProducer struct {
-	log               *zap.SugaredLogger
-	ceProtocol        interface{}
-	ceClient          cloudevents.Client
-	kafkaProducer     *kafka.Producer
-	messageSizeLimit  int
-	eventErrorHandler func(event *kafka.Message)
+	log                  *zap.SugaredLogger
+	ceProtocol           interface{}
+	ceClient             cloudevents.Client
+	kafkaProducer        *kafka.Producer
+	messageSizeLimit     int
+	eventErrorHandler    func(event *kafka.Message)
+	sendMu               sync.Mutex
+	pendingDeliveryMu    sync.Mutex
+	pendingDelivery      *pendingDeliveryTracker
+	flushConfirmMu       sync.Mutex
+	flushConfirming      bool
+	flushFirstErr        error
+	asyncDeliveryMu      sync.Mutex
+	asyncDeliveryPending int
+}
+
+type pendingDeliveryTracker struct {
+	correlationID string
+	remaining     int
+	firstErr      error
+	done          chan error
 }
 
 func NewGenericProducer(transportConfig *transport.TransportInternalConfig, topic string,
@@ -36,7 +52,7 @@ func NewGenericProducer(transportConfig *transport.TransportInternalConfig, topi
 ) (*GenericProducer, error) {
 	genericProducer := &GenericProducer{
 		log:               logger.ZapLogger(fmt.Sprintf("%s-producer", transportConfig.TransportType)),
-		messageSizeLimit:  constants.KafkaClientMessageMaxBytes,
+		messageSizeLimit:  config.MaxSizeToChunk,
 		eventErrorHandler: eventErrorHandler,
 	}
 	err := genericProducer.initClient(transportConfig, topic)
@@ -56,6 +72,12 @@ func (p *GenericProducer) Protocol() *kafka_confluent.Protocol {
 }
 
 func (p *GenericProducer) SendEvent(ctx context.Context, evt cloudevents.Event) error {
+	p.sendMu.Lock()
+	defer p.sendMu.Unlock()
+	return p.sendEventLocked(ctx, evt)
+}
+
+func (p *GenericProducer) sendEventLocked(ctx context.Context, evt cloudevents.Event) error {
 	// cloudevent kafka/gochan client
 	// message key
 	evtCtx := cectx.WithLogger(ctx, logger.ZapLogger("cloudevents"))
@@ -88,6 +110,209 @@ func (p *GenericProducer) SendEvent(ctx context.Context, evt cloudevents.Event) 
 	return nil
 }
 
+// SendEventWithDeliveryConfirmation sends an event and waits for all Kafka delivery
+// reports for that event (including every chunk). Non-Kafka transports fall back to SendEvent.
+func (p *GenericProducer) SendEventWithDeliveryConfirmation(
+	ctx context.Context, evt cloudevents.Event, timeout time.Duration,
+) error {
+	if p.kafkaProducer == nil {
+		p.sendMu.Lock()
+		defer p.sendMu.Unlock()
+		return p.sendEventLocked(ctx, evt)
+	}
+
+	p.sendMu.Lock()
+	defer p.sendMu.Unlock()
+
+	// Drain in-flight messages from ordinary SendEvent traffic before capturing
+	// delivery errors, so unrelated failures are not attributed to this publish.
+	p.drainKafkaProducerQueue()
+	p.waitAsyncDeliveryReportsSettled(500 * time.Millisecond)
+
+	if err := p.sendEventLocked(ctx, evt); err != nil {
+		return err
+	}
+
+	p.beginFlushConfirmation()
+	defer p.endFlushConfirmation()
+
+	deadline := time.Now().Add(timeout)
+	for {
+		if err := p.flushDeliveryError(); err != nil {
+			return err
+		}
+
+		remaining := p.kafkaProducer.Flush(250)
+		if err := p.flushDeliveryError(); err != nil {
+			return err
+		}
+		if remaining == 0 {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf(
+				"timed out waiting for %d kafka delivery reports after %v",
+				remaining, timeout,
+			)
+		}
+	}
+}
+
+func (p *GenericProducer) beginFlushConfirmation() {
+	p.flushConfirmMu.Lock()
+	defer p.flushConfirmMu.Unlock()
+	p.flushConfirming = true
+	p.flushFirstErr = nil
+}
+
+func (p *GenericProducer) endFlushConfirmation() {
+	p.flushConfirmMu.Lock()
+	defer p.flushConfirmMu.Unlock()
+	p.flushConfirming = false
+	p.flushFirstErr = nil
+}
+
+func (p *GenericProducer) recordFlushDeliveryError(err error) {
+	if err == nil {
+		return
+	}
+	p.flushConfirmMu.Lock()
+	defer p.flushConfirmMu.Unlock()
+	if p.flushConfirming && p.flushFirstErr == nil {
+		p.flushFirstErr = err
+	}
+}
+
+func (p *GenericProducer) flushDeliveryError() error {
+	p.flushConfirmMu.Lock()
+	defer p.flushConfirmMu.Unlock()
+	return p.flushFirstErr
+}
+
+func (p *GenericProducer) drainKafkaProducerQueue() {
+	for {
+		if p.kafkaProducer.Flush(250) == 0 {
+			return
+		}
+	}
+}
+
+func (p *GenericProducer) beginAsyncDeliveryReport() {
+	p.asyncDeliveryMu.Lock()
+	p.asyncDeliveryPending++
+	p.asyncDeliveryMu.Unlock()
+}
+
+func (p *GenericProducer) endAsyncDeliveryReport() {
+	p.asyncDeliveryMu.Lock()
+	p.asyncDeliveryPending--
+	p.asyncDeliveryMu.Unlock()
+}
+
+func (p *GenericProducer) waitAsyncDeliveryReportsSettled(timeout time.Duration) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		p.asyncDeliveryMu.Lock()
+		pending := p.asyncDeliveryPending
+		p.asyncDeliveryMu.Unlock()
+		if pending == 0 {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func (p *GenericProducer) expectedDeliveryReports(evt cloudevents.Event) int {
+	expected := len(p.splitPayloadIntoChunks(evt.Data()))
+	if expected == 0 {
+		return 1
+	}
+	return expected
+}
+
+func (p *GenericProducer) beginPendingDelivery(expected int, correlationID string) *pendingDeliveryTracker {
+	p.pendingDeliveryMu.Lock()
+	defer p.pendingDeliveryMu.Unlock()
+	if p.pendingDelivery != nil {
+		return nil
+	}
+	tracker := &pendingDeliveryTracker{
+		correlationID: correlationID,
+		remaining:     expected,
+		done:          make(chan error, 1),
+	}
+	p.pendingDelivery = tracker
+	return tracker
+}
+
+func (p *GenericProducer) clearPendingDelivery(tracker *pendingDeliveryTracker) {
+	p.pendingDeliveryMu.Lock()
+	defer p.pendingDeliveryMu.Unlock()
+	if p.pendingDelivery == tracker {
+		p.pendingDelivery = nil
+	}
+}
+
+func (p *GenericProducer) recordDeliveryReport(m *kafka.Message) {
+	p.beginAsyncDeliveryReport()
+	defer p.endAsyncDeliveryReport()
+
+	if m != nil && m.TopicPartition.Error != nil {
+		p.recordFlushDeliveryError(m.TopicPartition.Error)
+	}
+
+	correlationID := deliveryCorrelationFromMessage(m)
+	if correlationID == "" {
+		return
+	}
+
+	var deliveryErr error
+	if m.TopicPartition.Error != nil {
+		deliveryErr = m.TopicPartition.Error
+	}
+
+	p.pendingDeliveryMu.Lock()
+	tracker := p.pendingDelivery
+	if tracker == nil || correlationID != tracker.correlationID {
+		p.pendingDeliveryMu.Unlock()
+		return
+	}
+
+	if deliveryErr != nil && tracker.firstErr == nil {
+		tracker.firstErr = deliveryErr
+		p.pendingDelivery = nil
+		p.pendingDeliveryMu.Unlock()
+		tracker.done <- deliveryErr
+		return
+	}
+
+	tracker.remaining--
+	if tracker.remaining <= 0 {
+		p.pendingDelivery = nil
+		pendingErr := tracker.firstErr
+		p.pendingDeliveryMu.Unlock()
+		tracker.done <- pendingErr
+		return
+	}
+	p.pendingDeliveryMu.Unlock()
+}
+
+func deliveryCorrelationFromMessage(m *kafka.Message) string {
+	if m == nil {
+		return ""
+	}
+	if correlationID, ok := m.Opaque.(string); ok && correlationID != "" {
+		return correlationID
+	}
+	headerKey := "ce_" + transport.DeliveryCorrelationKey
+	for _, header := range m.Headers {
+		if header.Key == headerKey {
+			return string(header.Value)
+		}
+	}
+	return ""
+}
+
 // Reconnect close the previous producer state and init a new producer
 func (p *GenericProducer) Reconnect(config *transport.TransportInternalConfig, topic string) error {
 	// cloudevent kafka/gochan client
@@ -104,7 +329,7 @@ func (p *GenericProducer) Reconnect(config *transport.TransportInternalConfig, t
 func (p *GenericProducer) initClient(transportConfig *transport.TransportInternalConfig, topic string) error {
 	switch transportConfig.TransportType {
 	case string(transport.Kafka):
-		producer, kafkaProtocol, err := getConfluentSenderProtocol(transportConfig.KafkaCredential, topic)
+		producer, kafkaProtocol, err := getConfluentSenderProtocol(p.log, transportConfig.KafkaCredential, topic)
 		if err != nil {
 			return err
 		}
@@ -113,7 +338,7 @@ func (p *GenericProducer) initClient(transportConfig *transport.TransportInterna
 		if err != nil {
 			return err
 		}
-		handleProducerEvents(p.log, eventChan, transportConfig.FailureThreshold, p.eventErrorHandler)
+		handleProducerEvents(p, eventChan, transportConfig.FailureThreshold)
 		p.ceProtocol = kafkaProtocol
 		p.kafkaProducer = producer
 	case string(transport.Chan):
@@ -141,7 +366,7 @@ func (p *GenericProducer) initClient(transportConfig *transport.TransportInterna
 
 func (p *GenericProducer) splitPayloadIntoChunks(payload []byte) [][]byte {
 	var chunk []byte
-	chunks := make([][]byte, 0, len(payload)/(p.messageSizeLimit)+1)
+	chunks := make([][]byte, 0, len(payload)/p.messageSizeLimit+1)
 	for len(payload) >= p.messageSizeLimit {
 		chunk, payload = payload[:p.messageSizeLimit], payload[p.messageSizeLimit:]
 		chunks = append(chunks, chunk)
@@ -156,13 +381,16 @@ func (p *GenericProducer) SetDataLimit(size int) {
 	p.messageSizeLimit = size
 }
 
-func getConfluentSenderProtocol(kafkaCredentail *transport.KafkaConfig,
+func getConfluentSenderProtocol(logger *zap.SugaredLogger, kafkaCredentail *transport.KafkaConfig,
 	defaultTopic string,
 ) (*kafka.Producer, *kafka_confluent.Protocol, error) {
-	configMap, err := config.GetConfluentConfigMapByKafkaCredential(kafkaCredentail, "")
+	configMap, err := config.GetConfluentConfigMapByKafkaCredential(kafkaCredentail, "", 0)
 	if err != nil {
 		return nil, nil, err
 	}
+	logger.Debugw("the configurations applied to the Kafka producer", "configMap",
+		utils.FilterSensitiveKafkaConfig(configMap))
+
 	producer, err := kafka.NewProducer(configMap)
 	if err != nil {
 		return nil, nil, err
@@ -175,9 +403,7 @@ func getConfluentSenderProtocol(kafkaCredentail *transport.KafkaConfig,
 	return producer, protocol, nil
 }
 
-func handleProducerEvents(log *zap.SugaredLogger, eventChan chan kafka.Event, transportFailureThreshold int,
-	eventErrorHandler func(event *kafka.Message),
-) {
+func handleProducerEvents(p *GenericProducer, eventChan chan kafka.Event, transportFailureThreshold int) {
 	// Listen to all the events on the default events channel
 	// It's important to read these events otherwise the events channel will eventually fill up
 	go func() {
@@ -192,10 +418,13 @@ func handleProducerEvents(log *zap.SugaredLogger, eventChan chan kafka.Event, tr
 				// is already configured to do that.
 				m := ev
 				if m.TopicPartition.Error != nil {
-					if eventErrorHandler != nil {
-						eventErrorHandler(m)
+					p.recordDeliveryReport(m)
+					if p.eventErrorHandler != nil {
+						p.eventErrorHandler(m)
 					}
-					log.Warnw("delivery failed", "error", m.TopicPartition.Error)
+					p.log.Warnw("delivery failed", "error", m.TopicPartition.Error)
+				} else {
+					p.recordDeliveryReport(m)
 				}
 			case kafka.Error:
 				// Generic client instance-level errors, such as
@@ -210,13 +439,13 @@ func handleProducerEvents(log *zap.SugaredLogger, eventChan chan kafka.Event, tr
 					// to the application that currently there are no brokers to communicate with.
 					// But librdkafka will continue to try to reconnect indefinately,
 					// and it will attempt to re-send messages until message.timeout.ms or message.max.retries are exceeded.
-					log.Debugw("transport producer client error(ALL_BROKERS_DOWN), ignore it for most cases", "error", ev)
+					p.log.Debugw("transport producer client error(ALL_BROKERS_DOWN), ignore it for most cases", "error", ev)
 				} else {
-					log.Warnw("transport producer client error", "error", ev)
+					p.log.Warnw("transport producer client error", "error", ev)
 
 					errorCount++
 					if errorCount >= transportFailureThreshold {
-						log.Panicf("transport producer error > 10 in 5 minutes, error: %v", ev)
+						p.log.Panicf("transport producer error > 10 in 5 minutes, error: %v", ev)
 					}
 					// return panic when error more than 10 times in 5 minites
 					if lastErrorTime.Add(5 * time.Minute).Before(time.Now()) {

--- a/pkg/transport/producer/generic_producer_test.go
+++ b/pkg/transport/producer/generic_producer_test.go
@@ -4,8 +4,11 @@
 package producer
 
 import (
+	"errors"
 	"testing"
+	"time"
 
+	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	"github.com/stretchr/testify/require"
 
@@ -40,10 +43,208 @@ func Test_handleProducerEvents(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			log := logger.DefaultZapLogger()
+			p := &GenericProducer{log: logger.DefaultZapLogger()}
 			eventChan := make(chan kafka.Event)
-			go handleProducerEvents(log, eventChan, tt.transportFailureThreshold, nil)
+			go handleProducerEvents(p, eventChan, tt.transportFailureThreshold)
 			eventChan <- tt.event
 		})
 	}
+}
+
+func TestRecordDeliveryReport_multiChunkSuccess(t *testing.T) {
+	p := &GenericProducer{}
+	const correlationID = "corr-multi"
+	tracker := p.beginPendingDelivery(3, correlationID)
+	require.NotNil(t, tracker)
+
+	p.recordDeliveryReport(kafkaDeliveryReportWithOpaque(correlationID, nil))
+	p.recordDeliveryReport(kafkaDeliveryReportWithOpaque(correlationID, nil))
+	assertPendingNotDone(t, tracker)
+
+	p.recordDeliveryReport(kafkaDeliveryReportWithOpaque(correlationID, nil))
+	require.NoError(t, waitPendingDone(t, tracker))
+}
+
+func TestRecordDeliveryReport_firstChunkFailure(t *testing.T) {
+	p := &GenericProducer{}
+	const correlationID = "corr-fail"
+	tracker := p.beginPendingDelivery(3, correlationID)
+	require.NotNil(t, tracker)
+
+	sendErr := errors.New("Topic authorization failed")
+	p.recordDeliveryReport(kafkaDeliveryReport(correlationID, sendErr))
+
+	require.Equal(t, sendErr, waitPendingDone(t, tracker))
+}
+
+func TestRecordDeliveryReport_ignoredWithoutTracker(t *testing.T) {
+	p := &GenericProducer{}
+	require.NotPanics(t, func() {
+		p.recordDeliveryReport(kafkaDeliveryReport("corr-orphan", nil))
+		p.recordDeliveryReport(kafkaDeliveryReport("corr-orphan", errors.New("ignored")))
+	})
+}
+
+func TestRecordDeliveryReport_ignoresUnrelatedCorrelation(t *testing.T) {
+	p := &GenericProducer{}
+	const correlationID = "corr-current"
+	tracker := p.beginPendingDelivery(2, correlationID)
+	require.NotNil(t, tracker)
+
+	// Pre-existing or unrelated delivery reports must not advance this tracker.
+	p.recordDeliveryReport(kafkaDeliveryReport("corr-old", nil))
+	p.recordDeliveryReport(kafkaDeliveryReport("", nil))
+	assertPendingNotDone(t, tracker)
+
+	p.recordDeliveryReport(kafkaDeliveryReport(correlationID, nil))
+	p.recordDeliveryReport(kafkaDeliveryReport(correlationID, nil))
+	require.NoError(t, waitPendingDone(t, tracker))
+
+	// Late unrelated report after completion is ignored.
+	require.NotPanics(t, func() {
+		p.recordDeliveryReport(kafkaDeliveryReport("corr-old", nil))
+	})
+}
+
+func TestRecordDeliveryReport_lateReportAfterTrackerCleared(t *testing.T) {
+	p := &GenericProducer{}
+	const correlationA = "corr-a"
+	const correlationB = "corr-b"
+
+	trackerA := p.beginPendingDelivery(2, correlationA)
+	require.NotNil(t, trackerA)
+	// Simulate confirmation timeout clearing the tracker before all reports arrive.
+	p.clearPendingDelivery(trackerA)
+
+	trackerB := p.beginPendingDelivery(2, correlationB)
+	require.NotNil(t, trackerB)
+
+	// Late report from tracker A must not satisfy tracker B.
+	p.recordDeliveryReport(kafkaDeliveryReport(correlationA, nil))
+	assertPendingNotDone(t, trackerB)
+
+	p.recordDeliveryReport(kafkaDeliveryReport(correlationB, nil))
+	p.recordDeliveryReport(kafkaDeliveryReport(correlationB, nil))
+	require.NoError(t, waitPendingDone(t, trackerB))
+}
+
+func TestDeliveryCorrelationFromMessage(t *testing.T) {
+	require.Equal(t, "abc", deliveryCorrelationFromMessage(kafkaDeliveryReport("abc", nil)))
+	require.Equal(t, "opaque-id", deliveryCorrelationFromMessage(kafkaDeliveryReportWithOpaque("opaque-id", nil)))
+	require.Equal(t, "", deliveryCorrelationFromMessage(kafkaDeliveryReport("", nil)))
+	require.Equal(t, "", deliveryCorrelationFromMessage(nil))
+}
+
+func TestExpectedDeliveryReports(t *testing.T) {
+	p := &GenericProducer{messageSizeLimit: 4}
+
+	evt := cloudeventsEventWithData([]byte("123456789"))
+	require.Equal(t, 3, p.expectedDeliveryReports(evt))
+
+	evt = cloudeventsEventWithData(nil)
+	require.Equal(t, 1, p.expectedDeliveryReports(evt))
+}
+
+func TestBeginPendingDelivery_rejectsConcurrentTracker(t *testing.T) {
+	p := &GenericProducer{}
+	first := p.beginPendingDelivery(1, "corr-1")
+	require.NotNil(t, first)
+	require.Nil(t, p.beginPendingDelivery(1, "corr-2"))
+}
+
+func TestRecordFlushDeliveryError_ignoredWhenNotConfirming(t *testing.T) {
+	p := &GenericProducer{}
+	p.recordFlushDeliveryError(errors.New("unrelated"))
+	require.NoError(t, p.flushDeliveryError())
+}
+
+func TestFlushConfirmation_ignoresPredrainDeliveryErrors(t *testing.T) {
+	p := &GenericProducer{}
+
+	// Simulate an ordinary SendEvent failure still being processed before confirmation.
+	p.recordDeliveryReport(kafkaDeliveryReport("", errors.New("unrelated ordinary send failure")))
+	require.NoError(t, p.flushDeliveryError())
+
+	p.waitAsyncDeliveryReportsSettled(time.Second)
+
+	p.beginFlushConfirmation()
+	defer p.endFlushConfirmation()
+
+	p.recordDeliveryReport(kafkaDeliveryReport("", nil))
+	require.NoError(t, p.flushDeliveryError())
+}
+
+func TestFlushConfirmation_unrelatedErrorDuringConfirmationStillFails(t *testing.T) {
+	p := &GenericProducer{}
+
+	p.beginFlushConfirmation()
+	defer p.endFlushConfirmation()
+
+	unrelatedErr := errors.New("unrelated failure during confirmation window")
+	p.recordDeliveryReport(kafkaDeliveryReport("", unrelatedErr))
+	require.Equal(t, unrelatedErr, p.flushDeliveryError())
+}
+
+func TestWaitAsyncDeliveryReportsSettled_waitsForInFlightHandler(t *testing.T) {
+	p := &GenericProducer{}
+	p.beginAsyncDeliveryReport()
+
+	done := make(chan struct{})
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		p.endAsyncDeliveryReport()
+		close(done)
+	}()
+
+	p.waitAsyncDeliveryReportsSettled(time.Second)
+	<-done
+}
+
+func assertPendingNotDone(t *testing.T, tracker *pendingDeliveryTracker) {
+	t.Helper()
+	select {
+	case err := <-tracker.done:
+		t.Fatalf("expected pending delivery to remain open, got %v", err)
+	default:
+	}
+}
+
+func waitPendingDone(t *testing.T, tracker *pendingDeliveryTracker) error {
+	t.Helper()
+	select {
+	case err := <-tracker.done:
+		return err
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for pending delivery")
+		return nil
+	}
+}
+
+func kafkaDeliveryReport(correlationID string, deliveryErr error) *kafka.Message {
+	msg := &kafka.Message{}
+	if correlationID != "" {
+		msg.Headers = []kafka.Header{{
+			Key:   "ce_" + transport.DeliveryCorrelationKey,
+			Value: []byte(correlationID),
+		}}
+	}
+	if deliveryErr != nil {
+		msg.TopicPartition.Error = deliveryErr
+	}
+	return msg
+}
+
+func kafkaDeliveryReportWithOpaque(correlationID string, deliveryErr error) *kafka.Message {
+	msg := &kafka.Message{Opaque: correlationID}
+	if deliveryErr != nil {
+		msg.TopicPartition.Error = deliveryErr
+	}
+	return msg
+}
+
+func cloudeventsEventWithData(data []byte) cloudevents.Event {
+	evt := cloudevents.NewEvent()
+	evt.SetType("test.event")
+	_ = evt.SetData(cloudevents.ApplicationJSON, data)
+	return evt
 }

--- a/pkg/transport/type.go
+++ b/pkg/transport/type.go
@@ -8,6 +8,8 @@ const (
 	Broadcast      = "broadcast" // Broadcast can be used as destination when a bundle should be broadcasted.
 	ChunkSizeKey   = "extsize"   // ChunkSizeKey is the key used for total bundle size header.
 	ChunkOffsetKey = "extoffset" // ChunkOffsetKey is the key used for message fragment offset header.
+	// DeliveryCorrelationKey tags Kafka messages during producer delivery confirmation.
+	DeliveryCorrelationKey = "deliverycorrelation"
 )
 
 // indicate the transport type, only support kafka or go chan
@@ -36,7 +38,7 @@ type TransportInternalConfig struct {
 	CommitterInterval time.Duration
 	// EnableDatabaseOffset affects only the manager, deciding if consumption starts from a database-stored offset
 	EnableDatabaseOffset bool
-	// set the kafka credentail in the transport controller
+	// set the kafka credential in the transport controller
 	KafkaCredential   *KafkaConfig
 	RestfulCredential *RestfulConfig
 	Extends           map[string]interface{}
@@ -67,15 +69,16 @@ type KafkaConsumerConfig struct {
 
 // topics
 type ClusterTopic struct {
-	SpecTopic   string
-	StatusTopic string
+	SpecTopic      string
+	MigrationTopic string
+	StatusTopic    string
 }
 
 type EventPosition struct {
 	Topic     string `json:"-"`
 	Partition int32  `json:"partition"`
 	Offset    int64  `json:"offset"`
-	// define the kafka cluster identiy:
+	// define the kafka cluster identity:
 	// 1. built in kafka, use the kafka cluster id
 	// 2. byo kafka, use the kafka bootstrapserver as the identity
 	OwnerIdentity string `json:"ownerIdentity"`

--- a/pkg/transport/utils/utils.go
+++ b/pkg/transport/utils/utils.go
@@ -1,0 +1,29 @@
+package utils
+
+import (
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
+)
+
+var sensitiveKafkaConfigKeys = map[string]struct{}{
+	"bootstrap.servers":   {},
+	"sasl.username":       {},
+	"sasl.password":       {},
+	"ssl.ca.pem":          {},
+	"ssl.certificate.pem": {},
+	"ssl.key.pem":         {},
+	"ssl.key.password":    {},
+}
+
+// FilterSensitiveKafkaConfig filters out sensitive data from Kafka ConfigMap for safe logging.
+// It replaces broker endpoints, credentials, and certificate/key values with "[REDACTED]".
+func FilterSensitiveKafkaConfig(configMap *kafka.ConfigMap) map[string]interface{} {
+	safeConfig := make(map[string]interface{})
+	for key, value := range *configMap {
+		if _, sensitive := sensitiveKafkaConfigKeys[key]; sensitive {
+			safeConfig[key] = "[REDACTED]"
+		} else {
+			safeConfig[key] = value
+		}
+	}
+	return safeConfig
+}

--- a/pkg/transport/utils/utils_test.go
+++ b/pkg/transport/utils/utils_test.go
@@ -1,0 +1,96 @@
+package utils
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
+)
+
+func TestFilterSensitiveKafkaConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    kafka.ConfigMap
+		expected map[string]interface{}
+	}{
+		{
+			name: "No sensitive keys",
+			input: kafka.ConfigMap{
+				"group.id":          "test-group",
+				"security.protocol": "SSL",
+			},
+			expected: map[string]interface{}{
+				"group.id":          "test-group",
+				"security.protocol": "SSL",
+			},
+		},
+		{
+			name: "All sensitive keys present",
+			input: kafka.ConfigMap{
+				"ssl.ca.pem":          "ca-data",
+				"ssl.certificate.pem": "cert-data",
+				"ssl.key.pem":         "key-data",
+				"bootstrap.servers":   "localhost:9092",
+				"sasl.username":       "user",
+				"sasl.password":       "secret",
+			},
+			expected: map[string]interface{}{
+				"ssl.ca.pem":          "[REDACTED]",
+				"ssl.certificate.pem": "[REDACTED]",
+				"ssl.key.pem":         "[REDACTED]",
+				"bootstrap.servers":   "[REDACTED]",
+				"sasl.username":       "[REDACTED]",
+				"sasl.password":       "[REDACTED]",
+			},
+		},
+		{
+			name: "Some sensitive keys present",
+			input: kafka.ConfigMap{
+				"ssl.ca.pem":        "ca-data",
+				"bootstrap.servers": "localhost:9092",
+			},
+			expected: map[string]interface{}{
+				"ssl.ca.pem":        "[REDACTED]",
+				"bootstrap.servers": "[REDACTED]",
+			},
+		},
+		{
+			name:     "Empty config",
+			input:    kafka.ConfigMap{},
+			expected: map[string]interface{}{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FilterSensitiveKafkaConfig(&tt.input)
+			assertFilteredKafkaConfig(t, result, tt.expected)
+		})
+	}
+}
+
+func assertFilteredKafkaConfig(t *testing.T, got, want map[string]interface{}) {
+	t.Helper()
+
+	for key, wantVal := range want {
+		gotVal, ok := got[key]
+		if !ok {
+			t.Errorf("missing key %q in filtered config", key)
+			continue
+		}
+		if reflect.DeepEqual(gotVal, wantVal) {
+			continue
+		}
+		if _, sensitive := sensitiveKafkaConfigKeys[key]; sensitive {
+			t.Errorf("key %q: expected redaction marker, got unexpected value", key)
+			continue
+		}
+		t.Errorf("key %q: got %v, want %v", key, gotVal, wantVal)
+	}
+
+	for key := range got {
+		if _, ok := want[key]; !ok {
+			t.Errorf("unexpected key %q in filtered config", key)
+		}
+	}
+}

--- a/test/Makefile
+++ b/test/Makefile
@@ -21,6 +21,7 @@ e2e-test-all: tidy vendor
 	sh ./test/script/e2e_run.sh -f "e2e-test-transport-identity" -v $(VERBOSE)
 	sh ./test/script/e2e_run_byo.sh -v $(VERBOSE)
 	sh ./test/script/e2e_clean_globalhub.sh -n mgh
+	sh ./test/script/e2e_clean_globalhub.sh
 	sh ./test/script/e2e_run.sh -f "e2e-test-transport-migration-topic" -v $(VERBOSE)
 
 e2e-test-cluster e2e-test-local-agent e2e-test-placement e2e-test-app e2e-test-policy e2e-test-localpolicy e2e-test-grafana e2e-test-agent e2e-test-transport-identity e2e-test-transport-migration-topic: tidy vendor

--- a/test/Makefile
+++ b/test/Makefile
@@ -18,10 +18,8 @@ e2e-test-all: tidy vendor
 	sh ./test/script/e2e_run.sh -f "e2e-test-localpolicy,e2e-test-placement,e2e-test-app,e2e-test-policy,e2e-tests-backup,e2e-test-grafana,e2e-test-agent,e2e-test-local-agent" -v $(VERBOSE)
 	sh ./test/script/e2e_run.sh -f "e2e-test-prune" -v $(VERBOSE)
 	sh ./test/script/e2e_clean_globalhub.sh
-	sh ./test/script/e2e_run.sh -f "e2e-test-transport-identity" -v $(VERBOSE)
 	sh ./test/script/e2e_run_byo.sh -v $(VERBOSE)
-	sh ./test/script/e2e_clean_globalhub.sh -n mgh
-	sh ./test/script/e2e_clean_globalhub.sh
+	sh ./test/script/e2e_run.sh -f "e2e-test-transport-identity" -v $(VERBOSE)
 	sh ./test/script/e2e_run.sh -f "e2e-test-transport-migration-topic" -v $(VERBOSE)
 
 e2e-test-cluster e2e-test-local-agent e2e-test-placement e2e-test-app e2e-test-policy e2e-test-localpolicy e2e-test-grafana e2e-test-agent e2e-test-transport-identity e2e-test-transport-migration-topic: tidy vendor

--- a/test/Makefile
+++ b/test/Makefile
@@ -20,8 +20,9 @@ e2e-test-all: tidy vendor
 	sh ./test/script/e2e_clean_globalhub.sh
 	sh ./test/script/e2e_run.sh -f "e2e-test-transport-identity" -v $(VERBOSE)
 	sh ./test/script/e2e_run_byo.sh -v $(VERBOSE)
+	sh ./test/script/e2e_run.sh -f "e2e-test-transport-migration-topic" -v $(VERBOSE)
 
-e2e-test-cluster e2e-test-local-agent e2e-test-placement e2e-test-app e2e-test-policy e2e-test-localpolicy e2e-test-grafana e2e-test-agent e2e-test-transport-identity: tidy vendor
+e2e-test-cluster e2e-test-local-agent e2e-test-placement e2e-test-app e2e-test-policy e2e-test-localpolicy e2e-test-grafana e2e-test-agent e2e-test-transport-identity e2e-test-transport-migration-topic: tidy vendor
 	./test/script/e2e_run.sh -f $@ -v $(VERBOSE)
 
 e2e-prow-tests: 

--- a/test/Makefile
+++ b/test/Makefile
@@ -20,6 +20,7 @@ e2e-test-all: tidy vendor
 	sh ./test/script/e2e_clean_globalhub.sh
 	sh ./test/script/e2e_run.sh -f "e2e-test-transport-identity" -v $(VERBOSE)
 	sh ./test/script/e2e_run_byo.sh -v $(VERBOSE)
+	sh ./test/script/e2e_clean_globalhub.sh -n mgh
 	sh ./test/script/e2e_run.sh -f "e2e-test-transport-migration-topic" -v $(VERBOSE)
 
 e2e-test-cluster e2e-test-local-agent e2e-test-placement e2e-test-app e2e-test-policy e2e-test-localpolicy e2e-test-grafana e2e-test-agent e2e-test-transport-identity e2e-test-transport-migration-topic: tidy vendor

--- a/test/Makefile
+++ b/test/Makefile
@@ -15,7 +15,7 @@ e2e-cleanup:
 	./test/script/e2e_cleanup.sh
 
 e2e-test-all: tidy vendor
-	sh ./test/script/e2e_run.sh -f "e2e-test-localpolicy,e2e-test-placement,e2e-test-app,e2e-test-policy,e2e-tests-backup,e2e-test-grafana,e2e-test-agent,e2e-test-local-agent" -v $(VERBOSE)
+	sh ./test/script/e2e_run.sh -f "e2e-test-localpolicy,e2e-tests-backup,e2e-test-grafana,e2e-test-local-agent" -v $(VERBOSE)
 	sh ./test/script/e2e_run.sh -f "e2e-test-prune" -v $(VERBOSE)
 	sh ./test/script/e2e_clean_globalhub.sh
 	sh ./test/script/e2e_run_byo.sh -v $(VERBOSE)

--- a/test/e2e/application_test.go
+++ b/test/e2e/application_test.go
@@ -27,8 +27,20 @@ const (
 
 var _ = Describe("Deploy the application to the managed cluster", Label("e2e-test-app"), Ordered, func() {
 	BeforeAll(func() {
-		_, err := testClients.Kubectl(testOptions.GlobalHub.Name, "apply", "-f", APP_SUB_YAML)
-		Expect(err).To(Succeed())
+		By("Clean up overlapping helloworld app resources from the placement e2e")
+		Eventually(func() error {
+			if _, err := testClients.Kubectl(testOptions.GlobalHub.Name, "delete", "-f", PLACEMENT_APP_SUB_YAML, "--ignore-not-found"); err != nil {
+				return err
+			}
+			_, err := testClients.Kubectl(testOptions.GlobalHub.Name, "delete", "-f", APP_SUB_YAML, "--ignore-not-found")
+			return err
+		}, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+		By("Deploy the application subscription manifest")
+		Eventually(func() error {
+			_, err := testClients.Kubectl(testOptions.GlobalHub.Name, "apply", "-f", APP_SUB_YAML)
+			return err
+		}, 2*time.Minute, 5*time.Second).Should(Succeed())
 	})
 	Context("deploy the application", func() {
 		It("deploy the application/subscription", func() {

--- a/test/e2e/grafana_test.go
+++ b/test/e2e/grafana_test.go
@@ -328,7 +328,6 @@ func getGrafanaResource(ctx context.Context, path string) (int, error) {
 
 	responseBody, err := testClients.Kubectl(testOptions.GlobalHub.Name,
 		"exec",
-		"-it",
 		grafanaPod.Name,
 		"-n",
 		configNamespace,

--- a/test/e2e/grafana_test.go
+++ b/test/e2e/grafana_test.go
@@ -2,13 +2,14 @@ package tests
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"gopkg.in/ini.v1"
-	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
@@ -302,26 +303,10 @@ var _ = Describe("The grafana resources counts should be right", Ordered, Label(
 func getGrafanaResource(ctx context.Context, path string) (int, error) {
 	configNamespace := testOptions.GlobalHub.Namespace
 
-	labelSelector := fmt.Sprintf("name=%s", grafanaDeploymentName)
-	var grafanaPod corev1.Pod
-	Eventually(func() error {
-		poList, err := testClients.KubeClient().CoreV1().Pods(configNamespace).List(ctx, metav1.ListOptions{
-			LabelSelector: labelSelector,
-		})
-		if err != nil {
-			return err
-		}
-
-		klog.Infof("Get grafana path:%v", path)
-		if len(poList.Items) == 0 {
-			return fmt.Errorf("Can not get grafana pod")
-		}
-		if len(poList.Items[0].Status.PodIP) == 0 {
-			return fmt.Errorf("Can not get grafana pod IP")
-		}
-		grafanaPod = poList.Items[0]
-		return nil
-	}, 2*time.Minute, 1*time.Second).ShouldNot(HaveOccurred())
+	grafanaPod, err := getReadyGrafanaPod(ctx, configNamespace)
+	if err != nil {
+		return 0, err
+	}
 
 	url := "http://" + grafanaPod.Status.PodIP + ":3001/api/" + path
 	klog.Infof("Sending request: %v", url)
@@ -335,32 +320,65 @@ func getGrafanaResource(ctx context.Context, path string) (int, error) {
 		"grafana",
 		"--",
 		"/usr/bin/curl",
+		"-sf",
 		"-H",
 		"Content-Type: application/json",
 		"-H",
 		"X-Forwarded-User: WHAT_YOU_ARE_DOING_IS_VOIDING_SUPPORT_0000000000000000000000000000000000000000000000000000000000000000",
 		url)
 	if err != nil {
-		klog.Errorf("responseBody: %v, err: %v", string(responseBody), err)
+		klog.Errorf("grafana API request failed for %s: %v", path, err)
 		return 0, err
 	}
 
-	var mapObj map[string]interface{}
-	var arrayObj []interface{}
-
+	responseBody = strings.TrimSpace(responseBody)
 	if len(responseBody) == 0 {
-		return 0, nil
+		return 0, fmt.Errorf("empty response from grafana API %s", path)
 	}
 
-	err = yaml.Unmarshal([]byte(responseBody), &mapObj)
-	if err == nil {
+	var mapObj map[string]interface{}
+	if err := json.Unmarshal([]byte(responseBody), &mapObj); err == nil {
 		return 1, nil
 	}
 
-	err = yaml.Unmarshal([]byte(responseBody), &arrayObj)
-	if err == nil {
+	var arrayObj []interface{}
+	if err := json.Unmarshal([]byte(responseBody), &arrayObj); err == nil {
 		return len(arrayObj), nil
 	}
 
-	return 0, err
+	return 0, fmt.Errorf("grafana API %s returned non-JSON response", path)
+}
+
+func getReadyGrafanaPod(ctx context.Context, namespace string) (*corev1.Pod, error) {
+	labelSelector := fmt.Sprintf("name=%s", grafanaDeploymentName)
+	poList, err := testClients.KubeClient().CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(poList.Items) == 0 {
+		return nil, fmt.Errorf("grafana pod not found")
+	}
+
+	pod := poList.Items[0]
+	if pod.Status.PodIP == "" {
+		return nil, fmt.Errorf("grafana pod IP is not assigned")
+	}
+	if pod.Status.Phase != corev1.PodRunning {
+		return nil, fmt.Errorf("grafana pod is not running: %s", pod.Status.Phase)
+	}
+
+	grafanaReady := false
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.Name == "grafana" && cs.Ready {
+			grafanaReady = true
+			break
+		}
+	}
+	if !grafanaReady {
+		return nil, fmt.Errorf("grafana container is not ready")
+	}
+
+	return &pod, nil
 }

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -336,40 +336,8 @@ func deployGlobalHub() {
 	Expect(err).NotTo(HaveOccurred())
 
 	By("Removing stale e2e nonk8s NodePort service if present")
-	// nodePort 30080 is cluster-scoped; transport-identity may leave the service in the default GH ns while BYO deploys to mgh.
-	nonk8sServiceNamespaces := []string{testOptions.GlobalHub.Namespace, commonconstants.GHDefaultNamespace}
-	seenNamespaces := map[string]struct{}{}
-	for _, ns := range nonk8sServiceNamespaces {
-		if ns == "" {
-			continue
-		}
-		if _, exists := seenNamespaces[ns]; exists {
-			continue
-		}
-		seenNamespaces[ns] = struct{}{}
-		err = testClients.KubeClient().CoreV1().Services(ns).Delete(ctx,
-			"multicluster-global-hub-manager-nonk8s-service", metav1.DeleteOptions{})
-		if err != nil && !errors.IsNotFound(err) {
-			Expect(err).NotTo(HaveOccurred())
-		}
-	}
-
-	Eventually(func() error {
-		for _, ns := range nonk8sServiceNamespaces {
-			if ns == "" {
-				continue
-			}
-			_, err := testClients.KubeClient().CoreV1().Services(ns).Get(
-				ctx, "multicluster-global-hub-manager-nonk8s-service", metav1.GetOptions{})
-			if err == nil {
-				return fmt.Errorf("nonk8s service still exists in namespace %s", ns)
-			}
-			if !errors.IsNotFound(err) {
-				return err
-			}
-		}
-		return nil
-	}, 30*time.Second, time.Second).Should(Succeed())
+	// nodePort 30080 is cluster-scoped; BYO deploys to mgh while later suites use multicluster-global-hub.
+	deleteServicesUsingNodePort(30080)
 
 	Expect(utils.Apply(testClients, testOptions,
 		utils.RenderOptions{Namespace: testOptions.GlobalHub.Namespace, KustomizationPath: fmt.Sprintf("%s/test/manifest/resources", rootDir)})).NotTo(HaveOccurred())
@@ -586,6 +554,45 @@ func patchGHDeployment(runtimeClient client.Client, namespace, name string) erro
 	args := deployment.Spec.Template.Spec.Containers[0].Args
 	deployment.Spec.Template.Spec.Containers[0].Args = append(args, "--global-resource-enabled=true")
 	return runtimeClient.Update(ctx, deployment)
+}
+
+func deleteServicesUsingNodePort(nodePort int32) {
+	serviceList, err := testClients.KubeClient().CoreV1().Services("").List(ctx, metav1.ListOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	for i := range serviceList.Items {
+		svc := &serviceList.Items[i]
+		if !serviceUsesNodePort(svc, nodePort) {
+			continue
+		}
+		err = testClients.KubeClient().CoreV1().Services(svc.Namespace).Delete(ctx, svc.Name, metav1.DeleteOptions{})
+		if err != nil && !errors.IsNotFound(err) {
+			Expect(err).NotTo(HaveOccurred())
+		}
+	}
+
+	Eventually(func() error {
+		serviceList, err := testClients.KubeClient().CoreV1().Services("").List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return err
+		}
+		for i := range serviceList.Items {
+			svc := &serviceList.Items[i]
+			if serviceUsesNodePort(svc, nodePort) {
+				return fmt.Errorf("service %s/%s still uses nodePort %d", svc.Namespace, svc.Name, nodePort)
+			}
+		}
+		return nil
+	}, time.Minute, time.Second).Should(Succeed())
+}
+
+func serviceUsesNodePort(svc *corev1.Service, nodePort int32) bool {
+	for _, port := range svc.Spec.Ports {
+		if port.NodePort == nodePort {
+			return true
+		}
+	}
+	return false
 }
 
 func writeFile(bytes []byte, file string) error {

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -354,6 +354,23 @@ func deployGlobalHub() {
 		}
 	}
 
+	Eventually(func() error {
+		for _, ns := range nonk8sServiceNamespaces {
+			if ns == "" {
+				continue
+			}
+			_, err := testClients.KubeClient().CoreV1().Services(ns).Get(
+				ctx, "multicluster-global-hub-manager-nonk8s-service", metav1.GetOptions{})
+			if err == nil {
+				return fmt.Errorf("nonk8s service still exists in namespace %s", ns)
+			}
+			if !errors.IsNotFound(err) {
+				return err
+			}
+		}
+		return nil
+	}, 30*time.Second, time.Second).Should(Succeed())
+
 	Expect(utils.Apply(testClients, testOptions,
 		utils.RenderOptions{Namespace: testOptions.GlobalHub.Namespace, KustomizationPath: fmt.Sprintf("%s/test/manifest/resources", rootDir)})).NotTo(HaveOccurred())
 	Expect(utils.Apply(testClients, testOptions,

--- a/test/e2e/transport_identity_test.go
+++ b/test/e2e/transport_identity_test.go
@@ -294,6 +294,11 @@ func waitForTrustedMigrationDeploy(
 }
 
 func deleteNamespaceAndWait(targetClient client.Client, namespaceName string) {
+	mc := &clusterv1.ManagedCluster{ObjectMeta: metav1.ObjectMeta{Name: namespaceName}}
+	if err := targetClient.Delete(ctx, mc); err != nil && !apierrors.IsNotFound(err) {
+		Expect(err).NotTo(HaveOccurred(), "expected to delete managed cluster %q during test cleanup", namespaceName)
+	}
+
 	err := targetClient.Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespaceName}})
 	if err != nil && !apierrors.IsNotFound(err) {
 		Expect(err).NotTo(HaveOccurred(), "expected to delete namespace %q during test cleanup", namespaceName)
@@ -301,7 +306,7 @@ func deleteNamespaceAndWait(targetClient client.Client, namespaceName string) {
 
 	Eventually(func() bool {
 		err := targetClient.Get(ctx, types.NamespacedName{Name: namespaceName}, &corev1.Namespace{})
-		return client.IgnoreNotFound(err) == nil && err != nil
-	}, 30*time.Second, 500*time.Millisecond).Should(BeTrue(),
+		return apierrors.IsNotFound(err)
+	}, 2*time.Minute, 500*time.Millisecond).Should(BeTrue(),
 		"expected namespace %q to be fully removed before next test", namespaceName)
 }

--- a/test/e2e/transport_migration_topic_test.go
+++ b/test/e2e/transport_migration_topic_test.go
@@ -1,0 +1,190 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package tests
+
+import (
+	"fmt"
+	"time"
+
+	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	operatorconfig "github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	pkgutils "github.com/stolostron/multicluster-global-hub/pkg/utils"
+	e2eutils "github.com/stolostron/multicluster-global-hub/test/e2e/utils"
+)
+
+var _ = Describe("Transport Migration Topic E2E", Label("e2e-test-transport-migration-topic"), Ordered, func() {
+	var (
+		sourceHubName   string
+		targetHubName   string
+		sourceHubClient client.Client
+		targetHubClient client.Client
+		migrationTopic  string
+	)
+
+	BeforeAll(func() {
+		Expect(len(managedHubNames)).To(BeNumerically(">=", 2),
+			"transport migration topic e2e requires two regional hubs (source and target)")
+		sourceHubName = managedHubNames[0]
+		targetHubName = managedHubNames[1]
+		// Operator in-process topic config is not initialized in the e2e test binary.
+		migrationTopic = operatorconfig.DEFAULT_MIGRATION_TOPIC
+
+		var err error
+		sourceHubClient, err = testClients.RuntimeClient(sourceHubName, agentScheme)
+		Expect(err).NotTo(HaveOccurred(), "expected source hub %q kubeconfig to be valid", sourceHubName)
+		targetHubClient, err = testClients.RuntimeClient(targetHubName, agentScheme)
+		Expect(err).NotTo(HaveOccurred(), "expected target hub %q kubeconfig to be valid", targetHubName)
+	})
+
+	Context("Phase 3 - dedicated gh-migration topic", func() {
+		It("should provision the gh-migration KafkaTopic in the global hub namespace", func() {
+			topic := &kafkav1beta2.KafkaTopic{}
+			Eventually(func() error {
+				return globalHubClient.Get(ctx, types.NamespacedName{
+					Name:      migrationTopic,
+					Namespace: testOptions.GlobalHub.Namespace,
+				}, topic)
+			}, 2*time.Minute, 5*time.Second).Should(Succeed(),
+				"expected gh-migration KafkaTopic to be provisioned in the global hub namespace")
+			Expect(topic.Spec.Partitions).NotTo(BeNil(),
+				"gh-migration topic must define partitions in spec")
+			Expect(int(*topic.Spec.Partitions)).To(BeNumerically(">", 0),
+				"gh-migration topic must have at least one partition")
+		})
+
+		It("should include the migration topic in managed hub transport credentials", func() {
+			Eventually(func() error {
+				secret := &corev1.Secret{}
+				if err := sourceHubClient.Get(ctx, types.NamespacedName{
+					Name:      constants.GHTransportConfigSecret,
+					Namespace: constants.GHAgentNamespace,
+				}, secret); err != nil {
+					return fmt.Errorf("get transport secret on managed hub agent namespace: %w", err)
+				}
+
+				kafkaConfig, err := pkgutils.GetKafkaCredentialBySecret(secret, sourceHubClient)
+				if err != nil {
+					return fmt.Errorf("parse transport secret kafka credentials: %w", err)
+				}
+				if kafkaConfig.MigrationTopic != migrationTopic {
+					return fmt.Errorf("managed hub transport credentials migration topic = %q, want %q",
+						kafkaConfig.MigrationTopic, migrationTopic)
+				}
+				return nil
+			}, 2*time.Minute, 5*time.Second).Should(Succeed(),
+				"managed hub transport credentials must include the gh-migration topic")
+		})
+	})
+
+	Context("Migration deploying over gh-migration", func() {
+		var (
+			publisher        *e2eutils.KafkaEventPublisher
+			trustedMigration string
+			spoofMigrationNS string
+		)
+
+		BeforeEach(func() {
+			trustedMigration = fmt.Sprintf("%s-trusted-%d", spoofMigrationNSPrefix, time.Now().UnixNano())
+			spoofMigrationNS = fmt.Sprintf("%s-spoof-%d", spoofMigrationNSPrefix, time.Now().UnixNano())
+
+			var err error
+			publisher, err = e2eutils.NewKafkaEventPublisher(ctx, globalHubClient, constants.GHDefaultNamespace)
+			Expect(err).NotTo(HaveOccurred(), "expected Kafka publisher from global hub transport-config secret")
+		})
+
+		AfterEach(func() {
+			deleteNamespaceAndWait(targetHubClient, trustedMigration)
+			deleteNamespaceAndWait(targetHubClient, spoofMigrationNS)
+		})
+
+		It("should apply deploying migration resources received on gh-migration from the registered source hub", func() {
+			migrationID := fmt.Sprintf("%s-trusted-%d", spoofMigrationID, time.Now().UnixNano())
+			seedClusterName := fmt.Sprintf("e2e-migration-topic-seed-%d", time.Now().UnixNano())
+			seedMSAName := fmt.Sprintf("e2e-migration-topic-msa-%d", time.Now().UnixNano())
+
+			seedInFlightMigrationState(
+				publisher,
+				sourceHubName,
+				targetHubName,
+				migrationID,
+				seedMSAName,
+				seedClusterName,
+			)
+
+			// Wait for validating to settle and align agent migration state (transport-identity
+			// suite may leave a stale processingMigrationId on the target hub agent).
+			probeNS := fmt.Sprintf("%s-probe-%d", spoofMigrationNSPrefix, time.Now().UnixNano())
+			waitForTrustedMigrationDeploy(
+				publisher,
+				targetHubClient,
+				sourceHubName,
+				targetHubName,
+				probeNS,
+				migrationID,
+			)
+			deleteNamespaceAndWait(targetHubClient, probeNS)
+
+			evt := migrationDeployingEvent(sourceHubName, targetHubName, trustedMigration, migrationID)
+			Expect(publisher.SendToTopic(ctx, publisher.MigrationTopic(), evt)).To(Succeed(),
+				"expected trusted migration deploying event to publish on gh-migration")
+
+			Eventually(func() error {
+				ns := &corev1.Namespace{}
+				return targetHubClient.Get(ctx, types.NamespacedName{Name: trustedMigration}, ns)
+			}, 2*time.Minute, 2*time.Second).Should(Succeed(),
+				"trusted migration deploying event on gh-migration must create target resources")
+		})
+
+		It("should drop migration deploying events on gh-migration from an untrusted source hub", func() {
+			migrationID := fmt.Sprintf("%s-untrusted-%d", spoofMigrationID, time.Now().UnixNano())
+			seedClusterName := fmt.Sprintf("e2e-migration-topic-spoof-seed-%d", time.Now().UnixNano())
+			seedMSAName := fmt.Sprintf("e2e-migration-topic-spoof-msa-%d", time.Now().UnixNano())
+
+			seedInFlightMigrationState(
+				publisher,
+				sourceHubName,
+				targetHubName,
+				migrationID,
+				seedMSAName,
+				seedClusterName,
+			)
+
+			probeNS := fmt.Sprintf("%s-probe-%d", spoofMigrationNSPrefix, time.Now().UnixNano())
+			waitForTrustedMigrationDeploy(
+				publisher,
+				targetHubClient,
+				sourceHubName,
+				targetHubName,
+				probeNS,
+				migrationID,
+			)
+			deleteNamespaceAndWait(targetHubClient, probeNS)
+
+			evt := migrationDeployingEvent(spoofMigrationSource, targetHubName, spoofMigrationNS, migrationID)
+			Expect(publisher.SendToTopic(ctx, publisher.MigrationTopic(), evt)).To(Succeed(),
+				"expected spoofed migration event to publish on gh-migration for rejection testing")
+
+			Consistently(func() error {
+				ns := &corev1.Namespace{}
+				err := targetHubClient.Get(ctx, types.NamespacedName{Name: spoofMigrationNS}, ns)
+				if err == nil {
+					return fmt.Errorf("namespace %q must not be created from spoofed migration source on %s",
+						spoofMigrationNS, migrationTopic)
+				}
+				if client.IgnoreNotFound(err) != nil {
+					return err
+				}
+				return nil
+			}, 45*time.Second, 500*time.Millisecond).Should(Succeed(),
+				"spoofed migration deploying event on gh-migration must not create resources")
+		})
+	})
+})

--- a/test/e2e/transport_migration_topic_test.go
+++ b/test/e2e/transport_migration_topic_test.go
@@ -16,7 +16,7 @@ import (
 
 	operatorconfig "github.com/stolostron/multicluster-global-hub/operator/pkg/config"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
-	pkgutils "github.com/stolostron/multicluster-global-hub/pkg/utils"
+	transportconfig "github.com/stolostron/multicluster-global-hub/pkg/transport/config"
 	e2eutils "github.com/stolostron/multicluster-global-hub/test/e2e/utils"
 )
 
@@ -70,7 +70,7 @@ var _ = Describe("Transport Migration Topic E2E", Label("e2e-test-transport-migr
 					return fmt.Errorf("get transport secret on managed hub agent namespace: %w", err)
 				}
 
-				kafkaConfig, err := pkgutils.GetKafkaCredentialBySecret(secret, sourceHubClient)
+				kafkaConfig, err := transportconfig.GetKafkaCredentialBySecret(secret, sourceHubClient)
 				if err != nil {
 					return fmt.Errorf("parse transport secret kafka credentials: %w", err)
 				}

--- a/test/e2e/utils/client.go
+++ b/test/e2e/utils/client.go
@@ -105,29 +105,29 @@ func (c *testClient) KubeDynamicClient() dynamic.Interface {
 
 func (c *testClient) Kubectl(clusterName string, args ...string) (string, error) {
 	config := ""
-	context := ""
+	kubeContext := ""
 	if c.options.GlobalHub.Name == clusterName {
 		config = c.options.GlobalHub.KubeConfig
-		context = c.options.GlobalHub.KubeContext
+		kubeContext = c.options.GlobalHub.KubeContext
 	}
 	for _, hub := range c.options.GlobalHub.ManagedHubs {
 		if hub.Name == clusterName {
-			context = hub.KubeContext
+			kubeContext = hub.KubeContext
 			config = hub.KubeConfig
 		}
 		for _, cluster := range hub.ManagedClusters {
 			if cluster.Name == clusterName {
-				context = cluster.KubeContext
+				kubeContext = cluster.KubeContext
 				config = cluster.KubeConfig
 			}
 		}
 	}
 
-	if config == "" && context == "" {
+	if config == "" && kubeContext == "" {
 		return "", fmt.Errorf("cluster %s is not found in options", clusterName)
 	}
 
-	args = append([]string{"--context", context}, args...)
+	args = append([]string{"--context", kubeContext}, args...)
 	args = append([]string{"--kubeconfig", config}, args...)
 	kubectlCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()

--- a/test/e2e/utils/client.go
+++ b/test/e2e/utils/client.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net/http"
@@ -128,12 +129,14 @@ func (c *testClient) Kubectl(clusterName string, args ...string) (string, error)
 
 	args = append([]string{"--context", context}, args...)
 	args = append([]string{"--kubeconfig", config}, args...)
-	output, err := exec.Command("kubectl", args...).Output()
+	kubectlCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	cmd := exec.CommandContext(kubectlCtx, "kubectl", args...)
+	combinedOutput, err := cmd.CombinedOutput()
 	if err != nil {
-		combinedOutput, err := exec.Command("kubectl", args...).CombinedOutput()
 		klog.Errorf("Output:%v, err:%v", string(combinedOutput), err)
 	}
-	return string(output), err
+	return string(combinedOutput), err
 }
 
 func (c *testClient) RestConfig(clusterName string) (*rest.Config, error) {

--- a/test/e2e/utils/kafka_producer.go
+++ b/test/e2e/utils/kafka_producer.go
@@ -17,8 +17,8 @@ import (
 	operatorconfig "github.com/stolostron/multicluster-global-hub/operator/pkg/config"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
+	transportconfig "github.com/stolostron/multicluster-global-hub/pkg/transport/config"
 	genericproducer "github.com/stolostron/multicluster-global-hub/pkg/transport/producer"
-	pkgutils "github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
 // KafkaEventPublisher sends CloudEvents to Kafka using transport credentials from a cluster secret.
@@ -37,7 +37,7 @@ func NewKafkaEventPublisher(ctx context.Context, c client.Client, namespace stri
 		return nil, fmt.Errorf("get transport secret in namespace %s: %w", namespace, err)
 	}
 
-	kafkaConfig, err := pkgutils.GetKafkaCredentialBySecret(secret, c)
+	kafkaConfig, err := transportconfig.GetKafkaCredentialBySecret(secret, c)
 	if err != nil {
 		return nil, fmt.Errorf("parse kafka credentials: %w", err)
 	}

--- a/test/e2e/utils/kafka_producer.go
+++ b/test/e2e/utils/kafka_producer.go
@@ -17,8 +17,8 @@ import (
 	operatorconfig "github.com/stolostron/multicluster-global-hub/operator/pkg/config"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
-	transportconfig "github.com/stolostron/multicluster-global-hub/pkg/transport/config"
 	genericproducer "github.com/stolostron/multicluster-global-hub/pkg/transport/producer"
+	pkgutils "github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
 // KafkaEventPublisher sends CloudEvents to Kafka using transport credentials from a cluster secret.
@@ -37,7 +37,7 @@ func NewKafkaEventPublisher(ctx context.Context, c client.Client, namespace stri
 		return nil, fmt.Errorf("get transport secret in namespace %s: %w", namespace, err)
 	}
 
-	kafkaConfig, err := transportconfig.GetKafkaCredentialBySecret(secret, c)
+	kafkaConfig, err := pkgutils.GetKafkaCredentialBySecret(secret, c)
 	if err != nil {
 		return nil, fmt.Errorf("parse kafka credentials: %w", err)
 	}
@@ -66,6 +66,14 @@ func (p *KafkaEventPublisher) SendToTopic(ctx context.Context, topic string, evt
 // SpecTopic returns the configured spec topic (typically gh-spec).
 func (p *KafkaEventPublisher) SpecTopic() string {
 	return p.kafkaConfig.SpecTopic
+}
+
+// MigrationTopic returns the configured migration topic (typically gh-migration).
+func (p *KafkaEventPublisher) MigrationTopic() string {
+	if p.kafkaConfig.MigrationTopic != "" {
+		return p.kafkaConfig.MigrationTopic
+	}
+	return operatorconfig.GetMigrationTopic()
 }
 
 // StatusTopic returns the status topic for hubName (per-hub topic or credential override).

--- a/test/integration/manager/migration/migration_test.go
+++ b/test/integration/manager/migration/migration_test.go
@@ -410,6 +410,11 @@ var _ = Describe("migration", Ordered, func() {
 				return err
 			}
 
+			migration.SetDeployingACLReadyTime(
+				string(migrationInstance.GetUID()),
+				time.Now().Add(-time.Second),
+			)
+
 			// mock the source hub report result
 			migration.SetFinished(string(migrationInstance.GetUID()), migrationInstance.Spec.From,
 				migrationv1alpha1.PhaseDeploying)

--- a/test/integration/manager/migration/migration_test.go
+++ b/test/integration/manager/migration/migration_test.go
@@ -287,11 +287,17 @@ var _ = Describe("migration", Ordered, func() {
 		}
 
 		// add a label to trigger the reconcile
-		err = mgr.GetClient().Get(testCtx, client.ObjectKeyFromObject(migrationInstance), migrationInstance)
-		Expect(err).To(Succeed())
-		migrationInstance.Labels = map[string]string{"test": "foo"}
-		err = mgr.GetClient().Update(ctx, migrationInstance)
-		Expect(err).To(Succeed())
+		Eventually(func() error {
+			err := mgr.GetClient().Get(testCtx, client.ObjectKeyFromObject(migrationInstance), migrationInstance)
+			if err != nil {
+				return err
+			}
+			if migrationInstance.Labels == nil {
+				migrationInstance.Labels = map[string]string{}
+			}
+			migrationInstance.Labels["test"] = "foo"
+			return mgr.GetClient().Update(ctx, migrationInstance)
+		}, 30*time.Second, 100*time.Millisecond).Should(Succeed())
 
 		// validating: not found cluster
 		By("validating: not found cluster")

--- a/test/integration/operator/controllers/agent/cluster_none_addon_test.go
+++ b/test/integration/operator/controllers/agent/cluster_none_addon_test.go
@@ -68,6 +68,23 @@ func prepareCluster(name string, labels, annotations map[string]string,
 	})).Should(Succeed())
 }
 
+func cleanupCluster(name string) {
+	cluster := &clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}
+	_ = runtimeClient.Delete(ctx, &addonv1alpha1.ManagedClusterAddOn{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.GHManagedClusterAddonName,
+			Namespace: name,
+		},
+	})
+	_ = runtimeClient.Delete(ctx, cluster)
+	Eventually(func() bool {
+		err := runtimeClient.Get(ctx, types.NamespacedName{Name: name}, cluster)
+		return errors.IsNotFound(err)
+	}, timeout, interval).Should(BeTrue())
+}
+
 // go test ./test/integration/operator/controllers/agent -ginkgo.focus "none addon" -v
 var _ = Describe("none addon", func() {
 	It("Should not create addon in these cases", func() {

--- a/test/integration/operator/controllers/agent/managedclusteraddon_test.go
+++ b/test/integration/operator/controllers/agent/managedclusteraddon_test.go
@@ -17,9 +17,10 @@ import (
 )
 
 // go test ./test/integration/operator/controllers/agent -ginkgo.focus "deploy default addon" -v
-var _ = Describe("deploy default addon", func() {
+var _ = Describe("deploy default addon", Ordered, func() {
 	It("Should skip to create agent when importing an bare OCP in brownfield(enable local cluster)", func() {
 		clusterName := fmt.Sprintf("hub-%s", rand.String(6))
+		defer cleanupCluster(clusterName)
 
 		By("By preparing an OCP Managed Clusters")
 		prepareCluster(clusterName,
@@ -59,6 +60,7 @@ var _ = Describe("deploy default addon", func() {
 
 	It("Should create default addon with deploy label = Default under brownfield mode", func() {
 		clusterName := fmt.Sprintf("hub-%s", rand.String(6))
+		defer cleanupCluster(clusterName)
 		workName := fmt.Sprintf("addon-%s-deploy-0",
 			constants.GHManagedClusterAddonName)
 
@@ -96,6 +98,7 @@ var _ = Describe("deploy default addon", func() {
 
 	It("Should create default addon and ACM with deploy label = Default under brownfield mode", func() {
 		clusterName := fmt.Sprintf("hub-%s", rand.String(6))
+		defer cleanupCluster(clusterName)
 		workName := fmt.Sprintf("addon-%s-deploy-0",
 			constants.GHManagedClusterAddonName)
 

--- a/test/integration/operator/controllers/agent/suite_test.go
+++ b/test/integration/operator/controllers/agent/suite_test.go
@@ -43,7 +43,6 @@ import (
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/agent/addon"
 	operatortrans "github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/transporter/protocol"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
-	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
@@ -123,9 +122,12 @@ var _ = BeforeSuite(func() {
 			EnablePprof:           false,
 		},
 	}
-	config.SetTransporterConn(&transport.KafkaConfig{
-		ClusterID: "fake",
-	})
+	Expect(config.SetTransportConfig(ctx, runtimeClient, existMgh)).To(Succeed())
+	Expect(runtimeClient.Get(ctx, config.GetMGHNamespacedName(), existMgh)).To(Succeed())
+	controllerOption.MulticlusterGlobalHub = existMgh
+	conn, err := config.GetTransporter().GetConnCredential("")
+	Expect(err).ToNot(HaveOccurred())
+	config.SetTransporterConn(conn)
 
 	By("start the addon manager and add addon controller to manager")
 	_, err = addon.StartAddonManagerController(controllerOption)
@@ -139,13 +141,6 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 	err = config.LoadControllerConfig(ctx, kubeClient)
 	Expect(err).ToNot(HaveOccurred())
-
-	By("Create an external transport")
-	trans := operatortrans.NewBYOTransporter(ctx, types.NamespacedName{
-		Namespace: mgh.Namespace,
-		Name:      constants.GHTransportSecretName,
-	}, runtimeClient)
-	config.SetTransporter(trans)
 
 	go func() {
 		defer GinkgoRecover()

--- a/test/integration/operator/controllers/manager_test.go
+++ b/test/integration/operator/controllers/manager_test.go
@@ -69,6 +69,7 @@ var _ = Describe("manager", Ordered, func() {
 		initOption = config.ControllerOption{
 			Manager:               runtimeManager,
 			MulticlusterGlobalHub: mgh,
+			KubeClient:            kubeClient,
 			OperatorConfig:        &config.OperatorConfig{},
 		}
 		// transport

--- a/test/integration/operator/controllers/transporter_test.go
+++ b/test/integration/operator/controllers/transporter_test.go
@@ -258,9 +258,11 @@ var _ = Describe("transporter", Ordered, func() {
 		}
 		mgh.Spec.ImagePullSecret = "mgh-image-pull"
 
-		var updated bool
+		var (
+			updated bool
+			err     error
+		)
 		Eventually(func() error {
-			var err error
 			err, updated = trans.CreateUpdateKafkaCluster(mgh)
 			return err
 		}, 10*time.Second, 100*time.Millisecond).Should(Succeed())

--- a/test/integration/operator/controllers/transporter_test.go
+++ b/test/integration/operator/controllers/transporter_test.go
@@ -388,13 +388,14 @@ var _ = Describe("transporter", Ordered, func() {
 		err = runtimeClient.Get(ctx, client.ObjectKeyFromObject(kafkaUser), kafkaUser)
 		Expect(err).To(Succeed())
 		// utils.PrettyPrint(kafkaUser.Spec.Authorization)
-		Expect(3).To(Equal(len(kafkaUser.Spec.Authorization.Acls)))
+		Expect(4).To(Equal(len(kafkaUser.Spec.Authorization.Acls)))
 
 		// topic: create
 		clusterTopic, err := trans.EnsureTopic(clusterName)
 		Expect(err).To(Succeed())
 		Expect("gh-spec").To(Equal(clusterTopic.SpecTopic))
 		Expect(config.GetStatusTopic(clusterName)).To(Equal(clusterTopic.StatusTopic))
+		Expect(config.GetMigrationTopic()).To(Equal(clusterTopic.MigrationTopic))
 
 		// topic: update
 		_, err = trans.EnsureTopic(clusterName)
@@ -417,7 +418,7 @@ var _ = Describe("transporter", Ordered, func() {
 })
 
 func UpdateKafkaClusterReady(c client.Client, ns string) error {
-	kafkaVersion := "3.9.0"
+	kafkaVersion := "4.0.0"
 	kafkaClusterName := "kafka"
 	globalHubKafkaUser := "global-hub-kafka-user"
 	clientCa := "kafka-clients-ca-cert"
@@ -467,7 +468,7 @@ func UpdateKafkaClusterReady(c client.Client, ns string) error {
 		},
 	}
 
-	err := wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		existkafkaCluster := &kafkav1beta2.Kafka{}
 		err := c.Get(context.Background(), types.NamespacedName{
 			Name:      kafkaClusterName,
@@ -506,9 +507,11 @@ func UpdateKafkaClusterReady(c client.Client, ns string) error {
 			return false, nil
 		}
 		return true, nil
-	})
+	}); err != nil {
+		return err
+	}
 
-	err = createSecret(c, ns, globalHubKafkaUser, map[string][]byte{
+	err := createSecret(c, ns, globalHubKafkaUser, map[string][]byte{
 		"user.crt": []byte("usercrt"),
 		"user.key": []byte("userkey"),
 	})

--- a/test/integration/operator/controllers/transporter_test.go
+++ b/test/integration/operator/controllers/transporter_test.go
@@ -258,8 +258,12 @@ var _ = Describe("transporter", Ordered, func() {
 		}
 		mgh.Spec.ImagePullSecret = "mgh-image-pull"
 
-		err, updated := trans.CreateUpdateKafkaCluster(mgh)
-		Expect(err).To(Succeed())
+		var updated bool
+		Eventually(func() error {
+			var err error
+			err, updated = trans.CreateUpdateKafkaCluster(mgh)
+			return err
+		}, 10*time.Second, 100*time.Millisecond).Should(Succeed())
 		Expect(updated).To(BeTrue())
 
 		mgh.Spec.NodeSelector = map[string]string{

--- a/test/manifest/kafka/kafka-cluster/kafka-byo-resource.yaml
+++ b/test/manifest/kafka/kafka-cluster/kafka-byo-resource.yaml
@@ -46,4 +46,13 @@ spec:
         name: gh-spec
         patternType: literal
         type: topic
+    - host: '*'
+      operations:
+      - Describe
+      - Read
+      - Write
+      resource:
+        name: gh-migration
+        patternType: literal
+        type: topic
     type: simple

--- a/test/manifest/kafka/kafka-cluster/kafka-topics.yaml
+++ b/test/manifest/kafka/kafka-cluster/kafka-topics.yaml
@@ -13,6 +13,20 @@ spec:
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
+  name: gh-migration
+  labels:
+    strimzi.io/cluster: kafka
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    cleanup.policy: compact,delete
+    retention.ms: "86400000"
+    retention.bytes: "1073741824"
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
   name: gh-status.global-hub
   labels:
     strimzi.io/cluster: kafka

--- a/test/script/e2e_clean_globalhub.sh
+++ b/test/script/e2e_clean_globalhub.sh
@@ -55,27 +55,11 @@ if [[ ! -z $(kubectl get kafka -n "$GH_NAMESPACE" --ignore-not-found=true) ]]; t
   exit 1
 fi
 
-echo "Delete e2e nonk8s NodePort service"
-kubectl delete service multicluster-global-hub-manager-nonk8s-service -n "$GH_NAMESPACE" --ignore-not-found=true
-kubectl delete service multicluster-global-hub-manager-nonk8s-service -n mgh --ignore-not-found=true
+cd operator
+make undeploy ignore-not-found=true
 
-if [[ "$GH_NAMESPACE" == "multicluster-global-hub" ]]; then
-  cd operator
-  make undeploy ignore-not-found=true
-
-  ## clean
-  wait_cmd "kubectl delete crd kafkas.kafka.strimzi.io --ignore-not-found=true"
-  wait_cmd "kubectl delete crd kafkanodepools.kafka.strimzi.io --ignore-not-found=true"
-  wait_cmd "kubectl delete crd kafkatopics.kafka.strimzi.io --ignore-not-found=true"
-  wait_cmd "kubectl delete crd kafkausers.kafka.strimzi.io --ignore-not-found=true"
-else
-  # BYO deploys to mgh; make undeploy removes cluster-scoped RBAC/CRDs and can
-  # delete leader-election roles in multicluster-global-hub, breaking the next
-  # suite that deploys the operator there.
-  echo "Delete BYO namespace $GH_NAMESPACE (skip operator undeploy and CRD deletion)"
-  kubectl delete namespace "$GH_NAMESPACE" --ignore-not-found=true --timeout=180s
-fi
-
-echo "Recreate namespace for subsequent e2e runs"
-kubectl get namespace "$GH_NAMESPACE" >/dev/null 2>&1 || kubectl create namespace "$GH_NAMESPACE"
-
+## clean
+wait_cmd "kubectl delete crd kafkas.kafka.strimzi.io --ignore-not-found=true"
+wait_cmd "kubectl delete crd kafkanodepools.kafka.strimzi.io --ignore-not-found=true"
+wait_cmd "kubectl delete crd kafkatopics.kafka.strimzi.io --ignore-not-found=true"
+wait_cmd "kubectl delete crd kafkausers.kafka.strimzi.io --ignore-not-found=true"

--- a/test/script/e2e_clean_globalhub.sh
+++ b/test/script/e2e_clean_globalhub.sh
@@ -61,7 +61,7 @@ kubectl delete service multicluster-global-hub-manager-nonk8s-service -n mgh --i
 
 if [[ "$GH_NAMESPACE" == "multicluster-global-hub" ]]; then
   cd operator
-  make undeploy
+  make undeploy ignore-not-found=true
 
   ## clean
   wait_cmd "kubectl delete crd kafkas.kafka.strimzi.io --ignore-not-found=true"

--- a/test/script/e2e_clean_globalhub.sh
+++ b/test/script/e2e_clean_globalhub.sh
@@ -57,6 +57,7 @@ fi
 
 echo "Delete e2e nonk8s NodePort service"
 kubectl delete service multicluster-global-hub-manager-nonk8s-service -n "$GH_NAMESPACE" --ignore-not-found=true
+kubectl delete service multicluster-global-hub-manager-nonk8s-service -n mgh --ignore-not-found=true
 
 cd operator
 make undeploy

--- a/test/script/e2e_clean_globalhub.sh
+++ b/test/script/e2e_clean_globalhub.sh
@@ -59,14 +59,22 @@ echo "Delete e2e nonk8s NodePort service"
 kubectl delete service multicluster-global-hub-manager-nonk8s-service -n "$GH_NAMESPACE" --ignore-not-found=true
 kubectl delete service multicluster-global-hub-manager-nonk8s-service -n mgh --ignore-not-found=true
 
-cd operator
-make undeploy
+if [[ "$GH_NAMESPACE" == "multicluster-global-hub" ]]; then
+  cd operator
+  make undeploy
 
-## clean
-wait_cmd "kubectl delete crd kafkas.kafka.strimzi.io --ignore-not-found=true"
-wait_cmd "kubectl delete crd kafkanodepools.kafka.strimzi.io --ignore-not-found=true"
-wait_cmd "kubectl delete crd kafkatopics.kafka.strimzi.io --ignore-not-found=true"
-wait_cmd "kubectl delete crd kafkausers.kafka.strimzi.io --ignore-not-found=true"
+  ## clean
+  wait_cmd "kubectl delete crd kafkas.kafka.strimzi.io --ignore-not-found=true"
+  wait_cmd "kubectl delete crd kafkanodepools.kafka.strimzi.io --ignore-not-found=true"
+  wait_cmd "kubectl delete crd kafkatopics.kafka.strimzi.io --ignore-not-found=true"
+  wait_cmd "kubectl delete crd kafkausers.kafka.strimzi.io --ignore-not-found=true"
+else
+  # BYO deploys to mgh; make undeploy removes cluster-scoped RBAC/CRDs and can
+  # delete leader-election roles in multicluster-global-hub, breaking the next
+  # suite that deploys the operator there.
+  echo "Delete BYO namespace $GH_NAMESPACE (skip operator undeploy and CRD deletion)"
+  kubectl delete namespace "$GH_NAMESPACE" --ignore-not-found=true --timeout=180s
+fi
 
 echo "Recreate namespace for subsequent e2e runs"
 kubectl get namespace "$GH_NAMESPACE" >/dev/null 2>&1 || kubectl create namespace "$GH_NAMESPACE"

--- a/test/script/e2e_run.sh
+++ b/test/script/e2e_run.sh
@@ -121,13 +121,23 @@ data:
   logLevel: debug
 EOF
 
+GINKGO_FLAGS=(--fail-fast --poll-progress-after=30s --poll-progress-interval=30s)
+
+run_ginkgo() {
+  # Match the ginkgo/v2 module in go.mod; avoid stale ginkgo CLIs on CI images.
+  (
+    cd "$PROJECT_DIR"
+    go run github.com/onsi/ginkgo/v2/ginkgo@${GINKGO_VERSION} "$@"
+  )
+}
+
 if [ "${filter}" = "e2e-test-prune" ]; then
   export ISPRUNE="true"
   echo "run prune"
-  ginkgo --fail-fast --label-filter="e2e-test-prune" --output-dir="$CONFIG_DIR" --json-report=report.json \
+  run_ginkgo "${GINKGO_FLAGS[@]}" --label-filter="e2e-test-prune" --output-dir="$CONFIG_DIR" --json-report=report.json \
     --junit-report=report.xml "$TEST_DIR/e2e" -- -options="$OPTION_FILE" -v="$verbose"
 else
-  ginkgo --fail-fast --label-filter="${filter}" --output-dir="$CONFIG_DIR" --json-report=report.json \
+  run_ginkgo "${GINKGO_FLAGS[@]}" --label-filter="${filter}" --output-dir="$CONFIG_DIR" --json-report=report.json \
     --junit-report=report.xml "$TEST_DIR"/e2e -- -options="$OPTION_FILE" -v="$verbose"
 fi
 

--- a/test/script/e2e_run_byo.sh
+++ b/test/script/e2e_run_byo.sh
@@ -64,6 +64,7 @@ wait_cmd "kubectl get kafka kafka -n $kafka_namespace --kubeconfig $KAFKA_KUBECO
 
 # wait the byo kafkatopic and kafkauser
 wait_cmd "kubectl get kafkatopic gh-spec -n $kafka_namespace --kubeconfig $KAFKA_KUBECONFIG | grep -C 1 True"
+wait_cmd "kubectl get kafkatopic gh-migration -n $kafka_namespace --kubeconfig $KAFKA_KUBECONFIG | grep -C 1 True"
 wait_cmd "kubectl get kafkatopic gh-status -n $kafka_namespace --kubeconfig $KAFKA_KUBECONFIG | grep -C 1 True"
 wait_cmd "kubectl get kafkauser $byo_user -n $kafka_namespace --kubeconfig $KAFKA_KUBECONFIG | grep -C 1 True"
 echo "Kafka topic and user is ready"

--- a/test/script/e2e_run_byo.sh
+++ b/test/script/e2e_run_byo.sh
@@ -84,4 +84,14 @@ echo "transport secret is ready in $target_namespace namespace!"
 ## run e2e
 bash "$CURRENT_DIR/e2e_run.sh" -n $target_namespace -f "e2e-test-localpolicy,e2e-test-grafana,e2e-test-local-agent"
 
+# Clean up BYO namespace before transport suites. The operator only reconciles when exactly
+# one MulticlusterGlobalHub exists cluster-wide; leaving the mgh operand blocks transport-identity.
+echo "Cleaning up BYO test resources..."
+kubectl delete multiclusterglobalhubs --all -n "${target_namespace}" --kubeconfig "${GH_KUBECONFIG}" --ignore-not-found=true
+wait_cmd "[[ -z \$(kubectl get multiclusterglobalhubs -n ${target_namespace} --kubeconfig ${GH_KUBECONFIG} --ignore-not-found=true -o name 2>/dev/null) ]]"
+kubectl delete service multicluster-global-hub-manager-nonk8s-service -n "${target_namespace}" --kubeconfig "${GH_KUBECONFIG}" --ignore-not-found=true
+kubectl delete deployment multicluster-global-hub-operator -n "${target_namespace}" --kubeconfig "${GH_KUBECONFIG}" --ignore-not-found=true
+kubectl wait --for=delete deployment/multicluster-global-hub-operator -n "${target_namespace}" --kubeconfig "${GH_KUBECONFIG}" --timeout=120s 2>/dev/null || true
+
 unset ISBYO
+unset NAMESPACE

--- a/test/script/e2e_run_byo.sh
+++ b/test/script/e2e_run_byo.sh
@@ -85,9 +85,11 @@ kubectl create secret generic "$transport_secret" -n "$target_namespace" --kubec
   --from-file=client.key="$CURRENT_DIR"/config/kafka-client-key.pem
 echo "transport secret is ready in $target_namespace namespace!"
 
-# nodePort 30080 is cluster-scoped; transport-identity leaves the nonk8s service in multicluster-global-hub.
-echo "Delete stale nonk8s NodePort service from built-in GH namespace"
+# nodePort 30080 is cluster-scoped; BYO leaves the nonk8s service in mgh.
+echo "Delete stale nonk8s NodePort services"
 kubectl delete service multicluster-global-hub-manager-nonk8s-service -n multicluster-global-hub \
+  --kubeconfig "$GH_KUBECONFIG" --ignore-not-found=true
+kubectl delete service multicluster-global-hub-manager-nonk8s-service -n mgh \
   --kubeconfig "$GH_KUBECONFIG" --ignore-not-found=true
 
 ## run e2e

--- a/test/script/e2e_run_byo.sh
+++ b/test/script/e2e_run_byo.sh
@@ -15,10 +15,6 @@ POSTGRES_KUBECONFIG="${CONFIG_DIR}/hub1"
 
 export ISBYO="true"
 
-# transport-identity runs in multicluster-global-hub before BYO; undeploy it so
-# cluster-scoped operator RBAC and nodePort 30080 are free for the mgh deploy.
-bash "$CURRENT_DIR/e2e_clean_globalhub.sh"
-
 target_namespace=${TARGET_NAMESPACE:-"mgh"}
 export NAMESPACE="$target_namespace"
 
@@ -84,13 +80,6 @@ kubectl create secret generic "$transport_secret" -n "$target_namespace" --kubec
   --from-file=client.crt="$CURRENT_DIR"/config/kafka-client-cert.pem \
   --from-file=client.key="$CURRENT_DIR"/config/kafka-client-key.pem
 echo "transport secret is ready in $target_namespace namespace!"
-
-# nodePort 30080 is cluster-scoped; BYO leaves the nonk8s service in mgh.
-echo "Delete stale nonk8s NodePort services"
-kubectl delete service multicluster-global-hub-manager-nonk8s-service -n multicluster-global-hub \
-  --kubeconfig "$GH_KUBECONFIG" --ignore-not-found=true
-kubectl delete service multicluster-global-hub-manager-nonk8s-service -n mgh \
-  --kubeconfig "$GH_KUBECONFIG" --ignore-not-found=true
 
 ## run e2e
 bash "$CURRENT_DIR/e2e_run.sh" -n $target_namespace -f "e2e-test-localpolicy,e2e-test-grafana,e2e-test-local-agent"

--- a/test/script/util.sh
+++ b/test/script/util.sh
@@ -9,7 +9,7 @@ export CLUSTERADM_VERSION=0.10.1
 export KIND_VERSION=v0.19.0
 export ROUTE_VERSION=release-4.12
 export GO_VERSION=go1.26.4
-export GINKGO_VERSION=v2.17.2
+export GINKGO_VERSION=v2.28.1
 
 # Environment Variables
 CURRENT_DIR=$(
@@ -620,11 +620,11 @@ check_golang() {
 }
 
 check_ginkgo() {
-  if ! command -v ginkgo >/dev/null 2>&1; then
-    go install github.com/onsi/ginkgo/v2/ginkgo@$GINKGO_VERSION
-    go get github.com/onsi/gomega/...
-    sudo mv $(go env GOPATH)/bin/ginkgo $INSTALL_DIR/ginkgo
-  fi
+  # Always install the pinned CLI so CI images with a stale ginkgo on PATH cannot
+  # mismatch the ginkgo/v2 module version used by test/e2e (see go.mod).
+  go install github.com/onsi/ginkgo/v2/ginkgo@$GINKGO_VERSION
+  go get github.com/onsi/gomega/...
+  sudo mv -f "$(go env GOPATH)/bin/ginkgo" "$INSTALL_DIR/ginkgo"
   echo "ginkgo version: $(ginkgo version)"
 }
 


### PR DESCRIPTION
Fixes: [ACM-38862](https://redhat.atlassian.net/browse/ACM-38862)

## Summary

Backport **transport** to **release-2.14** (Global Hub 1.5), adapted from [#2687](https://github.com/stolostron/multicluster-global-hub/pull/2687):

- Dedicated `gh-migration` Kafka topic, ACL reconciler, credential wiring
- Migration deploying bundles routed over `gh-migration` with retry on ACL authorization
- Manager ACL propagation wait before triggering source-hub deploy
- transport e2e suite (`e2e-test-transport-migration-topic`)

## Not included: ZTP deploy allow-list ([#2704](https://github.com/stolostron/multicluster-global-hub/pull/2704))

GH 1.5 still uses the pre-1.6 **`syncers/`** migration layout and does **not** have `agent/pkg/spec/migration/source_validation.go` or `IsMigrationDeployResourceAllowed`. The ZTP GVK allow-list fix targets code introduced in 1.6+ — it cannot be cherry-picked to 1.5 without the 1.5→1.6 migration refactor.

## Adaptations for release-2.14

- Agent changes ported to `agent/pkg/spec/syncers/migration_from_syncer.go` (not `migration/` package)
- Minimal manager ACL wait added to existing `migration_deploying.go` / `migration_eventstatus.go`
- Kept release-2.14 dispatcher and source validation (cluster-name extension)
- Makefile: added `e2e-test-transport-migration-topic`, preserved 1.5 e2e targets (placement/app/policy/agent)

## Context

- transport parent: [#2687](https://github.com/stolostron/multicluster-global-hub/pull/2687) — release-2.17
- Sibling backports: [#2710](https://github.com/stolostron/multicluster-global-hub/pull/2710) (1.6), [#2709](https://github.com/stolostron/multicluster-global-hub/pull/2709) (1.7), [#2708](https://github.com/stolostron/multicluster-global-hub/pull/2708) (1.8 ZTP)

## Test plan

- [x] Manual port applies cleanly on release-2.14 layout
- [ ] CI format / unit / integration on release-2.14

Made with [Cursor](https://cursor.com)

[ACM-38862]: https://redhat.atlassian.net/browse/ACM-38862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ