### PR TITLE
ACM-32678: Hub HA batched resource sync with size-aware sending

### DIFF
--- a/agent/pkg/spec/hubha/hubha_emitter.go
+++ b/agent/pkg/spec/hubha/hubha_emitter.go
@@ -26,6 +26,9 @@ import (
 
 // HubHAEmitter implements the Emitter interface for Hub HA resource synchronization.
 // It tracks changes to resources across all GVKs and bundles them for transmission to the standby hub.
+// Update/Delete send immediately after a successful size-aware add (flush-first when the bundle
+// would exceed MaxBundleBytes). Resync sends size-capped batches plus per-GVK ResyncMetadata
+// inventory frames (InventoryBegin / Complete) so standby can safely clean stale resources.
 // It is safe for concurrent use from multiple goroutines.
 type HubHAEmitter struct {
 	producer        transport.Producer
@@ -35,6 +38,9 @@ type HubHAEmitter struct {
 	resourceFilter  *utils.HubHAResourceFilter
 	bundle          *generic.GenericBundle[*unstructured.Unstructured]
 	mu              sync.Mutex
+	// deltaGen increments on every successful Update/Delete send. Resync captures it
+	// before listing and aborts/retries emission if a delta landed after the snapshot.
+	deltaGen uint64
 
 	// Dynamic lifecycle fields managed by the Hub HA lifecycle controller.
 	client          client.Client             // used for self-listing in Resync(nil)
@@ -56,7 +62,13 @@ func NewHubHAEmitter(
 		activeHubName:   activeHubName,
 		standbyHubName:  standbyHubName,
 		resourceFilter:  utils.NewHubHAResourceFilter(),
-		bundle:          generic.NewGenericBundle[*unstructured.Unstructured](),
+		bundle: generic.NewGenericBundle(
+			generic.WithKeyFunc(func(obj *unstructured.Unstructured) string {
+				gvk := obj.GroupVersionKind()
+				return fmt.Sprintf("%s/%s/%s/%s/%s",
+					gvk.Group, gvk.Version, gvk.Kind, obj.GetNamespace(), obj.GetName())
+			}),
+		),
 	}
 }
 
@@ -109,7 +121,9 @@ func (e *HubHAEmitter) Predicate() predicate.Predicate {
 	})
 }
 
