### PR TITLE
ACM-40739: set operator bundle channel and version to release-5.1

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -3,14 +3,14 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 5.0.0-dev
+VERSION ?= 5.1.0-dev
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
 # To re-generate a bundle for other specific channels without changing the standard setup, you can:
 # - use the CHANNELS as arg of the bundle target (e.g make bundle CHANNELS=candidate,fast,stable)
 # - use environment variables to overwrite this value (e.g export CHANNELS="candidate,fast,stable")
-CHANNELS = "release-5.0"
+CHANNELS = "release-5.1"
 ifneq ($(origin CHANNELS), undefined)
 BUNDLE_CHANNELS := --channels=$(CHANNELS)
 endif
@@ -20,7 +20,7 @@ endif
 # To re-generate a bundle for any other default channel without changing the default setup, you can:
 # - use the DEFAULT_CHANNEL as arg of the bundle target (e.g make bundle DEFAULT_CHANNEL=stable)
 # - use environment variables to overwrite this value (e.g export DEFAULT_CHANNEL="stable")
-DEFAULT_CHANNEL = "release-5.0"
+DEFAULT_CHANNEL = "release-5.1"
 ifneq ($(origin DEFAULT_CHANNEL), undefined)
 BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
 endif

--- a/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -53,7 +53,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=1.8.0 <5.0.0'
+    olm.skipRange: '>=5.0.0 <5.1.0'
     operatorframework.io/initialization-resource: '{"apiVersion":"operator.open-cluster-management.io/v1alpha4",
       "kind":"MulticlusterGlobalHub","metadata":{"name":"multiclusterglobalhub","namespace":"multicluster-global-hub"},
       "spec": {}}'
@@ -71,7 +71,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: multicluster-global-hub-operator.v5.0.0-dev
+  name: multicluster-global-hub-operator.v5.1.0-dev
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1499,8 +1499,8 @@ spec:
   maintainers:
   - email: acm-contact@redhat.com
     name: acm-contact
-  maturity: release-5.0
+  maturity: release-5.1
   provider:
     name: Red Hat, Inc
     url: https://github.com/stolostron/multicluster-global-hub
-  version: 5.0.0-dev
+  version: 5.1.0-dev

--- a/operator/bundle/metadata/annotations.yaml
+++ b/operator/bundle/metadata/annotations.yaml
@@ -4,8 +4,8 @@ annotations:
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: multicluster-global-hub-operator
-  operators.operatorframework.io.bundle.channels.v1: release-5.0
-  operators.operatorframework.io.bundle.channel.default.v1: release-5.0
+  operators.operatorframework.io.bundle.channels.v1: release-5.1
+  operators.operatorframework.io.bundle.channel.default.v1: release-5.1
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.34.1
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4


### PR DESCRIPTION
Related: [ACM-40739](https://redhat.atlassian.net/browse/ACM-40739)

## Summary

- Bump `operator/Makefile` to `VERSION=5.1.0-dev`, channel `release-5.1`
- Update `operator/bundle` metadata and CSV for the 5.1 dev bundle line
- Bundle compare remains skipped on `main` per `go.yml`

## Context
Phase 3 of [ACM-40739](https://redhat.atlassian.net/browse/ACM-40739).

## Test plan
- [ ] `verify bundle` job passes (`make bundle` + diff)

Made with [Cursor](https://cursor.com)

[ACM-40739]: https://redhat.atlassian.net/browse/ACM-40739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-40739]: https://redhat.atlassian.net/browse/ACM-40739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Updates**
  * Updated the operator bundle to version 5.1.0.
  * Promoted the default release channel to release-5.1.
  * Updated upgrade compatibility rules for upgrades from 5.0.x versions.
  * Refreshed release metadata to identify the 5.1 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->