### PR TITLE
ACM-34442: tighten managed-hub Kafka ACLs on gh-spec for GH 1.8

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.8.1
+VERSION ?= 1.8.2
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -1092,6 +1092,17 @@ spec:
           - get
           - update
         - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
           - observability.open-cluster-management.io
           resources:
           - observabilityaddons

--- a/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -71,7 +71,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: multicluster-global-hub-operator.v1.8.1
+  name: multicluster-global-hub-operator.v1.8.2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1436,4 +1436,4 @@ spec:
   provider:
     name: Red Hat, Inc
     url: https://github.com/stolostron/multicluster-global-hub
-  version: 1.8.1
+  version: 1.8.2

--- a/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -1092,17 +1092,6 @@ spec:
           - get
           - update
         - apiGroups:
-          - networking.k8s.io
-          resources:
-          - networkpolicies
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - update
-          - watch
-        - apiGroups:
           - observability.open-cluster-management.io
           resources:
           - observabilityaddons

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -451,6 +451,17 @@ rules:
   - get
   - update
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - observability.open-cluster-management.io
   resources:
   - observabilityaddons

--- a/operator/pkg/config/transport_config.go
+++ b/operator/pkg/config/transport_config.go
@@ -195,6 +195,10 @@ func SetMigrationTopic(topic string) {
 	migrationTopic = topic
 }
 
+func SetSpecTopic(topic string) {
+	specTopic = topic
+}
+
 func IsBYOKafka() bool {
 	return isBYOKafka
 }

--- a/operator/pkg/controllers/transporter/hubha_acl_reconciler.go
+++ b/operator/pkg/controllers/transporter/hubha_acl_reconciler.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transporter
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	operatorv1alpha4 "github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/transporter/protocol"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/logger"
+)
+
+var hubHAACLLog = logger.DefaultZapLogger()
+
+// +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;watch
+// +kubebuilder:rbac:groups=kafka.strimzi.io,resources=kafkausers,verbs=get;update;list;watch
+
+type HubHAACLReconciler struct {
+	mgr ctrl.Manager
+	client.Client
+}
+
+func (r *HubHAACLReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	if config.IsBYOKafka() {
+		return ctrl.Result{}, nil
+	}
+
+	mgh, err := config.GetMulticlusterGlobalHub(ctx, r.Client)
+	if err != nil || mgh == nil || config.IsPaused(mgh) {
+		return ctrl.Result{}, err
+	}
+
+	cluster := &clusterv1.ManagedCluster{}
+	if err := r.Get(ctx, req.NamespacedName, cluster); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, r.syncHubHASpecWriteACL(ctx, mgh, req.Name, false)
+		}
+		return ctrl.Result{}, err
+	}
+
+	grant := cluster.DeletionTimestamp == nil &&
+		cluster.Labels != nil &&
+		cluster.Labels[constants.GHHubRoleLabelKey] == constants.GHHubRoleActive
+
+	if err := r.syncHubHASpecWriteACL(ctx, mgh, req.Name, grant); err != nil {
+		return ctrl.Result{}, err
+	}
+	if grant {
+		hubHAACLLog.Infow("synced Hub HA spec write ACL", "activeHub", req.Name)
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *HubHAACLReconciler) syncHubHASpecWriteACL(
+	ctx context.Context,
+	mgh *operatorv1alpha4.MulticlusterGlobalHub,
+	activeHub string,
+	grant bool,
+) error {
+	if activeHub == "" {
+		return nil
+	}
+	if err := protocol.SyncHubHASpecWriteACL(r.mgr, mgh, activeHub, grant, protocol.WithContext(ctx)); err != nil {
+		return fmt.Errorf("failed to sync Hub HA spec write ACL for hub %q: %w", activeHub, err)
+	}
+	return nil
+}
+
+func (r *HubHAACLReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("hubha-transport-acl").
+		For(&clusterv1.ManagedCluster{}).
+		Complete(r)
+}
+
+func setupHubHAACLReconciler(mgr ctrl.Manager) error {
+	if hubHAACLControllerStarted {
+		return nil
+	}
+	reconciler := &HubHAACLReconciler{
+		mgr:    mgr,
+		Client: mgr.GetClient(),
+	}
+	if err := reconciler.SetupWithManager(mgr); err != nil {
+		return err
+	}
+	hubHAACLControllerStarted = true
+	return nil
+}
+
+var hubHAACLControllerStarted bool

