### PR TITLE
ACM-40478: Fix transport-config sync when MCGH Kafka topics change

### DIFF
--- a/operator/pkg/config/transport_config.go
+++ b/operator/pkg/config/transport_config.go
@@ -269,7 +269,7 @@ func SetKafkaClientCA(ctx context.Context, namespace, name string, c client.Clie
 	newKey := clientCAKeySecret.Data["ca.key"]
 	newCert := clientCACertSecret.Data["ca.crt"]
 	if len(newKey) == 0 || len(newCert) == 0 {
-		return fmt.Errorf("Kafka client CA secrets must contain ca.key and ca.crt")
+		return fmt.Errorf("kafka client CA secrets must contain ca.key and ca.crt")
 	}
 
 	kafkaClientCAMu.Lock()

--- a/operator/pkg/config/transport_config.go
+++ b/operator/pkg/config/transport_config.go
@@ -268,6 +268,9 @@ func SetKafkaClientCA(ctx context.Context, namespace, name string, c client.Clie
 
 	newKey := clientCAKeySecret.Data["ca.key"]
 	newCert := clientCACertSecret.Data["ca.crt"]
+	if len(newKey) == 0 || len(newCert) == 0 {
+		return fmt.Errorf("Kafka client CA secrets must contain ca.key and ca.crt")
+	}
 
 	kafkaClientCAMu.Lock()
 	defer kafkaClientCAMu.Unlock()

--- a/operator/pkg/config/transport_config.go
+++ b/operator/pkg/config/transport_config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -35,6 +36,7 @@ var (
 	statusTopic           = ""
 	kafkaResourceReady    = false
 	acmResourceReady      = false
+	kafkaClientCAMu       sync.RWMutex
 	kafkaClientCAKey      []byte
 	kafkaClientCACert     []byte
 	inventoryClientCAKey  []byte
@@ -205,6 +207,8 @@ func TransporterProtocol() transport.TransportProtocol {
 
 // GetKafkaClientCA the raw([]byte) of client ca key and ca cert
 func GetKafkaClientCA() ([]byte, []byte) {
+	kafkaClientCAMu.RLock()
+	defer kafkaClientCAMu.RUnlock()
 	return kafkaClientCAKey, kafkaClientCACert
 }
 
@@ -246,11 +250,6 @@ func SetKafkaClientCA(ctx context.Context, namespace, name string, c client.Clie
 	if err != nil {
 		return err
 	}
-	if kafkaClientCAKey == nil || !bytes.Equal(clientCAKeySecret.Data["ca.key"], kafkaClientCAKey) {
-		log.Infof("set the ca - client key: %s", clientCAKeySecret.Name)
-		kafkaClientCAKey = clientCAKeySecret.Data["ca.key"]
-	}
-
 	clientCACertSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-clients-ca-cert", name),
@@ -262,9 +261,18 @@ func SetKafkaClientCA(ctx context.Context, namespace, name string, c client.Clie
 		return err
 	}
 
-	if kafkaClientCACert == nil || !bytes.Equal(clientCACertSecret.Data["ca.crt"], kafkaClientCACert) {
+	newKey := clientCAKeySecret.Data["ca.key"]
+	newCert := clientCACertSecret.Data["ca.crt"]
+
+	kafkaClientCAMu.Lock()
+	defer kafkaClientCAMu.Unlock()
+	if kafkaClientCAKey == nil || !bytes.Equal(newKey, kafkaClientCAKey) {
+		log.Infof("set the ca - client key: %s", clientCAKeySecret.Name)
+		kafkaClientCAKey = newKey
+	}
+	if kafkaClientCACert == nil || !bytes.Equal(newCert, kafkaClientCACert) {
 		log.Infof("set the ca - client cert: %s", clientCACertSecret.Name)
-		kafkaClientCACert = clientCACertSecret.Data["ca.crt"]
+		kafkaClientCACert = newCert
 	}
 	return nil
 }

--- a/operator/pkg/config/transport_config.go
+++ b/operator/pkg/config/transport_config.go
@@ -234,11 +234,11 @@ func SetInventoryClientCA(ctx context.Context, namespace, name string, c client.
 	}
 
 	if inventoryClientCAKey == nil || !secretBytesEqual(clientCASecret.Data["tls.key"], inventoryClientCAKey) {
-		log.Infof("set the inventory clientCA - key: %s", clientCASecret.Name)
+		log.Infow("set the inventory clientCA - key", "secret", clientCASecret.Name)
 		inventoryClientCAKey = clientCASecret.Data["tls.key"]
 	}
 	if inventoryClientCACert == nil || !secretBytesEqual(clientCASecret.Data["tls.crt"], inventoryClientCACert) {
-		log.Infof("set the inventory clientCA - cert: %s", clientCASecret.Name)
+		log.Infow("set the inventory clientCA - cert", "secret", clientCASecret.Name)
 		inventoryClientCACert = clientCASecret.Data["tls.crt"]
 	}
 	return nil
@@ -277,11 +277,11 @@ func SetKafkaClientCA(ctx context.Context, namespace, name string, c client.Clie
 	kafkaClientCAMu.Lock()
 	defer kafkaClientCAMu.Unlock()
 	if kafkaClientCAKey == nil || !secretBytesEqual(newKey, kafkaClientCAKey) {
-		log.Infof("set the ca - client key: %s", clientCAKeySecret.Name)
+		log.Infow("set the ca - client key", "secret", clientCAKeySecret.Name)
 		kafkaClientCAKey = newKey
 	}
 	if kafkaClientCACert == nil || !secretBytesEqual(newCert, kafkaClientCACert) {
-		log.Infof("set the ca - client cert: %s", clientCACertSecret.Name)
+		log.Infow("set the ca - client cert", "secret", clientCACertSecret.Name)
 		kafkaClientCACert = newCert
 	}
 	return nil

--- a/operator/pkg/config/transport_config.go
+++ b/operator/pkg/config/transport_config.go
@@ -1,8 +1,8 @@
 package config
 
 import (
-	"bytes"
 	"context"
+	"crypto/subtle"
 	"fmt"
 	"regexp"
 	"strings"
@@ -233,17 +233,19 @@ func SetInventoryClientCA(ctx context.Context, namespace, name string, c client.
 		return err
 	}
 
-	if inventoryClientCAKey == nil || !bytes.Equal(clientCASecret.Data["tls.key"], inventoryClientCAKey) {
+	if inventoryClientCAKey == nil || !secretBytesEqual(clientCASecret.Data["tls.key"], inventoryClientCAKey) {
 		log.Infof("set the inventory clientCA - key: %s", clientCASecret.Name)
 		inventoryClientCAKey = clientCASecret.Data["tls.key"]
 	}
-	if inventoryClientCACert == nil || !bytes.Equal(clientCASecret.Data["tls.crt"], inventoryClientCACert) {
+	if inventoryClientCACert == nil || !secretBytesEqual(clientCASecret.Data["tls.crt"], inventoryClientCACert) {
 		log.Infof("set the inventory clientCA - cert: %s", clientCASecret.Name)
 		inventoryClientCACert = clientCASecret.Data["tls.crt"]
 	}
 	return nil
 }
 
+// SetKafkaClientCA loads and caches the Strimzi Kafka client CA key and certificate
+// from the cluster secrets when they change.
 func SetKafkaClientCA(ctx context.Context, namespace, name string, c client.Client) error {
 	clientCAKeySecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -274,15 +276,80 @@ func SetKafkaClientCA(ctx context.Context, namespace, name string, c client.Clie
 
 	kafkaClientCAMu.Lock()
 	defer kafkaClientCAMu.Unlock()
-	if kafkaClientCAKey == nil || !bytes.Equal(newKey, kafkaClientCAKey) {
+	if kafkaClientCAKey == nil || !secretBytesEqual(newKey, kafkaClientCAKey) {
 		log.Infof("set the ca - client key: %s", clientCAKeySecret.Name)
 		kafkaClientCAKey = newKey
 	}
-	if kafkaClientCACert == nil || !bytes.Equal(newCert, kafkaClientCACert) {
+	if kafkaClientCACert == nil || !secretBytesEqual(newCert, kafkaClientCACert) {
 		log.Infof("set the ca - client cert: %s", clientCACertSecret.Name)
 		kafkaClientCACert = newCert
 	}
 	return nil
+}
+
+// TransportConfigTestSnapshot captures in-memory transport config for test isolation.
+type TransportConfigTestSnapshot struct {
+	specTopic           string
+	statusTopic         string
+	migrationTopic      string
+	enableInventory     bool
+	isBYOKafka          bool
+	transporterProtocol transport.TransportProtocol
+	kafkaClientCAKey    []byte
+	kafkaClientCACert   []byte
+	transporterInstance transport.Transporter
+}
+
+// SnapshotTransportConfigForTest returns the current in-memory transport config state.
+// Tests that mutate shared config should restore it with RestoreTransportConfigForTest in t.Cleanup.
+func SnapshotTransportConfigForTest() TransportConfigTestSnapshot {
+	kafkaClientCAMu.RLock()
+	key := append([]byte(nil), kafkaClientCAKey...)
+	cert := append([]byte(nil), kafkaClientCACert...)
+	kafkaClientCAMu.RUnlock()
+
+	transporterInstanceMu.RLock()
+	transporter := transporterInstance
+	transporterInstanceMu.RUnlock()
+
+	return TransportConfigTestSnapshot{
+		specTopic:           specTopic,
+		statusTopic:         statusTopic,
+		migrationTopic:      migrationTopic,
+		enableInventory:     enableInventory,
+		isBYOKafka:          isBYOKafka,
+		transporterProtocol: transporterProtocol,
+		kafkaClientCAKey:    key,
+		kafkaClientCACert:   cert,
+		transporterInstance: transporter,
+	}
+}
+
+// RestoreTransportConfigForTest restores transport config captured by SnapshotTransportConfigForTest.
+func RestoreTransportConfigForTest(snapshot TransportConfigTestSnapshot) {
+	specTopic = snapshot.specTopic
+	statusTopic = snapshot.statusTopic
+	migrationTopic = snapshot.migrationTopic
+	enableInventory = snapshot.enableInventory
+	isBYOKafka = snapshot.isBYOKafka
+	transporterProtocol = snapshot.transporterProtocol
+
+	kafkaClientCAMu.Lock()
+	kafkaClientCAKey = append([]byte(nil), snapshot.kafkaClientCAKey...)
+	kafkaClientCACert = append([]byte(nil), snapshot.kafkaClientCACert...)
+	kafkaClientCAMu.Unlock()
+
+	SetTransporter(snapshot.transporterInstance)
+}
+
+func secretBytesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	if len(a) == 0 {
+		return true
+	}
+	return subtle.ConstantTimeCompare(a, b) == 1
 }
 
 func EnableInventory() bool {

--- a/operator/pkg/config/transport_config.go
+++ b/operator/pkg/config/transport_config.go
@@ -28,6 +28,7 @@ const (
 
 var (
 	transporterProtocol   transport.TransportProtocol
+	transporterInstanceMu sync.RWMutex
 	transporterInstance   transport.Transporter
 	enableInventory       = false
 	isBYOKafka            = false
@@ -44,10 +45,14 @@ var (
 )
 
 func SetTransporter(p transport.Transporter) {
+	transporterInstanceMu.Lock()
+	defer transporterInstanceMu.Unlock()
 	transporterInstance = p
 }
 
 func GetTransporter() transport.Transporter {
+	transporterInstanceMu.RLock()
+	defer transporterInstanceMu.RUnlock()
 	return transporterInstance
 }
 

--- a/operator/pkg/config/transport_config_test.go
+++ b/operator/pkg/config/transport_config_test.go
@@ -9,6 +9,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 )
 
 func TestGetMigrationTopic(t *testing.T) {
@@ -79,5 +81,45 @@ func TestSetKafkaClientCAConcurrentAccess(t *testing.T) {
 	key, cert := GetKafkaClientCA()
 	if string(key) != "key-v1" || string(cert) != "cert-v1" {
 		t.Fatalf("GetKafkaClientCA() = (%q, %q), want (key-v1, cert-v1)", key, cert)
+	}
+}
+
+type stubTransporter struct {
+	id int
+}
+
+func (s *stubTransporter) EnsureUser(string) (string, error) { return "", nil }
+
+func (s *stubTransporter) EnsureTopic(string) (*transport.ClusterTopic, error) {
+	return &transport.ClusterTopic{}, nil
+}
+
+func (s *stubTransporter) EnsureKafka() (bool, error) { return false, nil }
+
+func (s *stubTransporter) Prune(string) error { return nil }
+
+func (s *stubTransporter) GetConnCredential(string) (*transport.KafkaConfig, error) {
+	return &transport.KafkaConfig{}, nil
+}
+
+func TestSetTransporterConcurrentAccess(t *testing.T) {
+	original := GetTransporter()
+	t.Cleanup(func() { SetTransporter(original) })
+
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			SetTransporter(&stubTransporter{id: id})
+			if GetTransporter() == nil {
+				t.Error("GetTransporter() returned nil during concurrent access")
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if GetTransporter() == nil {
+		t.Fatal("GetTransporter() returned nil after concurrent updates")
 	}
 }

--- a/operator/pkg/config/transport_config_test.go
+++ b/operator/pkg/config/transport_config_test.go
@@ -1,6 +1,15 @@
 package config
 
-import "testing"
+import (
+	"context"
+	"sync"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
 
 func TestGetMigrationTopic(t *testing.T) {
 	original := migrationTopic
@@ -25,5 +34,50 @@ func TestSetMigrationTopic(t *testing.T) {
 	SetMigrationTopic("custom-migration")
 	if got := GetMigrationTopic(); got != "custom-migration" {
 		t.Fatalf("SetMigrationTopic() = %q, want custom-migration", got)
+	}
+}
+
+func TestSetKafkaClientCAConcurrentAccess(t *testing.T) {
+	originalKey := kafkaClientCAKey
+	originalCert := kafkaClientCACert
+	t.Cleanup(func() {
+		kafkaClientCAKey = originalKey
+		kafkaClientCACert = originalCert
+	})
+
+	ctx := context.Background()
+	testScheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(testScheme)
+	ns := "test-ns"
+	c := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "kafka-clients-ca", Namespace: ns},
+			Data:       map[string][]byte{"ca.key": []byte("key-v1")},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "kafka-clients-ca-cert", Namespace: ns},
+			Data:       map[string][]byte{"ca.crt": []byte("cert-v1")},
+		},
+	).Build()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := SetKafkaClientCA(ctx, ns, "kafka", c); err != nil {
+				t.Errorf("SetKafkaClientCA() error = %v", err)
+			}
+			key, cert := GetKafkaClientCA()
+			if len(key) == 0 || len(cert) == 0 {
+				t.Error("GetKafkaClientCA() returned empty snapshot")
+			}
+		}()
+	}
+	wg.Wait()
+
+	key, cert := GetKafkaClientCA()
+	if string(key) != "key-v1" || string(cert) != "cert-v1" {
+		t.Fatalf("GetKafkaClientCA() = (%q, %q), want (key-v1, cert-v1)", key, cert)
 	}
 }

--- a/operator/pkg/config/transport_config_test.go
+++ b/operator/pkg/config/transport_config_test.go
@@ -163,3 +163,108 @@ func TestSetTransporterConcurrentAccess(t *testing.T) {
 		t.Fatal("GetTransporter() returned nil after concurrent updates")
 	}
 }
+
+func TestSetKafkaClientCAUpdatesWhenSecretsChange(t *testing.T) {
+	ctx := context.Background()
+	testScheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(testScheme); err != nil {
+		t.Fatalf("add corev1 to test scheme: %v", err)
+	}
+
+	originalKey := kafkaClientCAKey
+	originalCert := kafkaClientCACert
+	t.Cleanup(func() {
+		kafkaClientCAKey = originalKey
+		kafkaClientCACert = originalCert
+	})
+
+	ns := "test-ns"
+	keySecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "kafka-clients-ca", Namespace: ns},
+		Data:       map[string][]byte{"ca.key": []byte("key-v1")},
+	}
+	certSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "kafka-clients-ca-cert", Namespace: ns},
+		Data:       map[string][]byte{"ca.crt": []byte("cert-v1")},
+	}
+	c := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(keySecret, certSecret).Build()
+
+	if err := SetKafkaClientCA(ctx, ns, "kafka", c); err != nil {
+		t.Fatalf("SetKafkaClientCA() error = %v", err)
+	}
+
+	keySecret.Data["ca.key"] = []byte("key-v2")
+	certSecret.Data["ca.crt"] = []byte("cert-v2")
+	if err := c.Update(ctx, keySecret); err != nil {
+		t.Fatalf("update key secret: %v", err)
+	}
+	if err := c.Update(ctx, certSecret); err != nil {
+		t.Fatalf("update cert secret: %v", err)
+	}
+	if err := SetKafkaClientCA(ctx, ns, "kafka", c); err != nil {
+		t.Fatalf("SetKafkaClientCA() second call error = %v", err)
+	}
+
+	key, cert := GetKafkaClientCA()
+	if string(key) != "key-v2" || string(cert) != "cert-v2" {
+		t.Fatalf("GetKafkaClientCA() = (%q, %q), want (key-v2, cert-v2)", key, cert)
+	}
+}
+
+func TestSetKafkaClientCAMissingCertSecret(t *testing.T) {
+	ctx := context.Background()
+	testScheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(testScheme); err != nil {
+		t.Fatalf("add corev1 to test scheme: %v", err)
+	}
+
+	ns := "test-ns"
+	c := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "kafka-clients-ca", Namespace: ns},
+			Data:       map[string][]byte{"ca.key": []byte("key-v1")},
+		},
+	).Build()
+
+	if err := SetKafkaClientCA(ctx, ns, "kafka", c); err == nil {
+		t.Fatal("SetKafkaClientCA() expected error when cert secret is missing")
+	}
+}
+
+func TestSetKafkaClientCAIdempotent(t *testing.T) {
+	ctx := context.Background()
+	testScheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(testScheme); err != nil {
+		t.Fatalf("add corev1 to test scheme: %v", err)
+	}
+
+	originalKey := kafkaClientCAKey
+	originalCert := kafkaClientCACert
+	t.Cleanup(func() {
+		kafkaClientCAKey = originalKey
+		kafkaClientCACert = originalCert
+	})
+
+	ns := "test-ns"
+	c := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "kafka-clients-ca", Namespace: ns},
+			Data:       map[string][]byte{"ca.key": []byte("key-v1")},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "kafka-clients-ca-cert", Namespace: ns},
+			Data:       map[string][]byte{"ca.crt": []byte("cert-v1")},
+		},
+	).Build()
+
+	for i := 0; i < 3; i++ {
+		if err := SetKafkaClientCA(ctx, ns, "kafka", c); err != nil {
+			t.Fatalf("SetKafkaClientCA() call %d error = %v", i, err)
+		}
+	}
+
+	key, cert := GetKafkaClientCA()
+	if string(key) != "key-v1" || string(cert) != "cert-v1" {
+		t.Fatalf("GetKafkaClientCA() = (%q, %q), want (key-v1, cert-v1)", key, cert)
+	}
+}

