### PR TITLE
ACM-34442: tighten managed-hub Kafka ACLs on gh-spec for GH 1.5

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.5.7
+VERSION ?= 1.5.8
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -70,7 +70,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: multicluster-global-hub-operator.v1.5.7
+  name: multicluster-global-hub-operator.v1.5.8
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1192,5 +1192,5 @@ spec:
   provider:
     name: Red Hat, Inc
     url: https://github.com/stolostron/multicluster-global-hub
-  replaces: multicluster-global-hub-operator.v1.5.6
-  version: 1.5.7
+  replaces: multicluster-global-hub-operator.v1.5.7
+  version: 1.5.8

--- a/operator/config/manifests/bases/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -240,5 +240,5 @@ spec:
   provider:
     name: Red Hat, Inc
     url: https://github.com/stolostron/multicluster-global-hub
-  replaces: multicluster-global-hub-operator.v1.5.6
+  replaces: multicluster-global-hub-operator.v1.5.7
   version: 0.0.1

--- a/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
@@ -336,24 +336,13 @@ func (k *strimziTransporter) isCSVInstalled() (bool, error) {
 	return true, nil
 }
 
-// EnsureUser to reconcile the kafkaUser's setting(authn and authz)
-// set the user can write to status
-func (k *strimziTransporter) EnsureUser(clusterName string) (string, error) {
-	userName := config.GetKafkaUserName(clusterName)
-	clusterTopic := k.getClusterTopic(clusterName)
-
-	authnType := kafkav1beta2.KafkaUserSpecAuthenticationTypeTlsExternal
-	if clusterName == config.GetLocalClusterName() || clusterName == constants.LocalClusterName {
-		authnType = kafkav1beta2.KafkaUserSpecAuthenticationTypeTls
-	}
-
-	simpleACLs := []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
-		utils.ConsumeGroupReadACL(),
-		// migration resource into mh: write access to the spec topic is required for cluster migration.
+func managedHubUserACLs(clusterTopic *transport.ClusterTopic, consumerGroupID string) []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem {
+	return []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
+		utils.ConsumeGroupReadACL(consumerGroupID),
+		// consume spec bundles from the global hub (read-only; managed hubs must not produce to gh-spec)
 		utils.GetTopicACL(clusterTopic.SpecTopic, []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
 			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
 			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
-			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite,
 		}),
 		// consume migration deploying bundles from the dedicated migration topic
 		utils.GetTopicACL(clusterTopic.MigrationTopic, []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
@@ -365,6 +354,21 @@ func (k *strimziTransporter) EnsureUser(clusterName string) (string, error) {
 			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite,
 		}),
 	}
