### PR TITLE
ACM-40478: Fix Kafka topic validation error for pattern-based status topics

### DIFF
--- a/operator/pkg/controllers/transporter/protocol/manifests/global-hub-kafka-topic.yaml
+++ b/operator/pkg/controllers/transporter/protocol/manifests/global-hub-kafka-topic.yaml
@@ -13,6 +13,7 @@ spec:
   partitions: {{.TopicPartition}}
   replicas: {{.TopicReplicas}}
 
+{{ if .CreateStatusPlaceholder }}
 ---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
@@ -31,6 +32,7 @@ spec:
     retention.bytes: "1073741824"
   partitions: {{.TopicPartition}}
   replicas: {{.TopicReplicas}}
+{{ end }}
 
 ---
 {{ if .EnableInventoryAPI }}

--- a/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
@@ -288,9 +288,11 @@ func (k *strimziTransporter) renderKafkaResources(mgh *operatorv1alpha4.Multiclu
 	statusTopic := config.GetRawStatusTopic()
 	statusPlaceholderTopic := config.GetRawStatusTopic()
 	topicPattern := kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypeLiteral
+	isPatternBasedStatusTopic := false
 	if strings.Contains(config.GetRawStatusTopic(), "*") {
+		isPatternBasedStatusTopic = true
 		statusTopic = strings.ReplaceAll(config.GetRawStatusTopic(), "*", "")
-		statusPlaceholderTopic = strings.ReplaceAll(config.GetRawStatusTopic(), "*", "global-hub")
+		statusPlaceholderTopic = ""
 		topicPattern = kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypePrefix
 	}
 	topicReplicas := k.topicPartitionReplicas
@@ -300,37 +302,39 @@ func (k *strimziTransporter) renderKafkaResources(mgh *operatorv1alpha4.Multiclu
 	kafkaObjects, err := kafkaRenderer.Render("manifests", "",
 		func(profile string) (interface{}, error) {
 			return struct {
-				EnableMetrics          bool
-				Namespace              string
-				KafkaCluster           string
-				GlobalHubKafkaUser     string
-				SpecTopic              string
-				MigrationTopic         string
-				StatusTopic            string
-				StatusTopicPattern     string
-				StatusPlaceholderTopic string
-				TopicPartition         int32
-				TopicReplicas          int32
-				EnableInventoryAPI     bool
-				KafkaInventoryTopic    string
-				StorageSize            string
-				StorageClass           string
+				EnableMetrics           bool
+				Namespace               string
+				KafkaCluster            string
+				GlobalHubKafkaUser      string
+				SpecTopic               string
+				MigrationTopic          string
+				StatusTopic             string
+				StatusTopicPattern      string
+				StatusPlaceholderTopic  string
+				CreateStatusPlaceholder bool
+				TopicPartition          int32
+				TopicReplicas           int32
+				EnableInventoryAPI      bool
+				KafkaInventoryTopic     string
+				StorageSize             string
+				StorageClass            string
 			}{
-				EnableMetrics:          mgh.Spec.EnableMetrics,
-				Namespace:              mgh.GetNamespace(),
-				KafkaCluster:           KafkaClusterName,
-				GlobalHubKafkaUser:     DefaultGlobalHubKafkaUserName,
-				SpecTopic:              config.GetSpecTopic(),
-				MigrationTopic:         config.GetMigrationTopic(),
-				StatusTopic:            statusTopic,
-				StatusTopicPattern:     string(topicPattern),
-				StatusPlaceholderTopic: statusPlaceholderTopic,
-				TopicPartition:         DefaultPartition,
-				TopicReplicas:          topicReplicas,
-				EnableInventoryAPI:     config.WithInventory(mgh),
-				KafkaInventoryTopic:    "kessel-inventory",
-				StorageSize:            config.GetKafkaStorageSize(mgh),
-				StorageClass:           mgh.Spec.DataLayerSpec.StorageClass,
+				EnableMetrics:           mgh.Spec.EnableMetrics,
+				Namespace:               mgh.GetNamespace(),
+				KafkaCluster:            KafkaClusterName,
+				GlobalHubKafkaUser:      DefaultGlobalHubKafkaUserName,
+				SpecTopic:               config.GetSpecTopic(),
+				MigrationTopic:          config.GetMigrationTopic(),
+				StatusTopic:             statusTopic,
+				StatusTopicPattern:      string(topicPattern),
+				StatusPlaceholderTopic:  statusPlaceholderTopic,
+				CreateStatusPlaceholder: !isPatternBasedStatusTopic,
+				TopicPartition:          DefaultPartition,
+				TopicReplicas:           topicReplicas,
+				EnableInventoryAPI:      config.WithInventory(mgh),
+				KafkaInventoryTopic:     "kessel-inventory",
+				StorageSize:             config.GetKafkaStorageSize(mgh),
+				StorageClass:            mgh.Spec.DataLayerSpec.StorageClass,
 			}, nil
 		})
 	if err != nil {


### PR DESCRIPTION
## Fix Kafka topic validation error for pattern-based status topics

  ### Problem
  When setting custom Kafka status topics with patterns (e.g., `gh-status.*`) in the MCGH operand,
  Strimzi rejects the placeholder KafkaTopic with error: "pattern type should be prefix". This happens
  because the code creates invalid topic names like `gh-status.global-hub` that confuse pattern validation.

  ### Solution
  Skip creating placeholder KafkaTopics for pattern-based topics. Actual cluster-specific topics are
  created dynamically via `EnsureTopic()` when clusters report status. Non-pattern topics maintain
  existing behavior for backward compatibility.

  ### Testing
  - All unit tests pass (40+ tests, 0 failures)
  - Logic verified for pattern and non-pattern topics
  - Code quality checks pass (vet, fmt)

  Fixes [ACM-40478](https://redhat.atlassian.net/browse/ACM-40478) (RHACM4K-51185)

[ACM-40478]: https://redhat.atlassian.net/browse/ACM-40478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of wildcard status topics.
  * Prevented unnecessary placeholder Kafka topics from being created when wildcard patterns are used.
  * Ensured rendered topic names no longer include wildcard characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->