### PR TITLE
ACM-34442: tighten managed-hub Kafka ACLs on gh-spec for GH 1.7

### DIFF
--- a/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
@@ -342,24 +342,13 @@ func (k *strimziTransporter) isCSVInstalled() (bool, error) {
 	return true, nil
 }
 
-// EnsureUser to reconcile the kafkaUser's setting(authn and authz)
-// set the user can write to status
-func (k *strimziTransporter) EnsureUser(clusterName string) (string, error) {
-	userName := config.GetKafkaUserName(clusterName)
-	clusterTopic := k.getClusterTopic(clusterName)
-
-	authnType := kafkav1beta2.KafkaUserSpecAuthenticationTypeTlsExternal
-	if clusterName == config.GetLocalClusterName() || clusterName == constants.LocalClusterName {
-		authnType = kafkav1beta2.KafkaUserSpecAuthenticationTypeTls
-	}
-
-	simpleACLs := []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
-		utils.ConsumeGroupReadACL(),
-		// migration resource into mh: write access to the spec topic is required for cluster migration.
+func managedHubUserACLs(clusterTopic *transport.ClusterTopic, consumerGroupID string) []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem {
+	return []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
+		utils.ConsumeGroupReadACL(consumerGroupID),
+		// consume spec bundles from the global hub (read-only; managed hubs must not produce to gh-spec)
 		utils.GetTopicACL(clusterTopic.SpecTopic, []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
 			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
 			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
-			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite,
 		}),
 		// consume migration deploying bundles from the dedicated migration topic
 		utils.GetTopicACL(clusterTopic.MigrationTopic, []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
@@ -371,6 +360,21 @@ func (k *strimziTransporter) EnsureUser(clusterName string) (string, error) {
 			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite,
 		}),
 	}