--- a/operator/pkg/config/transport_config_test.go
+++ b/operator/pkg/config/transport_config_test.go
@@ -212,6 +212,13 @@ func TestSetKafkaClientCAUpdatesWhenSecretsChange(t *testing.T) {
 }
 
 func TestSetKafkaClientCAMissingCertSecret(t *testing.T) {
+	originalKey := kafkaClientCAKey
+	originalCert := kafkaClientCACert
+	t.Cleanup(func() {
+		kafkaClientCAKey = originalKey
+		kafkaClientCACert = originalCert
+	})
+
 	ctx := context.Background()
 	testScheme := runtime.NewScheme()
 	if err := corev1.AddToScheme(testScheme); err != nil {

--- a/operator/pkg/config/transport_config_test.go
+++ b/operator/pkg/config/transport_config_test.go
@@ -49,7 +49,9 @@ func TestSetKafkaClientCAConcurrentAccess(t *testing.T) {
 
 	ctx := context.Background()
 	testScheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(testScheme)
+	if err := corev1.AddToScheme(testScheme); err != nil {
+		t.Fatalf("add corev1 to test scheme: %v", err)
+	}
 	ns := "test-ns"
 	c := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
 		&corev1.Secret{
@@ -81,6 +83,44 @@ func TestSetKafkaClientCAConcurrentAccess(t *testing.T) {
 	key, cert := GetKafkaClientCA()
 	if string(key) != "key-v1" || string(cert) != "cert-v1" {
 		t.Fatalf("GetKafkaClientCA() = (%q, %q), want (key-v1, cert-v1)", key, cert)
+	}
+}
+
+func TestSetKafkaClientCARejectsIncompleteSecrets(t *testing.T) {
+	ctx := context.Background()
+	testScheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(testScheme); err != nil {
+		t.Fatalf("add corev1 to test scheme: %v", err)
+	}
+
+	originalKey := kafkaClientCAKey
+	originalCert := kafkaClientCACert
+	t.Cleanup(func() {
+		kafkaClientCAKey = originalKey
+		kafkaClientCACert = originalCert
+	})
+	kafkaClientCAKey = []byte("cached-key")
+	kafkaClientCACert = []byte("cached-cert")
+
+	ns := "test-ns"
+	c := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "kafka-clients-ca", Namespace: ns},
+			Data:       map[string][]byte{},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "kafka-clients-ca-cert", Namespace: ns},
+			Data:       map[string][]byte{"ca.crt": []byte("cert-v1")},
+		},
+	).Build()
+
+	if err := SetKafkaClientCA(ctx, ns, "kafka", c); err == nil {
+		t.Fatal("SetKafkaClientCA() expected error for missing ca.key")
+	}
+
+	key, cert := GetKafkaClientCA()
+	if string(key) != "cached-key" || string(cert) != "cached-cert" {
+		t.Fatalf("GetKafkaClientCA() = (%q, %q), want cached values preserved", key, cert)
 	}
 }
 