--- a/operator/pkg/controllers/transporter/hubha_acl_reconciler_test.go
+++ b/operator/pkg/controllers/transporter/hubha_acl_reconciler_test.go
@@ -1,0 +1,250 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transporter
+
+import (
+	"context"
+	"testing"
+
+	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	operatorv1alpha4 "github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
+	operatorconfig "github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
+)
+
+func TestHubHAACLReconcilerReconcileActiveRoleGrantsACL(t *testing.T) {
+	originalBYO := operatorconfig.IsBYOKafka()
+	t.Cleanup(func() { operatorconfig.SetBYOKafka(originalBYO) })
+	operatorconfig.SetBYOKafka(false)
+	operatorconfig.SetSpecTopic("gh-spec")
+
+	_, fakeClient, _, kafkaUser := newHubHAACLReconcilerFixtures(t)
+	cluster := &clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "hub1",
+			Labels: map[string]string{
+				constants.GHHubRoleLabelKey: constants.GHHubRoleActive,
+			},
+		},
+	}
+	if err := fakeClient.Create(context.Background(), cluster); err != nil {
+		t.Fatalf("create active cluster: %v", err)
+	}
+
+	reconciler := &HubHAACLReconciler{
+		mgr:    &migrationACLReconcilerMockManager{client: fakeClient},
+		Client: fakeClient,
+	}
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(cluster)})
+	if err != nil {
+		t.Fatalf("Reconcile() active hub error = %v", err)
+	}
+
+	updated := &kafkav1beta2.KafkaUser{}
+	if err := fakeClient.Get(context.Background(), client.ObjectKeyFromObject(kafkaUser), updated); err != nil {
+		t.Fatalf("get updated kafka user: %v", err)
+	}
+	wantKey := utils.GenerateACLKey(utils.WriteTopicACL("gh-spec"))
+	found := false
+	for _, acl := range updated.Spec.Authorization.Acls {
+		if utils.GenerateACLKey(acl) == wantKey {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected Hub HA spec write ACL to be granted for active hub role")
+	}
+}
+
+func TestHubHAACLReconcilerReconcileSkipsBYO(t *testing.T) {
+	originalBYO := operatorconfig.IsBYOKafka()
+	t.Cleanup(func() { operatorconfig.SetBYOKafka(originalBYO) })
+	operatorconfig.SetBYOKafka(true)
+
+	reconciler := &HubHAACLReconciler{}
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: clientObjectKey("", "hub1"),
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() BYO skip error = %v", err)
+	}
+}
+
+func TestHubHAACLReconcilerReconcileNotFound(t *testing.T) {
+	originalBYO := operatorconfig.IsBYOKafka()
+	t.Cleanup(func() { operatorconfig.SetBYOKafka(originalBYO) })
+	operatorconfig.SetBYOKafka(false)
+	operatorconfig.SetSpecTopic("gh-spec")
+
+	_, fakeClient, _, kafkaUser := newHubHAACLReconcilerFixtures(t)
+	kafkaUser.Spec.Authorization.Acls = []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
+		utils.WriteTopicACL("gh-spec"),
+	}
+	if err := fakeClient.Update(context.Background(), kafkaUser); err != nil {
+		t.Fatalf("update kafka user with Hub HA ACL: %v", err)
+	}
+
+	reconciler := &HubHAACLReconciler{
+		mgr:    &migrationACLReconcilerMockManager{client: fakeClient},
+		Client: fakeClient,
+	}
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: clientObjectKey("", "hub1"),
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() deleted cluster should succeed, got %v", err)
+	}
+
+	updated := &kafkav1beta2.KafkaUser{}
+	if err := fakeClient.Get(context.Background(), client.ObjectKeyFromObject(kafkaUser), updated); err != nil {
+		t.Fatalf("get updated kafka user: %v", err)
+	}
+	if updated.Spec.Authorization != nil {
+		for _, acl := range updated.Spec.Authorization.Acls {
+			if utils.GenerateACLKey(acl) == utils.GenerateACLKey(utils.WriteTopicACL("gh-spec")) {
+				t.Fatal("expected Hub HA spec write ACL to be revoked after cluster deletion")
+			}
+		}
+	}
+}
+
+func TestHubHAACLReconcilerReconcileStandbyRevokesACL(t *testing.T) {
+	originalBYO := operatorconfig.IsBYOKafka()
+	t.Cleanup(func() { operatorconfig.SetBYOKafka(originalBYO) })
+	operatorconfig.SetBYOKafka(false)
+	operatorconfig.SetSpecTopic("gh-spec")
+
+	_, fakeClient, _, kafkaUser := newHubHAACLReconcilerFixtures(t)
+	kafkaUser.Spec.Authorization.Acls = []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
+		utils.WriteTopicACL("gh-spec"),
+	}
+	if err := fakeClient.Update(context.Background(), kafkaUser); err != nil {
+		t.Fatalf("update kafka user with Hub HA ACL: %v", err)
+	}
+
+	cluster := &clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "hub1",
+			Labels: map[string]string{
+				constants.GHHubRoleLabelKey: constants.GHHubRoleStandby,
+			},
+		},
+	}
+	if err := fakeClient.Create(context.Background(), cluster); err != nil {
+		t.Fatalf("create standby cluster: %v", err)
+	}
+
+	reconciler := &HubHAACLReconciler{
+		mgr:    &migrationACLReconcilerMockManager{client: fakeClient},
+		Client: fakeClient,
+	}
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(cluster)})
+	if err != nil {
+		t.Fatalf("Reconcile() standby hub error = %v", err)
+	}
+
+	updated := &kafkav1beta2.KafkaUser{}
+	if err := fakeClient.Get(context.Background(), client.ObjectKeyFromObject(kafkaUser), updated); err != nil {
+		t.Fatalf("get updated kafka user: %v", err)
+	}
+	if updated.Spec.Authorization != nil {
+		for _, acl := range updated.Spec.Authorization.Acls {
+			if utils.GenerateACLKey(acl) == utils.GenerateACLKey(utils.WriteTopicACL("gh-spec")) {
+				t.Fatal("expected Hub HA spec write ACL to be revoked for standby hub role")
+			}
+		}
+	}
+}
+
+func TestHubHAACLReconcilerReconcileSkipsPausedMGH(t *testing.T) {
+	originalBYO := operatorconfig.IsBYOKafka()
+	t.Cleanup(func() { operatorconfig.SetBYOKafka(originalBYO) })
+	operatorconfig.SetBYOKafka(false)
+
+	_, fakeClient, mgh, _ := newHubHAACLReconcilerFixtures(t)
+	mgh.Annotations = map[string]string{"mgh-pause": "true"}
+	if err := fakeClient.Update(context.Background(), mgh); err != nil {
+		t.Fatalf("update paused mgh: %v", err)
+	}
+
+	reconciler := &HubHAACLReconciler{
+		mgr:    &migrationACLReconcilerMockManager{client: fakeClient},
+		Client: fakeClient,
+	}
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: clientObjectKey("", "hub1"),
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() paused mgh should succeed, got %v", err)
+	}
+}
+
+func newHubHAACLReconcilerFixtures(
+	t *testing.T,
+) (*runtime.Scheme, client.Client, *operatorv1alpha4.MulticlusterGlobalHub, *kafkav1beta2.KafkaUser) {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	if err := kafkav1beta2.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(KafkaUser) error = %v", err)
+	}
+	if err := operatorv1alpha4.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(MulticlusterGlobalHub) error = %v", err)
+	}
+	if err := clusterv1.Install(scheme); err != nil {
+		t.Fatalf("Install(ManagedCluster) error = %v", err)
+	}
+
+	mgh := &operatorv1alpha4.MulticlusterGlobalHub{
+		ObjectMeta: metav1.ObjectMeta{Name: "mgh", Namespace: "test-ns"},
+		Spec: operatorv1alpha4.MulticlusterGlobalHubSpec{
+			DataLayerSpec: operatorv1alpha4.DataLayerSpec{
+				Kafka: operatorv1alpha4.KafkaSpec{
+					KafkaTopics: operatorv1alpha4.KafkaTopics{
+						SpecTopic: "gh-spec",
+					},
+				},
+			},
+		},
+	}
+	kafkaUser := &kafkav1beta2.KafkaUser{
+		ObjectMeta: metav1.ObjectMeta{Name: "hub1-kafka-user", Namespace: "test-ns"},
+		Spec: &kafkav1beta2.KafkaUserSpec{
+			Authorization: simpleKafkaUserAuthorization(
+				utils.GetTopicACL("gh-spec", []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+					kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
+					kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+				}),
+			),
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(mgh, kafkaUser).
+		Build()
+
+	return scheme, fakeClient, mgh, kafkaUser
+}