-// Update handles object creation/update events and sends immediately.
+// Update handles object creation/update events with size-aware sending.
+// When the bundle would exceed MaxBundleBytes, the current bundle is flushed first,
+// then the new item is added and sent (fast failover for deltas).
 // It is a no-op when the emitter is disabled (hub not in active role).
 func (e *HubHAEmitter) Update(obj client.Object) error {
 	e.mu.Lock()
@@ -126,12 +140,34 @@ func (e *HubHAEmitter) Update(obj client.Object) error {
 	gvk := uObj.GroupVersionKind()
 	cleanUnstructuredMetadata(uObj)
 
-	e.bundle.Update = append(e.bundle.Update, uObj)
-	log.Debugf("syncing update for %s/%s (%s)", uObj.GetNamespace(), uObj.GetName(), gvk.Kind)
-	return e.sendBundleUnlocked()
+	added, err := e.bundle.AddUpdate(uObj)
+	if err != nil {
+		return fmt.Errorf("failed to add update for %s/%s (%s): %w",
+			uObj.GetNamespace(), uObj.GetName(), gvk.Kind, err)
+	}
+	if !added {
+		if err := e.sendDeltaUnlocked(); err != nil {
+			return err
+		}
+		added, err = e.bundle.AddUpdate(uObj)
+		if err != nil {
+			return fmt.Errorf("failed to add update for %s/%s (%s) after flush: %w",
+				uObj.GetNamespace(), uObj.GetName(), gvk.Kind, err)
+		}
+		if !added {
+			return fmt.Errorf("update object too large: %s/%s (%s)",
+				uObj.GetNamespace(), uObj.GetName(), gvk.Kind)
+		}
+	}
+
+	log.Debugw("syncing Hub HA update",
+		"namespace", uObj.GetNamespace(), "name", uObj.GetName(), "kind", gvk.Kind)
+	return e.sendDeltaUnlocked()
 }
 
-// Delete handles object deletion events and sends immediately.
+// Delete handles object deletion events with size-aware sending.
+// When the bundle would exceed MaxBundleBytes, the current bundle is flushed first,
+// then the delete is added and sent (fast failover for deltas).
 // It is a no-op when the emitter is disabled (hub not in active role).
 func (e *HubHAEmitter) Delete(obj client.Object) error {
 	e.mu.Lock()
@@ -148,36 +184,95 @@ func (e *HubHAEmitter) Delete(obj client.Object) error {
 	gvk := uObj.GroupVersionKind()
 
 	for i, existingObj := range e.bundle.Update {
-		if existingObj.GetNamespace() == obj.GetNamespace() && existingObj.GetName() == obj.GetName() {
+		if existingObj.GetNamespace() == obj.GetNamespace() &&
+			existingObj.GetName() == obj.GetName() &&
+			existingObj.GroupVersionKind() == gvk {
 			e.bundle.Update = append(e.bundle.Update[:i], e.bundle.Update[i+1:]...)
 			break
 		}
 	}
 
-	e.bundle.Delete = append(e.bundle.Delete, generic.ObjectMetadata{
+	meta := generic.ObjectMetadata{
 		Namespace: obj.GetNamespace(),
 		Name:      obj.GetName(),
 		Group:     gvk.Group,
 		Version:   gvk.Version,
 		Kind:      gvk.Kind,
-	})
-	log.Debugf("syncing delete for %s/%s (%s)", obj.GetNamespace(), obj.GetName(), gvk.Kind)
-	return e.sendBundleUnlocked()
+	}
+	added, err := e.bundle.AddDelete(meta)
+	if err != nil {
+		return fmt.Errorf("failed to add delete for %s/%s (%s): %w",
+			obj.GetNamespace(), obj.GetName(), gvk.Kind, err)
+	}
+	if !added {
+		if err := e.sendDeltaUnlocked(); err != nil {
+			return err
+		}
+		added, err = e.bundle.AddDelete(meta)
+		if err != nil {
+			return fmt.Errorf("failed to add delete for %s/%s (%s) after flush: %w",
+				obj.GetNamespace(), obj.GetName(), gvk.Kind, err)
+		}
+		if !added {
+			return fmt.Errorf("delete metadata too large: %s/%s (%s)",
+				obj.GetNamespace(), obj.GetName(), gvk.Kind)
+		}
+	}
+
+	log.Debugw("syncing Hub HA delete",
+		"namespace", obj.GetNamespace(), "name", obj.GetName(), "kind", gvk.Kind)
+	return e.sendDeltaUnlocked()
 }
 
 // selfListTimeout is the maximum time allowed for a single Resync self-list round.
 const selfListTimeout = 30 * time.Second
 
-// Resync performs a full resync of all objects.
+// maxResyncAttempts caps retries when Update/Delete invalidates a self-list snapshot.
+const maxResyncAttempts = 5
+
+// errResyncStaleSnapshot indicates a delta was sent after the resync inventory was captured.
+var errResyncStaleSnapshot = errors.New("hub HA resync snapshot invalidated by concurrent delta")
+
+// Resync performs a size-aware full resync.
 // If objects is nil, the emitter self-lists using its stored client and activeResources
 // (the "ListFunc=nil" pattern for PeriodicSyncer integration).
-// The mutex is released before any K8s API calls to avoid blocking Update/Delete/Send.
+// Objects are sent in MaxBundleBytes batches. After each GVK, a ResyncMetadata bundle is
+// sent so the standby can delete stale resources of that type.
+//
+// Self-list snapshots are validated against deltaGen: if Update/Delete sends a delta
+// between the list and emission, Resync(nil) retries with a fresh list. Caller-provided
+// object lists cannot be refreshed and return an error so the PeriodicSyncer can retry.
 func (e *HubHAEmitter) Resync(objects []client.Object) error {
+	provided := objects != nil
+	var lastErr error
+	for attempt := 1; attempt <= maxResyncAttempts; attempt++ {
+		snapshot := objects
+		if !provided {
+			snapshot = nil
+		}
+		lastErr = e.resyncOnce(snapshot)
+		if lastErr == nil {
+			return nil
+		}
+		if !errors.Is(lastErr, errResyncStaleSnapshot) {
+			return lastErr
+		}
+		if provided {
+			return fmt.Errorf("%w: caller-provided snapshot cannot be refreshed", lastErr)
+		}
+		log.Infow("Hub HA resync retrying after concurrent delta",
+			"attempt", attempt, "maxAttempts", maxResyncAttempts)
+	}
+	return fmt.Errorf("%w after %d attempts: %v", errResyncStaleSnapshot, maxResyncAttempts, lastErr)
+}
+
+func (e *HubHAEmitter) resyncOnce(objects []client.Object) error {
 	// Phase 1: read fields under lock (short critical section, no I/O).
 	e.mu.Lock()
 	enabled := e.enabled
 	cl := e.client
 	gvks := append([]schema.GroupVersionKind(nil), e.activeResources...)
+	gen := e.deltaGen
 	e.mu.Unlock()
 
 	if !enabled {
@@ -194,7 +289,25 @@ func (e *HubHAEmitter) Resync(objects []client.Object) error {
 		}
 	}
 
-	// Phase 2: update bundle state under lock (no I/O).
+	// Group objects by GVK for per-type ResyncMetadata cleanup on standby.
+	grouped := make(map[schema.GroupVersionKind][]*unstructured.Unstructured)
+	var order []schema.GroupVersionKind
+	for _, obj := range objects {
+		uObj, err := toUnstructured(obj)
+		if err != nil {
+			return fmt.Errorf("failed to convert resync object to unstructured: %w", err)
+		}
+		gvk := uObj.GroupVersionKind()
+		if !e.resourceFilter.ShouldSyncResource(obj, gvk) {
+			continue
+		}
+		cleanUnstructuredMetadata(uObj)
+		if _, ok := grouped[gvk]; !ok {
+			order = append(order, gvk)
+		}
+		grouped[gvk] = append(grouped[gvk], uObj)
+	}
+
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
@@ -202,25 +315,163 @@ func (e *HubHAEmitter) Resync(objects []client.Object) error {
 	if !e.enabled {
 		return nil
 	}
-
-	e.bundle.Clean()
-	for _, obj := range objects {
-		uObj, err := toUnstructured(obj)
-		if err != nil {
-			log.Warnf("failed to convert object to unstructured during resync: %v", err)
-			continue
-		}
-		gvk := uObj.GroupVersionKind()
-		if !e.resourceFilter.ShouldSyncResource(obj, gvk) {
-			continue
-		}
-		cleanUnstructuredMetadata(uObj)
-		e.bundle.Resync = append(e.bundle.Resync, uObj)
+	// A delta sent after the snapshot was taken must not be followed by a stale
+	// resync recreate / inventory that marks the deleted object as live.
+	if e.deltaGen != gen {
+		return errResyncStaleSnapshot
 	}
 
-	// Bundle is populated; PeriodicSyncer's Send() tick will flush it.
-	log.Infof("Hub HA resync: %d objects queued", len(e.bundle.Resync))
+	e.bundle.Clean()
+	totalObjects := 0
+
+	// Include configured activeResources so empty inventories still emit a completion frame
+	// (standby can delete all stale objects of that GVK).
+	gvkOrder := make([]schema.GroupVersionKind, 0, len(gvks)+len(order))
+	seenGVK := make(map[schema.GroupVersionKind]bool, len(gvks)+len(order))
+	for _, gvk := range gvks {
+		if seenGVK[gvk] {
+			continue
+		}
+		seenGVK[gvk] = true
+		gvkOrder = append(gvkOrder, gvk)
+	}
+	for _, gvk := range order {
+		if seenGVK[gvk] {
+			continue
+		}
+		seenGVK[gvk] = true
+		gvkOrder = append(gvkOrder, gvk)
+	}
+
+	for _, gvk := range gvkOrder {
+		objs := grouped[gvk]
+		metadataList := make([]generic.ObjectMetadata, 0, len(objs))
+
+		for _, uObj := range objs {
+			added, err := e.bundle.AddResync(uObj)
+			if err != nil {
+				return fmt.Errorf("failed to add resync object %s/%s (%s): %w",
+					uObj.GetNamespace(), uObj.GetName(), gvk.Kind, err)
+			}
+			if !added {
+				if err := e.sendBundleUnlocked(); err != nil {
+					return err
+				}
+				added, err = e.bundle.AddResync(uObj)
+				if err != nil {
+					return fmt.Errorf("failed to add resync object %s/%s (%s) after flush: %w",
+						uObj.GetNamespace(), uObj.GetName(), gvk.Kind, err)
+				}
+				if !added {
+					return fmt.Errorf("resync object too large: %s/%s (%s)",
+						uObj.GetNamespace(), uObj.GetName(), gvk.Kind)
+				}
+			}
+
+			metadataList = append(metadataList, generic.ObjectMetadata{
+				Namespace: uObj.GetNamespace(),
+				Name:      uObj.GetName(),
+				Group:     gvk.Group,
+				Version:   gvk.Version,
+				Kind:      gvk.Kind,
+			})
+			totalObjects++
+		}
+
+		// Flush remaining resync objects for this GVK, then send inventory frames.
+		if err := e.sendBundleUnlocked(); err != nil {
+			return err
+		}
+		if err := e.sendResyncMetadataInventory(gvk, metadataList); err != nil {
+			return err
+		}
+	}
+
+	log.Infow("Hub HA resync completed", "objects", totalObjects, "gvks", len(gvkOrder))
 	return nil
+}
+
+// sendResyncMetadataInventory sends per-GVK inventory frames that fit MaxBundleBytes.
+// The first frame includes InventoryBegin; the last includes Complete. Empty inventories
+// still emit a begin+complete frame so standby can delete all stale objects of that type.
+// Caller must hold e.mu and the working bundle must be empty.
+func (e *HubHAEmitter) sendResyncMetadataInventory(
+	gvk schema.GroupVersionKind, metas []generic.ObjectMetadata,
+) error {
+	if len(metas) == 0 {
+		return e.sendMetadataFrame(gvk, nil, true, true)
+	}
+
+	begin := true
+	for i := 0; i < len(metas); {
+		best := -1
+		low, high := i+1, len(metas)
+		for low <= high {
+			mid := (low + high) / 2
+			isLast := mid == len(metas)
+			fits, err := metadataFrameFits(gvk, metas[i:mid], begin, isLast)
+			if err != nil {
+				return fmt.Errorf("failed to size resync metadata frame for %s: %w", gvk.Kind, err)
+			}
+			if fits {
+				best = mid
+				low = mid + 1
+			} else {
+				high = mid - 1
+			}
+		}
+		if best < 0 {
+			return fmt.Errorf("resync metadata entry too large for %s: %s/%s",
+				gvk.Kind, metas[i].Namespace, metas[i].Name)
+		}
+		isLast := best == len(metas)
+		if err := e.sendMetadataFrame(gvk, metas[i:best], begin, isLast); err != nil {
+			return err
+		}
+		begin = false
+		i = best
+	}
+	return nil
+}
+
+func metadataFrame(
+	gvk schema.GroupVersionKind, metas []generic.ObjectMetadata, begin, complete bool,
+) []generic.ObjectMetadata {
+	frame := make([]generic.ObjectMetadata, 0, len(metas)+2)
+	if begin {
+		frame = append(frame, generic.ObjectMetadata{
+			Group: gvk.Group, Version: gvk.Version, Kind: gvk.Kind, InventoryBegin: true,
+		})
+	}
+	frame = append(frame, metas...)
+	if complete {
+		frame = append(frame, generic.ObjectMetadata{
+			Group: gvk.Group, Version: gvk.Version, Kind: gvk.Kind, Complete: true,
+		})
+	}
+	return frame
+}
+
+func metadataFrameFits(
+	gvk schema.GroupVersionKind, metas []generic.ObjectMetadata, begin, complete bool,
+) (bool, error) {
+	tmp := generic.NewGenericBundle[*unstructured.Unstructured]()
+	tmp.ResyncMetadata = metadataFrame(gvk, metas, begin, complete)
+	size, err := tmp.Size()
+	if err != nil {
+		return false, fmt.Errorf("failed to marshal resync metadata frame: %w", err)
+	}
+	return size <= generic.MaxBundleBytes, nil
+}
+
+func (e *HubHAEmitter) sendMetadataFrame(
+	gvk schema.GroupVersionKind, metas []generic.ObjectMetadata, begin, complete bool,
+) error {
+	frame := metadataFrame(gvk, metas, begin, complete)
+	if err := e.bundle.AddResyncMetadata(frame); err != nil {
+		return fmt.Errorf("failed to add resync metadata for %s: %w", gvk.Kind, err)
+	}
+	return e.sendBundleUnlocked()
 }
 
 // selfList lists all objects for each GVK. It does not require e.mu to be held.
@@ -267,12 +518,25 @@ func (e *HubHAEmitter) Send() error {
 	if !e.enabled {
 		return nil
 	}
-	return e.sendBundleUnlocked()
+	return e.sendDeltaUnlocked()
+}
+
+// sendDeltaUnlocked sends the current bundle and bumps deltaGen so in-flight Resync
+// snapshots are invalidated. Caller must hold e.mu.
+func (e *HubHAEmitter) sendDeltaUnlocked() error {
+	if e.bundle.IsEmpty() {
+		return nil
+	}
+	if err := e.sendBundleUnlocked(); err != nil {
+		return err
+	}
+	e.deltaGen++
+	return nil
 }
 
 // sendBundleUnlocked sends the bundle without acquiring the lock (caller must hold lock).
 func (e *HubHAEmitter) sendBundleUnlocked() error {
-	if len(e.bundle.Update) == 0 && len(e.bundle.Delete) == 0 && len(e.bundle.Resync) == 0 {
+	if e.bundle.IsEmpty() {
 		return nil
 	}
 
@@ -291,8 +555,11 @@ func (e *HubHAEmitter) sendBundleUnlocked() error {
 		return fmt.Errorf("failed to send Hub HA bundle: %w", err)
 	}
 
-	log.Infof("sent Hub HA bundle: updates=%d, deletes=%d, resync=%d",
-		len(e.bundle.Update), len(e.bundle.Delete), len(e.bundle.Resync))
+	log.Infow("sent Hub HA bundle",
+		"updates", len(e.bundle.Update),
+		"deletes", len(e.bundle.Delete),
+		"resync", len(e.bundle.Resync),
+		"resync_metadata", len(e.bundle.ResyncMetadata))
 
 	// Clear bundle after successful send
 	e.bundle.Clean()

--- a/agent/pkg/spec/hubha/hubha_emitter_test.go
+++ b/agent/pkg/spec/hubha/hubha_emitter_test.go
@@ -7,14 +7,19 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"github.com/stolostron/multicluster-global-hub/pkg/bundle/generic"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
@@ -81,24 +86,21 @@ func TestHubHAEmitter_Update_SendsImmediately(t *testing.T) {
 		},
 	}
 
-	// Update should send immediately
+	// Update should send immediately after size-aware add
 	err := emitter.Update(secret)
 	if err != nil {
-		t.Errorf("Update() error = %v", err)
+		t.Fatalf("Update() error = %v", err)
 	}
 
-	// Verify event was sent
 	if len(producer.events) != 1 {
-		t.Errorf("Expected 1 event to be sent immediately, got %d", len(producer.events))
+		t.Fatalf("expected one event after Update before indexing producer.events[0]; got %d", len(producer.events))
 	}
 
-	// Verify event content
 	event := producer.events[0]
 	if event.Type() != constants.HubHAResourcesMsgKey {
 		t.Errorf("Expected event type %s, got %s", constants.HubHAResourcesMsgKey, event.Type())
 	}
 
-	// Parse bundle from event data
 	var bundle generic.GenericBundle[*unstructured.Unstructured]
 	err = json.Unmarshal(event.Data(), &bundle)
 	if err != nil {
@@ -113,7 +115,6 @@ func TestHubHAEmitter_Update_SendsImmediately(t *testing.T) {
 		t.Errorf("Expected secret name 'test-secret', got %s", bundle.Update[0].GetName())
 	}
 
-	// Bundle should be cleared after send
 	if len(emitter.bundle.Update) != 0 {
 		t.Errorf("Expected bundle to be cleared after send, got %d updates", len(emitter.bundle.Update))
 	}
@@ -130,7 +131,6 @@ func TestHubHAEmitter_Delete_SendsImmediately(t *testing.T) {
 	emitter := NewHubHAEmitter(producer, transportConfig, "hub1", "hub2")
 	emitter.SetEnabled(true)
 
-	// Create an unstructured Secret with required label
 	secret := &unstructured.Unstructured{
 		Object: map[string]any{
 			"apiVersion": "v1",
@@ -145,18 +145,15 @@ func TestHubHAEmitter_Delete_SendsImmediately(t *testing.T) {
 		},
 	}
 
-	// Delete should send immediately
 	err := emitter.Delete(secret)
 	if err != nil {
-		t.Errorf("Delete() error = %v", err)
+		t.Fatalf("Delete() error = %v", err)
 	}
 
-	// Verify event was sent
 	if len(producer.events) != 1 {
-		t.Errorf("Expected 1 event to be sent immediately, got %d", len(producer.events))
+		t.Fatalf("expected one event after Delete before indexing producer.events[0]; got %d", len(producer.events))
 	}
 
-	// Parse bundle from event data
 	var bundle generic.GenericBundle[*unstructured.Unstructured]
 	err = json.Unmarshal(producer.events[0].Data(), &bundle)
 	if err != nil {
@@ -203,7 +200,6 @@ func TestHubHAEmitter_Update_FilteredResource(t *testing.T) {
 		t.Errorf("Update() error = %v", err)
 	}
 
-	// Verify event was sent (predicate would have filtered it before calling Update)
 	if len(producer.events) != 1 {
 		t.Errorf("Expected 1 event to be sent, got %d", len(producer.events))
 	}
@@ -211,56 +207,37 @@ func TestHubHAEmitter_Update_FilteredResource(t *testing.T) {
 
 func TestHubHAEmitter_Delete_WithoutLabels(t *testing.T) {
 	producer := &mockProducer{events: []cloudevents.Event{}}
-	transportConfig := &transport.TransportInternalConfig{
-		KafkaCredential: &transport.KafkaConfig{
-			SpecTopic: "spec-topic",
-		},
-	}
-
-	emitter := NewHubHAEmitter(producer, transportConfig, "hub1", "hub2")
+	emitter := NewHubHAEmitter(producer, newTransportConfig(), "hub1", "hub2")
 	emitter.SetEnabled(true)
 
-	// Create a Secret WITH required label - simulating a deleted object that was synced
-	// The delete event contains the object's last known state with labels
+	// Filtering is the predicate's job; Delete still emits for unlabeled objects it receives.
 	secret := &unstructured.Unstructured{
 		Object: map[string]any{
 			"apiVersion": "v1",
 			"kind":       "Secret",
 			"metadata": map[string]any{
-				"name":      "test-secret",
+				"name":      "unlabeled-secret",
 				"namespace": "default",
-				"labels": map[string]any{
-					"hive.openshift.io/secret-type": "kubeconfig",
-				},
 			},
 		},
 	}
 
-	// Delete should send because object has required labels (was synced)
-	// This tests direct Delete() call (predicate is bypassed in unit tests)
-	err := emitter.Delete(secret)
-	if err != nil {
-		t.Errorf("Delete() error = %v", err)
+	if err := emitter.Delete(secret); err != nil {
+		t.Fatalf("Delete() error = %v", err)
 	}
-
-	// Verify event was sent
 	if len(producer.events) != 1 {
-		t.Errorf("Expected 1 event to be sent for deletion, got %d", len(producer.events))
+		t.Fatalf("expected Delete to send 1 event for unlabeled object, got %d", len(producer.events))
 	}
 
-	// Parse bundle from event data
 	var bundle generic.GenericBundle[*unstructured.Unstructured]
-	err = json.Unmarshal(producer.events[0].Data(), &bundle)
-	if err != nil {
-		t.Errorf("Failed to unmarshal bundle: %v", err)
+	if err := json.Unmarshal(producer.events[0].Data(), &bundle); err != nil {
+		t.Fatalf("Failed to unmarshal bundle: %v", err)
 	}
-
 	if len(bundle.Delete) != 1 {
-		t.Errorf("Expected 1 delete in bundle, got %d", len(bundle.Delete))
+		t.Fatalf("Expected 1 delete in bundle, got %d", len(bundle.Delete))
 	}
-
-	if bundle.Delete[0].Name != "test-secret" {
-		t.Errorf("Expected secret name 'test-secret', got %s", bundle.Delete[0].Name)
+	if bundle.Delete[0].Name != "unlabeled-secret" {
+		t.Errorf("Expected secret name 'unlabeled-secret', got %s", bundle.Delete[0].Name)
 	}
 }
 
@@ -304,37 +281,75 @@ func TestHubHAEmitter_Resync(t *testing.T) {
 		},
 	}
 
-	// Resync should NOT send immediately
+	// Resync sends object batches then a ResyncMetadata bundle for the GVK
 	err := emitter.Resync([]client.Object{secret1, secret2})
 	if err != nil {
-		t.Errorf("Resync() error = %v", err)
+		t.Fatalf("Resync() error = %v", err)
 	}
 
-	// No events should be sent yet
-	if len(producer.events) != 0 {
-		t.Errorf("Expected 0 events after Resync, got %d", len(producer.events))
+	if len(producer.events) != 2 {
+		t.Fatalf("expected 2 events after Resync before indexing producer.events[0]; got %d", len(producer.events))
 	}
 
-	// Now send the bundle
-	err = emitter.Send()
+	var resyncBundle generic.GenericBundle[*unstructured.Unstructured]
+	err = json.Unmarshal(producer.events[0].Data(), &resyncBundle)
 	if err != nil {
-		t.Errorf("Send() error = %v", err)
+		t.Errorf("Failed to unmarshal resync bundle: %v", err)
+	}
+	if len(resyncBundle.Resync) != 2 {
+		t.Errorf("Expected 2 resync items in first bundle, got %d", len(resyncBundle.Resync))
 	}
 
-	// Verify event was sent
+	var metaBundle generic.GenericBundle[*unstructured.Unstructured]
+	err = json.Unmarshal(producer.events[1].Data(), &metaBundle)
+	if err != nil {
+		t.Errorf("Failed to unmarshal metadata bundle: %v", err)
+	}
+	if len(metaBundle.ResyncMetadata) != 4 {
+		t.Errorf("Expected 4 resync metadata items (begin + 2 objects + complete), got %d",
+			len(metaBundle.ResyncMetadata))
+	}
+	hasBegin, hasComplete, named := false, false, 0
+	for _, m := range metaBundle.ResyncMetadata {
+		if m.InventoryBegin {
+			hasBegin = true
+		}
+		if m.Complete {
+			hasComplete = true
+		}
+		if m.Name != "" {
+			named++
+		}
+	}
+	if !hasBegin || !hasComplete {
+		t.Errorf("expected InventoryBegin and Complete markers, begin=%v complete=%v", hasBegin, hasComplete)
+	}
+	if named != 2 {
+		t.Errorf("expected 2 named metadata entries, got %d", named)
+	}
+}
+
+func TestHubHAEmitter_Resync_EmptyActiveResource_EmitsCompletionFrame(t *testing.T) {
+	producer := &mockProducer{events: []cloudevents.Event{}}
+	emitter := NewHubHAEmitter(producer, newTransportConfig(), "hub1", "hub2")
+	emitter.SetEnabled(true)
+	emitter.SetActiveResources([]schema.GroupVersionKind{{Group: "", Version: "v1", Kind: "Secret"}})
+
+	if err := emitter.Resync([]client.Object{}); err != nil {
+		t.Fatalf("Resync() error = %v", err)
+	}
 	if len(producer.events) != 1 {
-		t.Errorf("Expected 1 event after Send, got %d", len(producer.events))
+		t.Fatalf("expected 1 metadata event for empty inventory, got %d", len(producer.events))
 	}
-
-	// Parse bundle
-	var bundle generic.GenericBundle[*unstructured.Unstructured]
-	err = json.Unmarshal(producer.events[0].Data(), &bundle)
-	if err != nil {
-		t.Errorf("Failed to unmarshal bundle: %v", err)
+	var metaBundle generic.GenericBundle[*unstructured.Unstructured]
+	if err := json.Unmarshal(producer.events[0].Data(), &metaBundle); err != nil {
+		t.Fatalf("unmarshal: %v", err)
 	}
-
-	if len(bundle.Resync) != 2 {
-		t.Errorf("Expected 2 resync items in sent bundle, got %d", len(bundle.Resync))
+	if len(metaBundle.ResyncMetadata) != 2 {
+		t.Fatalf("expected begin+complete markers, got %d entries", len(metaBundle.ResyncMetadata))
+	}
+	if !metaBundle.ResyncMetadata[0].InventoryBegin || !metaBundle.ResyncMetadata[1].Complete {
+		t.Fatalf("expected begin then complete, got %+v", metaBundle.ResyncMetadata)
 	}
 }
 
@@ -399,7 +414,7 @@ func TestHubHAEmitter_SetEnabled_TogglesState(t *testing.T) {
 		t.Fatalf("expected 0 events while disabled, got %d", len(producer.events))
 	}
 
-	// Enable: events flow
+	// Enable: events flow immediately
 	emitter.SetEnabled(true)
 	if err := emitter.Update(secret); err != nil {
 		t.Fatalf("unexpected error from enabled Update: %v", err)
@@ -657,9 +672,12 @@ func TestHubHAEmitter_Delete_RemovesExistingUpdate(t *testing.T) {
 	if err := emitter.Delete(toDelete); err != nil {
 		t.Fatalf("Delete() returned unexpected error: %v", err)
 	}
-	// After Delete the Update list should be empty.
+	// After Delete the Update list should be empty (and delete already sent).
 	if len(emitter.bundle.Update) != 0 {
 		t.Errorf("expected empty Update list after Delete, got %d items", len(emitter.bundle.Update))
+	}
+	if len(emitter.bundle.Delete) != 0 {
+		t.Errorf("expected empty Delete list after send, got %d items", len(emitter.bundle.Delete))
 	}
 }
 
@@ -704,5 +722,173 @@ func TestHubHAEmitter_ToUnstructured_TypedObject(t *testing.T) {
 	}
 	if uObj.GetName() != "typed-cm" {
 		t.Errorf("expected name 'typed-cm', got %s", uObj.GetName())
+	}
+}
+
+// Covers size-aware flush on Update (auto-send current batch when MaxBundleBytes would be exceeded).
+func TestHubHAEmitter_Update_FlushesWhenBundleFull(t *testing.T) {
+	producer := &mockProducer{events: []cloudevents.Event{}}
+	emitter := NewHubHAEmitter(producer, newTransportConfig(), "hub1", "hub2")
+	emitter.SetEnabled(true)
+
+	payload := string(make([]byte, 100*1024))
+	for i := 0; ; i++ {
+		obj := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"metadata": map[string]any{
+					"name":      fmt.Sprintf("fill-%d", i),
+					"namespace": "default",
+					"labels":    map[string]any{"hive.openshift.io/secret-type": "kubeconfig"},
+				},
+				"data": map[string]any{"kubeconfig": payload},
+			},
+		}
+		added, err := emitter.bundle.AddUpdate(obj)
+		if err != nil {
+			t.Fatalf("AddUpdate fill error: %v", err)
+		}
+		if !added {
+			break
+		}
+		if i > 20 {
+			t.Fatal("bundle never filled")
+		}
+	}
+
+	overflow := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]any{
+				"name":      "overflow",
+				"namespace": "default",
+				"labels":    map[string]any{"hive.openshift.io/secret-type": "kubeconfig"},
+			},
+			"data": map[string]any{"kubeconfig": payload},
+		},
+	}
+	if err := emitter.Update(overflow); err != nil {
+		t.Fatalf("Update() after full bundle: %v", err)
+	}
+	if len(producer.events) < 2 {
+		t.Fatalf("expected at least 2 events after size flush, got %d", len(producer.events))
+	}
+}
+
+// TestHubHAEmitter_Resync_RetriesWhenDeleteBetweenListAndSend ensures a Delete that
+// lands after self-list but before resync emission invalidates the snapshot so the
+// deleted object is not recreated / marked live in ResyncMetadata.
+func TestHubHAEmitter_Resync_RetriesWhenDeleteBetweenListAndSend(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+
+	secret := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]any{
+				"name":      "to-delete",
+				"namespace": "default",
+				"labels": map[string]any{
+					"hive.openshift.io/secret-type": "kubeconfig",
+				},
+			},
+			"data": map[string]any{"kubeconfig": "dGVzdA=="},
+		},
+	}
+
+	listStarted := make(chan struct{})
+	listContinue := make(chan struct{})
+	var listCount atomic.Int32
+
+	base := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+	cl := interceptor.NewClient(base, interceptor.Funcs{
+		List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+			if err := c.List(ctx, list, opts...); err != nil {
+				return err
+			}
+			if listCount.Add(1) == 1 {
+				close(listStarted)
+				<-listContinue
+			}
+			return nil
+		},
+	})
+
+	producer := &mockProducer{events: []cloudevents.Event{}}
+	emitter := NewHubHAEmitter(producer, newTransportConfig(), "hub1", "hub2")
+	emitter.SetEnabled(true)
+	emitter.SetClient(cl)
+	emitter.SetActiveResources([]schema.GroupVersionKind{
+		{Group: "", Version: "v1", Kind: "Secret"},
+	})
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- emitter.Resync(nil)
+	}()
+
+	const waitTimeout = 5 * time.Second
+	select {
+	case <-listStarted:
+	case err := <-errCh:
+		t.Fatalf("Resync finished before list started: %v", err)
+	case <-time.After(waitTimeout):
+		t.Fatal("timed out waiting for self-list to start")
+	}
+
+	if err := emitter.Delete(secret); err != nil {
+		t.Fatalf("Delete during self-list: %v", err)
+	}
+	if err := cl.Delete(context.Background(), secret); err != nil {
+		t.Fatalf("delete from API during self-list: %v", err)
+	}
+	close(listContinue)
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Resync() error = %v", err)
+		}
+	case <-time.After(waitTimeout):
+		t.Fatal("timed out waiting for Resync to finish after delete")
+	}
+
+	if listCount.Load() < 2 {
+		t.Fatalf("expected Resync to retry self-list after delete, listCount=%d", listCount.Load())
+	}
+
+	var sawDeletedName bool
+	var sawResyncOfDeleted bool
+	for _, evt := range producer.events {
+		var bundle generic.GenericBundle[*unstructured.Unstructured]
+		if err := json.Unmarshal(evt.Data(), &bundle); err != nil {
+			t.Fatalf("unmarshal event: %v", err)
+		}
+		for _, d := range bundle.Delete {
+			if d.Name == "to-delete" {
+				sawDeletedName = true
+			}
+		}
+		for _, obj := range bundle.Resync {
+			if obj.GetName() == "to-delete" {
+				sawResyncOfDeleted = true
+			}
+		}
+		for _, m := range bundle.ResyncMetadata {
+			if m.Name == "to-delete" {
+				sawResyncOfDeleted = true
+			}
+		}
+	}
+	if !sawDeletedName {
+		t.Fatal("expected delete event for to-delete")
+	}
+	if sawResyncOfDeleted {
+		t.Fatal("stale snapshot must not resync or inventory-mark deleted object to-delete")
 	}
 }

--- a/agent/pkg/spec/hubha/hubha_standby_syncer.go
+++ b/agent/pkg/spec/hubha/hubha_standby_syncer.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	stderrors "errors"
 	"fmt"
+	"sync"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/util/retry"
@@ -19,16 +21,31 @@ import (
 
 	"github.com/stolostron/multicluster-global-hub/pkg/bundle/generic"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
 // HubHAStandbySyncer receives ACM resources from active hub and applies them to standby hub
 type HubHAStandbySyncer struct {
-	client client.Client
+	client         client.Client
+	resourceFilter *utils.HubHAResourceFilter
+
+	mu sync.Mutex
+	// pendingResyncSessions accumulates live object metadata per GVK until cleanup after
+	// Complete succeeds. Partial ResyncMetadata frames must not trigger stale cleanup.
+	pendingResyncSessions map[string]*resyncInventorySession
+}
+
+// resyncInventorySession tracks one per-GVK inventory across size-split frames.
+type resyncInventorySession struct {
+	items     map[string]generic.ObjectMetadata
+	beginSeen bool
 }
 
 func NewHubHAStandbySyncer(c client.Client) *HubHAStandbySyncer {
 	return &HubHAStandbySyncer{
-		client: c,
+		client:                c,
+		resourceFilter:        utils.NewHubHAResourceFilter(),
+		pendingResyncSessions: make(map[string]*resyncInventorySession),
 	}
 }
 
@@ -92,8 +109,18 @@ func (s *HubHAStandbySyncer) Sync(ctx context.Context, evt *cloudevents.Event) e
 		}
 	}
 
-	log.Infof("standby hub processed Hub HA bundle from %s: created=%d, updated=%d, resynced=%d, deleted=%d",
-		sourceHub, len(bundle.Create), len(bundle.Update), len(bundle.Resync), len(bundle.Delete))
+	// Handle resync metadata: accumulate inventory frames; cleanup only after Complete.
+	if len(bundle.ResyncMetadata) > 0 {
+		if err := s.handleResyncMetadata(ctx, bundle.ResyncMetadata, sourceHub); err != nil {
+			log.Errorw("failed to handle resync metadata", "sourceHub", sourceHub, "error", err)
+			syncErrs = append(syncErrs, err)
+		}
+	}
+
+	log.Infof("standby hub processed Hub HA bundle from %s: created=%d, updated=%d, "+
+		"resynced=%d, deleted=%d, resync_metadata=%d",
+		sourceHub, len(bundle.Create), len(bundle.Update), len(bundle.Resync), len(bundle.Delete),
+		len(bundle.ResyncMetadata))
 
 	if len(syncErrs) > 0 {
 		return fmt.Errorf("failed to apply Hub HA bundle from %s: %w", sourceHub, stderrors.Join(syncErrs...))
@@ -148,6 +175,8 @@ func (s *HubHAStandbySyncer) updateResource(ctx context.Context, obj *unstructur
 	// Owner resources may not exist on standby hub, and ownership will be
 	// recreated by controllers on standby if needed
 	obj.SetOwnerReferences(nil)
+	// Status is hub-local; including it in a full Update can fail ManagedCluster apply.
+	unstructured.RemoveNestedField(obj.Object, "status")
 
 	// For ManagedCluster resources, set hubAcceptsClient to false
 	// This prevents standby hub from accepting client connections while active hub is healthy
@@ -167,9 +196,10 @@ func (s *HubHAStandbySyncer) updateResource(ctx context.Context, obj *unstructur
 			return s.client.Create(ctx, obj)
 		}
 
-		// Preserve some metadata from existing resource
+		// Preserve standby identity and controller-owned finalizers.
 		obj.SetResourceVersion(existing.GetResourceVersion())
 		obj.SetUID(existing.GetUID())
+		obj.SetFinalizers(existing.GetFinalizers())
 
 		return s.client.Update(ctx, obj)
 	})
@@ -213,6 +243,201 @@ func (s *HubHAStandbySyncer) deleteResource(ctx context.Context, meta *generic.O
 	}
 
 	log.Infof("successfully deleted resource %s/%s from standby hub", meta.Namespace, meta.Name)
+	return nil
+}
+
+// handleResyncMetadata processes inventory frames for a GVK.
+// Frames may include InventoryBegin (start/reset session) and/or Complete (run stale cleanup).
+// Markerless middle frames append to an existing session; without a session they are treated
+// as a legacy single-shot inventory. The session is retained until cleanup succeeds so a
+// retried Complete frame still has the full inventory. Complete without an observed
+// InventoryBegin is ignored (not treated as an empty inventory).
+func (s *HubHAStandbySyncer) handleResyncMetadata(
+	ctx context.Context, metadata []generic.ObjectMetadata, sourceHub string,
+) error {
+	hasBegin := false
+	hasComplete := false
+	var gvk schema.GroupVersionKind
+	for _, m := range metadata {
+		if m.Kind != "" {
+			gvk = schema.GroupVersionKind{Group: m.Group, Version: m.Version, Kind: m.Kind}
+		}
+		if m.InventoryBegin {
+			hasBegin = true
+		}
+		if m.Complete {
+			hasComplete = true
+		}
+	}
+
+	if gvk.Kind == "" {
+		log.Warnw("no valid GVK found in resync metadata", "sourceHub", sourceHub)
+		return nil
+	}
+	gvkKey := gvk.String()
+
+	s.mu.Lock()
+	if s.pendingResyncSessions == nil {
+		s.pendingResyncSessions = make(map[string]*resyncInventorySession)
+	}
+	session, sessionExists := s.pendingResyncSessions[gvkKey]
+
+	// Markerless frame: append to an in-flight session, otherwise legacy single-shot cleanup.
+	if !hasBegin && !hasComplete {
+		if !sessionExists {
+			s.mu.Unlock()
+			return s.cleanupStaleResources(ctx, metadata, sourceHub)
+		}
+		s.appendInventoryEntries(session, metadata)
+		s.mu.Unlock()
+		return nil
+	}
+
+	if hasBegin {
+		session = &resyncInventorySession{
+			items:     make(map[string]generic.ObjectMetadata),
+			beginSeen: true,
+		}
+		s.pendingResyncSessions[gvkKey] = session
+		sessionExists = true
+	}
+
+	if !sessionExists {
+		// Complete (or other markers) without an open session / InventoryBegin must not
+		// run empty-inventory cleanup.
+		s.mu.Unlock()
+		if hasComplete {
+			log.Warnw("ignoring ResyncMetadata Complete without InventoryBegin",
+				"sourceHub", sourceHub, "gvk", gvk.String())
+		}
+		return nil
+	}
+
+	s.appendInventoryEntries(session, metadata)
+
+	if !hasComplete {
+		s.mu.Unlock()
+		return nil
+	}
+
+	if !session.beginSeen {
+		s.mu.Unlock()
+		log.Warnw("ignoring ResyncMetadata Complete without InventoryBegin",
+			"sourceHub", sourceHub, "gvk", gvk.String())
+		return nil
+	}
+
+	// Copy inventory for cleanup; keep the session until cleanup succeeds so retries
+	// of the Complete frame still see the full accumulated set.
+	full := make([]generic.ObjectMetadata, 0, len(session.items)+1)
+	for _, m := range session.items {
+		full = append(full, m)
+	}
+	full = append(full, generic.ObjectMetadata{
+		Group: gvk.Group, Version: gvk.Version, Kind: gvk.Kind,
+	})
+	s.mu.Unlock()
+
+	if err := s.cleanupStaleResources(ctx, full, sourceHub); err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	delete(s.pendingResyncSessions, gvkKey)
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *HubHAStandbySyncer) appendInventoryEntries(
+	session *resyncInventorySession, metadata []generic.ObjectMetadata,
+) {
+	for _, m := range metadata {
+		if m.InventoryBegin || m.Complete || m.Name == "" {
+			continue
+		}
+		session.items[m.Key()] = m
+	}
+}
+
+// cleanupStaleResources deletes local resources of the metadata GVK that are not listed
+// in the active hub's ResyncMetadata set (i.e., stale copies removed from active).
+func (s *HubHAStandbySyncer) cleanupStaleResources(
+	ctx context.Context, metadata []generic.ObjectMetadata, sourceHub string,
+) error {
+	activeKeys := make(map[string]bool, len(metadata))
+	var gvk schema.GroupVersionKind
+	for _, m := range metadata {
+		if m.Kind == "" {
+			continue
+		}
+		if gvk.Kind == "" {
+			gvk = schema.GroupVersionKind{Group: m.Group, Version: m.Version, Kind: m.Kind}
+		}
+		if m.InventoryBegin || m.Complete || m.Name == "" {
+			continue
+		}
+		activeKeys[m.Key()] = true
+	}
+
+	if gvk.Kind == "" {
+		log.Warnw("no valid GVK found in resync metadata", "sourceHub", sourceHub)
+		return nil
+	}
+
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(schema.GroupVersionKind{
+		Group: gvk.Group, Version: gvk.Version, Kind: gvk.Kind + "List",
+	})
+	if err := s.client.List(ctx, list); err != nil {
+		if meta.IsNoMatchError(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to list %s for stale cleanup: %w", gvk, err)
+	}
+
+	var deleteErrs []error
+	for i := range list.Items {
+		obj := &list.Items[i]
+		if s.resourceFilter != nil && !s.resourceFilter.ShouldSyncResource(obj, gvk) {
+			continue
+		}
+		// Global Hub standby also hosts topology ManagedClusters (imported hubs,
+		// local-cluster). Those are not copies of the active regional hub inventory
+		// and must not be deleted by ResyncMetadata stale cleanup.
+		if gvk.Group == clusterv1.GroupName && gvk.Kind == "ManagedCluster" &&
+			shouldSkipHAAnnotation(obj) {
+			log.Debugf("skipping Hub HA stale cleanup for global-hub topology ManagedCluster %s",
+				obj.GetName())
+			continue
+		}
+		key := generic.ObjectMetadata{
+			Namespace: obj.GetNamespace(),
+			Name:      obj.GetName(),
+			Group:     gvk.Group,
+			Version:   gvk.Version,
+			Kind:      gvk.Kind,
+		}.Key()
+		if activeKeys[key] {
+			continue
+		}
+		objMeta := generic.ObjectMetadata{
+			Namespace: obj.GetNamespace(),
+			Name:      obj.GetName(),
+			Group:     gvk.Group,
+			Version:   gvk.Version,
+			Kind:      gvk.Kind,
+		}
+		if err := s.deleteResource(ctx, &objMeta, sourceHub); err != nil {
+			log.Errorw("failed to delete stale resource",
+				"namespace", obj.GetNamespace(), "name", obj.GetName(),
+				"kind", gvk.Kind, "error", err)
+			deleteErrs = append(deleteErrs, fmt.Errorf("failed to delete stale %s/%s (%s): %w",
+				obj.GetNamespace(), obj.GetName(), gvk.Kind, err))
+		}
+	}
+	if len(deleteErrs) > 0 {
+		return stderrors.Join(deleteErrs...)
+	}
 	return nil
 }
 

--- a/agent/pkg/spec/hubha/hubha_standby_syncer_test.go
+++ b/agent/pkg/spec/hubha/hubha_standby_syncer_test.go
@@ -617,6 +617,103 @@ func TestHubHAStandbySyncer_UpdateManagedCluster_SetsHubAcceptsClient(t *testing
 	}
 }
 
+// Regression for e2e: ManagedCluster updates from active still carry status, and standby
+// already has controller finalizers. Apply must succeed and sync labels/spec.
+func TestHubHAStandbySyncer_UpdateManagedCluster_AppliesLabelsWithStatusAndFinalizers(t *testing.T) {
+	scheme := runtime.NewScheme()
+
+	existing := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": managedClusterAPIVersion,
+			"kind":       "ManagedCluster",
+			"metadata": map[string]interface{}{
+				"name": "hubha-test-cluster",
+				"labels": map[string]interface{}{
+					"env": "test",
+				},
+				"finalizers": []interface{}{
+					"cluster.open-cluster-management.io/api-resource-cleanup",
+				},
+			},
+			"spec": map[string]interface{}{
+				"hubAcceptsClient": false,
+				"managedClusterClientConfigs": []interface{}{
+					map[string]interface{}{
+						"url": "https://test-cluster-v1.example.com:6443",
+					},
+				},
+			},
+			"status": map[string]interface{}{
+				"version": map[string]interface{}{"kubernetes": "v1.28.0"},
+			},
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+	syncer := NewHubHAStandbySyncer(cl)
+
+	updated := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": managedClusterAPIVersion,
+			"kind":       "ManagedCluster",
+			"metadata": map[string]interface{}{
+				"name": "hubha-test-cluster",
+				"labels": map[string]interface{}{
+					"env": "production",
+				},
+			},
+			"spec": map[string]interface{}{
+				"hubAcceptsClient": true,
+				"managedClusterClientConfigs": []interface{}{
+					map[string]interface{}{
+						"url": "https://test-cluster-v2.example.com:6443",
+					},
+				},
+			},
+			"status": map[string]interface{}{
+				"version": map[string]interface{}{"kubernetes": "v1.29.0"},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	if err := syncer.updateResource(ctx, updated, "hub1"); err != nil {
+		t.Fatalf(errUpdateResource, err)
+	}
+
+	result := &unstructured.Unstructured{}
+	result.SetGroupVersionKind(updated.GroupVersionKind())
+	if err := cl.Get(ctx, types.NamespacedName{Name: "hubha-test-cluster"}, result); err != nil {
+		t.Fatalf("Failed to get updated ManagedCluster: %v", err)
+	}
+
+	if result.GetLabels()["env"] != "production" {
+		t.Errorf("label env = %q, want production", result.GetLabels()["env"])
+	}
+
+	hubAcceptsClient, found, err := unstructured.NestedBool(result.Object, "spec", "hubAcceptsClient")
+	if err != nil || !found || hubAcceptsClient {
+		t.Errorf("hubAcceptsClient = %v (found=%v err=%v), want false", hubAcceptsClient, found, err)
+	}
+
+	configs, found, err := unstructured.NestedSlice(result.Object, "spec", "managedClusterClientConfigs")
+	if err != nil || !found || len(configs) == 0 {
+		t.Fatalf("Failed to get client configs: found=%v len=%d err=%v", found, len(configs), err)
+	}
+	cfg, ok := configs[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("client config[0] type = %T, want map", configs[0])
+	}
+	if url, _ := cfg["url"].(string); url != "https://test-cluster-v2.example.com:6443" {
+		t.Errorf("URL = %q, want v2 URL", url)
+	}
+
+	finalizers := result.GetFinalizers()
+	if len(finalizers) != 1 || finalizers[0] != "cluster.open-cluster-management.io/api-resource-cleanup" {
+		t.Errorf("finalizers = %v, want standby finalizer preserved", finalizers)
+	}
+}
+
 func TestHubHAStandbySyncer_Sync_ReturnsAggregateErrors(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := corev1.AddToScheme(scheme); err != nil {
@@ -676,4 +773,482 @@ func TestHubHAStandbySyncer_Sync_ReturnsAggregateErrors(t *testing.T) {
 
 	err := syncer.Sync(context.Background(), &evt)
 	assertSyncAggregateErrors(t, err, 2, "delete failure one", "delete failure two")
+}
+
+func hubHALabeledConfigMap(name, namespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+				"labels": map[string]interface{}{
+					"hive.openshift.io/secret-type": "kubeconfig",
+				},
+			},
+			"data": map[string]interface{}{
+				"key": "value",
+			},
+		},
+	}
+}
+
+func TestHubHAStandbySyncer_Sync_ResyncMetadata_CleansStaleResources(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add corev1 to scheme: %v", err)
+	}
+
+	keep := hubHALabeledConfigMap("keep-cm", "default")
+	stale := hubHALabeledConfigMap("stale-cm", "default")
+	// Unlabeled ConfigMap should not be deleted by Hub HA cleanup.
+	localOnly := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name":      "local-only-cm",
+				"namespace": "default",
+			},
+			"data": map[string]interface{}{"key": "value"},
+		},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(keep, stale, localOnly).
+		Build()
+	syncer := NewHubHAStandbySyncer(cl)
+
+	bundle := generic.NewGenericBundle[*unstructured.Unstructured]()
+	bundle.ResyncMetadata = []generic.ObjectMetadata{
+		{Namespace: "default", Name: "keep-cm", Group: "", Version: "v1", Kind: "ConfigMap"},
+	}
+
+	evt := cloudevents.NewEvent()
+	evt.SetType(constants.HubHAResourcesMsgKey)
+	evt.SetSource("hub1")
+	if err := evt.SetData(cloudevents.ApplicationJSON, bundle); err != nil {
+		t.Fatalf("SetData() error = %v", err)
+	}
+
+	if err := syncer.Sync(context.Background(), &evt); err != nil {
+		t.Fatalf("Sync() error = %v", err)
+	}
+
+	ctx := context.Background()
+	keepObj := &unstructured.Unstructured{}
+	keepObj.SetAPIVersion("v1")
+	keepObj.SetKind("ConfigMap")
+	if err := cl.Get(ctx, types.NamespacedName{Name: "keep-cm", Namespace: "default"}, keepObj); err != nil {
+		t.Fatalf("expected keep-cm to remain: %v", err)
+	}
+
+	staleObj := &unstructured.Unstructured{}
+	staleObj.SetAPIVersion("v1")
+	staleObj.SetKind("ConfigMap")
+	err := cl.Get(ctx, types.NamespacedName{Name: "stale-cm", Namespace: "default"}, staleObj)
+	if err == nil {
+		t.Fatal("expected stale-cm to be deleted")
+	}
+	if !errors.IsNotFound(err) {
+		t.Fatalf("expected NotFound for stale-cm, got: %v", err)
+	}
+
+	localObj := &unstructured.Unstructured{}
+	localObj.SetAPIVersion("v1")
+	localObj.SetKind("ConfigMap")
+	if err := cl.Get(ctx, types.NamespacedName{Name: "local-only-cm", Namespace: "default"}, localObj); err != nil {
+		t.Fatalf("expected unlabeled local-only-cm to remain: %v", err)
+	}
+}
+
+func TestHubHAStandbySyncer_Sync_ResyncMetadata_WaitsForComplete(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add corev1 to scheme: %v", err)
+	}
+
+	stale := hubHALabeledConfigMap("stale-cm", "default")
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(stale).Build()
+	syncer := NewHubHAStandbySyncer(cl)
+
+	partial := generic.NewGenericBundle[*unstructured.Unstructured]()
+	partial.ResyncMetadata = []generic.ObjectMetadata{
+		{Group: "", Version: "v1", Kind: "ConfigMap", InventoryBegin: true},
+		{Namespace: "default", Name: "keep-cm", Group: "", Version: "v1", Kind: "ConfigMap"},
+	}
+	partialEvt := cloudevents.NewEvent()
+	partialEvt.SetType(constants.HubHAResourcesMsgKey)
+	partialEvt.SetSource("hub1")
+	if err := partialEvt.SetData(cloudevents.ApplicationJSON, partial); err != nil {
+		t.Fatalf("SetData() error = %v", err)
+	}
+	if err := syncer.Sync(context.Background(), &partialEvt); err != nil {
+		t.Fatalf("Sync() partial error = %v", err)
+	}
+
+	ctx := context.Background()
+	staleObj := &unstructured.Unstructured{}
+	staleObj.SetAPIVersion("v1")
+	staleObj.SetKind("ConfigMap")
+	if err := cl.Get(ctx, types.NamespacedName{Name: "stale-cm", Namespace: "default"}, staleObj); err != nil {
+		t.Fatalf("stale-cm should still exist before Complete, got: %v", err)
+	}
+
+	final := generic.NewGenericBundle[*unstructured.Unstructured]()
+	final.ResyncMetadata = []generic.ObjectMetadata{
+		{Group: "", Version: "v1", Kind: "ConfigMap", Complete: true},
+	}
+	finalEvt := cloudevents.NewEvent()
+	finalEvt.SetType(constants.HubHAResourcesMsgKey)
+	finalEvt.SetSource("hub1")
+	if err := finalEvt.SetData(cloudevents.ApplicationJSON, final); err != nil {
+		t.Fatalf("SetData() error = %v", err)
+	}
+	if err := syncer.Sync(context.Background(), &finalEvt); err != nil {
+		t.Fatalf("Sync() complete error = %v", err)
+	}
+
+	err := cl.Get(ctx, types.NamespacedName{Name: "stale-cm", Namespace: "default"}, staleObj)
+	if err == nil {
+		t.Fatal("expected stale-cm to be deleted after Complete")
+	}
+	if !errors.IsNotFound(err) {
+		t.Fatalf("expected NotFound for stale-cm, got: %v", err)
+	}
+}
+
+func TestHubHAStandbySyncer_Sync_ResyncMetadata_EmptyInventory_DeletesAll(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add corev1 to scheme: %v", err)
+	}
+
+	stale := hubHALabeledConfigMap("stale-cm", "default")
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(stale).Build()
+	syncer := NewHubHAStandbySyncer(cl)
+
+	bundle := generic.NewGenericBundle[*unstructured.Unstructured]()
+	bundle.ResyncMetadata = []generic.ObjectMetadata{
+		{Group: "", Version: "v1", Kind: "ConfigMap", InventoryBegin: true},
+		{Group: "", Version: "v1", Kind: "ConfigMap", Complete: true},
+	}
+	evt := cloudevents.NewEvent()
+	evt.SetType(constants.HubHAResourcesMsgKey)
+	evt.SetSource("hub1")
+	if err := evt.SetData(cloudevents.ApplicationJSON, bundle); err != nil {
+		t.Fatalf("SetData() error = %v", err)
+	}
+	if err := syncer.Sync(context.Background(), &evt); err != nil {
+		t.Fatalf("Sync() error = %v", err)
+	}
+
+	staleObj := &unstructured.Unstructured{}
+	staleObj.SetAPIVersion("v1")
+	staleObj.SetKind("ConfigMap")
+	err := cl.Get(context.Background(), types.NamespacedName{Name: "stale-cm", Namespace: "default"}, staleObj)
+	if err == nil {
+		t.Fatal("expected stale-cm to be deleted for empty inventory")
+	}
+	if !errors.IsNotFound(err) {
+		t.Fatalf("expected NotFound for stale-cm, got: %v", err)
+	}
+}
+
+func TestHubHAStandbySyncer_Sync_ResyncMetadata_BeginMiddleComplete(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add corev1 to scheme: %v", err)
+	}
+
+	keep1 := hubHALabeledConfigMap("keep-1", "default")
+	keep2 := hubHALabeledConfigMap("keep-2", "default")
+	stale := hubHALabeledConfigMap("stale-cm", "default")
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(keep1, keep2, stale).Build()
+	syncer := NewHubHAStandbySyncer(cl)
+
+	syncMeta := func(metas []generic.ObjectMetadata) {
+		t.Helper()
+		bundle := generic.NewGenericBundle[*unstructured.Unstructured]()
+		bundle.ResyncMetadata = metas
+		evt := cloudevents.NewEvent()
+		evt.SetType(constants.HubHAResourcesMsgKey)
+		evt.SetSource("hub1")
+		if err := evt.SetData(cloudevents.ApplicationJSON, bundle); err != nil {
+			t.Fatalf("SetData() error = %v", err)
+		}
+		if err := syncer.Sync(context.Background(), &evt); err != nil {
+			t.Fatalf("Sync() error = %v", err)
+		}
+	}
+
+	// Begin frame with first live object.
+	syncMeta([]generic.ObjectMetadata{
+		{Group: "", Version: "v1", Kind: "ConfigMap", InventoryBegin: true},
+		{Namespace: "default", Name: "keep-1", Group: "", Version: "v1", Kind: "ConfigMap"},
+	})
+	// Markerless middle frame must append, not run legacy cleanup (which would delete keep-1).
+	syncMeta([]generic.ObjectMetadata{
+		{Namespace: "default", Name: "keep-2", Group: "", Version: "v1", Kind: "ConfigMap"},
+	})
+	syncMeta([]generic.ObjectMetadata{
+		{Group: "", Version: "v1", Kind: "ConfigMap", Complete: true},
+	})
+
+	ctx := context.Background()
+	for _, name := range []string{"keep-1", "keep-2"} {
+		obj := &unstructured.Unstructured{}
+		obj.SetAPIVersion("v1")
+		obj.SetKind("ConfigMap")
+		if err := cl.Get(ctx, types.NamespacedName{Name: name, Namespace: "default"}, obj); err != nil {
+			t.Fatalf("expected %s to remain after Begin/middle/Complete: %v", name, err)
+		}
+	}
+	staleObj := &unstructured.Unstructured{}
+	staleObj.SetAPIVersion("v1")
+	staleObj.SetKind("ConfigMap")
+	err := cl.Get(ctx, types.NamespacedName{Name: "stale-cm", Namespace: "default"}, staleObj)
+	if err == nil {
+		t.Fatal("expected stale-cm to be deleted after Complete")
+	}
+	if !errors.IsNotFound(err) {
+		t.Fatalf("expected NotFound for stale-cm, got: %v", err)
+	}
+}
+
+func TestHubHAStandbySyncer_Sync_ResyncMetadata_RetryAfterCleanupFailure(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add corev1 to scheme: %v", err)
+	}
+
+	keep := hubHALabeledConfigMap("keep-cm", "default")
+	stale := hubHALabeledConfigMap("stale-cm", "default")
+	base := fake.NewClientBuilder().WithScheme(scheme).WithObjects(keep, stale).Build()
+
+	var deleteCalls atomicInt
+	cl := interceptor.NewClient(base, interceptor.Funcs{
+		Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+			if obj.GetName() == "stale-cm" {
+				if deleteCalls.add(1) == 1 {
+					return fmt.Errorf("transient delete failure")
+				}
+			}
+			return c.Delete(ctx, obj, opts...)
+		},
+	})
+	syncer := NewHubHAStandbySyncer(cl)
+
+	syncMeta := func(metas []generic.ObjectMetadata) error {
+		bundle := generic.NewGenericBundle[*unstructured.Unstructured]()
+		bundle.ResyncMetadata = metas
+		evt := cloudevents.NewEvent()
+		evt.SetType(constants.HubHAResourcesMsgKey)
+		evt.SetSource("hub1")
+		if err := evt.SetData(cloudevents.ApplicationJSON, bundle); err != nil {
+			return err
+		}
+		return syncer.Sync(context.Background(), &evt)
+	}
+
+	if err := syncMeta([]generic.ObjectMetadata{
+		{Group: "", Version: "v1", Kind: "ConfigMap", InventoryBegin: true},
+		{Namespace: "default", Name: "keep-cm", Group: "", Version: "v1", Kind: "ConfigMap"},
+		{Group: "", Version: "v1", Kind: "ConfigMap", Complete: true},
+	}); err == nil {
+		t.Fatal("expected cleanup failure on first Complete")
+	}
+
+	ctx := context.Background()
+	staleObj := &unstructured.Unstructured{}
+	staleObj.SetAPIVersion("v1")
+	staleObj.SetKind("ConfigMap")
+	if err := cl.Get(ctx, types.NamespacedName{Name: "stale-cm", Namespace: "default"}, staleObj); err != nil {
+		t.Fatalf("stale-cm should remain after failed cleanup: %v", err)
+	}
+
+	// Retry Complete only — session must still hold keep-cm so cleanup does not delete it.
+	if err := syncMeta([]generic.ObjectMetadata{
+		{Group: "", Version: "v1", Kind: "ConfigMap", Complete: true},
+	}); err != nil {
+		t.Fatalf("retry Complete error = %v", err)
+	}
+
+	keepObj := &unstructured.Unstructured{}
+	keepObj.SetAPIVersion("v1")
+	keepObj.SetKind("ConfigMap")
+	if err := cl.Get(ctx, types.NamespacedName{Name: "keep-cm", Namespace: "default"}, keepObj); err != nil {
+		t.Fatalf("expected keep-cm to remain after retry: %v", err)
+	}
+	err := cl.Get(ctx, types.NamespacedName{Name: "stale-cm", Namespace: "default"}, staleObj)
+	if err == nil {
+		t.Fatal("expected stale-cm to be deleted after successful retry")
+	}
+	if !errors.IsNotFound(err) {
+		t.Fatalf("expected NotFound for stale-cm, got: %v", err)
+	}
+}
+
+func TestHubHAStandbySyncer_Sync_ResyncMetadata_CompleteWithoutBegin_Ignored(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add corev1 to scheme: %v", err)
+	}
+
+	stale := hubHALabeledConfigMap("stale-cm", "default")
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(stale).Build()
+	syncer := NewHubHAStandbySyncer(cl)
+
+	bundle := generic.NewGenericBundle[*unstructured.Unstructured]()
+	bundle.ResyncMetadata = []generic.ObjectMetadata{
+		{Group: "", Version: "v1", Kind: "ConfigMap", Complete: true},
+	}
+	evt := cloudevents.NewEvent()
+	evt.SetType(constants.HubHAResourcesMsgKey)
+	evt.SetSource("hub1")
+	if err := evt.SetData(cloudevents.ApplicationJSON, bundle); err != nil {
+		t.Fatalf("SetData() error = %v", err)
+	}
+	if err := syncer.Sync(context.Background(), &evt); err != nil {
+		t.Fatalf("Sync() error = %v", err)
+	}
+
+	staleObj := &unstructured.Unstructured{}
+	staleObj.SetAPIVersion("v1")
+	staleObj.SetKind("ConfigMap")
+	err := cl.Get(context.Background(), types.NamespacedName{
+		Name: "stale-cm", Namespace: "default",
+	}, staleObj)
+	if err != nil {
+		t.Fatalf("Complete without Begin must not empty-delete inventory, got: %v", err)
+	}
+}
+
+// TestHubHAStandbySyncer_Sync_ResyncMetadata_PreservesGlobalHubTopologyManagedClusters
+// ensures ResyncMetadata stale cleanup on the global-hub standby does not delete
+// imported hubs / local-cluster ManagedClusters that are not part of the active
+// regional hub's spoke inventory (regression for Hub HA e2e BeforeAll).
+func TestHubHAStandbySyncer_Sync_ResyncMetadata_PreservesGlobalHubTopologyManagedClusters(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add corev1 to scheme: %v", err)
+	}
+
+	keepSpoke := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": managedClusterAPIVersion,
+			"kind":       "ManagedCluster",
+			"metadata": map[string]interface{}{
+				"name": "spoke-keep",
+			},
+		},
+	}
+	staleSpoke := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": managedClusterAPIVersion,
+			"kind":       "ManagedCluster",
+			"metadata": map[string]interface{}{
+				"name": "spoke-stale",
+			},
+		},
+	}
+	importedHub := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": managedClusterAPIVersion,
+			"kind":       "ManagedCluster",
+			"metadata": map[string]interface{}{
+				"name": "hub1",
+				"labels": map[string]interface{}{
+					constants.GHDeployModeLabelKey: "default",
+					constants.GHHubRoleLabelKey:    constants.GHHubRoleActive,
+				},
+			},
+		},
+	}
+	otherHub := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": managedClusterAPIVersion,
+			"kind":       "ManagedCluster",
+			"metadata": map[string]interface{}{
+				"name": "hub2",
+				"labels": map[string]interface{}{
+					constants.GHDeployModeLabelKey: "default",
+				},
+			},
+		},
+	}
+	localCluster := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": managedClusterAPIVersion,
+			"kind":       "ManagedCluster",
+			"metadata": map[string]interface{}{
+				"name": constants.LocalClusterName,
+				"labels": map[string]interface{}{
+					constants.LocalClusterName: "true",
+				},
+			},
+		},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(keepSpoke, staleSpoke, importedHub, otherHub, localCluster).
+		Build()
+	syncer := NewHubHAStandbySyncer(cl)
+
+	bundle := generic.NewGenericBundle[*unstructured.Unstructured]()
+	bundle.ResyncMetadata = []generic.ObjectMetadata{
+		{
+			Group: "cluster.open-cluster-management.io", Version: "v1",
+			Kind: "ManagedCluster", InventoryBegin: true,
+		},
+		{
+			Name: "spoke-keep", Group: "cluster.open-cluster-management.io",
+			Version: "v1", Kind: "ManagedCluster",
+		},
+		{
+			Group: "cluster.open-cluster-management.io", Version: "v1",
+			Kind: "ManagedCluster", Complete: true,
+		},
+	}
+	evt := cloudevents.NewEvent()
+	evt.SetType(constants.HubHAResourcesMsgKey)
+	evt.SetSource("hub1")
+	if err := evt.SetData(cloudevents.ApplicationJSON, bundle); err != nil {
+		t.Fatalf("SetData() error = %v", err)
+	}
+	if err := syncer.Sync(context.Background(), &evt); err != nil {
+		t.Fatalf("Sync() error = %v", err)
+	}
+
+	ctx := context.Background()
+	for _, name := range []string{"spoke-keep", "hub1", "hub2", constants.LocalClusterName} {
+		obj := &unstructured.Unstructured{}
+		obj.SetAPIVersion(managedClusterAPIVersion)
+		obj.SetKind("ManagedCluster")
+		if err := cl.Get(ctx, types.NamespacedName{Name: name}, obj); err != nil {
+			t.Fatalf("expected ManagedCluster %s to remain: %v", name, err)
+		}
+	}
+
+	staleObj := &unstructured.Unstructured{}
+	staleObj.SetAPIVersion(managedClusterAPIVersion)
+	staleObj.SetKind("ManagedCluster")
+	err := cl.Get(ctx, types.NamespacedName{Name: "spoke-stale"}, staleObj)
+	if err == nil {
+		t.Fatal("expected spoke-stale ManagedCluster to be deleted")
+	}
+	if !errors.IsNotFound(err) {
+		t.Fatalf("expected NotFound for spoke-stale, got: %v", err)
+	}
+}
+
+// atomicInt is a tiny counter for interceptor tests without importing sync/atomic in assertions.
+type atomicInt struct{ v int }
+
+func (a *atomicInt) add(n int) int {
+	a.v += n
+	return a.v
 }

