### PR TITLE
ACM-38678: [release-2.14] reduce MSA token validity from 86400h to 24h

### DIFF
--- a/manager/pkg/migration/migration_initializing.go
+++ b/manager/pkg/migration/migration_initializing.go
@@ -328,8 +328,15 @@ func (m *ClusterMigrationController) ensureManagedServiceAccount(ctx context.Con
 		Spec: v1beta1.ManagedServiceAccountSpec{
 			Rotation: v1beta1.ManagedServiceAccountRotation{
 				Enabled: true,
+				// The MSA token is embedded in the bootstrap kubeconfig
+				// that is broadcast on the shared gh-spec topic to which
+				// every managed hub holds a Read ACL, so it must be
+				// short-lived. 24h comfortably covers all migration
+				// stage timeouts (5–12 min each) and matches the spec
+				// topic's default retention; the MSA itself is removed
+				// in the cleaning phase.
 				Validity: metav1.Duration{
-					Duration: 86400 * time.Hour,
+					Duration: 24 * time.Hour,
 				},
 			},
 		},


### PR DESCRIPTION
## Summary
Backport of #2733 to release-2.14.

- Reduces the ManagedServiceAccount token validity from 86400h (~10 years) to 24h
- The MSA token is embedded in the bootstrap kubeconfig broadcast on the shared gh-spec Kafka topic; a short-lived token limits exposure since every managed hub holds a Read ACL on that topic
- 24h comfortably covers all migration stage timeouts and matches the spec topic's default retention; the MSA is removed in the cleaning phase

## Test plan
- [ ] Unit tests pass (`make unit-tests-manager`)
- [ ] Migration e2e test passes with the reduced token validity

🤖 Generated with [Claude Code](https://claude.com/claude-code)