--- a/operator/pkg/controllers/transporter/protocol/hubha_acl.go
+++ b/operator/pkg/controllers/transporter/protocol/hubha_acl.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protocol
+
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	operatorv1alpha4 "github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
+)
+
+// SyncHubHASpecWriteACL grants or revokes Write-only on gh-spec for a Hub HA active hub.
+func SyncHubHASpecWriteACL(
+	mgr ctrl.Manager,
+	mgh *operatorv1alpha4.MulticlusterGlobalHub,
+	activeHub string,
+	grant bool,
+	opts ...KafkaOption,
+) error {
+	trans := NewStrimziTransporter(mgr, mgh, opts...)
+	return trans.SyncHubHASpecWriteACL(activeHub, grant)
+}

--- a/operator/pkg/controllers/transporter/protocol/strimzi_hubha_acl.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_hubha_acl.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protocol
+
+import (
+	"fmt"
+
+	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
+)
+
+func hubHASpecWriteACLKey(specTopic string) string {
+	return utils.GenerateACLKey(utils.WriteTopicACL(specTopic))
+}
+
+func (k *strimziTransporter) hasHubHASpecWriteACL(
+	acls []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem,
+	specTopic string,
+) bool {
+	key := hubHASpecWriteACLKey(specTopic)
+	for _, acl := range acls {
+		if utils.GenerateACLKey(acl) == key {
+			return true
+		}
+	}
+	return false
+}
+
+// SyncHubHASpecWriteACL grants or revokes Write-only on gh-spec for Hub HA active hubs.
+func (k *strimziTransporter) SyncHubHASpecWriteACL(activeHub string, grant bool) error {
+	if activeHub == "" {
+		return nil
+	}
+
+	userName := config.GetKafkaUserName(activeHub)
+	kafkaUser := &kafkav1beta2.KafkaUser{}
+	err := k.manager.GetClient().Get(k.ctx, types.NamespacedName{
+		Name:      userName,
+		Namespace: k.kafkaClusterNamespace,
+	}, kafkaUser)
+	if errors.IsNotFound(err) {
+		if !grant {
+			return nil
+		}
+		return fmt.Errorf("kafka user %s not found for Hub HA spec write ACL", userName)
+	}
+	if err != nil {
+		return err
+	}
+
+	specTopic := config.GetSpecTopic()
+	desiredWriteACL := utils.WriteTopicACL(specTopic)
+
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latestKafkaUser := &kafkav1beta2.KafkaUser{}
+		if err := k.manager.GetClient().Get(k.ctx, types.NamespacedName{
+			Name:      userName,
+			Namespace: k.kafkaClusterNamespace,
+		}, latestKafkaUser); err != nil {
+			return err
+		}
+
+		currentACLs := currentKafkaUserACLs(latestKafkaUser)
+		if k.hasHubHASpecWriteACL(currentACLs, specTopic) == grant {
+			return nil
+		}
+
+		updatedACLs := make([]kafkav1beta2.KafkaUserSpecAuthorizationAclsElem, 0, len(currentACLs))
+		for _, acl := range currentACLs {
+			if utils.GenerateACLKey(acl) == hubHASpecWriteACLKey(specTopic) {
+				continue
+			}
+			updatedACLs = append(updatedACLs, acl)
+		}
+		if grant {
+			updatedACLs = append(updatedACLs, desiredWriteACL)
+		}
+
+		if len(updatedACLs) == 0 {
+			latestKafkaUser.Spec.Authorization = nil
+		} else {
+			if latestKafkaUser.Spec.Authorization == nil {
+				latestKafkaUser.Spec.Authorization = &kafkav1beta2.KafkaUserSpecAuthorization{
+					Type: kafkav1beta2.KafkaUserSpecAuthorizationTypeSimple,
+				}
+			}
+			if latestKafkaUser.Spec.Authorization.Type == "" {
+				latestKafkaUser.Spec.Authorization.Type = kafkav1beta2.KafkaUserSpecAuthorizationTypeSimple
+			}
+			latestKafkaUser.Spec.Authorization.Acls = updatedACLs
+		}
+		return k.manager.GetClient().Update(k.ctx, latestKafkaUser)
+	})
+}