--- a/agent/pkg/status/generic/periodic_syncer.go
+++ b/agent/pkg/status/generic/periodic_syncer.go
@@ -125,20 +125,24 @@ func (p *PeriodicSyncer) Resync(ctx context.Context, eventType string) error {
 				return nil
 			}
 			err = state.Registration.Emitter.Resync(objects)
-			if err == nil {
-				log.Infof("resynced %d objects for event type: %s", len(objects), enum.ShortenEventType(registeredType))
+			if err != nil {
+				return fmt.Errorf("failed to resync objects for event type %s: %w", registeredType, err)
 			}
+			// Flush any remaining delta/resync payload for ListFunc-based emitters.
+			if err = state.Registration.Emitter.Send(); err != nil {
+				return fmt.Errorf("failed to send resync bundle for event type %s: %w", registeredType, err)
+			}
+			log.Infof("resynced %d objects for event type: %s", len(objects), enum.ShortenEventType(registeredType))
 		} else {
-			// Emitter handles its own listing internally via Resync(nil)
+			// Emitter handles its own listing and flushing internally via Resync(nil)
+			// (e.g. Hub HA size-aware batching + ResyncMetadata).
 			err = state.Registration.Emitter.Resync(nil)
-			if err == nil {
-				log.Infof("resynced (self-listing) for event type: %s", enum.ShortenEventType(registeredType))
+			if err != nil {
+				return fmt.Errorf("failed to resync objects for event type %s: %w", registeredType, err)
 			}
+			log.Infof("resynced (self-listing) for event type: %s", enum.ShortenEventType(registeredType))
 		}
 
-		if err != nil {
-			return fmt.Errorf("failed to resync objects for event type %s: %w", registeredType, err)
-		}
 		resynced = true
 		state.NextResyncAt = time.Now().Add(configmap.GetResyncInterval(enum.EventType(registeredType)))
 	}

