### PR TITLE
ACM-38860: subscribe agent consumer to gh-migration on release-2.15 (GH 1.6)

### DIFF
--- a/pkg/transport/controller/controller.go
+++ b/pkg/transport/controller/controller.go
@@ -209,6 +209,10 @@ func (c *TransportCtrl) ReconcileConsumer(ctx context.Context) error {
 		options = append(options, consumer.SetTopicMetadataRefreshInterval(constants.TopicMetadataRefreshInterval))
 	} else {
 		c.consumerTopics = []string{c.transportConfig.KafkaCredential.SpecTopic}
+		if migrationTopic := c.transportConfig.KafkaCredential.GetMigrationTopic(); migrationTopic != "" &&
+			migrationTopic != c.transportConfig.KafkaCredential.SpecTopic {
+			c.consumerTopics = append(c.consumerTopics, migrationTopic)
+		}
 	}
 
 	consumerGroupID := c.transportConfig.KafkaCredential.ConsumerGroupID


### PR DESCRIPTION
## Summary

- Subscribe managed hub agents to `gh-migration` alongside the spec topic in `ReconcileConsumer` — the only migration gap left on `release-2.15` after #2710
- Phase 3 producer, ACL reconciler, ZTP deploy allow-list, and target syncer routing are already on this branch (#2710); RBAC for ZTP migration is already merged (#2725)
- Without this fix, Deploying bundles published to `gh-migration` are never consumed and migration times out at Deploying (reproduced on GH 1.6.5)

## Scope

Migration consumer fix only — no CloudEvents extension refactors, stage-ordering, or other 2.16/2.17 backports.

## Test plan

- [ ] Agent logs show `Subscribing to topics: [byo-spec gh-migration]` (or equivalent) after deploy
- [ ] ZTP/cluster migration reaches Deploying and target hub applies resources
- [ ] Existing transport e2e / unit tests pass on `release-2.15`

Fixes: ACM-38860
Related: ACM-39301

Made with [Cursor](https://cursor.com)