--- a/operator/pkg/controllers/transporter/protocol/byo_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/byo_transporter.go
@@ -32,6 +32,9 @@ var byoTransporter *BYOTransporter
 func NewBYOTransporter(ctx context.Context, namespacedName types.NamespacedName,
 	c client.Client,
 ) *BYOTransporter {
+	transporterConstructMu.Lock()
+	defer transporterConstructMu.Unlock()
+
 	if byoTransporter == nil {
 		byoTransporter = &BYOTransporter{
 			log:           logger.ZaprLogger(),

--- a/operator/pkg/controllers/transporter/protocol/byo_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/byo_transporter.go
@@ -24,8 +24,6 @@ type BYOTransporter struct {
 	runtimeClient client.Client
 }
 
-var byoTransporter *BYOTransporter
-
 // create the transport with secret(BYO case), it should meet the following conditions
 // 1. name: "multicluster-global-hub-transport"
 // 2. properties: "bootstrap_server", "ca.crt", "client.crt" and "client.key"
@@ -42,7 +40,6 @@ func NewBYOTransporter(ctx context.Context, namespacedName types.NamespacedName,
 		name:          namespacedName.Name,
 		namespace:     namespacedName.Namespace,
 	}
-	byoTransporter = t
 	config.SetTransporter(t)
 	return t
 }

--- a/operator/pkg/controllers/transporter/protocol/byo_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/byo_transporter.go
@@ -35,17 +35,16 @@ func NewBYOTransporter(ctx context.Context, namespacedName types.NamespacedName,
 	transporterConstructMu.Lock()
 	defer transporterConstructMu.Unlock()
 
-	if byoTransporter == nil {
-		byoTransporter = &BYOTransporter{
-			log:           logger.ZaprLogger(),
-			ctx:           ctx,
-			runtimeClient: c,
-		}
+	t := &BYOTransporter{
+		log:           logger.ZaprLogger(),
+		ctx:           ctx,
+		runtimeClient: c,
+		name:          namespacedName.Name,
+		namespace:     namespacedName.Namespace,
 	}
-	byoTransporter.name = namespacedName.Name
-	byoTransporter.namespace = namespacedName.Namespace
-	config.SetTransporter(byoTransporter)
-	return byoTransporter
+	byoTransporter = t
+	config.SetTransporter(t)
+	return t
 }
 
 func (s *BYOTransporter) EnsureUser(clusterName string) (string, error) {

--- a/operator/pkg/controllers/transporter/protocol/byo_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/byo_transporter.go
@@ -38,10 +38,10 @@ func NewBYOTransporter(ctx context.Context, namespacedName types.NamespacedName,
 			ctx:           ctx,
 			runtimeClient: c,
 		}
-		config.SetTransporter(byoTransporter)
 	}
 	byoTransporter.name = namespacedName.Name
 	byoTransporter.namespace = namespacedName.Namespace
+	config.SetTransporter(byoTransporter)
 	return byoTransporter
 }
 

--- a/operator/pkg/controllers/transporter/protocol/strimzi_kafka_controller.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_kafka_controller.go
@@ -118,24 +118,15 @@ func (r *KafkaController) Reconcile(ctx context.Context, request ctrl.Request) (
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 
-	// use the client ca to sign the csr for the managed hubs
-	if err := config.SetKafkaClientCA(r.trans.ctx, r.trans.mgh.Namespace, KafkaClusterName,
-		r.trans.manager.GetClient()); err != nil {
-		return ctrl.Result{}, err
-	}
-	// update the transporter
 	config.SetTransporter(r.trans)
-	conn, err := getManagerTransportConn(r.trans)
+	synced, err := syncManagerTransportSecretIfReady(ctx, mgh, r.trans, r.c)
 	if err != nil {
-		return ctrl.Result{}, err
-	}
-	if conn == nil {
-		log.Infow("waiting the kafka cluster credential to be ready...", "message", "kafka cluster credential is not ready")
-		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
-	}
-	if err := CreateManagerTransportSecret(ctx, mgh, conn, r.c); err != nil {
 		log.Errorf("failed to create manager transport-config secret: %v", err)
 		return ctrl.Result{}, err
+	}
+	if !synced {
+		log.Infow("waiting the kafka cluster credential to be ready...", "message", "kafka cluster credential is not ready")
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 
 	return ctrl.Result{}, nil
@@ -235,31 +226,41 @@ func applyManagerKafkaTopics(conn *transport.KafkaConfig) {
 	conn.StatusTopic = config.ManagerStatusTopic()
 }
 
+// syncManagerTransportSecretIfReady performs the shared readiness check, CA setup,
+// connection lookup, and secret creation used by both the async reconcile loop and
+// the synchronous post-EnsureKafka sync call.
+func syncManagerTransportSecretIfReady(ctx context.Context, mgh *v1alpha4.MulticlusterGlobalHub,
+	trans *strimziTransporter, c client.Client,
+) (synced bool, err error) {
+	kafkaStatus, err := trans.kafkaClusterReady()
+	if err != nil {
+		return false, err
+	}
+	if !kafkaStatus.kafkaReady {
+		return false, nil
+	}
+	if err := config.SetKafkaClientCA(trans.ctx, trans.mgh.Namespace, KafkaClusterName,
+		trans.manager.GetClient()); err != nil {
+		return false, err
+	}
+	conn, err := getManagerTransportConn(trans)
+	if err != nil {
+		return false, err
+	}
+	if conn == nil {
+		return false, nil
+	}
+	return true, CreateManagerTransportSecret(ctx, mgh, conn, c)
+}
+
 // SyncManagerTransportConfigSecret creates or updates the hub transport-config secret
 // when Kafka is ready. Called from the transport reconciler on MGH spec changes so
 // customized topics propagate without waiting for an async kafka-controller event.
 func SyncManagerTransportConfigSecret(ctx context.Context, mgh *v1alpha4.MulticlusterGlobalHub,
 	trans *strimziTransporter, c client.Client,
 ) error {
-	kafkaStatus, err := trans.kafkaClusterReady()
-	if err != nil {
-		return err
-	}
-	if !kafkaStatus.kafkaReady {
-		return nil
-	}
-	if err := config.SetKafkaClientCA(trans.ctx, trans.mgh.Namespace, KafkaClusterName,
-		trans.manager.GetClient()); err != nil {
-		return err
-	}
-	conn, err := getManagerTransportConn(trans)
-	if err != nil {
-		return err
-	}
-	if conn == nil {
-		return nil
-	}
-	return CreateManagerTransportSecret(ctx, mgh, conn, c)
+	_, err := syncManagerTransportSecretIfReady(ctx, mgh, trans, c)
+	return err
 }
 
 func (r *KafkaController) getKafkaComponentStatus(reconcileErr error, kafkaClusterStatus KafkaStatus,

--- a/operator/pkg/controllers/transporter/protocol/strimzi_kafka_controller.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_kafka_controller.go
@@ -269,7 +269,7 @@ func syncManagerTransportSecretIfReady(ctx context.Context, mgh *v1alpha4.Multic
 	if !kafkaStatus.kafkaReady {
 		return false, nil
 	}
-	if err := config.SetKafkaClientCA(trans.ctx, trans.mgh.Namespace, KafkaClusterName,
+	if err := config.SetKafkaClientCA(ctx, trans.mgh.Namespace, KafkaClusterName,
 		trans.manager.GetClient()); err != nil {
 		return false, fmt.Errorf("set Kafka client CA: %w", err)
 	}

--- a/operator/pkg/controllers/transporter/protocol/strimzi_kafka_controller.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_kafka_controller.go
@@ -121,7 +121,7 @@ func (r *KafkaController) Reconcile(ctx context.Context, request ctrl.Request) (
 	config.SetTransporter(r.trans)
 	synced, err := syncManagerTransportSecretIfReady(ctx, mgh, r.trans, r.c)
 	if err != nil {
-		log.Errorf("failed to create manager transport-config secret: %v", err)
+		log.Errorw("failed to create manager transport-config secret", "error", err)
 		return ctrl.Result{}, err
 	}
 	if !synced {
@@ -234,18 +234,18 @@ func syncManagerTransportSecretIfReady(ctx context.Context, mgh *v1alpha4.Multic
 ) (synced bool, err error) {
 	kafkaStatus, err := trans.kafkaClusterReady()
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("check Kafka cluster readiness: %w", err)
 	}
 	if !kafkaStatus.kafkaReady {
 		return false, nil
 	}
 	if err := config.SetKafkaClientCA(trans.ctx, trans.mgh.Namespace, KafkaClusterName,
 		trans.manager.GetClient()); err != nil {
-		return false, err
+		return false, fmt.Errorf("set Kafka client CA: %w", err)
 	}
 	conn, err := getManagerTransportConn(trans)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("get manager transport connection: %w", err)
 	}
 	if conn == nil {
 		return false, nil

--- a/operator/pkg/controllers/transporter/protocol/strimzi_kafka_controller.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_kafka_controller.go
@@ -197,6 +197,7 @@ func StartKafkaController(ctx context.Context, mgr ctrl.Manager, transporter tra
 	return nil
 }
 
+// activeStrimziTransporter returns the currently registered Strimzi transporter instance.
 func activeStrimziTransporter() (*strimziTransporter, error) {
 	transporter := config.GetTransporter()
 	if transporter == nil {
@@ -209,6 +210,7 @@ func activeStrimziTransporter() (*strimziTransporter, error) {
 	return st, nil
 }
 
+// refreshStrimziTransporter reloads the active Strimzi transporter from the shared registry.
 func (r *KafkaController) refreshStrimziTransporter() error {
 	trans, err := activeStrimziTransporter()
 	if err != nil {
@@ -218,6 +220,7 @@ func (r *KafkaController) refreshStrimziTransporter() error {
 	return nil
 }
 
+// getManagerTransportConn builds the manager Kafka connection from cluster and user credentials.
 func getManagerTransportConn(trans *strimziTransporter) (
 	*transport.KafkaConfig, error,
 ) {

--- a/operator/pkg/controllers/transporter/protocol/strimzi_kafka_controller.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_kafka_controller.go
@@ -80,6 +80,9 @@ func (r *KafkaController) Reconcile(ctx context.Context, request ctrl.Request) (
 	if mgh == nil || config.IsPaused(mgh) {
 		return ctrl.Result{}, nil
 	}
+	if err := r.refreshStrimziTransporter(); err != nil {
+		return ctrl.Result{}, err
+	}
 	if mgh.DeletionTimestamp != nil {
 		if !config.GetGlobalhubAgentRemoved() {
 			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
@@ -118,7 +121,6 @@ func (r *KafkaController) Reconcile(ctx context.Context, request ctrl.Request) (
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 
-	config.SetTransporter(r.trans)
 	synced, err := syncManagerTransportSecretIfReady(ctx, mgh, r.trans, r.c)
 	if err != nil {
 		log.Errorw("failed to create manager transport-config secret", "error", err)
@@ -168,8 +170,12 @@ func StartKafkaController(ctx context.Context, mgr ctrl.Manager, transporter tra
 	}
 	log.Info("start kafka controller")
 	r := &KafkaController{
-		c:     mgr.GetClient(),
-		trans: transporter.(*strimziTransporter),
+		c: mgr.GetClient(),
+	}
+	if transporter != nil {
+		if st, ok := transporter.(*strimziTransporter); ok {
+			r.trans = st
+		}
 	}
 
 	// even if the following controller will reconcile the transport, but it's asynchoronized
@@ -188,6 +194,27 @@ func StartKafkaController(ctx context.Context, mgr ctrl.Manager, transporter tra
 	}
 	startedKafkaController = true
 	log.Info("kafka controller is started")
+	return nil
+}
+
+func activeStrimziTransporter() (*strimziTransporter, error) {
+	transporter := config.GetTransporter()
+	if transporter == nil {
+		return nil, fmt.Errorf("transporter is not configured")
+	}
+	st, ok := transporter.(*strimziTransporter)
+	if !ok {
+		return nil, fmt.Errorf("active transporter is %T, want *strimziTransporter", transporter)
+	}
+	return st, nil
+}
+
+func (r *KafkaController) refreshStrimziTransporter() error {
+	trans, err := activeStrimziTransporter()
+	if err != nil {
+		return err
+	}
+	r.trans = trans
 	return nil
 }
 

--- a/operator/pkg/controllers/transporter/protocol/strimzi_kafka_controller.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_kafka_controller.go
@@ -125,7 +125,6 @@ func (r *KafkaController) Reconcile(ctx context.Context, request ctrl.Request) (
 	}
 	// update the transporter
 	config.SetTransporter(r.trans)
-	// update the transport connection, if conn is nil, requeue to let it ready
 	conn, err := getManagerTransportConn(r.trans)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -134,8 +133,6 @@ func (r *KafkaController) Reconcile(ctx context.Context, request ctrl.Request) (
 		log.Infow("waiting the kafka cluster credential to be ready...", "message", "kafka cluster credential is not ready")
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
-
-	// Create/update transport-config secret for manager
 	if err := CreateManagerTransportSecret(ctx, mgh, conn, r.c); err != nil {
 		log.Errorf("failed to create manager transport-config secret: %v", err)
 		return ctrl.Result{}, err
@@ -228,6 +225,43 @@ func getManagerTransportConn(trans *strimziTransporter) (
 	return conn, nil
 }
 
+// applyManagerKafkaTopics refreshes kafka.yaml topic fields from the transport config
+// populated by SetTransportConfig on the latest MGH spec.
+func applyManagerKafkaTopics(conn *transport.KafkaConfig) {
+	if conn == nil {
+		return
+	}
+	conn.SpecTopic = config.GetSpecTopic()
+	conn.StatusTopic = config.ManagerStatusTopic()
+}
+
+// SyncManagerTransportConfigSecret creates or updates the hub transport-config secret
+// when Kafka is ready. Called from the transport reconciler on MGH spec changes so
+// customized topics propagate without waiting for an async kafka-controller event.
+func SyncManagerTransportConfigSecret(ctx context.Context, mgh *v1alpha4.MulticlusterGlobalHub,
+	trans *strimziTransporter, c client.Client,
+) error {
+	kafkaStatus, err := trans.kafkaClusterReady()
+	if err != nil {
+		return err
+	}
+	if !kafkaStatus.kafkaReady {
+		return nil
+	}
+	if err := config.SetKafkaClientCA(trans.ctx, trans.mgh.Namespace, KafkaClusterName,
+		trans.manager.GetClient()); err != nil {
+		return err
+	}
+	conn, err := getManagerTransportConn(trans)
+	if err != nil {
+		return err
+	}
+	if conn == nil {
+		return nil
+	}
+	return CreateManagerTransportSecret(ctx, mgh, conn, c)
+}
+
 func (r *KafkaController) getKafkaComponentStatus(reconcileErr error, kafkaClusterStatus KafkaStatus,
 ) v1alpha4.StatusCondition {
 	if reconcileErr != nil {
@@ -278,6 +312,7 @@ func CreateManagerTransportSecret(ctx context.Context, mgh *v1alpha4.Multicluste
 	secretData := make(map[string][]byte)
 	// Build kafka config yaml
 	if kafkaConfig != nil {
+		applyManagerKafkaTopics(kafkaConfig)
 		kafkaConfigYaml, err := kafkaConfig.YamlMarshal(true)
 		if err != nil {
 			return fmt.Errorf("failed to marshal kafka config: %w", err)

--- a/operator/pkg/controllers/transporter/protocol/strimzi_kafka_controller_test.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_kafka_controller_test.go
@@ -171,6 +171,42 @@ func readyKafkaCluster(ns, bootServer, readyType, readyStatus string) *kafkav1be
 	}
 }
 
+func TestKafkaControllerRefreshUsesActiveStrimziTransporter(t *testing.T) {
+	t.Cleanup(func() { config.SetTransporter(nil) })
+
+	ns := utils.GetDefaultNamespace()
+	mgh1 := &operatorv1alpha4.MulticlusterGlobalHub{
+		ObjectMeta: metav1.ObjectMeta{Name: "globalhub", Namespace: ns},
+		Spec: operatorv1alpha4.MulticlusterGlobalHubSpec{
+			DataLayerSpec: operatorv1alpha4.DataLayerSpec{
+				Kafka: operatorv1alpha4.KafkaSpec{
+					KafkaTopics: operatorv1alpha4.KafkaTopics{SpecTopic: "spec1"},
+				},
+			},
+		},
+	}
+	mgh2 := mgh1.DeepCopy()
+	mgh2.Spec.DataLayerSpec.Kafka.KafkaTopics.SpecTopic = "spec2"
+
+	trans1 := NewStrimziTransporter(nil, mgh1)
+	kc := &KafkaController{trans: trans1}
+
+	trans2 := NewStrimziTransporter(nil, mgh2)
+	if trans2 == trans1 {
+		t.Fatal("expected distinct Strimzi transporter instances")
+	}
+
+	if err := kc.refreshStrimziTransporter(); err != nil {
+		t.Fatalf("refreshStrimziTransporter() error = %v", err)
+	}
+	if kc.trans != trans2 {
+		t.Fatal("KafkaController should reconcile with the active Strimzi transporter")
+	}
+	if got := kc.trans.mgh.Spec.DataLayerSpec.Kafka.KafkaTopics.SpecTopic; got != "spec2" {
+		t.Fatalf("SpecTopic = %q, want spec2", got)
+	}
+}
+
 func TestMulticlusterGlobalHubReconcilerStrimziResources(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/operator/pkg/controllers/transporter/protocol/strimzi_kafka_controller_test.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_kafka_controller_test.go
@@ -207,6 +207,331 @@ func TestKafkaControllerRefreshUsesActiveStrimziTransporter(t *testing.T) {
 	}
 }
 
+func TestActiveStrimziTransporter(t *testing.T) {
+	config.SetTransporter(nil)
+	t.Cleanup(func() { config.SetTransporter(nil) })
+
+	if _, err := activeStrimziTransporter(); err == nil {
+		t.Fatal("activeStrimziTransporter() expected error when transporter is nil")
+	}
+
+	config.SetTransporter(&stubBYOTransporter{})
+	if _, err := activeStrimziTransporter(); err == nil {
+		t.Fatal("activeStrimziTransporter() expected error for non-Strimzi transporter")
+	}
+
+	mgh := &operatorv1alpha4.MulticlusterGlobalHub{
+		ObjectMeta: metav1.ObjectMeta{Name: "globalhub", Namespace: utils.GetDefaultNamespace()},
+	}
+	st := NewStrimziTransporter(nil, mgh)
+	got, err := activeStrimziTransporter()
+	if err != nil {
+		t.Fatalf("activeStrimziTransporter() error = %v", err)
+	}
+	if got != st {
+		t.Fatal("activeStrimziTransporter() should return the registered Strimzi transporter")
+	}
+}
+
+type stubBYOTransporter struct{}
+
+func (s *stubBYOTransporter) EnsureUser(string) (string, error) { return "", nil }
+
+func (s *stubBYOTransporter) EnsureTopic(string) (*transport.ClusterTopic, error) {
+	return &transport.ClusterTopic{}, nil
+}
+
+func (s *stubBYOTransporter) EnsureKafka() (bool, error) { return false, nil }
+
+func (s *stubBYOTransporter) Prune(string) error { return nil }
+
+func (s *stubBYOTransporter) GetConnCredential(string) (*transport.KafkaConfig, error) {
+	return &transport.KafkaConfig{}, nil
+}
+
+func TestApplyManagerKafkaTopicsNilConn(t *testing.T) {
+	applyManagerKafkaTopics(nil)
+}
+
+func TestSyncManagerTransportSecretIfReadyKafkaNotReady(t *testing.T) {
+	ctx := context.Background()
+	testScheme := runtime.NewScheme()
+	_ = operatorv1alpha4.AddToScheme(testScheme)
+	_ = kafkav1beta2.AddToScheme(testScheme)
+
+	ns := utils.GetDefaultNamespace()
+	mgh := &operatorv1alpha4.MulticlusterGlobalHub{
+		ObjectMeta: metav1.ObjectMeta{Name: "globalhub", Namespace: ns},
+	}
+	notReadyType := "Ready"
+	notReadyStatus := "False"
+	notReadyReason := "NotReady"
+	notReadyMessage := "Kafka cluster not ready"
+	notReadyKafka := &kafkav1beta2.Kafka{
+		ObjectMeta: metav1.ObjectMeta{Name: KafkaClusterName, Namespace: ns},
+		Spec: &kafkav1beta2.KafkaSpec{
+			Kafka: kafkav1beta2.KafkaSpecKafka{
+				Listeners: []kafkav1beta2.KafkaSpecKafkaListenersElem{
+					{Name: "tls", Port: 9093, Type: "nodeport", Tls: true},
+				},
+			},
+		},
+		Status: &kafkav1beta2.KafkaStatus{
+			Conditions: []kafkav1beta2.KafkaStatusConditionsElem{
+				{
+					Type:    &notReadyType,
+					Status:  &notReadyStatus,
+					Reason:  &notReadyReason,
+					Message: &notReadyMessage,
+				},
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(mgh, notReadyKafka).Build()
+	trans := &strimziTransporter{
+		ctx:                   ctx,
+		mgh:                   mgh,
+		kafkaClusterName:      KafkaClusterName,
+		kafkaClusterNamespace: ns,
+		manager:               &fakeManager{c: fakeClient},
+	}
+
+	synced, err := syncManagerTransportSecretIfReady(ctx, mgh, trans, fakeClient)
+	if err != nil {
+		t.Fatalf("syncManagerTransportSecretIfReady() error = %v", err)
+	}
+	if synced {
+		t.Fatal("syncManagerTransportSecretIfReady() should not sync when Kafka is not ready")
+	}
+}
+
+func TestSyncManagerTransportSecretIfReadyRejectsIncompleteCA(t *testing.T) {
+	ctx := context.Background()
+	testScheme := runtime.NewScheme()
+	_ = operatorv1alpha4.AddToScheme(testScheme)
+	_ = corev1.AddToScheme(testScheme)
+	_ = kafkav1beta2.AddToScheme(testScheme)
+
+	ns := utils.GetDefaultNamespace()
+	mgh := &operatorv1alpha4.MulticlusterGlobalHub{
+		ObjectMeta: metav1.ObjectMeta{Name: "globalhub", Namespace: ns},
+	}
+	bootServer := "kafka-kafka-bootstrap.example.svc:9092"
+	kafkaCluster := readyKafkaCluster(ns, bootServer, "Ready", "True")
+	clientCAKeySecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: KafkaClusterName + "-clients-ca", Namespace: ns},
+		Data:       map[string][]byte{},
+	}
+	clientCACertSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: KafkaClusterName + "-clients-ca-cert", Namespace: ns},
+		Data:       map[string][]byte{"ca.crt": []byte("cacert")},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
+		mgh, kafkaCluster, clientCAKeySecret, clientCACertSecret,
+	).Build()
+	trans := &strimziTransporter{
+		ctx:                   ctx,
+		mgh:                   mgh,
+		kafkaClusterName:      KafkaClusterName,
+		kafkaClusterNamespace: ns,
+		manager:               &fakeManager{c: fakeClient},
+	}
+
+	_, err := syncManagerTransportSecretIfReady(ctx, mgh, trans, fakeClient)
+	if err == nil {
+		t.Fatal("syncManagerTransportSecretIfReady() expected error for incomplete CA secrets")
+	}
+	if !strings.Contains(err.Error(), "set Kafka client CA") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSyncManagerTransportSecretIfReadyWaitsForUserCredential(t *testing.T) {
+	ctx := context.Background()
+	testScheme := runtime.NewScheme()
+	_ = operatorv1alpha4.AddToScheme(testScheme)
+	_ = corev1.AddToScheme(testScheme)
+	_ = kafkav1beta2.AddToScheme(testScheme)
+
+	ns := utils.GetDefaultNamespace()
+	mgh := &operatorv1alpha4.MulticlusterGlobalHub{
+		ObjectMeta: metav1.ObjectMeta{Name: "globalhub", Namespace: ns},
+	}
+	bootServer := "kafka-kafka-bootstrap.example.svc:9092"
+	kafkaCluster := readyKafkaCluster(ns, bootServer, "Ready", "True")
+	clientCAKeySecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: KafkaClusterName + "-clients-ca", Namespace: ns},
+		Data:       map[string][]byte{"ca.key": []byte("cakey")},
+	}
+	clientCACertSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: KafkaClusterName + "-clients-ca-cert", Namespace: ns},
+		Data:       map[string][]byte{"ca.crt": []byte("cacert")},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
+		mgh, kafkaCluster, clientCAKeySecret, clientCACertSecret,
+	).Build()
+	trans := &strimziTransporter{
+		ctx:                   ctx,
+		mgh:                   mgh,
+		kafkaClusterName:      KafkaClusterName,
+		kafkaClusterNamespace: ns,
+		manager:               &fakeManager{c: fakeClient},
+	}
+
+	synced, err := syncManagerTransportSecretIfReady(ctx, mgh, trans, fakeClient)
+	if err != nil {
+		t.Fatalf("syncManagerTransportSecretIfReady() error = %v", err)
+	}
+	if synced {
+		t.Fatal("syncManagerTransportSecretIfReady() should wait when global-hub user credential is missing")
+	}
+}
+
+func TestCreateManagerTransportSecretUpdatesExistingTopics(t *testing.T) {
+	ctx := context.Background()
+	testScheme := runtime.NewScheme()
+	_ = operatorv1alpha4.AddToScheme(testScheme)
+	_ = corev1.AddToScheme(testScheme)
+	_ = kafkav1beta2.AddToScheme(testScheme)
+
+	ns := utils.GetDefaultNamespace()
+	mgh := &operatorv1alpha4.MulticlusterGlobalHub{
+		ObjectMeta: metav1.ObjectMeta{Name: "globalhub", Namespace: ns},
+		Spec: operatorv1alpha4.MulticlusterGlobalHubSpec{
+			DataLayerSpec: operatorv1alpha4.DataLayerSpec{
+				Kafka: operatorv1alpha4.KafkaSpec{
+					KafkaTopics: operatorv1alpha4.KafkaTopics{
+						SpecTopic:   "spec-old",
+						StatusTopic: "gh-status.*",
+					},
+				},
+			},
+		},
+	}
+	existingSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.GHTransportConfigSecret,
+			Namespace: ns,
+		},
+		Data: map[string][]byte{"kafka.yaml": []byte("topic.spec: spec-old\n")},
+	}
+	bootServer := "kafka-kafka-bootstrap.example.svc:9092"
+	kafkaCluster := readyKafkaCluster(ns, bootServer, "Ready", "True")
+	kafkaUserSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: DefaultGlobalHubKafkaUserName, Namespace: ns},
+		Data: map[string][]byte{
+			"user.crt": []byte("usercrt"),
+			"user.key": []byte("userkey"),
+		},
+	}
+	clientCAKeySecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: KafkaClusterName + "-clients-ca", Namespace: ns},
+		Data:       map[string][]byte{"ca.key": []byte("cakey")},
+	}
+	clientCACertSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: KafkaClusterName + "-clients-ca-cert", Namespace: ns},
+		Data:       map[string][]byte{"ca.crt": []byte("cacert")},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
+		mgh, existingSecret, kafkaCluster, kafkaUserSecret, clientCAKeySecret, clientCACertSecret,
+	).Build()
+	if err := config.SetTransportConfig(ctx, fakeClient, mgh); err != nil {
+		t.Fatalf("SetTransportConfig() error = %v", err)
+	}
+
+	mgh.Spec.DataLayerSpec.Kafka.KafkaTopics.SpecTopic = "spec-new"
+	if err := config.SetTransportConfig(ctx, fakeClient, mgh); err != nil {
+		t.Fatalf("SetTransportConfig() error = %v", err)
+	}
+
+	trans := &strimziTransporter{
+		ctx:                   ctx,
+		mgh:                   mgh,
+		kafkaClusterName:      KafkaClusterName,
+		kafkaClusterNamespace: ns,
+		manager:               &fakeManager{c: fakeClient},
+	}
+	if err := SyncManagerTransportConfigSecret(ctx, mgh, trans, fakeClient); err != nil {
+		t.Fatalf("SyncManagerTransportConfigSecret() error = %v", err)
+	}
+
+	secret := &corev1.Secret{}
+	if err := fakeClient.Get(ctx, types.NamespacedName{
+		Name:      constants.GHTransportConfigSecret,
+		Namespace: ns,
+	}, secret); err != nil {
+		t.Fatalf("Get transport-config secret error = %v", err)
+	}
+	kafkaYAML := string(secret.Data["kafka.yaml"])
+	if !strings.Contains(kafkaYAML, "topic.spec: spec-new") {
+		t.Fatalf("kafka.yaml should reflect updated spec topic: %s", kafkaYAML)
+	}
+}
+
+func TestGetManagerTransportConn(t *testing.T) {
+	ctx := context.Background()
+	testScheme := runtime.NewScheme()
+	_ = operatorv1alpha4.AddToScheme(testScheme)
+	_ = corev1.AddToScheme(testScheme)
+	_ = kafkav1beta2.AddToScheme(testScheme)
+
+	ns := utils.GetDefaultNamespace()
+	mgh := &operatorv1alpha4.MulticlusterGlobalHub{
+		ObjectMeta: metav1.ObjectMeta{Name: "globalhub", Namespace: ns},
+		Spec: operatorv1alpha4.MulticlusterGlobalHubSpec{
+			DataLayerSpec: operatorv1alpha4.DataLayerSpec{
+				Kafka: operatorv1alpha4.KafkaSpec{
+					KafkaTopics: operatorv1alpha4.KafkaTopics{
+						SpecTopic:   "spec1",
+						StatusTopic: "gh-status.*",
+					},
+					ConsumerGroupPrefix: "gh_",
+				},
+			},
+		},
+	}
+	bootServer := "kafka-kafka-bootstrap.example.svc:9092"
+	kafkaCluster := readyKafkaCluster(ns, bootServer, "Ready", "True")
+	kafkaUserSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: DefaultGlobalHubKafkaUserName, Namespace: ns},
+		Data: map[string][]byte{
+			"user.crt": []byte("usercrt"),
+			"user.key": []byte("userkey"),
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
+		mgh, kafkaCluster, kafkaUserSecret,
+	).Build()
+	if err := config.SetTransportConfig(ctx, fakeClient, mgh); err != nil {
+		t.Fatalf("SetTransportConfig() error = %v", err)
+	}
+
+	trans := &strimziTransporter{
+		ctx:                   ctx,
+		mgh:                   mgh,
+		kafkaClusterName:      KafkaClusterName,
+		kafkaClusterNamespace: ns,
+		manager:               &fakeManager{c: fakeClient},
+	}
+
+	conn, err := getManagerTransportConn(trans)
+	if err != nil {
+		t.Fatalf("getManagerTransportConn() error = %v", err)
+	}
+	if conn == nil {
+		t.Fatal("getManagerTransportConn() returned nil connection")
+	}
+	if conn.SpecTopic != "spec1" {
+		t.Fatalf("SpecTopic = %q, want spec1", conn.SpecTopic)
+	}
+	if conn.StatusTopic != "^gh-status.*" {
+		t.Fatalf("StatusTopic = %q, want ^gh-status.*", conn.StatusTopic)
+	}
+	if conn.ConsumerGroupID != "gh_global_hub" {
+		t.Fatalf("ConsumerGroupID = %q, want gh_global_hub", conn.ConsumerGroupID)
+	}
+}
+
 func TestMulticlusterGlobalHubReconcilerStrimziResources(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/operator/pkg/controllers/transporter/protocol/strimzi_kafka_controller_test.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_kafka_controller_test.go
@@ -73,6 +73,7 @@ func TestCreateManagerTransportSecretAppliesCustomSpecTopic(t *testing.T) {
 	testScheme := runtime.NewScheme()
 	_ = operatorv1alpha4.AddToScheme(testScheme)
 	_ = corev1.AddToScheme(testScheme)
+	_ = kafkav1beta2.AddToScheme(testScheme)
 
 	ns := utils.GetDefaultNamespace()
 	mgh := &operatorv1alpha4.MulticlusterGlobalHub{
@@ -91,18 +92,41 @@ func TestCreateManagerTransportSecretAppliesCustomSpecTopic(t *testing.T) {
 			},
 		},
 	}
-	fakeClient := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(mgh).Build()
+	readyCondition := "Ready"
+	trueCondition := "True"
+	bootServer := "kafka-kafka-bootstrap.example.svc:9092"
+	kafkaCluster := readyKafkaCluster(ns, bootServer, readyCondition, trueCondition)
+	kafkaUserSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: DefaultGlobalHubKafkaUserName, Namespace: ns},
+		Data: map[string][]byte{
+			"user.crt": []byte("usercrt"),
+			"user.key": []byte("userkey"),
+		},
+	}
+	clientCAKeySecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: KafkaClusterName + "-clients-ca", Namespace: ns},
+		Data:       map[string][]byte{"ca.key": []byte("cakey")},
+	}
+	clientCACertSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: KafkaClusterName + "-clients-ca-cert", Namespace: ns},
+		Data:       map[string][]byte{"ca.crt": []byte("cacert")},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
+		mgh, kafkaCluster, kafkaUserSecret, clientCAKeySecret, clientCACertSecret,
+	).Build()
 	if err := config.SetTransportConfig(ctx, fakeClient, mgh); err != nil {
 		t.Fatalf("SetTransportConfig() error = %v", err)
 	}
 
-	conn := &transport.KafkaConfig{
-		BootstrapServer: "kafka.example:9092",
-		SpecTopic:       "gh-spec",
-		StatusTopic:     "gh-spec",
+	trans := &strimziTransporter{
+		ctx:                   ctx,
+		mgh:                   mgh,
+		kafkaClusterName:      KafkaClusterName,
+		kafkaClusterNamespace: ns,
+		manager:               &fakeManager{c: fakeClient},
 	}
-	if err := CreateManagerTransportSecret(ctx, mgh, conn, fakeClient); err != nil {
-		t.Fatalf("CreateManagerTransportSecret() error = %v", err)
+	if err := SyncManagerTransportConfigSecret(ctx, mgh, trans, fakeClient); err != nil {
+		t.Fatalf("SyncManagerTransportConfigSecret() error = %v", err)
 	}
 
 	secret := &corev1.Secret{}
@@ -118,6 +142,32 @@ func TestCreateManagerTransportSecretAppliesCustomSpecTopic(t *testing.T) {
 	}
 	if !strings.Contains(kafkaYAML, "topic.status: ^gh-status.*") {
 		t.Fatalf("kafka.yaml missing customized status topic: %s", kafkaYAML)
+	}
+}
+
+func readyKafkaCluster(ns, bootServer, readyType, readyStatus string) *kafkav1beta2.Kafka {
+	clusterID := "test-cluster-id"
+	return &kafkav1beta2.Kafka{
+		ObjectMeta: metav1.ObjectMeta{Name: KafkaClusterName, Namespace: ns},
+		Spec: &kafkav1beta2.KafkaSpec{
+			Kafka: kafkav1beta2.KafkaSpecKafka{
+				Listeners: []kafkav1beta2.KafkaSpecKafkaListenersElem{
+					{Name: "tls", Port: 9093, Type: "nodeport", Tls: true},
+				},
+			},
+		},
+		Status: &kafkav1beta2.KafkaStatus{
+			ClusterId: &clusterID,
+			Listeners: []kafkav1beta2.KafkaStatusListenersElem{
+				{
+					BootstrapServers: &bootServer,
+					Certificates:     []string{"cert"},
+				},
+			},
+			Conditions: []kafkav1beta2.KafkaStatusConditionsElem{
+				{Type: &readyType, Status: &readyStatus},
+			},
+		},
 	}
 }
 

--- a/operator/pkg/controllers/transporter/protocol/strimzi_kafka_controller_test.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_kafka_controller_test.go
@@ -27,7 +27,16 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
+func restoreTransportConfigAfterTest(t *testing.T) {
+	t.Helper()
+	snapshot := config.SnapshotTransportConfigForTest()
+	t.Cleanup(func() {
+		config.RestoreTransportConfigForTest(snapshot)
+	})
+}
+
 func TestApplyManagerKafkaTopics(t *testing.T) {
+	restoreTransportConfigAfterTest(t)
 	ctx := context.Background()
 	testScheme := runtime.NewScheme()
 	_ = operatorv1alpha4.AddToScheme(testScheme)
@@ -69,6 +78,7 @@ func TestApplyManagerKafkaTopics(t *testing.T) {
 }
 
 func TestCreateManagerTransportSecretAppliesCustomSpecTopic(t *testing.T) {
+	restoreTransportConfigAfterTest(t)
 	ctx := context.Background()
 	testScheme := runtime.NewScheme()
 	_ = operatorv1alpha4.AddToScheme(testScheme)
@@ -172,7 +182,7 @@ func readyKafkaCluster(ns, bootServer, readyType, readyStatus string) *kafkav1be
 }
 
 func TestKafkaControllerRefreshUsesActiveStrimziTransporter(t *testing.T) {
-	t.Cleanup(func() { config.SetTransporter(nil) })
+	restoreTransportConfigAfterTest(t)
 
 	ns := utils.GetDefaultNamespace()
 	mgh1 := &operatorv1alpha4.MulticlusterGlobalHub{
@@ -208,8 +218,8 @@ func TestKafkaControllerRefreshUsesActiveStrimziTransporter(t *testing.T) {
 }
 
 func TestActiveStrimziTransporter(t *testing.T) {
+	restoreTransportConfigAfterTest(t)
 	config.SetTransporter(nil)
-	t.Cleanup(func() { config.SetTransporter(nil) })
 
 	if _, err := activeStrimziTransporter(); err == nil {
 		t.Fatal("activeStrimziTransporter() expected error when transporter is nil")
@@ -254,6 +264,7 @@ func TestApplyManagerKafkaTopicsNilConn(t *testing.T) {
 }
 
 func TestSyncManagerTransportSecretIfReadyKafkaNotReady(t *testing.T) {
+	restoreTransportConfigAfterTest(t)
 	ctx := context.Background()
 	testScheme := runtime.NewScheme()
 	_ = operatorv1alpha4.AddToScheme(testScheme)
@@ -306,6 +317,7 @@ func TestSyncManagerTransportSecretIfReadyKafkaNotReady(t *testing.T) {
 }
 
 func TestSyncManagerTransportSecretIfReadyRejectsIncompleteCA(t *testing.T) {
+	restoreTransportConfigAfterTest(t)
 	ctx := context.Background()
 	testScheme := runtime.NewScheme()
 	_ = operatorv1alpha4.AddToScheme(testScheme)
@@ -347,6 +359,7 @@ func TestSyncManagerTransportSecretIfReadyRejectsIncompleteCA(t *testing.T) {
 }
 
 func TestSyncManagerTransportSecretIfReadyWaitsForUserCredential(t *testing.T) {
+	restoreTransportConfigAfterTest(t)
 	ctx := context.Background()
 	testScheme := runtime.NewScheme()
 	_ = operatorv1alpha4.AddToScheme(testScheme)
@@ -388,6 +401,7 @@ func TestSyncManagerTransportSecretIfReadyWaitsForUserCredential(t *testing.T) {
 }
 
 func TestCreateManagerTransportSecretUpdatesExistingTopics(t *testing.T) {
+	restoreTransportConfigAfterTest(t)
 	ctx := context.Background()
 	testScheme := runtime.NewScheme()
 	_ = operatorv1alpha4.AddToScheme(testScheme)
@@ -469,6 +483,7 @@ func TestCreateManagerTransportSecretUpdatesExistingTopics(t *testing.T) {
 }
 
 func TestGetManagerTransportConn(t *testing.T) {
+	restoreTransportConfigAfterTest(t)
 	ctx := context.Background()
 	testScheme := runtime.NewScheme()
 	_ = operatorv1alpha4.AddToScheme(testScheme)

--- a/operator/pkg/controllers/transporter/protocol/strimzi_kafka_controller_test.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_kafka_controller_test.go
@@ -5,6 +5,7 @@ package protocol
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -22,8 +23,103 @@ import (
 	operatorv1alpha4 "github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
+
+func TestApplyManagerKafkaTopics(t *testing.T) {
+	ctx := context.Background()
+	testScheme := runtime.NewScheme()
+	_ = operatorv1alpha4.AddToScheme(testScheme)
+	_ = corev1.AddToScheme(testScheme)
+
+	mgh := &operatorv1alpha4.MulticlusterGlobalHub{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "globalhub",
+			Namespace: utils.GetDefaultNamespace(),
+		},
+		Spec: operatorv1alpha4.MulticlusterGlobalHubSpec{
+			DataLayerSpec: operatorv1alpha4.DataLayerSpec{
+				Kafka: operatorv1alpha4.KafkaSpec{
+					KafkaTopics: operatorv1alpha4.KafkaTopics{
+						SpecTopic:   "spec1",
+						StatusTopic: "gh-status.*",
+					},
+				},
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(mgh).Build()
+	if err := config.SetTransportConfig(ctx, fakeClient, mgh); err != nil {
+		t.Fatalf("SetTransportConfig() error = %v", err)
+	}
+
+	conn := &transport.KafkaConfig{
+		SpecTopic:   "gh-spec",
+		StatusTopic: "gh-spec",
+	}
+	applyManagerKafkaTopics(conn)
+
+	if conn.SpecTopic != "spec1" {
+		t.Fatalf("SpecTopic = %q, want %q", conn.SpecTopic, "spec1")
+	}
+	if conn.StatusTopic != "^gh-status.*" {
+		t.Fatalf("StatusTopic = %q, want %q", conn.StatusTopic, "^gh-status.*")
+	}
+}
+
+func TestCreateManagerTransportSecretAppliesCustomSpecTopic(t *testing.T) {
+	ctx := context.Background()
+	testScheme := runtime.NewScheme()
+	_ = operatorv1alpha4.AddToScheme(testScheme)
+	_ = corev1.AddToScheme(testScheme)
+
+	ns := utils.GetDefaultNamespace()
+	mgh := &operatorv1alpha4.MulticlusterGlobalHub{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "globalhub",
+			Namespace: ns,
+		},
+		Spec: operatorv1alpha4.MulticlusterGlobalHubSpec{
+			DataLayerSpec: operatorv1alpha4.DataLayerSpec{
+				Kafka: operatorv1alpha4.KafkaSpec{
+					KafkaTopics: operatorv1alpha4.KafkaTopics{
+						SpecTopic:   "spec1",
+						StatusTopic: "gh-status.*",
+					},
+				},
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(mgh).Build()
+	if err := config.SetTransportConfig(ctx, fakeClient, mgh); err != nil {
+		t.Fatalf("SetTransportConfig() error = %v", err)
+	}
+
+	conn := &transport.KafkaConfig{
+		BootstrapServer: "kafka.example:9092",
+		SpecTopic:       "gh-spec",
+		StatusTopic:     "gh-spec",
+	}
+	if err := CreateManagerTransportSecret(ctx, mgh, conn, fakeClient); err != nil {
+		t.Fatalf("CreateManagerTransportSecret() error = %v", err)
+	}
+
+	secret := &corev1.Secret{}
+	if err := fakeClient.Get(ctx, types.NamespacedName{
+		Name:      constants.GHTransportConfigSecret,
+		Namespace: ns,
+	}, secret); err != nil {
+		t.Fatalf("Get transport-config secret error = %v", err)
+	}
+	kafkaYAML := string(secret.Data["kafka.yaml"])
+	if !strings.Contains(kafkaYAML, "topic.spec: spec1") {
+		t.Fatalf("kafka.yaml missing customized spec topic: %s", kafkaYAML)
+	}
+	if !strings.Contains(kafkaYAML, "topic.status: ^gh-status.*") {
+		t.Fatalf("kafka.yaml missing customized status topic: %s", kafkaYAML)
+	}
+}
 
 func TestMulticlusterGlobalHubReconcilerStrimziResources(t *testing.T) {
 	tests := []struct {

--- a/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
@@ -138,7 +138,6 @@ func NewStrimziTransporter(mgr ctrl.Manager, mgh *operatorv1alpha4.MulticlusterG
 
 			manager: mgr,
 		}
-		config.SetTransporter(transporter)
 		if mgh.Spec.AvailabilityConfig == operatorv1alpha4.HABasic {
 			transporter.topicPartitionReplicas = 1
 		}
@@ -151,6 +150,7 @@ func NewStrimziTransporter(mgr ctrl.Manager, mgh *operatorv1alpha4.MulticlusterG
 	for _, opt := range opts {
 		opt(transporter)
 	}
+	config.SetTransporter(transporter)
 
 	if transporter.subCommunity {
 		transporter.subChannel = CommunityChannel

--- a/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
@@ -53,8 +53,11 @@ const (
 	// Global hub kafkaUser name
 	DefaultGlobalHubKafkaUserName = "global-hub-kafka-user"
 
+	// Strimzi operator package/subscription/ClusterExtension name (shared across OLM install paths).
+	StrimziOperatorName = "strimzi-kafka-operator"
+
 	// subscription - common
-	DefaultKafkaSubName           = "strimzi-kafka-operator"
+	DefaultKafkaSubName           = StrimziOperatorName
 	DefaultInstallPlanApproval    = subv1alpha1.ApprovalAutomatic
 	DefaultCatalogSourceNamespace = "openshift-marketplace"
 
@@ -65,11 +68,11 @@ const (
 
 	// subscription - community
 	CommunityChannel           = "strimzi-0.49.x"
-	CommunityPackageName       = "strimzi-kafka-operator"
+	CommunityPackageName       = StrimziOperatorName
 	CommunityCatalogSourceName = "community-operators"
 
 	// OLMv1 ClusterExtension
-	StrimziClusterExtensionName = "strimzi-kafka-operator"
+	StrimziClusterExtensionName = StrimziOperatorName
 	StrimziInstallerSAName      = "strimzi-kafka-installer"
 	StrimziInstallerCRBName     = "strimzi-kafka-installer"
 )

--- a/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"sync"
 
 	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
 	jsonpatch "github.com/evanphx/json-patch"
@@ -115,11 +116,16 @@ type strimziTransporter struct {
 
 type KafkaOption func(*strimziTransporter)
 
+var transporterConstructMu sync.Mutex
+
 var transporter *strimziTransporter
 
 func NewStrimziTransporter(mgr ctrl.Manager, mgh *operatorv1alpha4.MulticlusterGlobalHub,
 	opts ...KafkaOption,
 ) *strimziTransporter {
+	transporterConstructMu.Lock()
+	defer transporterConstructMu.Unlock()
+
 	if transporter == nil {
 		transporter = &strimziTransporter{
 			ctx:                       context.TODO(),
@@ -150,7 +156,6 @@ func NewStrimziTransporter(mgr ctrl.Manager, mgh *operatorv1alpha4.MulticlusterG
 	for _, opt := range opts {
 		opt(transporter)
 	}
-	config.SetTransporter(transporter)
 
 	if transporter.subCommunity {
 		transporter.subChannel = CommunityChannel
@@ -175,6 +180,7 @@ func NewStrimziTransporter(mgr ctrl.Manager, mgh *operatorv1alpha4.MulticlusterG
 		transporter.subPackageName = subscriptionPackageName
 	}
 
+	config.SetTransporter(transporter)
 	return transporter
 }
 

--- a/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
@@ -120,68 +120,69 @@ var transporterConstructMu sync.Mutex
 
 var transporter *strimziTransporter
 
+func newStrimziTransporter(mgr ctrl.Manager, mgh *operatorv1alpha4.MulticlusterGlobalHub) *strimziTransporter {
+	t := &strimziTransporter{
+		ctx:                       context.TODO(),
+		kafkaClusterName:          KafkaClusterName,
+		subName:                   DefaultKafkaSubName,
+		subCommunity:              false,
+		subChannel:                DefaultAMQChannel,
+		subPackageName:            DefaultAMQPackageName,
+		subCatalogSourceName:      DefaultCatalogSourceName,
+		subCatalogSourceNamespace: DefaultCatalogSourceNamespace,
+
+		waitReady:              true,
+		enableTLS:              true,
+		sharedTopics:           false,
+		topicPartitionReplicas: DefaultPartitionReplicas,
+
+		mgh:                   mgh,
+		manager:               mgr,
+		kafkaClusterNamespace: mgh.Namespace,
+	}
+	if mgh.Spec.AvailabilityConfig == operatorv1alpha4.HABasic {
+		t.topicPartitionReplicas = 1
+	}
+	return t
+}
+
 func NewStrimziTransporter(mgr ctrl.Manager, mgh *operatorv1alpha4.MulticlusterGlobalHub,
 	opts ...KafkaOption,
 ) *strimziTransporter {
 	transporterConstructMu.Lock()
 	defer transporterConstructMu.Unlock()
 
-	if transporter == nil {
-		transporter = &strimziTransporter{
-			ctx:                       context.TODO(),
-			kafkaClusterName:          KafkaClusterName,
-			subName:                   DefaultKafkaSubName,
-			subCommunity:              false,
-			subChannel:                DefaultAMQChannel,
-			subPackageName:            DefaultAMQPackageName,
-			subCatalogSourceName:      DefaultCatalogSourceName,
-			subCatalogSourceNamespace: DefaultCatalogSourceNamespace,
-
-			waitReady:              true,
-			enableTLS:              true,
-			sharedTopics:           false,
-			topicPartitionReplicas: DefaultPartitionReplicas,
-
-			manager: mgr,
-		}
-		if mgh.Spec.AvailabilityConfig == operatorv1alpha4.HABasic {
-			transporter.topicPartitionReplicas = 1
-		}
-	}
-
-	transporter.mgh = mgh
-	transporter.manager = mgr
-	transporter.kafkaClusterNamespace = mgh.Namespace
-	// apply options
+	t := newStrimziTransporter(mgr, mgh)
 	for _, opt := range opts {
-		opt(transporter)
+		opt(t)
 	}
 
-	if transporter.subCommunity {
-		transporter.subChannel = CommunityChannel
-		transporter.subPackageName = CommunityPackageName
-		transporter.subCatalogSourceName = CommunityCatalogSourceName
+	if t.subCommunity {
+		t.subChannel = CommunityChannel
+		t.subPackageName = CommunityPackageName
+		t.subCatalogSourceName = CommunityCatalogSourceName
 	}
 	// user could customize the catalog config
 	catalogSourceName, ok := mgh.Annotations[operatorconstants.CatalogSourceNameKey]
 	if ok && catalogSourceName != "" {
-		transporter.subCatalogSourceName = catalogSourceName
+		t.subCatalogSourceName = catalogSourceName
 	}
 	catalogSourceNamespace, ok := mgh.Annotations[operatorconstants.CatalogSourceNamespaceKey]
 	if ok && catalogSourceNamespace != "" {
-		transporter.subCatalogSourceNamespace = catalogSourceNamespace
+		t.subCatalogSourceNamespace = catalogSourceNamespace
 	}
 	subscriptionChannel, ok := mgh.Annotations[operatorconstants.SubscriptionChannel]
 	if ok && catalogSourceNamespace != "" {
-		transporter.subChannel = subscriptionChannel
+		t.subChannel = subscriptionChannel
 	}
 	subscriptionPackageName, ok := mgh.Annotations[operatorconstants.SubscriptionPackageName]
 	if ok && catalogSourceNamespace != "" {
-		transporter.subPackageName = subscriptionPackageName
+		t.subPackageName = subscriptionPackageName
 	}
 
-	config.SetTransporter(transporter)
-	return transporter
+	transporter = t
+	config.SetTransporter(t)
+	return t
 }
 
 func (k *strimziTransporter) getCurrentReplicas() (int32, error) {

--- a/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
@@ -173,11 +173,11 @@ func NewStrimziTransporter(mgr ctrl.Manager, mgh *operatorv1alpha4.MulticlusterG
 		t.subCatalogSourceNamespace = catalogSourceNamespace
 	}
 	subscriptionChannel, ok := mgh.Annotations[operatorconstants.SubscriptionChannel]
-	if ok && catalogSourceNamespace != "" {
+	if ok && subscriptionChannel != "" {
 		t.subChannel = subscriptionChannel
 	}
 	subscriptionPackageName, ok := mgh.Annotations[operatorconstants.SubscriptionPackageName]
-	if ok && catalogSourceNamespace != "" {
+	if ok && subscriptionPackageName != "" {
 		t.subPackageName = subscriptionPackageName
 	}
 

--- a/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
@@ -118,8 +118,6 @@ type KafkaOption func(*strimziTransporter)
 
 var transporterConstructMu sync.Mutex
 
-var transporter *strimziTransporter
-
 func newStrimziTransporter(mgr ctrl.Manager, mgh *operatorv1alpha4.MulticlusterGlobalHub) *strimziTransporter {
 	t := &strimziTransporter{
 		ctx:                       context.TODO(),
@@ -180,7 +178,6 @@ func NewStrimziTransporter(mgr ctrl.Manager, mgh *operatorv1alpha4.MulticlusterG
 		t.subPackageName = subscriptionPackageName
 	}
 
-	transporter = t
 	config.SetTransporter(t)
 	return t
 }

--- a/operator/pkg/controllers/transporter/protocol/strimzi_transporter_test.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_transporter_test.go
@@ -128,12 +128,16 @@ func TestTransporterConcurrentConstruction(t *testing.T) {
 	if err := corev1.AddToScheme(testScheme); err != nil {
 		t.Fatalf("add corev1 to test scheme: %v", err)
 	}
+	if err := kafkav1beta2.AddToScheme(testScheme); err != nil {
+		t.Fatalf("add kafkav1beta2 to test scheme: %v", err)
+	}
 
 	ns := utils.GetDefaultNamespace()
 	mgh := &v1alpha4.MulticlusterGlobalHub{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-mgh", Namespace: ns},
 	}
 	fakeClient := fake.NewClientBuilder().WithScheme(testScheme).Build()
+	fakeMgr := &fakeManager{c: fakeClient}
 
 	t.Cleanup(func() {
 		transporter = nil
@@ -141,22 +145,46 @@ func TestTransporterConcurrentConstruction(t *testing.T) {
 		config.SetTransporter(nil)
 	})
 
-	var wg sync.WaitGroup
+	done := make(chan struct{})
+	var readerWg sync.WaitGroup
+	var writerWg sync.WaitGroup
+
+	for i := 0; i < 8; i++ {
+		readerWg.Add(1)
+		go func() {
+			defer readerWg.Done()
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					tr := config.GetTransporter()
+					if tr == nil {
+						continue
+					}
+					_, _ = tr.EnsureTopic("hub1")
+					_, _ = tr.EnsureUser("hub1")
+					_, _ = tr.GetConnCredential("hub1")
+				}
+			}
+		}()
+	}
+
 	for i := 0; i < 16; i++ {
-		wg.Add(1)
+		writerWg.Add(1)
 		go func(i int) {
-			defer wg.Done()
+			defer writerWg.Done()
 			if i%2 == 0 {
-				NewStrimziTransporter(nil, mgh)
+				NewStrimziTransporter(fakeMgr, mgh)
 			} else {
 				NewBYOTransporter(ctx, types.NamespacedName{Name: "transport", Namespace: ns}, fakeClient)
 			}
-			if config.GetTransporter() == nil {
-				t.Error("GetTransporter() returned nil during concurrent construction")
-			}
 		}(i)
 	}
-	wg.Wait()
+
+	writerWg.Wait()
+	close(done)
+	readerWg.Wait()
 }
 
 func TestNewKafkaCluster(t *testing.T) {

--- a/operator/pkg/controllers/transporter/protocol/strimzi_transporter_test.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_transporter_test.go
@@ -74,8 +74,29 @@ func TestNewStrimziTransporter(t *testing.T) {
 	if trans.subChannel != "test-channel" {
 		t.Errorf("subChannel name should be test-channel, but %v", trans.subCatalogSourceNamespace)
 	}
+	if trans.subName != StrimziOperatorName {
+		t.Errorf("subName = %q, want %q", trans.subName, StrimziOperatorName)
+	}
 	if config.GetTransporter() != trans {
 		t.Fatal("GetTransporter() should return the active Strimzi transporter")
+	}
+}
+
+func TestNewStrimziTransporterCommunityDefaults(t *testing.T) {
+	t.Cleanup(func() { config.SetTransporter(nil) })
+
+	mgh := &v1alpha4.MulticlusterGlobalHub{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-mgh",
+			Namespace: utils.GetDefaultNamespace(),
+		},
+	}
+	trans := NewStrimziTransporter(nil, mgh, WithCommunity(true))
+	if trans.subName != StrimziOperatorName {
+		t.Errorf("subName = %q, want %q", trans.subName, StrimziOperatorName)
+	}
+	if trans.subPackageName != StrimziOperatorName {
+		t.Errorf("subPackageName = %q, want %q", trans.subPackageName, StrimziOperatorName)
 	}
 }
 

--- a/operator/pkg/controllers/transporter/protocol/strimzi_transporter_test.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_transporter_test.go
@@ -73,6 +73,45 @@ func TestNewStrimziTransporter(t *testing.T) {
 	if trans.subChannel != "test-channel" {
 		t.Errorf("subChannel name should be test-channel, but %v", trans.subCatalogSourceNamespace)
 	}
+	if config.GetTransporter() != trans {
+		t.Fatal("GetTransporter() should return the active Strimzi transporter")
+	}
+}
+
+func TestTransporterSingletonRefreshOnConstruction(t *testing.T) {
+	ctx := context.Background()
+	testScheme := runtime.NewScheme()
+	_ = v1alpha4.AddToScheme(testScheme)
+	_ = corev1.AddToScheme(testScheme)
+
+	ns := utils.GetDefaultNamespace()
+	mgh := &v1alpha4.MulticlusterGlobalHub{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-mgh", Namespace: ns},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(testScheme).Build()
+
+	t.Cleanup(func() {
+		transporter = nil
+		byoTransporter = nil
+	})
+
+	strimzi := NewStrimziTransporter(nil, mgh)
+	if config.GetTransporter() != strimzi {
+		t.Fatal("expected Strimzi transporter after NewStrimziTransporter")
+	}
+
+	byo := NewBYOTransporter(ctx, types.NamespacedName{Name: "transport", Namespace: ns}, fakeClient)
+	if config.GetTransporter() != byo {
+		t.Fatal("expected BYO transporter after NewBYOTransporter")
+	}
+
+	strimziAgain := NewStrimziTransporter(nil, mgh)
+	if config.GetTransporter() != strimziAgain {
+		t.Fatal("expected Strimzi transporter after switching back from BYO")
+	}
+	if config.GetTransporter() == byo {
+		t.Fatal("GetTransporter() still returns BYO after Strimzi re-construction")
+	}
 }
 
 func TestNewKafkaCluster(t *testing.T) {

--- a/operator/pkg/controllers/transporter/protocol/strimzi_transporter_test.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_transporter_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"strings"
+	"sync"
 	"testing"
 
 	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
@@ -48,7 +49,10 @@ func TestNewStrimziTransporter(t *testing.T) {
 		},
 	}
 
-	t.Cleanup(func() { transporter = nil })
+	t.Cleanup(func() {
+		transporter = nil
+		config.SetTransporter(nil)
+	})
 	trans := NewStrimziTransporter(
 		nil,
 		mgh,
@@ -93,6 +97,7 @@ func TestTransporterSingletonRefreshOnConstruction(t *testing.T) {
 	t.Cleanup(func() {
 		transporter = nil
 		byoTransporter = nil
+		config.SetTransporter(nil)
 	})
 
 	strimzi := NewStrimziTransporter(nil, mgh)
@@ -112,6 +117,46 @@ func TestTransporterSingletonRefreshOnConstruction(t *testing.T) {
 	if config.GetTransporter() == byo {
 		t.Fatal("GetTransporter() still returns BYO after Strimzi re-construction")
 	}
+}
+
+func TestTransporterConcurrentConstruction(t *testing.T) {
+	ctx := context.Background()
+	testScheme := runtime.NewScheme()
+	if err := v1alpha4.AddToScheme(testScheme); err != nil {
+		t.Fatalf("add v1alpha4 to test scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(testScheme); err != nil {
+		t.Fatalf("add corev1 to test scheme: %v", err)
+	}
+
+	ns := utils.GetDefaultNamespace()
+	mgh := &v1alpha4.MulticlusterGlobalHub{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-mgh", Namespace: ns},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(testScheme).Build()
+
+	t.Cleanup(func() {
+		transporter = nil
+		byoTransporter = nil
+		config.SetTransporter(nil)
+	})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if i%2 == 0 {
+				NewStrimziTransporter(nil, mgh)
+			} else {
+				NewBYOTransporter(ctx, types.NamespacedName{Name: "transport", Namespace: ns}, fakeClient)
+			}
+			if config.GetTransporter() == nil {
+				t.Error("GetTransporter() returned nil during concurrent construction")
+			}
+		}(i)
+	}
+	wg.Wait()
 }
 
 func TestNewKafkaCluster(t *testing.T) {
@@ -429,7 +474,10 @@ func TestNewKafkaCluster(t *testing.T) {
 }
 
 func TestWithOLMVersion(t *testing.T) {
-	t.Cleanup(func() { transporter = nil })
+	t.Cleanup(func() {
+		transporter = nil
+		config.SetTransporter(nil)
+	})
 	mgh := &v1alpha4.MulticlusterGlobalHub{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-mgh",
@@ -495,7 +543,10 @@ func TestNewClusterExtension(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			transporter = nil
-			t.Cleanup(func() { transporter = nil })
+			t.Cleanup(func() {
+				transporter = nil
+				config.SetTransporter(nil)
+			})
 			trans := NewStrimziTransporter(
 				nil, mgh,
 				WithCommunity(tt.community),

--- a/operator/pkg/controllers/transporter/protocol/strimzi_transporter_test.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_transporter_test.go
@@ -49,10 +49,7 @@ func TestNewStrimziTransporter(t *testing.T) {
 		},
 	}
 
-	t.Cleanup(func() {
-		transporter = nil
-		config.SetTransporter(nil)
-	})
+	t.Cleanup(func() { config.SetTransporter(nil) })
 	trans := NewStrimziTransporter(
 		nil,
 		mgh,
@@ -94,11 +91,7 @@ func TestTransporterSingletonRefreshOnConstruction(t *testing.T) {
 	}
 	fakeClient := fake.NewClientBuilder().WithScheme(testScheme).Build()
 
-	t.Cleanup(func() {
-		transporter = nil
-		byoTransporter = nil
-		config.SetTransporter(nil)
-	})
+	t.Cleanup(func() { config.SetTransporter(nil) })
 
 	strimzi := NewStrimziTransporter(nil, mgh)
 	if config.GetTransporter() != strimzi {
@@ -139,11 +132,7 @@ func TestTransporterConcurrentConstruction(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(testScheme).Build()
 	fakeMgr := &fakeManager{c: fakeClient}
 
-	t.Cleanup(func() {
-		transporter = nil
-		byoTransporter = nil
-		config.SetTransporter(nil)
-	})
+	t.Cleanup(func() { config.SetTransporter(nil) })
 
 	done := make(chan struct{})
 	var readerWg sync.WaitGroup
@@ -502,10 +491,7 @@ func TestNewKafkaCluster(t *testing.T) {
 }
 
 func TestWithOLMVersion(t *testing.T) {
-	t.Cleanup(func() {
-		transporter = nil
-		config.SetTransporter(nil)
-	})
+	t.Cleanup(func() { config.SetTransporter(nil) })
 	mgh := &v1alpha4.MulticlusterGlobalHub{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-mgh",
@@ -522,13 +508,11 @@ func TestWithOLMVersion(t *testing.T) {
 		t.Errorf("expected olmVersion %q, got %q", config.OLMVersionV1, trans.olmVersion)
 	}
 
-	transporter = nil
 	trans = NewStrimziTransporter(nil, mgh, WithOLMVersion(config.OLMVersionV0))
 	if trans.olmVersion != config.OLMVersionV0 {
 		t.Errorf("expected olmVersion %q, got %q", config.OLMVersionV0, trans.olmVersion)
 	}
 
-	transporter = nil
 	trans = NewStrimziTransporter(nil, mgh)
 	if trans.olmVersion != "" {
 		t.Errorf("expected empty olmVersion, got %q", trans.olmVersion)
@@ -570,11 +554,7 @@ func TestNewClusterExtension(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			transporter = nil
-			t.Cleanup(func() {
-				transporter = nil
-				config.SetTransporter(nil)
-			})
+			t.Cleanup(func() { config.SetTransporter(nil) })
 			trans := NewStrimziTransporter(
 				nil, mgh,
 				WithCommunity(tt.community),

--- a/operator/pkg/controllers/transporter/protocol/strimzi_transporter_test.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_transporter_test.go
@@ -168,13 +168,10 @@ func TestTransporterConcurrentConstruction(t *testing.T) {
 				case <-done:
 					return
 				default:
-					tr := config.GetTransporter()
-					if tr == nil {
-						continue
+					if tr := config.GetTransporter(); tr != nil {
+						// Exercise concurrent reads only; avoid I/O that requires Kafka/Secret fixtures.
+						_ = tr
 					}
-					_, _ = tr.EnsureTopic("hub1")
-					_, _ = tr.EnsureUser("hub1")
-					_, _ = tr.GetConnCredential("hub1")
 				}
 			}
 		}()

--- a/operator/pkg/controllers/transporter/transport_reconciler.go
+++ b/operator/pkg/controllers/transporter/transport_reconciler.go
@@ -215,10 +215,12 @@ func (r *TransportReconciler) reconcileStrimziKafka(ctx context.Context, mgh *v1
 	if needRequeue {
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
-	// deliver the transport resources and config secret to the kafka controller
-	// TODO: may need to wait the kafka resources to be ready before delivering the config secret
-	err = protocol.StartKafkaController(ctx, r.Manager, r.transporter)
+	// Start the async kafka controller; sync transport-config when Kafka is already ready.
+	err = protocol.StartKafkaController(ctx, r.Manager, strimziTransporter)
 	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if err := protocol.SyncManagerTransportConfigSecret(ctx, mgh, strimziTransporter, r.GetClient()); err != nil {
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{}, nil

--- a/test/integration/operator/controllers/transporter_test.go
+++ b/test/integration/operator/controllers/transporter_test.go
@@ -215,7 +215,7 @@ var _ = Describe("transporter", Ordered, func() {
 		}, 10*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
 
 		// update the kafka resource to make it ready
-		err = UpdateKafkaClusterReady(runtimeClient, mgh.Namespace)
+		err = UpdateKafkaClusterReady(ctx, runtimeClient, mgh.Namespace)
 		Expect(err).To(Succeed())
 
 		// verify the metrics resources and pod monitor
@@ -458,7 +458,7 @@ var _ = Describe("transporter", Ordered, func() {
 	})
 })
 
-func UpdateKafkaClusterReady(c client.Client, ns string) error {
+func UpdateKafkaClusterReady(ctx context.Context, c client.Client, ns string) error {
 	kafkaVersion := "4.1.0"
 	kafkaClusterName := "kafka"
 	globalHubKafkaUser := "global-hub-kafka-user"
@@ -552,7 +552,7 @@ func UpdateKafkaClusterReady(c client.Client, ns string) error {
 		return err
 	}
 
-	err := createSecret(c, ns, globalHubKafkaUser, map[string][]byte{
+	err := createSecret(ctx, c, ns, globalHubKafkaUser, map[string][]byte{
 		"user.crt": []byte("usercrt"),
 		"user.key": []byte("userkey"),
 	})
@@ -560,14 +560,14 @@ func UpdateKafkaClusterReady(c client.Client, ns string) error {
 		return err
 	}
 
-	err = createSecret(c, ns, clientCAKeySecret, map[string][]byte{
+	err = createSecret(ctx, c, ns, clientCAKeySecret, map[string][]byte{
 		"ca.key": []byte("cakey"),
 	})
 	if err != nil {
 		return err
 	}
 
-	err = createSecret(c, ns, clientCACertSecret, map[string][]byte{
+	err = createSecret(ctx, c, ns, clientCACertSecret, map[string][]byte{
 		"ca.crt": []byte("cacert"),
 	})
 	if err != nil {
@@ -576,21 +576,21 @@ func UpdateKafkaClusterReady(c client.Client, ns string) error {
 	return nil
 }
 
-func createSecret(c client.Client, ns, name string, data map[string][]byte) error {
+func createSecret(ctx context.Context, c client.Client, ns, name string, data map[string][]byte) error {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ns,
 			Name:      name,
 		},
 	}
-	err := c.Get(context.Background(), client.ObjectKeyFromObject(secret), secret)
+	err := c.Get(ctx, client.ObjectKeyFromObject(secret), secret)
 	if errors.IsNotFound(err) {
 		secret.Data = data
-		return c.Create(context.Background(), secret)
+		return c.Create(ctx, secret)
 	}
 	if err != nil {
 		return err
 	}
 	secret.Data = data
-	return c.Update(context.Background(), secret)
+	return c.Update(ctx, secret)
 }

--- a/test/integration/operator/controllers/transporter_test.go
+++ b/test/integration/operator/controllers/transporter_test.go
@@ -461,8 +461,8 @@ func UpdateKafkaClusterReady(c client.Client, ns string) error {
 	kafkaVersion := "4.1.0"
 	kafkaClusterName := "kafka"
 	globalHubKafkaUser := "global-hub-kafka-user"
-	clientCa := "kafka-clients-ca-cert"
-	clientCaCert := "kafka-clients-ca"
+	clientCAKeySecret := "kafka-clients-ca"
+	clientCACertSecret := "kafka-clients-ca-cert"
 
 	readyCondition := "Ready"
 	trueCondition := "True"
@@ -559,14 +559,14 @@ func UpdateKafkaClusterReady(c client.Client, ns string) error {
 		return err
 	}
 
-	err = createSecret(c, ns, clientCa, map[string][]byte{
+	err = createSecret(c, ns, clientCAKeySecret, map[string][]byte{
 		"ca.key": []byte("cakey"),
 	})
 	if err != nil {
 		return err
 	}
 
-	err = createSecret(c, ns, clientCaCert, map[string][]byte{
+	err = createSecret(c, ns, clientCACertSecret, map[string][]byte{
 		"ca.crt": []byte("cacert"),
 	})
 	if err != nil {
@@ -576,21 +576,20 @@ func UpdateKafkaClusterReady(c client.Client, ns string) error {
 }
 
 func createSecret(c client.Client, ns, name string, data map[string][]byte) error {
-	clientCaCertSecret := &corev1.Secret{
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ns,
 			Name:      name,
 		},
-		Data: data,
 	}
-	err := c.Get(context.Background(), client.ObjectKeyFromObject(clientCaCertSecret), clientCaCertSecret)
+	err := c.Get(context.Background(), client.ObjectKeyFromObject(secret), secret)
 	if errors.IsNotFound(err) {
-		e := c.Create(context.Background(), clientCaCertSecret)
-		if e != nil {
-			return e
-		}
-	} else if err != nil {
+		secret.Data = data
+		return c.Create(context.Background(), secret)
+	}
+	if err != nil {
 		return err
 	}
-	return nil
+	secret.Data = data
+	return c.Update(context.Background(), secret)
 }

--- a/test/integration/operator/controllers/transporter_test.go
+++ b/test/integration/operator/controllers/transporter_test.go
@@ -266,6 +266,7 @@ var _ = Describe("transporter", Ordered, func() {
 			runtimeManager,
 			mgh,
 			protocol.WithCommunity(false),
+			protocol.WithOLMVersion(config.OLMVersionV0),
 			protocol.WithNamespacedName(types.NamespacedName{
 				Name:      protocol.KafkaClusterName,
 				Namespace: mgh.Namespace,

--- a/test/integration/operator/controllers/transporter_test.go
+++ b/test/integration/operator/controllers/transporter_test.go
@@ -509,15 +509,15 @@ func UpdateKafkaClusterReady(ctx context.Context, c client.Client, ns string) er
 		},
 	}
 
-	if err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(pollCtx context.Context) (bool, error) {
 		existkafkaCluster := &kafkav1beta2.Kafka{}
-		err := c.Get(context.Background(), types.NamespacedName{
+		err := c.Get(pollCtx, types.NamespacedName{
 			Name:      kafkaClusterName,
 			Namespace: ns,
 		}, existkafkaCluster)
 		if err != nil {
 			if errors.IsNotFound(err) {
-				if e := c.Create(context.Background(), statusKafkaCluster); e != nil {
+				if e := c.Create(pollCtx, statusKafkaCluster); e != nil {
 					klog.Errorf("Failed to create kafka cluster, error: %v", e)
 					return false, nil
 				}
@@ -542,7 +542,7 @@ func UpdateKafkaClusterReady(ctx context.Context, c client.Client, ns string) er
 				},
 			},
 		}
-		err = c.Status().Update(context.Background(), existkafkaCluster)
+		err = c.Status().Update(pollCtx, existkafkaCluster)
 		if err != nil {
 			klog.Errorf("Failed to update Kafka cluster, error:%v", err)
 			return false, nil
@@ -586,11 +586,17 @@ func createSecret(ctx context.Context, c client.Client, ns, name string, data ma
 	err := c.Get(ctx, client.ObjectKeyFromObject(secret), secret)
 	if errors.IsNotFound(err) {
 		secret.Data = data
-		return c.Create(ctx, secret)
+		if err := c.Create(ctx, secret); err != nil {
+			return fmt.Errorf("create secret %s/%s: %w", ns, name, err)
+		}
+		return nil
 	}
 	if err != nil {
-		return err
+		return fmt.Errorf("get secret %s/%s: %w", ns, name, err)
 	}
 	secret.Data = data
-	return c.Update(ctx, secret)
+	if err := c.Update(ctx, secret); err != nil {
+		return fmt.Errorf("update secret %s/%s: %w", ns, name, err)
+	}
+	return nil
 }


### PR DESCRIPTION
Related: [ACM-40478](https://redhat.atlassian.net/browse/ACM-40478), [ACM-27001](https://redhat.atlassian.net/browse/ACM-27001)

## Summary

- Refresh `topic.spec` and `topic.status` from the current MGH spec whenever `CreateManagerTransportSecret` writes hub `transport-config`
- Sync `transport-config` from the transport reconciler immediately after `EnsureKafka` when Kafka is already ready, instead of relying only on async kafka-controller events
- Remove the stale TODO in `reconcileStrimziKafka` (superseded by the explicit sync path)

## Context

Fixes the intermittent RHACM4K-51185 failure where customized Kafka spec topics (e.g. `spec1`) were created in Strimzi but hub `transport-config` could remain on `gh-spec` for up to 600s. This is a latent reconcile-timing issue, not a z-stream regression.

Same symptom as [ACM-27001](https://redhat.atlassian.net/browse/ACM-27001) (transport-config not updated after Kafka topic changes on MCGH). QE validation tracked in [ACM-40478](https://redhat.atlassian.net/browse/ACM-40478).

## Test plan

- [x] `go test ./operator/pkg/controllers/transporter/protocol/... -run 'TestApplyManagerKafkaTopics|TestCreateManagerTransportSecret'`
- [ ] CI `test-unit` / operator integration tests
- [ ] Re-run RHACM4K-51185 on a GH e2e cluster after operator build ([ACM-40478](https://redhat.atlassian.net/browse/ACM-40478))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom Kafka topic settings are applied to transport configuration.
  * Transport credentials, certificates, and topic settings synchronize after Kafka reconciliation.
  * Transport secrets reflect the latest Kafka configuration.

* **Bug Fixes**
  * Improved handling of unavailable or incomplete Kafka credentials and certificates.
  * Improved Kafka readiness and synchronization error handling.
  * Prevented failures when no compatible transporter is configured.
  * Ensured transporter selection stays current.
  * Improved consistency during concurrent transport configuration updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


[ACM-40478]: https://redhat.atlassian.net/browse/ACM-40478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-27001]: https://redhat.atlassian.net/browse/ACM-27001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-27001]: https://redhat.atlassian.net/browse/ACM-27001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-40478]: https://redhat.atlassian.net/browse/ACM-40478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-40478]: https://redhat.atlassian.net/browse/ACM-40478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