### PR TITLE
Merge release-5.0 into main to restore fast-forward sync

### DIFF
--- a/pkg/bundle/version/version.go
+++ b/pkg/bundle/version/version.go
@@ -131,3 +131,5 @@ func (v *Version) Reset() {
 func (v *Version) InitGen() bool {
 	return v.Generation == 0
 }
+
+// konflux-rebuild-touch


### PR DESCRIPTION
## Summary

- Merges `release-5.0` into `main` to close the divergence blocking Prow `ocm-ci-fastforward`
- Branches diverged after [#2707](https://github.com/stolostron/multicluster-global-hub/pull/2707) merged a Konflux rebuild chore directly to `release-5.0` (Aug 2) while `main` received 7 commits since [#2719](https://github.com/stolostron/multicluster-global-hub/pull/2719)
- Compare currently shows **diverged** (`release-5.0` ahead 2, behind 7); ffwd postsubmit fails with `fatal: Not possible to fast-forward, aborting` ([latest job](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-stolostron-multicluster-global-hub-main-fast-forward/2087163640963665920))

## Why

Prow ffwd runs `git pull --ff-only origin main` on `release-5.0`. That requires `release-5.0` to be an ancestor of `main`. [#2706](https://github.com/stolostron/multicluster-global-hub/pull/2706) restored sync on Aug 2, but [#2707](https://github.com/stolostron/multicluster-global-hub/pull/2707) landed only on `release-5.0` and broke it again.

## After merge

- `release-5.0` becomes an ancestor of `main` again
- Next ffwd postsubmit on `main` should fast-forward `release-5.0` to include all 7 pending commits (#2719–#2732)
- **Going forward:** Konflux retrigger / chore commits must target `main` (not `release-5.0`) so CI ffwd can promote them

## Test plan

- [ ] Merge this PR
- [ ] Verify compare shows `main` ahead of `release-5.0` only (not diverged)
- [ ] Confirm `branch-ci-stolostron-multicluster-global-hub-main-fast-forward` succeeds on the merge commit

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build metadata to trigger a package rebuild.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->