### PR TITLE
ACM-39301: ZTP migration agent/operator RBAC backport to release-2.14 (GH 1.5)

### DIFF
--- a/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -739,6 +739,18 @@ spec:
           - update
           - watch
         - apiGroups:
+          - extensions.hive.openshift.io
+          resources:
+          - imageclusterinstalls
+          - imageclusterinstalls/status
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
           - global-hub.open-cluster-management.io
           resources:
           - managedclustermigrations
@@ -748,6 +760,18 @@ spec:
           - get
           - list
           - patch
+          - update
+          - watch
+        - apiGroups:
+          - hive.openshift.io
+          resources:
+          - clusterdeployments
+          - clusterdeployments/status
+          verbs:
+          - create
+          - delete
+          - get
+          - list
           - update
           - watch
         - apiGroups:
@@ -782,6 +806,25 @@ spec:
           - update
           - watch
         - apiGroups:
+          - metal3.io
+          resources:
+          - baremetalhosts
+          - baremetalhosts/status
+          - dataimages
+          - firmwareschemas
+          - firmwareschemas/status
+          - hostfirmwarecomponents
+          - hostfirmwarecomponents/status
+          - hostfirmwaresettings
+          - hostfirmwaresettings/status
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
           - monitoring.coreos.com
           resources:
           - podmonitors
@@ -803,6 +846,15 @@ spec:
           verbs:
           - create
           - get
+          - update
+        - apiGroups:
+          - observability.open-cluster-management.io
+          resources:
+          - observabilityaddons
+          verbs:
+          - delete
+          - get
+          - list
           - update
         - apiGroups:
           - operator.open-cluster-management.io

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -367,6 +367,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - extensions.hive.openshift.io
+  resources:
+  - imageclusterinstalls
+  - imageclusterinstalls/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - global-hub.open-cluster-management.io
   resources:
   - managedclustermigrations
@@ -376,6 +388,18 @@ rules:
   - get
   - list
   - patch
+  - update
+  - watch
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - clusterdeployments
+  - clusterdeployments/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
   - update
   - watch
 - apiGroups:
@@ -410,6 +434,25 @@ rules:
   - update
   - watch
 - apiGroups:
+  - metal3.io
+  resources:
+  - baremetalhosts
+  - baremetalhosts/status
+  - dataimages
+  - firmwareschemas
+  - firmwareschemas/status
+  - hostfirmwarecomponents
+  - hostfirmwarecomponents/status
+  - hostfirmwaresettings
+  - hostfirmwaresettings/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - monitoring.coreos.com
   resources:
   - podmonitors
@@ -431,6 +474,15 @@ rules:
   verbs:
   - create
   - get
+  - update
+- apiGroups:
+  - observability.open-cluster-management.io
+  resources:
+  - observabilityaddons
+  verbs:
+  - delete
+  - get
+  - list
   - update
 - apiGroups:
   - operator.open-cluster-management.io

--- a/operator/pkg/controllers/agent/addon/manifests/templates/agent/multicluster-global-hub-agent-clusterrole.yaml
+++ b/operator/pkg/controllers/agent/addon/manifests/templates/agent/multicluster-global-hub-agent-clusterrole.yaml
@@ -261,6 +261,58 @@ rules:
   - watch
   - list
 - apiGroups:
+  - extensions.hive.openshift.io
+  resources:
+  - imageclusterinstalls
+  - imageclusterinstalls/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - clusterdeployments
+  - clusterdeployments/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - metal3.io
+  resources:
+  - baremetalhosts
+  - baremetalhosts/status
+  - dataimages
+  - firmwareschemas
+  - firmwareschemas/status
+  - hostfirmwarecomponents
+  - hostfirmwarecomponents/status
+  - hostfirmwaresettings
+  - hostfirmwaresettings/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - observability.open-cluster-management.io
+  resources:
+  - observabilityaddons
+  verbs:
+  - delete
+  - get
+  - list
+  - update
+- apiGroups:
   - register.open-cluster-management.io
   resources:
   - managedclusters/accept