--- a/operator/pkg/controllers/transporter/protocol/strimzi_hubha_acl_test.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_hubha_acl_test.go
@@ -1,0 +1,379 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protocol
+
+import (
+	"context"
+	"testing"
+
+	kafkav1beta2 "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	operatorv1alpha4 "github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
+	operatorconfig "github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
+)
+
+func TestHubHASpecWriteACLKey(t *testing.T) {
+	t.Parallel()
+
+	key := hubHASpecWriteACLKey("gh-spec")
+	want := utils.GenerateACLKey(utils.WriteTopicACL("gh-spec"))
+	if key != want {
+		t.Fatalf("hubHASpecWriteACLKey() = %q, want %q", key, want)
+	}
+}
+
+func TestHasHubHASpecWriteACL(t *testing.T) {
+	t.Parallel()
+
+	operatorconfig.SetSpecTopic("gh-spec")
+	transporter := &strimziTransporter{}
+	withACL := []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
+		utils.WriteTopicACL("gh-spec"),
+	}
+	if !transporter.hasHubHASpecWriteACL(withACL, "gh-spec") {
+		t.Fatal("expected Hub HA spec write ACL to be present")
+	}
+	if transporter.hasHubHASpecWriteACL(nil, "gh-spec") {
+		t.Fatal("expected nil ACL list to return false")
+	}
+}
+
+func TestSyncHubHASpecWriteACLGrantAndRevoke(t *testing.T) {
+	operatorconfig.SetSpecTopic("gh-spec")
+
+	scheme := runtime.NewScheme()
+	if err := kafkav1beta2.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+
+	kafkaUser := &kafkav1beta2.KafkaUser{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hub1-kafka-user",
+			Namespace: "test-ns",
+		},
+		Spec: &kafkav1beta2.KafkaUserSpec{
+			Authorization: &kafkav1beta2.KafkaUserSpecAuthorization{
+				Type: kafkav1beta2.KafkaUserSpecAuthorizationTypeSimple,
+				Acls: []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
+					utils.GetTopicACL("gh-spec", []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+						kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
+						kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+					}),
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(kafkaUser).
+		Build()
+
+	transporter := &strimziTransporter{
+		ctx:                   context.Background(),
+		kafkaClusterNamespace: "test-ns",
+		manager:               &migrationACLMockManager{client: fakeClient},
+	}
+
+	if err := transporter.SyncHubHASpecWriteACL("hub1", true); err != nil {
+		t.Fatalf("grant Hub HA spec write ACL: %v", err)
+	}
+
+	updated := &kafkav1beta2.KafkaUser{}
+	if err := fakeClient.Get(context.Background(), client.ObjectKeyFromObject(kafkaUser), updated); err != nil {
+		t.Fatalf("get updated kafka user: %v", err)
+	}
+	if !transporter.hasHubHASpecWriteACL(updated.Spec.Authorization.Acls, "gh-spec") {
+		t.Fatal("expected Hub HA spec write ACL to be granted")
+	}
+
+	if err := transporter.SyncHubHASpecWriteACL("hub1", false); err != nil {
+		t.Fatalf("revoke Hub HA spec write ACL: %v", err)
+	}
+	if err := fakeClient.Get(context.Background(), client.ObjectKeyFromObject(kafkaUser), updated); err != nil {
+		t.Fatalf("get updated kafka user after revoke: %v", err)
+	}
+	if transporter.hasHubHASpecWriteACL(updated.Spec.Authorization.Acls, "gh-spec") {
+		t.Fatal("expected Hub HA spec write ACL to be revoked")
+	}
+}
+
+func TestSyncHubHASpecWriteACLSkipsEmptyHub(t *testing.T) {
+	t.Parallel()
+
+	transporter := &strimziTransporter{}
+	if err := transporter.SyncHubHASpecWriteACL("", true); err != nil {
+		t.Fatalf("SyncHubHASpecWriteACL with empty hub should succeed, got %v", err)
+	}
+}
+
+func TestSyncHubHASpecWriteACLNotFoundWhenGranting(t *testing.T) {
+	operatorconfig.SetSpecTopic("gh-spec")
+
+	scheme := runtime.NewScheme()
+	if err := kafkav1beta2.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+
+	transporter := &strimziTransporter{
+		ctx:                   context.Background(),
+		kafkaClusterNamespace: "test-ns",
+		manager:               &migrationACLMockManager{client: fake.NewClientBuilder().WithScheme(scheme).Build()},
+	}
+
+	if err := transporter.SyncHubHASpecWriteACL("hub1", true); err == nil {
+		t.Fatal("expected error when kafka user is missing during grant")
+	}
+}
+
+func TestSyncHubHASpecWriteACLNotFoundWhenRevoking(t *testing.T) {
+	operatorconfig.SetSpecTopic("gh-spec")
+
+	scheme := runtime.NewScheme()
+	if err := kafkav1beta2.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+
+	transporter := &strimziTransporter{
+		ctx:                   context.Background(),
+		kafkaClusterNamespace: "test-ns",
+		manager:               &migrationACLMockManager{client: fake.NewClientBuilder().WithScheme(scheme).Build()},
+	}
+
+	if err := transporter.SyncHubHASpecWriteACL("hub1", false); err != nil {
+		t.Fatalf("revoke with missing kafka user should succeed, got %v", err)
+	}
+}
+
+func TestSyncHubHASpecWriteACLGrantWithNilAuthorization(t *testing.T) {
+	operatorconfig.SetSpecTopic("gh-spec")
+
+	scheme := runtime.NewScheme()
+	if err := kafkav1beta2.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+
+	kafkaUser := &kafkav1beta2.KafkaUser{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hub1-kafka-user",
+			Namespace: "test-ns",
+		},
+		Spec: &kafkav1beta2.KafkaUserSpec{},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(kafkaUser).
+		Build()
+
+	transporter := &strimziTransporter{
+		ctx:                   context.Background(),
+		kafkaClusterNamespace: "test-ns",
+		manager:               &migrationACLMockManager{client: fakeClient},
+	}
+
+	if err := transporter.SyncHubHASpecWriteACL("hub1", true); err != nil {
+		t.Fatalf("grant Hub HA spec write ACL with nil authorization: %v", err)
+	}
+
+	updated := &kafkav1beta2.KafkaUser{}
+	if err := fakeClient.Get(context.Background(), client.ObjectKeyFromObject(kafkaUser), updated); err != nil {
+		t.Fatalf("get updated kafka user: %v", err)
+	}
+	if !transporter.hasHubHASpecWriteACL(updated.Spec.Authorization.Acls, "gh-spec") {
+		t.Fatal("expected Hub HA spec write ACL to be granted on nil authorization")
+	}
+}
+
+func TestSyncHubHASpecWriteACLWrapper(t *testing.T) {
+	operatorconfig.SetSpecTopic("gh-spec")
+
+	scheme := runtime.NewScheme()
+	if err := kafkav1beta2.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+
+	kafkaUser := &kafkav1beta2.KafkaUser{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hub1-kafka-user",
+			Namespace: "test-ns",
+		},
+		Spec: &kafkav1beta2.KafkaUserSpec{
+			Authorization: &kafkav1beta2.KafkaUserSpecAuthorization{
+				Type: kafkav1beta2.KafkaUserSpecAuthorizationTypeSimple,
+				Acls: []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
+					utils.ReadTopicACL("gh-spec", false),
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(kafkaUser).
+		Build()
+
+	mgh := &operatorv1alpha4.MulticlusterGlobalHub{
+		ObjectMeta: metav1.ObjectMeta{Name: "mgh", Namespace: "test-ns"},
+	}
+
+	mgr := &migrationACLMockManager{client: fakeClient}
+	if err := SyncHubHASpecWriteACL(mgr, mgh, "hub1", true, WithContext(context.Background())); err != nil {
+		t.Fatalf("SyncHubHASpecWriteACL() grant error = %v", err)
+	}
+
+	updated := &kafkav1beta2.KafkaUser{}
+	if err := fakeClient.Get(context.Background(), client.ObjectKeyFromObject(kafkaUser), updated); err != nil {
+		t.Fatalf("get updated kafka user: %v", err)
+	}
+	wantKey := utils.GenerateACLKey(utils.WriteTopicACL("gh-spec"))
+	foundWrite := false
+	for _, acl := range updated.Spec.Authorization.Acls {
+		if utils.GenerateACLKey(acl) == wantKey {
+			foundWrite = true
+			break
+		}
+	}
+	if !foundWrite {
+		t.Fatal("expected Hub HA spec topic write ACL")
+	}
+}
+
+func TestIsObsoleteManagedHubACL(t *testing.T) {
+	t.Parallel()
+
+	specTopic := "gh-spec"
+	wildcard := "*"
+	otherTopic := "gh-other"
+	namePtr := func(name string) *string { return &name }
+
+	tests := []struct {
+		name string
+		acl  kafkav1beta2.KafkaUserSpecAuthorizationAclsElem
+		want bool
+	}{
+		{
+			name: "nil resource name",
+			acl: kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
+				Resource: kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResource{
+					Type: kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "wildcard consumer group",
+			acl: kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
+				Resource: kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResource{
+					Type: kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeGroup,
+					Name: namePtr(wildcard),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "literal consumer group",
+			acl: kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
+				Resource: kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResource{
+					Type: kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeGroup,
+					Name: namePtr("hub1"),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "non spec topic",
+			acl: kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
+				Resource: kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResource{
+					Type: kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic,
+					Name: namePtr(otherTopic),
+				},
+				Operations: []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+					kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite,
+					kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "legacy combined spec topic write",
+			acl: utils.GetTopicACL(specTopic, []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+				kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
+				kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+				kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite,
+			}),
+			want: true,
+		},
+		{
+			name: "hub ha write only",
+			acl:  utils.WriteTopicACL(specTopic),
+			want: false,
+		},
+		{
+			name: "spec topic read only",
+			acl: utils.GetTopicACL(specTopic, []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+				kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
+				kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+			}),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isObsoleteManagedHubACL(tt.acl, specTopic); got != tt.want {
+				t.Fatalf("isObsoleteManagedHubACL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterObsoleteManagedHubACLsEmptyInput(t *testing.T) {
+	t.Parallel()
+
+	if got := filterObsoleteManagedHubACLs(nil, "gh-spec"); got != nil {
+		t.Fatalf("filterObsoleteManagedHubACLs(nil) = %#v, want nil", got)
+	}
+}
+
+func TestFilterObsoleteManagedHubACLPreservesHubHAWrite(t *testing.T) {
+	t.Parallel()
+
+	specTopic := "gh-spec"
+	legacyACL := utils.GetTopicACL(specTopic, []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite,
+	})
+	hubHAWriteACL := utils.WriteTopicACL(specTopic)
+
+	filtered := filterObsoleteManagedHubACLs([]kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
+		legacyACL,
+		hubHAWriteACL,
+	}, specTopic)
+
+	if len(filtered) != 1 {
+		t.Fatalf("expected one ACL after filtering legacy combined gh-spec Write, got %d", len(filtered))
+	}
+	if utils.GenerateACLKey(filtered[0]) != utils.GenerateACLKey(hubHAWriteACL) {
+		t.Fatal("expected Hub HA Write-only ACL to survive obsolete ACL filtering")
+	}
+}

--- a/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
@@ -342,24 +342,13 @@ func (k *strimziTransporter) isCSVInstalled() (bool, error) {
 	return true, nil
 }
 
-// EnsureUser to reconcile the kafkaUser's setting(authn and authz)
-// set the user can write to status
-func (k *strimziTransporter) EnsureUser(clusterName string) (string, error) {
-	userName := config.GetKafkaUserName(clusterName)
-	clusterTopic := k.getClusterTopic(clusterName)
-
-	authnType := kafkav1beta2.KafkaUserSpecAuthenticationTypeTlsExternal
-	if clusterName == config.GetLocalClusterName() || clusterName == constants.LocalClusterName {
-		authnType = kafkav1beta2.KafkaUserSpecAuthenticationTypeTls
-	}
-
-	simpleACLs := []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
-		utils.ConsumeGroupReadACL(),
-		// migration resource into mh: write access to the spec topic is required for cluster migration.
+func managedHubUserACLs(clusterTopic *transport.ClusterTopic, consumerGroupID string) []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem {
+	return []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
+		utils.ConsumeGroupReadACL(consumerGroupID),
+		// consume spec bundles from the global hub (read-only; managed hubs must not produce to gh-spec)
 		utils.GetTopicACL(clusterTopic.SpecTopic, []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
 			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
 			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
-			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite,
 		}),
 		// consume migration deploying bundles from the dedicated migration topic
 		utils.GetTopicACL(clusterTopic.MigrationTopic, []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
@@ -371,6 +360,21 @@ func (k *strimziTransporter) EnsureUser(clusterName string) (string, error) {
 			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite,
 		}),
 	}
+}
+
+// EnsureUser to reconcile the kafkaUser's setting(authn and authz)
+// set the user can write to status
+func (k *strimziTransporter) EnsureUser(clusterName string) (string, error) {
+	userName := config.GetKafkaUserName(clusterName)
+	clusterTopic := k.getClusterTopic(clusterName)
+
+	authnType := kafkav1beta2.KafkaUserSpecAuthenticationTypeTlsExternal
+	if clusterName == config.GetLocalClusterName() || clusterName == constants.LocalClusterName {
+		authnType = kafkav1beta2.KafkaUserSpecAuthenticationTypeTls
+	}
+
+	consumerGroupID := config.GetConsumerGroupID(k.mgh.Spec.DataLayerSpec.Kafka.ConsumerGroupPrefix, clusterName)
+	simpleACLs := managedHubUserACLs(clusterTopic, consumerGroupID)
 
 	desiredKafkaUser := newKafkaUser(k.kafkaClusterNamespace, k.kafkaClusterName, userName, authnType, simpleACLs)
 
@@ -401,8 +405,9 @@ func (k *strimziTransporter) EnsureUser(clusterName string) (string, error) {
 		if err := operatorutils.MergeObjects(latestKafkaUser, desiredKafkaUser, updatedKafkaUser); err != nil {
 			return err
 		}
-		// combine the acls of kafkaUser and the acls of desiredKafkaUser
-		updatedKafkaUser.Spec.Authorization.Acls = combineACLs(latestKafkaUser.Spec.Authorization.Acls,
+		// combine the acls of kafkaUser and the desired acls of desiredKafkaUser
+		existingACLs := filterObsoleteManagedHubACLs(currentKafkaUserACLs(latestKafkaUser), clusterTopic.SpecTopic)
+		updatedKafkaUser.Spec.Authorization.Acls = combineACLs(existingACLs,
 			desiredKafkaUser.Spec.Authorization.Acls)
 
 		if !equality.Semantic.DeepDerivative(updatedKafkaUser.Spec, latestKafkaUser.Spec) {
@@ -416,6 +421,59 @@ func (k *strimziTransporter) EnsureUser(clusterName string) (string, error) {
 		return "", retryErr
 	}
 	return userName, nil
+}
+
+func filterObsoleteManagedHubACLs(
+	acls []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem,
+	specTopic string,
+) []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem {
+	if len(acls) == 0 {
+		return nil
+	}
+
+	filtered := make([]kafkav1beta2.KafkaUserSpecAuthorizationAclsElem, 0, len(acls))
+	for _, acl := range acls {
+		if isObsoleteManagedHubACL(acl, specTopic) {
+			continue
+		}
+		filtered = append(filtered, acl)
+	}
+	return filtered
+}
+
+func isObsoleteManagedHubACL(acl kafkav1beta2.KafkaUserSpecAuthorizationAclsElem, specTopic string) bool {
+	if acl.Resource.Name == nil {
+		return false
+	}
+
+	switch acl.Resource.Type {
+	case kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeGroup:
+		return *acl.Resource.Name == "*"
+	case kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic:
+		if *acl.Resource.Name != specTopic {
+			return false
+		}
+		return topicACLHasLegacyCombinedWrite(acl.Operations)
+	}
+
+	return false
+}
+
+func topicACLHasLegacyCombinedWrite(
+	operations []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem,
+) bool {
+	hasWrite := false
+	hasReadOrDescribe := false
+	for _, op := range operations {
+		switch op {
+		case kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite:
+			hasWrite = true
+		case kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe:
+			hasReadOrDescribe = true
+		}
+	}
+	return hasWrite && hasReadOrDescribe
 }
 
 // combineACLs combines the existing acls and the desired acls

--- a/operator/pkg/controllers/transporter/protocol/strimzi_transporter_test.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_transporter_test.go
@@ -2,6 +2,7 @@ package protocol
 
 import (
 	"encoding/json"
+	"sort"
 	"strings"
 	"testing"
 
@@ -13,6 +14,7 @@ import (
 
 	"github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
 	operatorconstants "github.com/stolostron/multicluster-global-hub/operator/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
@@ -374,6 +376,322 @@ func TestNewKafkaCluster(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestManagedHubUserACLs(t *testing.T) {
+	t.Parallel()
+
+	clusterTopic := &transport.ClusterTopic{
+		SpecTopic:      "gh-spec",
+		MigrationTopic: "gh-migration",
+		StatusTopic:    "gh-status.hub1",
+	}
+	acls := managedHubUserACLs(clusterTopic, "hub1")
+
+	if len(acls) != 4 {
+		t.Fatalf("expected 4 ACLs, got %d", len(acls))
+	}
+
+	groupACL, ok := findGroupACL(acls, "hub1")
+	if !ok {
+		t.Fatal("expected consumer-group ACL for hub1")
+	}
+	assertACLContract(
+		t, groupACL,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeGroup,
+		"hub1",
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypeLiteral,
+		[]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+		},
+	)
+
+	specACL, ok := findTopicACL(acls, clusterTopic.SpecTopic)
+	if !ok {
+		t.Fatal("expected gh-spec topic ACL")
+	}
+	assertACLContract(
+		t, specACL,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic,
+		clusterTopic.SpecTopic,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypeLiteral,
+		[]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+		},
+	)
+
+	migrationACL, ok := findTopicACL(acls, clusterTopic.MigrationTopic)
+	if !ok {
+		t.Fatal("expected gh-migration topic ACL")
+	}
+	assertACLContract(
+		t, migrationACL,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic,
+		clusterTopic.MigrationTopic,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypeLiteral,
+		[]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+		},
+	)
+
+	statusACL, ok := findTopicACL(acls, clusterTopic.StatusTopic)
+	if !ok {
+		t.Fatal("expected status topic ACL")
+	}
+	assertACLContract(
+		t, statusACL,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic,
+		clusterTopic.StatusTopic,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypeLiteral,
+		[]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite,
+		},
+	)
+}
+
+func TestCombineManagedHubACLsUpgrade(t *testing.T) {
+	t.Parallel()
+
+	clusterTopic := &transport.ClusterTopic{
+		SpecTopic:      "gh-spec",
+		MigrationTopic: "gh-migration",
+		StatusTopic:    "gh-status.hub1",
+	}
+	legacyACLs := []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
+		utils.ConsumeGroupReadACL("*"),
+		utils.GetTopicACL(clusterTopic.SpecTopic, []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite,
+		}),
+		utils.WriteTopicACL(clusterTopic.MigrationTopic),
+	}
+
+	merged := combineACLs(filterObsoleteManagedHubACLs(legacyACLs, clusterTopic.SpecTopic),
+		managedHubUserACLs(clusterTopic, "hub1"))
+
+	hasWildcardGroup, specOps, migrationOps := collectManagedHubACLTopicOps(merged, clusterTopic)
+
+	if hasWildcardGroup {
+		t.Fatal("wildcard consumer group ACL should be removed on upgrade")
+	}
+
+	groupACL, ok := findGroupACL(merged, "hub1")
+	if !ok {
+		t.Fatal("expected literal consumer-group ACL for hub1 after upgrade")
+	}
+	assertACLContract(
+		t, groupACL,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeGroup,
+		"hub1",
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypeLiteral,
+		[]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+		},
+	)
+
+	specACL, ok := findTopicACL(merged, clusterTopic.SpecTopic)
+	if !ok {
+		t.Fatal("expected gh-spec topic ACL after upgrade")
+	}
+	assertACLContract(
+		t, specACL,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic,
+		clusterTopic.SpecTopic,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypeLiteral,
+		[]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+		},
+	)
+	for _, op := range specOps {
+		if op == kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite {
+			t.Fatal("legacy gh-spec Write ACL must be removed on upgrade")
+		}
+	}
+
+	migrationReadACL, ok := findTopicACLWithOperations(
+		merged, clusterTopic.MigrationTopic,
+		[]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+		},
+	)
+	if !ok {
+		t.Fatal("expected gh-migration Describe+Read ACL after upgrade")
+	}
+	assertACLContract(
+		t, migrationReadACL,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic,
+		clusterTopic.MigrationTopic,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypeLiteral,
+		[]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+		},
+	)
+
+	migrationWriteACL, ok := findTopicACLWithOperations(
+		merged, clusterTopic.MigrationTopic,
+		[]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite,
+		},
+	)
+	if !ok {
+		t.Fatal("migration topic Write ACL from migration watcher must be preserved on upgrade")
+	}
+	assertACLContract(
+		t, migrationWriteACL,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic,
+		clusterTopic.MigrationTopic,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypeLiteral,
+		[]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite,
+		},
+	)
+	if !containsOperation(migrationOps, kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead) {
+		t.Fatal("managed hub must retain Read on gh-migration after upgrade")
+	}
+}
+
+func collectManagedHubACLTopicOps(
+	merged []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem,
+	clusterTopic *transport.ClusterTopic,
+) (hasWildcardGroup bool, specOps, migrationOps []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem) {
+	for _, acl := range merged {
+		if acl.Resource.Name == nil {
+			continue
+		}
+		if acl.Resource.Type == kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeGroup {
+			if *acl.Resource.Name == "*" {
+				hasWildcardGroup = true
+			}
+			continue
+		}
+		if acl.Resource.Type != kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic {
+			continue
+		}
+		switch *acl.Resource.Name {
+		case clusterTopic.SpecTopic:
+			specOps = append(specOps, acl.Operations...)
+		case clusterTopic.MigrationTopic:
+			migrationOps = append(migrationOps, acl.Operations...)
+		}
+	}
+	return hasWildcardGroup, specOps, migrationOps
+}
+
+func findTopicACL(acls []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem, topicName string) (
+	kafkav1beta2.KafkaUserSpecAuthorizationAclsElem, bool,
+) {
+	for _, acl := range acls {
+		if acl.Resource.Name == nil || *acl.Resource.Name != topicName {
+			continue
+		}
+		if acl.Resource.Type != kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic {
+			continue
+		}
+		return acl, true
+	}
+	return kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{}, false
+}
+
+func findGroupACL(acls []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem, groupName string) (
+	kafkav1beta2.KafkaUserSpecAuthorizationAclsElem, bool,
+) {
+	for _, acl := range acls {
+		if acl.Resource.Name == nil || *acl.Resource.Name != groupName {
+			continue
+		}
+		if acl.Resource.Type != kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeGroup {
+			continue
+		}
+		return acl, true
+	}
+	return kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{}, false
+}
+
+func findTopicACLWithOperations(
+	acls []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem,
+	topicName string,
+	wantOps []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem,
+) (kafkav1beta2.KafkaUserSpecAuthorizationAclsElem, bool) {
+	for _, acl := range acls {
+		if acl.Resource.Name == nil || *acl.Resource.Name != topicName {
+			continue
+		}
+		if acl.Resource.Type != kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic {
+			continue
+		}
+		if aclOperationsEqual(acl.Operations, wantOps) {
+			return acl, true
+		}
+	}
+	return kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{}, false
+}
+
+func assertACLContract(
+	t *testing.T,
+	acl kafkav1beta2.KafkaUserSpecAuthorizationAclsElem,
+	wantType kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceType,
+	wantName string,
+	wantPattern kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternType,
+	wantOps []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem,
+) {
+	t.Helper()
+	if acl.Resource.Name == nil {
+		t.Fatal("ACL resource name must be set")
+	}
+	if *acl.Resource.Name != wantName {
+		t.Fatalf("ACL resource name = %q, want %q", *acl.Resource.Name, wantName)
+	}
+	if acl.Resource.Type != wantType {
+		t.Fatalf("ACL resource type = %q, want %q", acl.Resource.Type, wantType)
+	}
+	if acl.Resource.PatternType == nil {
+		t.Fatal("ACL pattern type must be set")
+	}
+	if *acl.Resource.PatternType != wantPattern {
+		t.Fatalf("ACL pattern type = %q, want %q", *acl.Resource.PatternType, wantPattern)
+	}
+	if !aclOperationsEqual(acl.Operations, wantOps) {
+		t.Fatalf("ACL operations = %#v, want %#v", acl.Operations, wantOps)
+	}
+}
+
+func aclOperationsEqual(got, want []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	gotCopy := append([]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem(nil), got...)
+	wantCopy := append([]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem(nil), want...)
+	sortOperations(gotCopy)
+	sortOperations(wantCopy)
+	for i := range gotCopy {
+		if gotCopy[i] != wantCopy[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func sortOperations(ops []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem) {
+	sort.Slice(ops, func(i, j int) bool {
+		return ops[i] < ops[j]
+	})
+}
+
+func containsOperation(ops []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem,
+	target kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem,
+) bool {
+	for _, op := range ops {
+		if op == target {
+			return true
+		}
+	}
+	return false
 }
 
 func TestCombineACLs(t *testing.T) {

--- a/operator/pkg/controllers/transporter/transport_reconciler.go
+++ b/operator/pkg/controllers/transporter/transport_reconciler.go
@@ -28,6 +28,7 @@ import (
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=podmonitors,verbs=get;create;delete;update;list;watch
 // +kubebuilder:rbac:groups=operator.open-cluster-management.io,resources=multiclusterglobalhubs,verbs=get;list;watch;
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;delete;patch
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;delete
 
 var WatchedSecret = sets.NewString(
 	constants.GHTransportSecretName,

--- a/operator/pkg/controllers/transporter/transport_reconciler.go
+++ b/operator/pkg/controllers/transporter/transport_reconciler.go
@@ -57,6 +57,11 @@ func StartController(controllerOption config.ControllerOption) (config.Controlle
 				return nil, err
 			}
 		}
+		if !hubHAACLControllerStarted {
+			if err := hubHAACLReconcilerSetup(controllerOption.Manager); err != nil {
+				return nil, err
+			}
+		}
 		return transportReconciler, nil
 	}
 	log.Info("start transport controller")
@@ -70,11 +75,17 @@ func StartController(controllerOption config.ControllerOption) (config.Controlle
 	if err := migrationACLReconcilerSetup(controllerOption.Manager); err != nil {
 		return nil, err
 	}
+	if err := hubHAACLReconcilerSetup(controllerOption.Manager); err != nil {
+		return nil, err
+	}
 	log.Infof("inited transport controller")
 	return transportReconciler, nil
 }
 
-var migrationACLReconcilerSetup = setupMigrationACLReconciler
+var (
+	migrationACLReconcilerSetup = setupMigrationACLReconciler
+	hubHAACLReconcilerSetup     = setupHubHAACLReconciler
+)
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *TransportReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/operator/pkg/controllers/transporter/transport_reconciler_test.go
+++ b/operator/pkg/controllers/transporter/transport_reconciler_test.go
@@ -226,14 +226,17 @@ func TestStartControllerSingleton(t *testing.T) {
 	// Save and restore the singleton so we don't affect other tests.
 	original := transportReconciler
 	originalMigrationACL := migrationACLControllerStarted
+	originalHubHAACL := hubHAACLControllerStarted
 	t.Cleanup(func() {
 		transportReconciler = original
 		migrationACLControllerStarted = originalMigrationACL
+		hubHAACLControllerStarted = originalHubHAACL
 	})
 
 	existing := &TransportReconciler{}
 	transportReconciler = existing
 	migrationACLControllerStarted = true
+	hubHAACLControllerStarted = true
 
 	// Second call must return the pre-existing instance without error.
 	controller, err := StartController(config.ControllerOption{})

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -217,9 +217,8 @@ func ReadTopicACL(topicName string, prefixPattern bool) kafkav1beta2.KafkaUserSp
 	}
 }
 
-func ConsumeGroupReadACL() kafkav1beta2.KafkaUserSpecAuthorizationAclsElem {
+func ConsumeGroupReadACL(consumerGroup string) kafkav1beta2.KafkaUserSpecAuthorizationAclsElem {
 	host := "*"
-	consumerGroup := "*"
 	consumerPatternType := kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypeLiteral
 	consumerAcl := kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
 		Host: &host,

--- a/test/integration/manager/migration/migration_error_scenarios_test.go
+++ b/test/integration/manager/migration/migration_error_scenarios_test.go
@@ -150,6 +150,9 @@ var _ = Describe("Migration Error Scenarios", func() {
 		})
 
 		It("should transition to cleaning when from hub reports error", func() {
+			By("Waiting for migration ManagedServiceAccount before injecting initialization error")
+			waitForMigrationManagedServiceAccount(ctx, m.Name, toHubName)
+
 			By("Simulating from hub error during initialization")
 			migration.SetStarted(string(m.GetUID()), fromHubName, migrationv1alpha1.PhaseInitializing)
 			migration.SetErrorMessage(string(m.GetUID()), fromHubName, migrationv1alpha1.PhaseInitializing, "initialization failed")
@@ -175,10 +178,13 @@ var _ = Describe("Migration Error Scenarios", func() {
 					return fmt.Errorf("expected phase %s, got %s", migrationv1alpha1.PhaseRollbacking, m.Status.Phase)
 				}
 				return nil
-			}, "10s", "200ms").Should(Succeed())
+			}, "20s", "200ms").Should(Succeed())
 		})
 
 		It("should transition to cleaning when to hub reports error", func() {
+			By("Waiting for migration ManagedServiceAccount before injecting initialization error")
+			waitForMigrationManagedServiceAccount(ctx, m.Name, toHubName)
+
 			By("Simulating to hub error during initialization")
 			migration.SetStarted(string(m.GetUID()), toHubName, migrationv1alpha1.PhaseInitializing)
 			migration.SetErrorMessage(string(m.GetUID()), toHubName, migrationv1alpha1.PhaseInitializing, "initialization failed")
@@ -204,7 +210,7 @@ var _ = Describe("Migration Error Scenarios", func() {
 					return fmt.Errorf("expected phase %s, got %s", migrationv1alpha1.PhaseRollbacking, m.Status.Phase)
 				}
 				return nil
-			}, "10s", "200ms").Should(Succeed())
+			}, "20s", "200ms").Should(Succeed())
 		})
 
 		It("should handle timeout when hub doesn't respond", func() {

--- a/test/integration/manager/migration/suite_test.go
+++ b/test/integration/manager/migration/suite_test.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/client-go/rest"
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	v1beta1 "open-cluster-management.io/managed-serviceaccount/apis/authentication/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -316,6 +317,13 @@ func ensureManagedServiceAccount(migrationName, toHub string) error {
 	}
 
 	return nil
+}
+
+func waitForMigrationManagedServiceAccount(ctx context.Context, migrationName, toHub string) {
+	Eventually(func() error {
+		msa := &v1beta1.ManagedServiceAccount{}
+		return mgr.GetClient().Get(ctx, client.ObjectKey{Name: migrationName, Namespace: toHub}, msa)
+	}, "15s", "200ms").Should(Succeed())
 }
 
 // cleanupHubAndClusters removes all resources created for a test.