+}
+
+// EnsureUser to reconcile the kafkaUser's setting(authn and authz)
+// set the user can write to status
+func (k *strimziTransporter) EnsureUser(clusterName string) (string, error) {
+	userName := config.GetKafkaUserName(clusterName)
+	clusterTopic := k.getClusterTopic(clusterName)
+
+	authnType := kafkav1beta2.KafkaUserSpecAuthenticationTypeTlsExternal
+	if clusterName == config.GetLocalClusterName() || clusterName == constants.LocalClusterName {
+		authnType = kafkav1beta2.KafkaUserSpecAuthenticationTypeTls
+	}
+
+	consumerGroupID := config.GetConsumerGroupID(k.mgh.Spec.DataLayerSpec.Kafka.ConsumerGroupPrefix, clusterName)
+	simpleACLs := managedHubUserACLs(clusterTopic, consumerGroupID)
 
 	desiredKafkaUser := newKafkaUser(k.kafkaClusterNamespace, k.kafkaClusterName, userName, authnType, simpleACLs)
 
@@ -401,8 +405,9 @@ func (k *strimziTransporter) EnsureUser(clusterName string) (string, error) {
 		if err := operatorutils.MergeObjects(latestKafkaUser, desiredKafkaUser, updatedKafkaUser); err != nil {
 			return err
 		}
-		// combine the acls of kafkaUser and the acls of desiredKafkaUser
-		updatedKafkaUser.Spec.Authorization.Acls = combineACLs(latestKafkaUser.Spec.Authorization.Acls,
+		// combine the acls of kafkaUser and the desired acls of desiredKafkaUser
+		existingACLs := filterObsoleteManagedHubACLs(currentKafkaUserACLs(latestKafkaUser), clusterTopic.SpecTopic)
+		updatedKafkaUser.Spec.Authorization.Acls = combineACLs(existingACLs,
 			desiredKafkaUser.Spec.Authorization.Acls)
 
 		if !equality.Semantic.DeepDerivative(updatedKafkaUser.Spec, latestKafkaUser.Spec) {
@@ -416,6 +421,59 @@ func (k *strimziTransporter) EnsureUser(clusterName string) (string, error) {
 		return "", retryErr
 	}
 	return userName, nil
+}
+
+func filterObsoleteManagedHubACLs(
+	acls []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem,
+	specTopic string,
+) []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem {
+	if len(acls) == 0 {
+		return nil
+	}
+
+	filtered := make([]kafkav1beta2.KafkaUserSpecAuthorizationAclsElem, 0, len(acls))
+	for _, acl := range acls {
+		if isObsoleteManagedHubACL(acl, specTopic) {
+			continue
+		}
+		filtered = append(filtered, acl)
+	}
+	return filtered
+}
+
+func isObsoleteManagedHubACL(acl kafkav1beta2.KafkaUserSpecAuthorizationAclsElem, specTopic string) bool {
+	if acl.Resource.Name == nil {
+		return false
+	}
+
+	switch acl.Resource.Type {
+	case kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeGroup:
+		return *acl.Resource.Name == "*"
+	case kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic:
+		if *acl.Resource.Name != specTopic {
+			return false
+		}
+		return topicACLHasLegacyCombinedWrite(acl.Operations)
+	}
+
+	return false
+}
+
+func topicACLHasLegacyCombinedWrite(
+	operations []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem,
+) bool {
+	hasWrite := false
+	hasReadOrDescribe := false
+	for _, op := range operations {
+		switch op {
+		case kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite:
+			hasWrite = true
+		case kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe:
+			hasReadOrDescribe = true
+		}
+	}
+	return hasWrite && hasReadOrDescribe
 }
 
 // combineACLs combines the existing acls and the desired acls

--- a/operator/pkg/controllers/transporter/protocol/strimzi_transporter_test.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_transporter_test.go
@@ -2,6 +2,7 @@ package protocol
 
 import (
 	"encoding/json"
+	"sort"
 	"strings"
 	"testing"
 
@@ -13,6 +14,7 @@ import (
 
 	"github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
 	operatorconstants "github.com/stolostron/multicluster-global-hub/operator/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
@@ -374,6 +376,322 @@ func TestNewKafkaCluster(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestManagedHubUserACLs(t *testing.T) {
+	t.Parallel()
+
+	clusterTopic := &transport.ClusterTopic{
+		SpecTopic:      "gh-spec",
+		MigrationTopic: "gh-migration",
+		StatusTopic:    "gh-status.hub1",
+	}
+	acls := managedHubUserACLs(clusterTopic, "hub1")
+
+	if len(acls) != 4 {
+		t.Fatalf("expected 4 ACLs, got %d", len(acls))
+	}
+
+	groupACL, ok := findGroupACL(acls, "hub1")
+	if !ok {
+		t.Fatal("expected consumer-group ACL for hub1")
+	}
+	assertACLContract(
+		t, groupACL,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeGroup,
+		"hub1",
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypeLiteral,
+		[]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+		},
+	)
+
+	specACL, ok := findTopicACL(acls, clusterTopic.SpecTopic)
+	if !ok {
+		t.Fatal("expected gh-spec topic ACL")
+	}
+	assertACLContract(
+		t, specACL,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic,
+		clusterTopic.SpecTopic,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypeLiteral,
+		[]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+		},
+	)
+
+	migrationACL, ok := findTopicACL(acls, clusterTopic.MigrationTopic)
+	if !ok {
+		t.Fatal("expected gh-migration topic ACL")
+	}
+	assertACLContract(
+		t, migrationACL,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic,
+		clusterTopic.MigrationTopic,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypeLiteral,
+		[]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+		},
+	)
+
+	statusACL, ok := findTopicACL(acls, clusterTopic.StatusTopic)
+	if !ok {
+		t.Fatal("expected status topic ACL")
+	}
+	assertACLContract(
+		t, statusACL,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic,
+		clusterTopic.StatusTopic,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypeLiteral,
+		[]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite,
+		},
+	)
+}
+
+func TestCombineManagedHubACLsUpgrade(t *testing.T) {
+	t.Parallel()
+
+	clusterTopic := &transport.ClusterTopic{
+		SpecTopic:      "gh-spec",
+		MigrationTopic: "gh-migration",
+		StatusTopic:    "gh-status.hub1",
+	}
+	legacyACLs := []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
+		utils.ConsumeGroupReadACL("*"),
+		utils.GetTopicACL(clusterTopic.SpecTopic, []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite,
+		}),
+		utils.WriteTopicACL(clusterTopic.MigrationTopic),
+	}
+
+	merged := combineACLs(filterObsoleteManagedHubACLs(legacyACLs, clusterTopic.SpecTopic),
+		managedHubUserACLs(clusterTopic, "hub1"))
+
+	hasWildcardGroup, specOps, migrationOps := collectManagedHubACLTopicOps(merged, clusterTopic)
+
+	if hasWildcardGroup {
+		t.Fatal("wildcard consumer group ACL should be removed on upgrade")
+	}
+
+	groupACL, ok := findGroupACL(merged, "hub1")
+	if !ok {
+		t.Fatal("expected literal consumer-group ACL for hub1 after upgrade")
+	}
+	assertACLContract(
+		t, groupACL,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeGroup,
+		"hub1",
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypeLiteral,
+		[]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+		},
+	)
+
+	specACL, ok := findTopicACL(merged, clusterTopic.SpecTopic)
+	if !ok {
+		t.Fatal("expected gh-spec topic ACL after upgrade")
+	}
+	assertACLContract(
+		t, specACL,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic,
+		clusterTopic.SpecTopic,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypeLiteral,
+		[]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+		},
+	)
+	for _, op := range specOps {
+		if op == kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite {
+			t.Fatal("legacy gh-spec Write ACL must be removed on upgrade")
+		}
+	}
+
+	migrationReadACL, ok := findTopicACLWithOperations(
+		merged, clusterTopic.MigrationTopic,
+		[]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+		},
+	)
+	if !ok {
+		t.Fatal("expected gh-migration Describe+Read ACL after upgrade")
+	}
+	assertACLContract(
+		t, migrationReadACL,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic,
+		clusterTopic.MigrationTopic,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypeLiteral,
+		[]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+		},
+	)
+
+	migrationWriteACL, ok := findTopicACLWithOperations(
+		merged, clusterTopic.MigrationTopic,
+		[]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite,
+		},
+	)
+	if !ok {
+		t.Fatal("migration topic Write ACL from migration watcher must be preserved on upgrade")
+	}
+	assertACLContract(
+		t, migrationWriteACL,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic,
+		clusterTopic.MigrationTopic,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypeLiteral,
+		[]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite,
+		},
+	)
+	if !containsOperation(migrationOps, kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead) {
+		t.Fatal("managed hub must retain Read on gh-migration after upgrade")
+	}
+}
+
+func collectManagedHubACLTopicOps(
+	merged []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem,
+	clusterTopic *transport.ClusterTopic,
+) (hasWildcardGroup bool, specOps, migrationOps []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem) {
+	for _, acl := range merged {
+		if acl.Resource.Name == nil {
+			continue
+		}
+		if acl.Resource.Type == kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeGroup {
+			if *acl.Resource.Name == "*" {
+				hasWildcardGroup = true
+			}
+			continue
+		}
+		if acl.Resource.Type != kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic {
+			continue
+		}
+		switch *acl.Resource.Name {
+		case clusterTopic.SpecTopic:
+			specOps = append(specOps, acl.Operations...)
+		case clusterTopic.MigrationTopic:
+			migrationOps = append(migrationOps, acl.Operations...)
+		}
+	}
+	return hasWildcardGroup, specOps, migrationOps
+}
+
+func findTopicACL(acls []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem, topicName string) (
+	kafkav1beta2.KafkaUserSpecAuthorizationAclsElem, bool,
+) {
+	for _, acl := range acls {
+		if acl.Resource.Name == nil || *acl.Resource.Name != topicName {
+			continue
+		}
+		if acl.Resource.Type != kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic {
+			continue
+		}
+		return acl, true
+	}
+	return kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{}, false
+}
+
+func findGroupACL(acls []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem, groupName string) (
+	kafkav1beta2.KafkaUserSpecAuthorizationAclsElem, bool,
+) {
+	for _, acl := range acls {
+		if acl.Resource.Name == nil || *acl.Resource.Name != groupName {
+			continue
+		}
+		if acl.Resource.Type != kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeGroup {
+			continue
+		}
+		return acl, true
+	}
+	return kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{}, false
+}
+
+func findTopicACLWithOperations(
+	acls []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem,
+	topicName string,
+	wantOps []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem,
+) (kafkav1beta2.KafkaUserSpecAuthorizationAclsElem, bool) {
+	for _, acl := range acls {
+		if acl.Resource.Name == nil || *acl.Resource.Name != topicName {
+			continue
+		}
+		if acl.Resource.Type != kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic {
+			continue
+		}
+		if aclOperationsEqual(acl.Operations, wantOps) {
+			return acl, true
+		}
+	}
+	return kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{}, false
+}
+
+func assertACLContract(
+	t *testing.T,
+	acl kafkav1beta2.KafkaUserSpecAuthorizationAclsElem,
+	wantType kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceType,
+	wantName string,
+	wantPattern kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternType,
+	wantOps []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem,
+) {
+	t.Helper()
+	if acl.Resource.Name == nil {
+		t.Fatal("ACL resource name must be set")
+	}
+	if *acl.Resource.Name != wantName {
+		t.Fatalf("ACL resource name = %q, want %q", *acl.Resource.Name, wantName)
+	}
+	if acl.Resource.Type != wantType {
+		t.Fatalf("ACL resource type = %q, want %q", acl.Resource.Type, wantType)
+	}
+	if acl.Resource.PatternType == nil {
+		t.Fatal("ACL pattern type must be set")
+	}
+	if *acl.Resource.PatternType != wantPattern {
+		t.Fatalf("ACL pattern type = %q, want %q", *acl.Resource.PatternType, wantPattern)
+	}
+	if !aclOperationsEqual(acl.Operations, wantOps) {
+		t.Fatalf("ACL operations = %#v, want %#v", acl.Operations, wantOps)
+	}
+}
+
+func aclOperationsEqual(got, want []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	gotCopy := append([]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem(nil), got...)
+	wantCopy := append([]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem(nil), want...)
+	sortOperations(gotCopy)
+	sortOperations(wantCopy)
+	for i := range gotCopy {
+		if gotCopy[i] != wantCopy[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func sortOperations(ops []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem) {
+	sort.Slice(ops, func(i, j int) bool {
+		return ops[i] < ops[j]
+	})
+}
+
+func containsOperation(ops []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem,
+	target kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem,
+) bool {
+	for _, op := range ops {
+		if op == target {
+			return true
+		}
+	}
+	return false
 }
 
 func TestCombineACLs(t *testing.T) {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -217,9 +217,8 @@ func ReadTopicACL(topicName string, prefixPattern bool) kafkav1beta2.KafkaUserSp
 	}
 }
 
-func ConsumeGroupReadACL() kafkav1beta2.KafkaUserSpecAuthorizationAclsElem {
+func ConsumeGroupReadACL(consumerGroup string) kafkav1beta2.KafkaUserSpecAuthorizationAclsElem {
 	host := "*"
-	consumerGroup := "*"
 	consumerPatternType := kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypeLiteral
 	consumerAcl := kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
 		Host: &host,

--- a/test/integration/operator/controllers/transporter_test.go
+++ b/test/integration/operator/controllers/transporter_test.go
@@ -409,8 +409,42 @@ var _ = Describe("transporter", Ordered, func() {
 
 		err = runtimeClient.Get(ctx, client.ObjectKeyFromObject(kafkaUser), kafkaUser)
 		Expect(err).To(Succeed())
-		// utils.PrettyPrint(kafkaUser.Spec.Authorization)
 		Expect(4).To(Equal(len(kafkaUser.Spec.Authorization.Acls)))
+
+		aclByTopic := map[string][]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{}
+		consumerGroupACLs := []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{}
+		for _, acl := range kafkaUser.Spec.Authorization.Acls {
+			switch acl.Resource.Type {
+			case kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic:
+				Expect(acl.Resource.Name).NotTo(BeNil())
+				aclByTopic[*acl.Resource.Name] = acl.Operations
+			case kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeGroup:
+				consumerGroupACLs = append(consumerGroupACLs, acl)
+			}
+		}
+
+		specOps := aclByTopic["gh-spec"]
+		Expect(specOps).To(ConsistOf(
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+		))
+		Expect(specOps).NotTo(ContainElement(kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite))
+
+		migrationOps := aclByTopic[config.GetMigrationTopic()]
+		Expect(migrationOps).To(ConsistOf(
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+		))
+
+		statusOps := aclByTopic[config.GetStatusTopic(clusterName)]
+		Expect(statusOps).To(Equal([]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite,
+		}))
+
+		Expect(consumerGroupACLs).To(HaveLen(1))
+		Expect(consumerGroupACLs[0].Resource.Name).NotTo(BeNil())
+		Expect(*consumerGroupACLs[0].Resource.Name).To(Equal(config.GetConsumerGroupID("", clusterName)))
+		Expect(*consumerGroupACLs[0].Resource.Name).NotTo(Equal("*"))
 
 		// topic: create
 		clusterTopic, err := trans.EnsureTopic(clusterName)

--- a/test/script/e2e_log.sh
+++ b/test/script/e2e_log.sh
@@ -47,13 +47,6 @@ if [ "$COMPONENT" = "multicluster-global-hub-operator" ]; then
 
   echo ">>>> KafkaTopics"
   kubectl get kafkatopics -n "$NAMESPACE" -oyaml 2>/dev/null || echo "KafkaTopic CRD not found or no resources, skipping..."
-
-  # If installAgentOnLocal is enabled, also dump the local agent deployment/pod, since it
-  # is never covered by the "e2e-log/agent" target (that only fetches hub1/hub2 agents).
-  echo ">>>> local agent (multicluster-global-hub-agent on global-hub)"
-  kubectl describe deploy multicluster-global-hub-agent -n "$NAMESPACE" 2>/dev/null || echo "local agent deployment not found, skipping..."
-  kubectl logs deployment/multicluster-global-hub-agent -n "$NAMESPACE" --all-containers=true --tail=-1 2>/dev/null || echo "local agent logs not found, skipping..."
-  kubectl logs deployment/multicluster-global-hub-agent -n "$NAMESPACE" --all-containers=true --previous --tail=-1 2>/dev/null || echo "no previous local agent logs, skipping..."
 fi
 
 # Print describe and logs at the end

--- a/test/script/e2e_log.sh
+++ b/test/script/e2e_log.sh
@@ -47,6 +47,13 @@ if [ "$COMPONENT" = "multicluster-global-hub-operator" ]; then
 
   echo ">>>> KafkaTopics"
   kubectl get kafkatopics -n "$NAMESPACE" -oyaml 2>/dev/null || echo "KafkaTopic CRD not found or no resources, skipping..."
+
+  # If installAgentOnLocal is enabled, also dump the local agent deployment/pod, since it
+  # is never covered by the "e2e-log/agent" target (that only fetches hub1/hub2 agents).
+  echo ">>>> local agent (multicluster-global-hub-agent on global-hub)"
+  kubectl describe deploy multicluster-global-hub-agent -n "$NAMESPACE" 2>/dev/null || echo "local agent deployment not found, skipping..."
+  kubectl logs deployment/multicluster-global-hub-agent -n "$NAMESPACE" --all-containers=true --tail=-1 2>/dev/null || echo "local agent logs not found, skipping..."
+  kubectl logs deployment/multicluster-global-hub-agent -n "$NAMESPACE" --all-containers=true --previous --tail=-1 2>/dev/null || echo "no previous local agent logs, skipping..."
 fi
 
 # Print describe and logs at the end

--- a/test/script/e2e_setup.sh
+++ b/test/script/e2e_setup.sh
@@ -118,6 +118,24 @@ fi
 
 echo -e "${YELLOW} installing ocm and policy:${NC} $(($(date +%s) - start_time)) seconds"
 
+# The multicluster-global-hub-agent unconditionally watches policy.open-cluster-management.io
+# Policy CRs (see agent/cmd/main.go initCache), including when running in "local" deploy mode
+# (installAgentOnLocal) directly on the global-hub cluster. POLICY_INIT is intentionally false
+# for the global-hub<->hub join above (policy propagation isn't needed there), so the Policy
+# CRDs are otherwise never installed on global-hub, which makes the local agent's manager
+# creation fail fatally with "no matches for kind Policy". Install just the CRDs (not the full
+# propagator deployment) so the local agent's RESTMapper can resolve the kind.
+propagator_dir="${CURRENT_DIR}/governance-policy-propagator"
+if [ -d "$propagator_dir/deploy/crds" ]; then
+  echo -e "${YELLOW}Installing Policy CRDs on global-hub (required by local agent cache)${NC}"
+  kubectl --context "$GH_NAME" apply -f "$propagator_dir/deploy/crds/policy.open-cluster-management.io_policies.yaml"
+  kubectl --context "$GH_NAME" apply -f "$propagator_dir/deploy/crds/policy.open-cluster-management.io_placementbindings.yaml"
+  kubectl --context "$GH_NAME" apply -f "$propagator_dir/deploy/crds/policy.open-cluster-management.io_policyautomations.yaml"
+  kubectl --context "$GH_NAME" apply -f "$propagator_dir/deploy/crds/policy.open-cluster-management.io_policysets.yaml"
+else
+  echo -e "${RED}governance-policy-propagator CRDs not found at $propagator_dir, skipping Policy CRD install on global-hub${NC}"
+fi
+
 # Install managed-serviceaccount addon on global hub
 # This is required for migration functionality to create ServiceAccounts and collect tokens
 echo -e "${YELLOW}Installing managed-serviceaccount addon on global hub${NC}"

--- a/test/script/e2e_setup.sh
+++ b/test/script/e2e_setup.sh
@@ -125,7 +125,7 @@ echo -e "${YELLOW} installing ocm and policy:${NC} $(($(date +%s) - start_time))
 # CRDs are otherwise never installed on global-hub, which makes the local agent's manager
 # creation fail fatally with "no matches for kind Policy". Install just the CRDs (not the full
 # propagator deployment) so the local agent's RESTMapper can resolve the kind.
-propagator_dir="${CURRENT_DIR}/governance-policy-propagator"
+propagator_dir="${PROJECT_DIR}/governance-policy-propagator"
 if [ -d "$propagator_dir/deploy/crds" ]; then
   echo -e "${YELLOW}Installing Policy CRDs on global-hub (required by local agent cache)${NC}"
   kubectl --context "$GH_NAME" apply -f "$propagator_dir/deploy/crds/policy.open-cluster-management.io_policies.yaml"

--- a/test/script/e2e_setup.sh
+++ b/test/script/e2e_setup.sh
@@ -76,7 +76,7 @@ start_time=$(date +%s)
 # gobal-hub: hub1, hub2
 pids=()
 for i in $(seq 1 "${MH_NUM}"); do
-  bash "${CURRENT_DIR}"/ocm.sh "${GH_NAME}" "hub$i" HUB_INIT=false POLICY_INIT=false 2>&1 &
+  HUB_INIT=false POLICY_INIT=false bash "${CURRENT_DIR}"/ocm.sh "${GH_NAME}" "hub$i" 2>&1 &
   pid=$!
   pids+=($pid)
   echo "$pid" >>"$CONFIG_DIR/PID"
@@ -85,7 +85,7 @@ done
 # hub1: cluster1 | hub2: cluster1
 for i in $(seq 1 "${MH_NUM}"); do
   for j in $(seq 1 "${MC_NUM}"); do
-    bash "${CURRENT_DIR}"/ocm.sh "hub$i" "hub$i-cluster$j" HUB_INIT=false 2>&1 &
+    HUB_INIT=false bash "${CURRENT_DIR}"/ocm.sh "hub$i" "hub$i-cluster$j" 2>&1 &
     pid=$!
     pids+=($pid)
     echo "$pid" >>"$CONFIG_DIR/PID"

--- a/test/script/util.sh
+++ b/test/script/util.sh
@@ -278,6 +278,49 @@ join_cluster() {
   fi
 }
 
+# init_policy is invoked concurrently (once per hub/managed-cluster pair) by
+# e2e_setup.sh, but all invocations clone into the same shared CWD. Without
+# locking, two processes can both see the target directory missing and both
+# run `git clone`, and the loser fails with "destination path already exists".
+# ensure_git_repo serializes the clone+checkout for a given repo across those
+# concurrent invocations using a simple mkdir-based lock (portable, no flock
+# dependency required on the CI host).
+ensure_git_repo() {
+  local repo_dir="$1"
+  local repo_url="$2"
+  local ref="$3"
+
+  (
+    local lock_dir="/tmp/.${repo_dir}.clone.lock"
+    trap 'rmdir "$lock_dir" 2>/dev/null' EXIT
+    local waited=0
+    while ! mkdir "$lock_dir" 2>/dev/null; do
+      sleep 1
+      waited=$((waited + 1))
+      if [ "$waited" -gt 180 ]; then
+        echo -e "${RED}Timed out waiting for clone lock on $repo_dir${NC}"
+        exit 1
+      fi
+    done
+
+    if [ ! -d "$repo_dir" ]; then
+      echo "Cloning $repo_dir repository..."
+      if ! git clone "$repo_url" "$repo_dir"; then
+        echo -e "${RED}Failed to clone $repo_dir repository${NC}"
+        exit 1
+      fi
+    fi
+
+    if ! (cd "$repo_dir" && git checkout "$ref" 2>/dev/null); then
+      echo -e "${RED}Failed to checkout $ref, fetching updates...${NC}"
+      if ! (cd "$repo_dir" && git fetch origin && git checkout "$ref"); then
+        echo -e "${RED}Failed to checkout $ref after fetch${NC}"
+        exit 1
+      fi
+    fi
+  ) || exit 1
+}
+
 init_policy() {
   echo -e "${CYAN} Init Policy $1:$2 $NC"
   local hub=$1
@@ -293,25 +336,7 @@ init_policy() {
   PROPAGATOR_GIT_HTTP_PATH="https://github.com/open-cluster-management-io/governance-policy-propagator.git"
   propagator="governance-policy-propagator"
 
-  # Clone repository if it doesn't exist
-  if [ ! -d $propagator ]; then
-    echo "Cloning $propagator repository..."
-    if ! git clone $PROPAGATOR_GIT_HTTP_PATH; then
-      echo -e "${RED}Failed to clone $propagator repository${NC}"
-      exit 1
-    fi
-  fi
-
-  # Always ensure we're on the correct version
-  cd $propagator || exit 1
-  if ! git checkout $GRC_VERSION 2>/dev/null; then
-    echo -e "${RED}Failed to checkout $GRC_VERSION, fetching updates...${NC}"
-    if ! git fetch origin && git checkout $GRC_VERSION; then
-      echo -e "${RED}Failed to checkout $GRC_VERSION after fetch${NC}"
-      exit 1
-    fi
-  fi
-  cd ../ || exit 1
+  ensure_git_repo "$propagator" "$PROPAGATOR_GIT_HTTP_PATH" "$GRC_VERSION"
 
   # Verify required CRD files exist
   required_crds=(
@@ -371,24 +396,7 @@ init_policy() {
   POLICY_ADDON_GIT_HTTP_PATH="https://github.com/open-cluster-management-io/governance-policy-framework-addon.git"
   policy_addon=governance-policy-framework-addon
 
-  # Clone repository if it doesn't exist
-  if [ ! -d $policy_addon ]; then
-    if ! git clone $POLICY_ADDON_GIT_HTTP_PATH; then
-      echo -e "${RED}Failed to clone $policy_addon repository${NC}"
-      exit 1
-    fi
-  fi
-
-  # Always ensure we're on the correct version
-  cd $policy_addon || exit 1
-  if ! git checkout $GRC_VERSION 2>/dev/null; then
-    echo -e "${RED}Failed to checkout $GRC_VERSION, fetching updates...${NC}"
-    if ! git fetch origin && git checkout $GRC_VERSION; then
-      echo -e "${RED}Failed to checkout $GRC_VERSION after fetch${NC}"
-      exit 1
-    fi
-  fi
-  cd ../ || exit 1
+  ensure_git_repo "$policy_addon" "$POLICY_ADDON_GIT_HTTP_PATH" "$GRC_VERSION"
 
   retry "(kubectl --context $cluster apply -f $policy_addon/deploy/operator.yaml -n $MANAGED_NAMESPACE) && (kubectl --context $cluster get deploy/$policy_addon -n $MANAGED_NAMESPACE)" 10
 
@@ -401,24 +409,7 @@ init_policy() {
   config_policy="config-policy-controller"
   CONFIG_POLICY_GIT_HTTP_PATH="https://github.com/open-cluster-management-io/config-policy-controller.git"
 
-  # Clone repository if it doesn't exist
-  if [ ! -d $config_policy ]; then
-    if ! git clone $CONFIG_POLICY_GIT_HTTP_PATH; then
-      echo -e "${RED}Failed to clone $config_policy repository${NC}"
-      exit 1
-    fi
-  fi
-
-  # Always ensure we're on the correct version
-  cd $config_policy || exit 1
-  if ! git checkout $GRC_VERSION 2>/dev/null; then
-    echo -e "${RED}Failed to checkout $GRC_VERSION, fetching updates...${NC}"
-    if ! git fetch origin && git checkout $GRC_VERSION; then
-      echo -e "${RED}Failed to checkout $GRC_VERSION after fetch${NC}"
-      exit 1
-    fi
-  fi
-  cd ../ || exit 1
+  ensure_git_repo "$config_policy" "$CONFIG_POLICY_GIT_HTTP_PATH" "$GRC_VERSION"
 
   kubectl --context "$cluster" apply -f ${config_policy}/deploy/crds/policy.open-cluster-management.io_configurationpolicies.yaml
   # kubectl --context "$cluster" apply -f ${GIT_PATH}/crds/policy.open-cluster-management.io_operatorpolicies.yaml


### PR DESCRIPTION
## Summary

Backport Phase 4 managed-hub Kafka ACL hardening to `release-2.16` (Global Hub 1.7).

- Remove managed-hub **Write** on `gh-spec` (Describe+Read only)
- Scope consumer-group ACLs to the hub literal instead of `*`
- Drop legacy wildcard/combined ACLs on KafkaUser upgrade reconcile

Related: [ACM-34442](https://issues.redhat.com/browse/ACM-34442), main PR https://github.com/stolostron/multicluster-global-hub/pull/2761

## Test plan

- [ ] `go test ./operator/pkg/controllers/transporter/protocol/...`
- [ ] CI unit/integration jobs on `release-2.16`

Made with [Cursor](https://cursor.com)

[ACM-34442]: https://redhat.atlassian.net/browse/ACM-34442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