+}
+
+// EnsureUser to reconcile the kafkaUser's setting(authn and authz)
+// set the user can write to status
+func (k *strimziTransporter) EnsureUser(clusterName string) (string, error) {
+	userName := config.GetKafkaUserName(clusterName)
+	clusterTopic := k.getClusterTopic(clusterName)
+
+	authnType := kafkav1beta2.KafkaUserSpecAuthenticationTypeTlsExternal
+	if clusterName == config.GetLocalClusterName() || clusterName == constants.LocalClusterName {
+		authnType = kafkav1beta2.KafkaUserSpecAuthenticationTypeTls
+	}
+
+	consumerGroupID := config.GetConsumerGroupID(k.mgh.Spec.DataLayerSpec.Kafka.ConsumerGroupPrefix, clusterName)
+	simpleACLs := managedHubUserACLs(clusterTopic, consumerGroupID)
 
 	desiredKafkaUser := newKafkaUser(k.kafkaClusterNamespace, k.kafkaClusterName, userName, authnType, simpleACLs)
 
@@ -395,8 +399,9 @@ func (k *strimziTransporter) EnsureUser(clusterName string) (string, error) {
 		if err := operatorutils.MergeObjects(latestKafkaUser, desiredKafkaUser, updatedKafkaUser); err != nil {
 			return err
 		}
-		// combine the acls of kafkaUser and the acls of desiredKafkaUser
-		updatedKafkaUser.Spec.Authorization.Acls = combineACLs(latestKafkaUser.Spec.Authorization.Acls,
+		// combine the acls of kafkaUser and the desired acls of desiredKafkaUser
+		existingACLs := filterObsoleteManagedHubACLs(currentKafkaUserACLs(latestKafkaUser), clusterTopic.SpecTopic)
+		updatedKafkaUser.Spec.Authorization.Acls = combineACLs(existingACLs,
 			desiredKafkaUser.Spec.Authorization.Acls)
 
 		if !equality.Semantic.DeepDerivative(updatedKafkaUser.Spec, latestKafkaUser.Spec) {
@@ -410,6 +415,59 @@ func (k *strimziTransporter) EnsureUser(clusterName string) (string, error) {
 		return "", retryErr
 	}
 	return userName, nil
+}
+
+func filterObsoleteManagedHubACLs(
+	acls []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem,
+	specTopic string,
+) []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem {
+	if len(acls) == 0 {
+		return nil
+	}
+
+	filtered := make([]kafkav1beta2.KafkaUserSpecAuthorizationAclsElem, 0, len(acls))
+	for _, acl := range acls {
+		if isObsoleteManagedHubACL(acl, specTopic) {
+			continue
+		}
+		filtered = append(filtered, acl)
+	}
+	return filtered
+}
+
+func isObsoleteManagedHubACL(acl kafkav1beta2.KafkaUserSpecAuthorizationAclsElem, specTopic string) bool {
+	if acl.Resource.Name == nil {
+		return false
+	}
+
+	switch acl.Resource.Type {
+	case kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeGroup:
+		return *acl.Resource.Name == "*"
+	case kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic:
+		if *acl.Resource.Name != specTopic {
+			return false
+		}
+		return topicACLHasLegacyCombinedWrite(acl.Operations)
+	}
+
+	return false
+}
+
+func topicACLHasLegacyCombinedWrite(
+	operations []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem,
+) bool {
+	hasWrite := false
+	hasReadOrDescribe := false
+	for _, op := range operations {
+		switch op {
+		case kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite:
+			hasWrite = true
+		case kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe:
+			hasReadOrDescribe = true
+		}
+	}
+	return hasWrite && hasReadOrDescribe
 }
 
 // combineACLs combines the existing acls and the desired acls

--- a/operator/pkg/controllers/transporter/protocol/strimzi_transporter_test.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_transporter_test.go
@@ -2,6 +2,7 @@ package protocol
 
 import (
 	"encoding/json"
+	"sort"
 	"strings"
 	"testing"
 
@@ -13,6 +14,7 @@ import (
 
 	"github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
 	operatorconstants "github.com/stolostron/multicluster-global-hub/operator/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
@@ -314,6 +316,322 @@ func TestNewKafkaCluster(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestManagedHubUserACLs(t *testing.T) {
+	t.Parallel()
+
+	clusterTopic := &transport.ClusterTopic{
+		SpecTopic:      "gh-spec",
+		MigrationTopic: "gh-migration",
+		StatusTopic:    "gh-status.hub1",
+	}
+	acls := managedHubUserACLs(clusterTopic, "hub1")
+
+	if len(acls) != 4 {
+		t.Fatalf("expected 4 ACLs, got %d", len(acls))
+	}
+
+	groupACL, ok := findGroupACL(acls, "hub1")
+	if !ok {
+		t.Fatal("expected consumer-group ACL for hub1")
+	}
+	assertACLContract(
+		t, groupACL,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeGroup,
+		"hub1",
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypeLiteral,
+		[]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+		},
+	)
+
+	specACL, ok := findTopicACL(acls, clusterTopic.SpecTopic)
+	if !ok {
+		t.Fatal("expected gh-spec topic ACL")
+	}
+	assertACLContract(
+		t, specACL,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic,
+		clusterTopic.SpecTopic,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypeLiteral,
+		[]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+		},
+	)
+
+	migrationACL, ok := findTopicACL(acls, clusterTopic.MigrationTopic)
+	if !ok {
+		t.Fatal("expected gh-migration topic ACL")
+	}
+	assertACLContract(
+		t, migrationACL,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic,
+		clusterTopic.MigrationTopic,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypeLiteral,
+		[]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+		},
+	)
+
+	statusACL, ok := findTopicACL(acls, clusterTopic.StatusTopic)
+	if !ok {
+		t.Fatal("expected status topic ACL")
+	}
+	assertACLContract(
+		t, statusACL,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic,
+		clusterTopic.StatusTopic,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypeLiteral,
+		[]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite,
+		},
+	)
+}
+
+func TestCombineManagedHubACLsUpgrade(t *testing.T) {
+	t.Parallel()
+
+	clusterTopic := &transport.ClusterTopic{
+		SpecTopic:      "gh-spec",
+		MigrationTopic: "gh-migration",
+		StatusTopic:    "gh-status.hub1",
+	}
+	legacyACLs := []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
+		utils.ConsumeGroupReadACL("*"),
+		utils.GetTopicACL(clusterTopic.SpecTopic, []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite,
+		}),
+		utils.WriteTopicACL(clusterTopic.MigrationTopic),
+	}
+
+	merged := combineACLs(filterObsoleteManagedHubACLs(legacyACLs, clusterTopic.SpecTopic),
+		managedHubUserACLs(clusterTopic, "hub1"))
+
+	hasWildcardGroup, specOps, migrationOps := collectManagedHubACLTopicOps(merged, clusterTopic)
+
+	if hasWildcardGroup {
+		t.Fatal("wildcard consumer group ACL should be removed on upgrade")
+	}
+
+	groupACL, ok := findGroupACL(merged, "hub1")
+	if !ok {
+		t.Fatal("expected literal consumer-group ACL for hub1 after upgrade")
+	}
+	assertACLContract(
+		t, groupACL,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeGroup,
+		"hub1",
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypeLiteral,
+		[]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+		},
+	)
+
+	specACL, ok := findTopicACL(merged, clusterTopic.SpecTopic)
+	if !ok {
+		t.Fatal("expected gh-spec topic ACL after upgrade")
+	}
+	assertACLContract(
+		t, specACL,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic,
+		clusterTopic.SpecTopic,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypeLiteral,
+		[]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+		},
+	)
+	for _, op := range specOps {
+		if op == kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite {
+			t.Fatal("legacy gh-spec Write ACL must be removed on upgrade")
+		}
+	}
+
+	migrationReadACL, ok := findTopicACLWithOperations(
+		merged, clusterTopic.MigrationTopic,
+		[]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+		},
+	)
+	if !ok {
+		t.Fatal("expected gh-migration Describe+Read ACL after upgrade")
+	}
+	assertACLContract(
+		t, migrationReadACL,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic,
+		clusterTopic.MigrationTopic,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypeLiteral,
+		[]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+		},
+	)
+
+	migrationWriteACL, ok := findTopicACLWithOperations(
+		merged, clusterTopic.MigrationTopic,
+		[]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite,
+		},
+	)
+	if !ok {
+		t.Fatal("migration topic Write ACL from migration watcher must be preserved on upgrade")
+	}
+	assertACLContract(
+		t, migrationWriteACL,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic,
+		clusterTopic.MigrationTopic,
+		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypeLiteral,
+		[]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite,
+		},
+	)
+	if !containsOperation(migrationOps, kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead) {
+		t.Fatal("managed hub must retain Read on gh-migration after upgrade")
+	}
+}
+
+func collectManagedHubACLTopicOps(
+	merged []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem,
+	clusterTopic *transport.ClusterTopic,
+) (hasWildcardGroup bool, specOps, migrationOps []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem) {
+	for _, acl := range merged {
+		if acl.Resource.Name == nil {
+			continue
+		}
+		if acl.Resource.Type == kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeGroup {
+			if *acl.Resource.Name == "*" {
+				hasWildcardGroup = true
+			}
+			continue
+		}
+		if acl.Resource.Type != kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic {
+			continue
+		}
+		switch *acl.Resource.Name {
+		case clusterTopic.SpecTopic:
+			specOps = append(specOps, acl.Operations...)
+		case clusterTopic.MigrationTopic:
+			migrationOps = append(migrationOps, acl.Operations...)
+		}
+	}
+	return hasWildcardGroup, specOps, migrationOps
+}
+
+func findTopicACL(acls []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem, topicName string) (
+	kafkav1beta2.KafkaUserSpecAuthorizationAclsElem, bool,
+) {
+	for _, acl := range acls {
+		if acl.Resource.Name == nil || *acl.Resource.Name != topicName {
+			continue
+		}
+		if acl.Resource.Type != kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic {
+			continue
+		}
+		return acl, true
+	}
+	return kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{}, false
+}
+
+func findGroupACL(acls []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem, groupName string) (
+	kafkav1beta2.KafkaUserSpecAuthorizationAclsElem, bool,
+) {
+	for _, acl := range acls {
+		if acl.Resource.Name == nil || *acl.Resource.Name != groupName {
+			continue
+		}
+		if acl.Resource.Type != kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeGroup {
+			continue
+		}
+		return acl, true
+	}
+	return kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{}, false
+}
+
+func findTopicACLWithOperations(
+	acls []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem,
+	topicName string,
+	wantOps []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem,
+) (kafkav1beta2.KafkaUserSpecAuthorizationAclsElem, bool) {
+	for _, acl := range acls {
+		if acl.Resource.Name == nil || *acl.Resource.Name != topicName {
+			continue
+		}
+		if acl.Resource.Type != kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic {
+			continue
+		}
+		if aclOperationsEqual(acl.Operations, wantOps) {
+			return acl, true
+		}
+	}
+	return kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{}, false
+}
+
+func assertACLContract(
+	t *testing.T,
+	acl kafkav1beta2.KafkaUserSpecAuthorizationAclsElem,
+	wantType kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceType,
+	wantName string,
+	wantPattern kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternType,
+	wantOps []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem,
+) {
+	t.Helper()
+	if acl.Resource.Name == nil {
+		t.Fatal("ACL resource name must be set")
+	}
+	if *acl.Resource.Name != wantName {
+		t.Fatalf("ACL resource name = %q, want %q", *acl.Resource.Name, wantName)
+	}
+	if acl.Resource.Type != wantType {
+		t.Fatalf("ACL resource type = %q, want %q", acl.Resource.Type, wantType)
+	}
+	if acl.Resource.PatternType == nil {
+		t.Fatal("ACL pattern type must be set")
+	}
+	if *acl.Resource.PatternType != wantPattern {
+		t.Fatalf("ACL pattern type = %q, want %q", *acl.Resource.PatternType, wantPattern)
+	}
+	if !aclOperationsEqual(acl.Operations, wantOps) {
+		t.Fatalf("ACL operations = %#v, want %#v", acl.Operations, wantOps)
+	}
+}
+
+func aclOperationsEqual(got, want []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	gotCopy := append([]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem(nil), got...)
+	wantCopy := append([]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem(nil), want...)
+	sortOperations(gotCopy)
+	sortOperations(wantCopy)
+	for i := range gotCopy {
+		if gotCopy[i] != wantCopy[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func sortOperations(ops []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem) {
+	sort.Slice(ops, func(i, j int) bool {
+		return ops[i] < ops[j]
+	})
+}
+
+func containsOperation(ops []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem,
+	target kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem,
+) bool {
+	for _, op := range ops {
+		if op == target {
+			return true
+		}
+	}
+	return false
 }
 
 func TestCombineACLs(t *testing.T) {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -217,9 +217,8 @@ func ReadTopicACL(topicName string, prefixPattern bool) kafkav1beta2.KafkaUserSp
 	}
 }
 
-func ConsumeGroupReadACL() kafkav1beta2.KafkaUserSpecAuthorizationAclsElem {
+func ConsumeGroupReadACL(consumerGroup string) kafkav1beta2.KafkaUserSpecAuthorizationAclsElem {
 	host := "*"
-	consumerGroup := "*"
 	consumerPatternType := kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypeLiteral
 	consumerAcl := kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
 		Host: &host,

--- a/test/integration/operator/controllers/transporter_test.go
+++ b/test/integration/operator/controllers/transporter_test.go
@@ -393,8 +393,42 @@ var _ = Describe("transporter", Ordered, func() {
 
 		err = runtimeClient.Get(ctx, client.ObjectKeyFromObject(kafkaUser), kafkaUser)
 		Expect(err).To(Succeed())
-		// utils.PrettyPrint(kafkaUser.Spec.Authorization)
 		Expect(4).To(Equal(len(kafkaUser.Spec.Authorization.Acls)))
+
+		aclByTopic := map[string][]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{}
+		consumerGroupACLs := []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{}
+		for _, acl := range kafkaUser.Spec.Authorization.Acls {
+			switch acl.Resource.Type {
+			case kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic:
+				Expect(acl.Resource.Name).NotTo(BeNil())
+				aclByTopic[*acl.Resource.Name] = acl.Operations
+			case kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeGroup:
+				consumerGroupACLs = append(consumerGroupACLs, acl)
+			}
+		}
+
+		specOps := aclByTopic["gh-spec"]
+		Expect(specOps).To(ConsistOf(
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+		))
+		Expect(specOps).NotTo(ContainElement(kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite))
+
+		migrationOps := aclByTopic[config.GetMigrationTopic()]
+		Expect(migrationOps).To(ConsistOf(
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
+		))
+
+		statusOps := aclByTopic[config.GetStatusTopic(clusterName)]
+		Expect(statusOps).To(Equal([]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
+			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite,
+		}))
+
+		Expect(consumerGroupACLs).To(HaveLen(1))
+		Expect(consumerGroupACLs[0].Resource.Name).NotTo(BeNil())
+		Expect(*consumerGroupACLs[0].Resource.Name).To(Equal(config.GetConsumerGroupID("", clusterName)))
+		Expect(*consumerGroupACLs[0].Resource.Name).NotTo(Equal("*"))
 
 		// topic: create
 		clusterTopic, err := trans.EnsureTopic(clusterName)


### PR DESCRIPTION
## Summary

Backport managed-hub Kafka ACL hardening to `release-2.14` (Global Hub 1.5).

- Remove managed-hub **Write** on `gh-spec` (Describe+Read only)
- Scope consumer-group ACLs to the hub literal instead of `*`
- Drop legacy wildcard/combined ACLs on KafkaUser upgrade reconcile


Related: [ACM-34442](https://issues.redhat.com/browse/ACM-34442), main PR https://github.com/stolostron/multicluster-global-hub/pull/2761

## Test plan

- [ ] `go test ./operator/pkg/controllers/transporter/protocol/...`
- [ ] CI unit/integration jobs on `release-2.14`

Made with [Cursor](https://cursor.com)

[ACM-34442]: https://redhat.atlassian.net/browse/ACM-34442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