--- a/test/integration/operator/controllers/transporter_test.go
+++ b/test/integration/operator/controllers/transporter_test.go
@@ -409,8 +409,42 @@ var _ = Describe("transporter", Ordered, func() {
 
 		err = runtimeClient.Get(ctx, client.ObjectKeyFromObject(kafkaUser), kafkaUser)
 		Expect(err).To(Succeed())
-		// utils.PrettyPrint(kafkaUser.Spec.Authorization)
 		Expect(4).To(Equal(len(kafkaUser.Spec.Authorization.Acls)))
+
+		aclByTopic := map[string][]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{}
+		consumerGroupACLs := []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{}
+		for _, acl := range kafkaUser.Spec.Authorization.Acls {
+			switch acl.Resource.Type {
+			case kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic:
+				Expect(acl.Resource.Name).NotTo(BeNil())
+				aclByTopic[*acl.Resource.Name] = acl.Operations
+			case kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeGroup:
+				consumerGroupACLs = append(consumerGroupACLs, acl)
+			}
+		}
+
+		specOps := aclByTopic["gh-spec"]
+		Expect(specOps).To(ConsistOf(
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+		))
+		Expect(specOps).NotTo(ContainElement(kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite))
+
+		migrationOps := aclByTopic[config.GetMigrationTopic()]
+		Expect(migrationOps).To(ConsistOf(
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+		))
+
+		statusOps := aclByTopic[config.GetStatusTopic(clusterName)]
+		Expect(statusOps).To(Equal([]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite,
+		}))
+
+		Expect(consumerGroupACLs).To(HaveLen(1))
+		Expect(consumerGroupACLs[0].Resource.Name).NotTo(BeNil())
+		Expect(*consumerGroupACLs[0].Resource.Name).To(Equal(config.GetConsumerGroupID("", clusterName)))
+		Expect(*consumerGroupACLs[0].Resource.Name).NotTo(Equal("*"))
 
 		// topic: create
 		clusterTopic, err := trans.EnsureTopic(clusterName)


### PR DESCRIPTION
## Summary

Backport managed-hub Kafka ACL hardening to `release-2.17` (Global Hub 1.8).

- Remove managed-hub **Write** on `gh-spec` (Describe+Read only)
- Scope consumer-group ACLs to the hub literal instead of `*`
- Drop legacy wildcard/combined ACLs on KafkaUser upgrade reconcile

Related: [ACM-34442](https://issues.redhat.com/browse/ACM-34442), main PR https://github.com/stolostron/multicluster-global-hub/pull/2761

## Test plan

- [ ] `go test ./operator/pkg/controllers/transporter/protocol/...`
- [ ] CI unit/integration jobs on `release-2.17`

Made with [Cursor](https://cursor.com)

[ACM-34442]: https://redhat.atlassian.net/browse/ACM-34442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