### PR TITLE
ACM-40223: stop per-cluster reconcile of shared gh-migration topic (release-2.17 / GH 1.8)

### DIFF
--- a/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
@@ -451,7 +451,9 @@ func combineACLs(kafkaUserAcls []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem
 func (k *strimziTransporter) EnsureTopic(clusterName string) (*transport.ClusterTopic, error) {
 	clusterTopic := k.getClusterTopic(clusterName)
 
-	topicNames := []string{clusterTopic.SpecTopic, clusterTopic.MigrationTopic, clusterTopic.StatusTopic}
+	// gh-migration is a shared hub topic provisioned once by renderKafkaResources; do not
+	// reconcile it per managed cluster (spec differs from newKafkaTopic and causes conflicts).
+	topicNames := []string{clusterTopic.SpecTopic, clusterTopic.StatusTopic}
 	for _, topicName := range topicNames {
 		if err := k.ensureTopic(topicName, nil); err != nil {
 			return nil, err


### PR DESCRIPTION
Fixes: [ACM-40223](https://redhat.atlassian.net/browse/ACM-40223)

## Summary

- Backport [#2727](https://github.com/stolostron/multicluster-global-hub/pull/2727) to `release-2.17` (Global Hub 1.8)
- Remove `gh-migration` from the per-managed-hub `EnsureTopic` loop in `strimzi_transporter.go`
- The shared migration topic is already provisioned once by `renderKafkaResources`; per-hub `EnsureTopic` was applying a different spec (`compact` only vs `compact,delete`), causing KafkaTopic update conflicts and `ManagedClusterAddOn` `ManifestApplied=False` after upgrade

## Context

- Parent fix: [#2727](https://github.com/stolostron/multicluster-global-hub/pull/2727)
- Related: [ACM-39301](https://redhat.atlassian.net/browse/ACM-39301) (separate MCE import-controller root cause)

## Test plan

- [ ] Operator integration tests pass on `release-2.17`
- [ ] Upgrade e2e: addon `ManifestApplied=True` after operator upgrade with multiple managed hubs
- [ ] `gh-migration` KafkaTopic remains `Ready=True` and retains template spec from `renderKafkaResources`


Made with [Cursor](https://cursor.com)

[ACM-40223]: https://redhat.atlassian.net/browse/ACM-40223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-39301]: https://redhat.atlassian.net/browse/ACM-39301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