### PR TITLE
ACM-40363: validate evt.Source() against Kafka topic in status dispatcher

### DIFF
--- a/manager/pkg/status/dispatcher/transport_dispatcher.go
+++ b/manager/pkg/status/dispatcher/transport_dispatcher.go
@@ -2,8 +2,14 @@ package dispatcher
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"strings"
 
+	"github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	cetypes "github.com/cloudevents/sdk-go/v2/types"
 	"go.uber.org/zap"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -20,21 +26,56 @@ type TransportDispatcher struct {
 	consumer          transport.Consumer
 	conflationManager *conflator.ConflationManager
 	statistic         *statistics.Statistics
+	// statusTopic is the manager's configured status-topic template
+	// (e.g. "^gh-status.*"). When it contains '*', per-hub status topics
+	// are in use and the broker-enforced topic name carries the hub
+	// identity, so the dispatcher binds evt.Source() to the topic.
+	statusTopic string
 }
 
 func AddTransportDispatcher(mgr ctrl.Manager, consumer transport.Consumer, managerConfig *configs.ManagerConfig,
 	conflationManager *conflator.ConflationManager, stats *statistics.Statistics,
 ) error {
+	statusTopic := ""
+	if managerConfig.TransportConfig != nil && managerConfig.TransportConfig.KafkaCredential != nil {
+		statusTopic = managerConfig.TransportConfig.KafkaCredential.StatusTopic
+	}
 	transportDispatcher := &TransportDispatcher{
 		log:               logger.DefaultZapLogger(),
 		consumer:          consumer,
 		conflationManager: conflationManager,
 		statistic:         stats,
+		statusTopic:       statusTopic,
 	}
 	if err := mgr.Add(transportDispatcher); err != nil {
 		return fmt.Errorf("failed to add transport dispatcher to runtime manager: %w", err)
 	}
 	return nil
+}
+
+// sourceMatchesTopic verifies that the self-asserted CloudEvent Source
+// matches the broker-enforced Kafka topic the event arrived on. Each
+// managed hub's KafkaUser only has Write ACL on its own per-hub status
+// topic, so the topic name is the only trustworthy carrier of leaf-hub
+// identity. Returns true when the binding holds or cannot be evaluated
+// (shared-topic / non-Kafka transport).
+func sourceMatchesTopic(evt *cloudevents.Event, statusTopic string) bool {
+	if !strings.Contains(statusTopic, "*") {
+		// Shared status topic (BYO or non-wildcard Strimzi config); the
+		// broker provides no per-hub identity to bind against.
+		return true
+	}
+	topic, err := cetypes.ToString(evt.Extensions()[kafka_confluent.KafkaTopicKey])
+	if err != nil || topic == "" {
+		// Non-Kafka transport (e.g. go-chan in tests) — nothing to bind.
+		return true
+	}
+	if evt.Source() == "" {
+		return false
+	}
+	template := strings.TrimPrefix(statusTopic, "^")
+	expected := strings.ReplaceAll(template, "*", evt.Source())
+	return topic == expected
 }
 
 // Start function starts bundles status syncer.
@@ -57,6 +98,12 @@ func (d *TransportDispatcher) dispatch(ctx context.Context) {
 		case evt := <-d.consumer.EventChan():
 			d.statistic.ReceivedEvent(evt)
 			d.log.Debugf("received event: %s", evt)
+			if !sourceMatchesTopic(evt, d.statusTopic) {
+				sourceHash := sha256.Sum256([]byte(evt.Source()))
+				d.log.Warnw("dropping status event: source does not match Kafka topic",
+					"sourceHash", hex.EncodeToString(sourceHash[:8]))
+				continue
+			}
 			d.conflationManager.Insert(evt)
 		}
 	}

--- a/manager/pkg/status/dispatcher/transport_dispatcher_test.go
+++ b/manager/pkg/status/dispatcher/transport_dispatcher_test.go
@@ -1,0 +1,50 @@
+package dispatcher
+
+import (
+	"testing"
+
+	"github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+)
+
+func evtWithSourceAndTopic(source, topic string) *cloudevents.Event {
+	e := cloudevents.NewEvent()
+	e.SetType("io.test")
+	e.SetSource(source)
+	if topic != "" {
+		e.SetExtension(kafka_confluent.KafkaTopicKey, topic)
+	}
+	return &e
+}
+
+// TestSourceMatchesTopic verifies that the dispatcher binds the
+// self-asserted CloudEvent Source to the broker-enforced per-hub status
+// topic so a managed hub cannot impersonate a peer in status handlers.
+func TestSourceMatchesTopic(t *testing.T) {
+	statusTopic := "^gh-status.*"
+
+	cases := []struct {
+		name   string
+		source string
+		topic  string
+		want   bool
+	}{
+		{"matching per-hub topic", "hub-a", "gh-status.hub-a", true},
+		{"spoofed source on own topic", "hub-b", "gh-status.hub-a", false},
+		{"empty source", "", "gh-status.hub-a", false},
+		{"non-kafka transport (no topic ext)", "hub-a", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sourceMatchesTopic(evtWithSourceAndTopic(tc.source, tc.topic), statusTopic); got != tc.want {
+				t.Fatalf("sourceMatchesTopic(source=%q, topic=%q) = %v, want %v",
+					tc.source, tc.topic, got, tc.want)
+			}
+		})
+	}
+
+	// Shared-topic mode (no '*') must not enforce binding.
+	if !sourceMatchesTopic(evtWithSourceAndTopic("hub-b", "gh-status"), "gh-status") {
+		t.Fatalf("shared-topic mode should not reject events")
+	}
+}


### PR DESCRIPTION
Fixes : [ACM-40363](https://redhat.atlassian.net/browse/ACM-40363)
## Summary
Backport of #2734 to release-2.15.

- Adds validation in the status transport dispatcher to bind the self-asserted CloudEvent Source against the broker-enforced Kafka topic name
- In per-hub status topic mode, each managed hub's KafkaUser only has Write ACL on its own topic — the topic name is the trustworthy carrier of hub identity
- Events with a mismatched source are dropped with a warning log
- Shared-topic and non-Kafka transports are unaffected (validation is skipped)

## Test plan
- [ ] Unit tests pass (`make unit-tests-manager`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ACM-40363]: https://redhat.atlassian.net/browse/ACM-40363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