### PR TITLE
ACM-40223: stop per-cluster reconcile of shared gh-migration topic

### DIFF
--- a/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
@@ -480,7 +480,9 @@ func combineACLs(kafkaUserAcls []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem
 func (k *strimziTransporter) EnsureTopic(clusterName string) (*transport.ClusterTopic, error) {
 	clusterTopic := k.getClusterTopic(clusterName)
 
-	topicNames := []string{clusterTopic.SpecTopic, clusterTopic.MigrationTopic, clusterTopic.StatusTopic}
+	// gh-migration is a shared hub topic provisioned once by renderKafkaResources; do not
+	// reconcile it per managed cluster (spec differs from newKafkaTopic and causes conflicts).
+	topicNames := []string{clusterTopic.SpecTopic, clusterTopic.StatusTopic}
 	for _, topicName := range topicNames {
 		if err := k.ensureTopic(topicName, nil); err != nil {
 			return nil, err


### PR DESCRIPTION
## Summary

- Remove `gh-migration` from the per-managed-hub `EnsureTopic` loop in `strimzi_transporter.go`.
- The shared migration topic is already provisioned once by `renderKafkaResources` via `global-hub-kafka-topic.yaml` (`compact,delete` + retention). Per-hub `EnsureTopic` was applying a different spec (`compact` only), causing KafkaTopic update conflicts and `ManagedClusterAddOn` `ManifestApplied=False` after upgrade.

Fixes [ACM-40223](https://redhat.atlassian.net/browse/ACM-40223)

Related: [ACM-39301](https://redhat.atlassian.net/browse/ACM-39301) (separate MCE import-controller root cause)

## Test plan

- [ ] Operator integration tests pass (`EnsureTopic` still creates spec/status topics per cluster)
- [ ] Upgrade e2e: addon `ManifestApplied=True` after operator upgrade with multiple managed hubs
- [ ] `gh-migration` KafkaTopic remains `Ready=True` and retains template spec from `renderKafkaResources`


Made with [Cursor](https://cursor.com)

[ACM-40223]: https://redhat.atlassian.net/browse/ACM-40223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-39301]: https://redhat.atlassian.net/browse/ACM-39301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kafka topic reconciliation during transporter deployments.
  * Shared migration topics are now managed consistently, preventing unnecessary per-cluster updates.
  * Specification and status topics continue to be reconciled as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->