--- a/pkg/bundle/generic/generic_bundle.go
+++ b/pkg/bundle/generic/generic_bundle.go
@@ -19,6 +19,17 @@ type ObjectMetadata struct {
 	Group     string `json:"group,omitempty"`
 	Version   string `json:"version,omitempty"`
 	Kind      string `json:"kind,omitempty"`
+	// InventoryBegin marks the start of a per-GVK resync inventory. Receivers clear any
+	// previously accumulated keys for this GVK before applying entries in the same frame.
+	InventoryBegin bool `json:"inventory_begin,omitempty"`
+	// Complete marks the end of a per-GVK resync inventory. Receivers must not run stale
+	// cleanup until Complete is observed (partial frames may be sent when metadata is large).
+	Complete bool `json:"complete,omitempty"`
+}
+
+// Key returns a unique identity for the metadata entry.
+func (m ObjectMetadata) Key() string {
+	return m.Group + "/" + m.Version + "/" + m.Kind + "/" + m.Namespace + "/" + m.Name
 }
 
 type GenericBundle[T any] struct {
@@ -27,10 +38,26 @@ type GenericBundle[T any] struct {
 	Delete         []ObjectMetadata `json:"delete,omitempty"`
 	Resync         []T              `json:"resync,omitempty"`
 	ResyncMetadata []ObjectMetadata `json:"resync_metadata,omitempty"`
+
+	keyFunc func(T) string `json:"-"`
 }
 
-func NewGenericBundle[T any]() *GenericBundle[T] {
-	return &GenericBundle[T]{}
+// BundleOption configures a GenericBundle at construction time.
+type BundleOption[T any] func(*GenericBundle[T])
+
+// WithKeyFunc enables deduplication in AddUpdate by object key.
+func WithKeyFunc[T any](fn func(T) string) BundleOption[T] {
+	return func(b *GenericBundle[T]) {
+		b.keyFunc = fn
+	}
+}
+
+func NewGenericBundle[T any](opts ...BundleOption[T]) *GenericBundle[T] {
+	b := &GenericBundle[T]{}
+	for _, opt := range opts {
+		opt(b)
+	}
+	return b
 }
 
 func (b *GenericBundle[T]) IsEmpty() bool {
@@ -64,6 +91,25 @@ func (b *GenericBundle[T]) AddCreate(obj T) (bool, error) {
 }
 
 func (b *GenericBundle[T]) AddUpdate(obj T) (bool, error) {
+	if b.keyFunc != nil {
+		key := b.keyFunc(obj)
+		for i, existing := range b.Update {
+			if b.keyFunc(existing) == key {
+				prev := existing
+				b.Update[i] = obj
+				size, err := b.Size()
+				if err != nil {
+					b.Update[i] = prev
+					return false, err
+				}
+				if size > MaxBundleBytes {
+					b.Update[i] = prev
+					return false, nil
+				}
+				return true, nil
+			}
+		}
+	}
 	return b.tryAdd(&b.Update, obj)
 }
 
@@ -72,6 +118,24 @@ func (b *GenericBundle[T]) AddResync(obj T) (bool, error) {
 }
 
 func (b *GenericBundle[T]) AddDelete(meta ObjectMetadata) (bool, error) {
+	key := meta.Key()
+	for i, existing := range b.Delete {
+		if existing.Key() == key {
+			prev := existing
+			b.Delete[i] = meta
+			size, err := b.Size()
+			if err != nil {
+				b.Delete[i] = prev
+				return false, err
+			}
+			if size > MaxBundleBytes {
+				b.Delete[i] = prev
+				return false, nil
+			}
+			return true, nil
+		}
+	}
+
 	wasEmptyBeforeAdd := b.IsEmpty()
 
 	b.Delete = append(b.Delete, meta)

--- a/pkg/bundle/generic/generic_bundle_test.go
+++ b/pkg/bundle/generic/generic_bundle_test.go
@@ -1,0 +1,189 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package generic
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestObjectMetadata_Key(t *testing.T) {
+	m := ObjectMetadata{
+		Group:     "apps",
+		Version:   "v1",
+		Kind:      "Deployment",
+		Namespace: "ns",
+		Name:      "name",
+	}
+	want := "apps/v1/Deployment/ns/name"
+	if got := m.Key(); got != want {
+		t.Errorf("Key() = %q, want %q", got, want)
+	}
+}
+
+func TestAddUpdate_DedupWithKeyFunc(t *testing.T) {
+	type item struct {
+		Name string `json:"name"`
+		Val  string `json:"val"`
+	}
+	b := NewGenericBundle(WithKeyFunc(func(i item) string { return i.Name }))
+
+	added, err := b.AddUpdate(item{Name: "a", Val: "1"})
+	if err != nil || !added {
+		t.Fatalf("first AddUpdate: added=%v err=%v", added, err)
+	}
+	added, err = b.AddUpdate(item{Name: "a", Val: "2"})
+	if err != nil || !added {
+		t.Fatalf("dedup AddUpdate: added=%v err=%v", added, err)
+	}
+	if len(b.Update) != 1 {
+		t.Fatalf("expected 1 update after dedup, got %d", len(b.Update))
+	}
+	if b.Update[0].Val != "2" {
+		t.Errorf("expected latest value 2, got %s", b.Update[0].Val)
+	}
+}
+
+func TestAddDelete_DedupByKey(t *testing.T) {
+	b := NewGenericBundle[string]()
+	meta := ObjectMetadata{Group: "g", Version: "v1", Kind: "K", Namespace: "ns", Name: "n"}
+
+	added, err := b.AddDelete(meta)
+	if err != nil || !added {
+		t.Fatalf("first AddDelete: added=%v err=%v", added, err)
+	}
+	meta2 := meta
+	meta2.ID = "updated-id"
+	added, err = b.AddDelete(meta2)
+	if err != nil || !added {
+		t.Fatalf("dedup AddDelete: added=%v err=%v", added, err)
+	}
+	if len(b.Delete) != 1 {
+		t.Fatalf("expected 1 delete after dedup, got %d", len(b.Delete))
+	}
+	if b.Delete[0].ID != "updated-id" {
+		t.Errorf("expected ID updated-id, got %s", b.Delete[0].ID)
+	}
+}
+
+func TestAddUpdate_ReplaceExceedsSizeLimit(t *testing.T) {
+	type item struct {
+		Name string `json:"name"`
+		Data string `json:"data"`
+	}
+	b := NewGenericBundle(WithKeyFunc(func(i item) string { return i.Name }))
+
+	small := item{Name: "target", Data: "small"}
+	added, err := b.AddUpdate(small)
+	if err != nil || !added {
+		t.Fatalf("add small target: added=%v err=%v", added, err)
+	}
+
+	// Fill the bundle until it cannot accept another filler.
+	for i := 0; ; i++ {
+		filler := item{Name: fmt.Sprintf("f%d", i), Data: string(make([]byte, 50*1024))}
+		added, err = b.AddUpdate(filler)
+		if err != nil {
+			t.Fatalf("add filler %d: %v", i, err)
+		}
+		if !added {
+			break
+		}
+		if i > 30 {
+			t.Fatal("bundle never filled")
+		}
+	}
+
+	before, err := b.Size()
+	if err != nil {
+		t.Fatalf("Size() before replace: %v", err)
+	}
+
+	large := item{Name: "target", Data: string(make([]byte, 200*1024))}
+	added, err = b.AddUpdate(large)
+	if err != nil {
+		t.Fatalf("replace with large: %v", err)
+	}
+	if added {
+		t.Fatal("expected keyed replace to return added=false when size exceeds MaxBundleBytes")
+	}
+
+	after, err := b.Size()
+	if err != nil {
+		t.Fatalf("Size() after replace: %v", err)
+	}
+	if after != before {
+		t.Errorf("bundle size changed after rejected replace: before=%d after=%d", before, after)
+	}
+
+	found := false
+	for _, u := range b.Update {
+		if u.Name == "target" {
+			found = true
+			if u.Data != "small" {
+				t.Errorf("expected original small target to remain, got data len=%d", len(u.Data))
+			}
+		}
+	}
+	if !found {
+		t.Fatal("target entry missing after rejected replace")
+	}
+}
+
+func TestAddDelete_ReplaceExceedsSizeLimit(t *testing.T) {
+	b := NewGenericBundle[string]()
+
+	target := ObjectMetadata{
+		Group: "g", Version: "v1", Kind: "K", Namespace: "ns", Name: "target", ID: "small",
+	}
+	added, err := b.AddDelete(target)
+	if err != nil || !added {
+		t.Fatalf("add small target: added=%v err=%v", added, err)
+	}
+
+	for i := 0; ; i++ {
+		filler := ObjectMetadata{
+			Group: "g", Version: "v1", Kind: "K", Namespace: "ns",
+			Name: fmt.Sprintf("f%d", i), ID: string(make([]byte, 2*1024)),
+		}
+		added, err = b.AddDelete(filler)
+		if err != nil {
+			t.Fatalf("add filler %d: %v", i, err)
+		}
+		if !added {
+			break
+		}
+		if i > 500 {
+			t.Fatal("bundle never filled")
+		}
+	}
+
+	before, err := b.Size()
+	if err != nil {
+		t.Fatalf("Size() before replace: %v", err)
+	}
+
+	large := target
+	large.ID = string(make([]byte, 100*1024))
+	added, err = b.AddDelete(large)
+	if err != nil {
+		t.Fatalf("replace with large: %v", err)
+	}
+	if added {
+		t.Fatal("expected keyed delete replace to return added=false when size exceeds MaxBundleBytes")
+	}
+
+	after, err := b.Size()
+	if err != nil {
+		t.Fatalf("Size() after replace: %v", err)
+	}
+	if after != before {
+		t.Errorf("bundle size changed after rejected replace: before=%d after=%d", before, after)
+	}
+	for _, d := range b.Delete {
+		if d.Name == "target" && d.ID != "small" {
+			t.Errorf("expected original small ID to remain, got len=%d", len(d.ID))
+		}
+	}
+}


### PR DESCRIPTION
Fixes: [ACM-32678](https://redhat.atlassian.net/browse/ACM-32678)

## Summary
Add size-aware batched Hub HA resource sync so Kafka messages stay under `MaxBundleBytes` (800KB), adapted from the approach in #2383:

- `GenericBundle` dedup via `ObjectMetadata.Key()` / `WithKeyFunc`
- Hub HA emitter: size-aware `AddUpdate`/`AddDelete`/`AddResync` with auto-flush when full
- Per-GVK `ResyncMetadata` after resync; standby deletes stale local resources not in the inventory
- PeriodicSyncer: `Send()` after ListFunc-based resync (Hub HA self-list resync flushes internally)

## Context
Reference PR #2383 was closed unmerged. This lands the same mechanisms on current `main` Hub HA layout (`agent/pkg/spec/hubha`).

## Test plan
- [x] `go test -mod=mod ./pkg/bundle/generic/... ./agent/pkg/spec/hubha/... ./agent/pkg/status/generic/...`
- [x] `go test -mod=mod ./test/integration/agent/hubha/...`

[ACM-32678]: https://redhat.atlassian.net/browse/ACM-32678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved synchronization for large updates and deletions with size-aware batching and automatic retries.
  * Added reliable resynchronization across multiple inventory batches, including completion markers and empty-inventory handling.
  * Prevented duplicate pending changes while retaining the latest resource state.

* **Bug Fixes**
  * Stale resources are removed only after a complete inventory is received.
  * Improved handling and reporting of listing, conversion, sizing, and delivery failures.
  * Pending updates and deletions now flush more reliably.
  * Improved behavior when synchronization is disabled or interrupted.
  * Added safer recovery when resources change during resynchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->