--- a/operator/pkg/controllers/agent/local_agent_controller.go
+++ b/operator/pkg/controllers/agent/local_agent_controller.go
@@ -127,6 +127,10 @@ func (s *LocalAgentController) IsResourceRemoved() bool {
 // +kubebuilder:rbac:groups=agent.open-cluster-management.io,resources=klusterletaddonconfigs,verbs=get;create;watch;list
 // +kubebuilder:rbac:groups=register.open-cluster-management.io,resources=managedclusters/accept,verbs=update
 // +kubebuilder:rbac:groups="apps",resources=deployments,verbs=get;list;watch;create;update;delete;deletecollection
+// +kubebuilder:rbac:groups=extensions.hive.openshift.io,resources=imageclusterinstalls;imageclusterinstalls/status,verbs=create;delete;get;list;update;watch
+// +kubebuilder:rbac:groups=hive.openshift.io,resources=clusterdeployments;clusterdeployments/status,verbs=create;delete;get;list;update;watch
+// +kubebuilder:rbac:groups=metal3.io,resources=baremetalhosts;baremetalhosts/status;dataimages;firmwareschemas;firmwareschemas/status;hostfirmwarecomponents;hostfirmwarecomponents/status;hostfirmwaresettings;hostfirmwaresettings/status,verbs=create;delete;get;list;update;watch
+// +kubebuilder:rbac:groups=observability.open-cluster-management.io,resources=observabilityaddons,verbs=delete;get;list;update
 
 func (s *LocalAgentController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log.Debugf("reconcile local agent controller: %v", req)

--- a/operator/pkg/controllers/agent/manifests/clusterrole.yaml
+++ b/operator/pkg/controllers/agent/manifests/clusterrole.yaml
@@ -273,6 +273,58 @@ rules:
   - watch
   - list
 - apiGroups:
+  - extensions.hive.openshift.io
+  resources:
+  - imageclusterinstalls
+  - imageclusterinstalls/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - clusterdeployments
+  - clusterdeployments/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - metal3.io
+  resources:
+  - baremetalhosts
+  - baremetalhosts/status
+  - dataimages
+  - firmwareschemas
+  - firmwareschemas/status
+  - hostfirmwarecomponents
+  - hostfirmwarecomponents/status
+  - hostfirmwaresettings
+  - hostfirmwaresettings/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - observability.open-cluster-management.io
+  resources:
+  - observabilityaddons
+  verbs:
+  - delete
+  - get
+  - list
+  - update
+- apiGroups:
   - work.open-cluster-management.io
   resources:
   - manifestworks


### PR DESCRIPTION
## Summary

- Add hive, metal3, and observability RBAC to agent ClusterRole templates (addon ManifestWork + standalone/local agent)
- Add matching operator escalation RBAC (`kubebuilder` markers, `operator/config/rbac/role.yaml`, bundle CSV)
- Mirrors [#2725](https://github.com/stolostron/multicluster-global-hub/pull/2725) on `release-2.15` (GH 1.6.5) / same pattern as [#2709](https://github.com/stolostron/multicluster-global-hub/pull/2709) (GH 1.7)

## Related

- ACM-39301
- Companion: stolostron/multicluster-global-hub-operator-bundle (release-1.5 CSV sync PR to follow)
- [#2725](https://github.com/stolostron/multicluster-global-hub/pull/2725) — GH 1.6.5 backport
- [#1746](https://github.com/stolostron/multicluster-global-hub-operator-bundle/pull/1746) — GH 1.6 bundle CSV sync

## Test plan

- [ ] CI format / verify bundle / unit / integration pass
- [ ] After merge + Konflux rebuild, regional hub migration passes ResourceDeployed past BMH prep
- [ ] Local agent e2e passes with operator escalation RBAC


Made with [Cursor](https://cursor.com)