### PR TITLE
ACM-40739: align globalhub-5-1 PR pipelines with dual ffwd model

### DIFF
--- a/.tekton/multicluster-global-hub-agent-globalhub-5-1-pull-request.yaml
+++ b/.tekton/multicluster-global-hub-agent-globalhub-5-1-pull-request.yaml
@@ -8,7 +8,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-5.1" && (".tekton/multicluster-global-hub-agent-[!b]*.yaml".pathChanged() || "go.{mod,sum}".pathChanged() || "{pkg,agent}/***".pathChanged() || "librdkafka".pathChanged() || "rpms.in.yaml".pathChanged() || "rpms.lock.yaml".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" &&
+      (target_branch == "main" || target_branch == "release-5.1") && (".tekton/multicluster-global-hub-agent-[!b]*.yaml".pathChanged() || "go.{mod,sum}".pathChanged() || "{pkg,agent}/***".pathChanged() || "librdkafka".pathChanged() || "rpms.in.yaml".pathChanged() || "rpms.lock.yaml".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: release-globalhub-5-1

--- a/.tekton/multicluster-global-hub-manager-globalhub-5-1-pull-request.yaml
+++ b/.tekton/multicluster-global-hub-manager-globalhub-5-1-pull-request.yaml
@@ -8,7 +8,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-5.1" && (".tekton/multicluster-global-hub-manager-[!b]*.yaml".pathChanged() || "go.{mod,sum}".pathChanged() || "{pkg,manager}/***".pathChanged() || "librdkafka".pathChanged() || "rpms.in.yaml".pathChanged() || "rpms.lock.yaml".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" &&
+      (target_branch == "main" || target_branch == "release-5.1") && (".tekton/multicluster-global-hub-manager-[!b]*.yaml".pathChanged() || "go.{mod,sum}".pathChanged() || "{pkg,manager}/***".pathChanged() || "librdkafka".pathChanged() || "rpms.in.yaml".pathChanged() || "rpms.lock.yaml".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: release-globalhub-5-1

--- a/.tekton/multicluster-global-hub-operator-globalhub-5-1-pull-request.yaml
+++ b/.tekton/multicluster-global-hub-operator-globalhub-5-1-pull-request.yaml
@@ -8,7 +8,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-5.1" && (".tekton/multicluster-global-hub-operator-[!b]*.yaml".pathChanged() || "go.{mod,sum}".pathChanged() || "{pkg,operator}/***".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" &&
+      (target_branch == "main" || target_branch == "release-5.1") && (".tekton/multicluster-global-hub-operator-[!b]*.yaml".pathChanged() || "go.{mod,sum}".pathChanged() || "{pkg,operator}/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: release-globalhub-5-1


### PR DESCRIPTION
## Summary

Aligns Global Hub Konflux PR triggers with the [cluster-backup-operator dual-line pattern](https://github.com/stolostron/cluster-backup-operator/tree/main/.tekton): **globalhub-5-1** PR pipelines now run for pull requests targeting **`main` or `release-5.1`**, matching how **globalhub-5-0** already runs for **`main` or `release-5.0`**.

This supports ffwd from `main` to both `release-5.0` and `release-5.1` without hub `operator/Makefile` channel bumps (see closed #2741).

Related: [ACM-40739](https://redhat.atlassian.net/browse/ACM-40739)

## Changes

- `multicluster-global-hub-*-globalhub-5-1-pull-request.yaml` (operator, manager, agent): CEL `target_branch == "main" || target_branch == "release-5.1"`

## Test plan

- [ ] Merge and confirm Konflux runs globalhub-5-1 PR pipeline on a test PR to `main`
- [ ] Confirm globalhub-5-0 PR pipeline still runs on PRs to `main`

Made with [Cursor](https://cursor.com)

[ACM-40739]: https://redhat.atlassian.net/browse/ACM-40739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pull request automation now runs for changes targeting both the `main` and `release-5.1` branches.
  * Existing path-based filtering remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->