### PR TITLE
🚀 ACM-39126: Create OLMv1 validation pipeline for Global Hub operator

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -29,8 +29,22 @@ e2e-test-all: tidy vendor
 e2e-test-cluster e2e-test-local-agent e2e-test-localpolicy e2e-test-grafana e2e-test-migration e2e-test-hubha e2e-test-transport-identity e2e-test-transport-migration-topic: tidy vendor
 	./test/script/e2e_run.sh -f $@ -v $(VERBOSE)
 
-e2e-prow-tests: 
+e2e-prow-tests:
 	./test/script/e2e_prow.sh
+
+olmv1-e2e-setup:
+	./test/script/olmv1_e2e_setup.sh
+
+olmv1-e2e-run:
+	./test/script/olmv1_e2e_run.sh
+
+olmv1-e2e-upgrade: tidy vendor
+	./test/script/olmv1_e2e_upgrade.sh
+
+olmv1-e2e-cleanup:
+	./test/script/olmv1_e2e_cleanup.sh
+
+olmv1-e2e-test-all: olmv1-e2e-setup olmv1-e2e-run olmv1-e2e-upgrade olmv1-e2e-cleanup
 
 e2e-log/operator:
 	./test/script/e2e_log.sh

--- a/test/script/olmv1_e2e_cleanup.sh
+++ b/test/script/olmv1_e2e_cleanup.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -euo pipefail
+
+CURRENT_DIR=$(
+  cd "$(dirname "$0")" || exit
+  pwd
+)
+# shellcheck source=/dev/null
+source "$CURRENT_DIR/util.sh"
+
+cluster_name="global-hub-olmv1"
+
+echo -e "${YELLOW}=== OLMv1 E2E Cleanup ===${NC}"
+
+# Delete KinD cluster
+echo -e "${YELLOW}Deleting KinD cluster: ${cluster_name}${NC}"
+kind delete cluster --name "$cluster_name" 2>/dev/null || true
+
+# Stop local registry
+echo -e "${YELLOW}Stopping local registry${NC}"
+stop_local_registry
+
+# Clean up kubeconfig
+rm -f "${CONFIG_DIR}/${cluster_name}" 2>/dev/null || true
+
+echo -e "${GREEN}=== Cleanup complete ===${NC}"

--- a/test/script/olmv1_e2e_run.sh
+++ b/test/script/olmv1_e2e_run.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+set -euo pipefail
+
+CURRENT_DIR=$(
+  cd "$(dirname "$0")" || exit
+  pwd
+)
+# shellcheck source=/dev/null
+source "$CURRENT_DIR/util.sh"
+
+cluster_name="global-hub-olmv1"
+GH_NAMESPACE="multicluster-global-hub"
+
+echo -e "${YELLOW}=== OLMv1 E2E Validation ===${NC}"
+
+# ── 1. Validate OLMv1 installation state ───────────────────────────────────
+echo -e "${YELLOW}--- Checking OLMv1 components ---${NC}"
+kubectl get deploy -n olmv1-system --context "$cluster_name"
+kubectl get clustercatalog --context "$cluster_name"
+kubectl get clusterextension --context "$cluster_name"
+
+# ── 2. Validate operator deployed via ClusterExtension ──────────────────────
+echo -e "${YELLOW}--- Checking operator deployment ---${NC}"
+kubectl get deploy -n "$GH_NAMESPACE" --context "$cluster_name"
+
+ce_status=$(kubectl get clusterextension/multicluster-global-hub-operator \
+  --context "$cluster_name" -o jsonpath='{.status.conditions[?(@.type=="Installed")].status}')
+if [[ "$ce_status" != "True" ]]; then
+  echo "ERROR: ClusterExtension not in Installed=True state"
+  exit 1
+fi
+echo -e "${GREEN}ClusterExtension: Installed=True${NC}"
+
+# ── 3. Validate operator health ─────────────────────────────────────────────
+echo -e "${YELLOW}--- Checking operator health ---${NC}"
+kubectl wait deploy/multicluster-global-hub-operator -n "$GH_NAMESPACE" \
+  --for=condition=Available=True --timeout=60s --context "$cluster_name"
+echo -e "${GREEN}Operator: Available${NC}"
+
+# ── 4. Validate manager health ──────────────────────────────────────────────
+echo -e "${YELLOW}--- Checking manager health ---${NC}"
+kubectl wait deploy/multicluster-global-hub-manager -n "$GH_NAMESPACE" \
+  --for=condition=Available=True --timeout=60s --context "$cluster_name"
+echo -e "${GREEN}Manager: Available${NC}"
+
+# ── 5. Validate Kafka ───────────────────────────────────────────────────────
+echo -e "${YELLOW}--- Checking Kafka ---${NC}"
+kubectl get kafka -n "$GH_NAMESPACE" --context "$cluster_name" || echo "Kafka not yet available"
+
+# ── 6. Validate Postgres ────────────────────────────────────────────────────
+echo -e "${YELLOW}--- Checking Postgres ---${NC}"
+kubectl get statefulset -n "$GH_NAMESPACE" --context "$cluster_name" | grep -i postgres || echo "Postgres not yet available"
+
+# ── 7. Validate Grafana ─────────────────────────────────────────────────────
+echo -e "${YELLOW}--- Checking Grafana ---${NC}"
+kubectl get deploy -n "$GH_NAMESPACE" --context "$cluster_name" | grep -i grafana || echo "Grafana not yet available"
+
+# ── 8. Validate MCGH status ─────────────────────────────────────────────────
+echo -e "${YELLOW}--- Checking MulticlusterGlobalHub status ---${NC}"
+kubectl get mcgh -n "$GH_NAMESPACE" --context "$cluster_name" -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "Phase not set"
+
+# ── 9. OLMv0/OLMv1 coexistence check ───────────────────────────────────────
+echo -e "${YELLOW}--- Checking OLMv0/OLMv1 coexistence ---${NC}"
+echo "OLMv0 Subscriptions:"
+kubectl get subscriptions.operators.coreos.com --all-namespaces --context "$cluster_name" 2>/dev/null || echo "No OLMv0 subscriptions"
+echo "OLMv1 ClusterExtensions:"
+kubectl get clusterextension --context "$cluster_name"
+
+echo -e "${GREEN}=== OLMv1 E2E Validation Complete ===${NC}"

--- a/test/script/olmv1_e2e_setup.sh
+++ b/test/script/olmv1_e2e_setup.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+
+set -euo pipefail
+
+CURRENT_DIR=$(
+  cd "$(dirname "$0")" || exit
+  pwd
+)
+# shellcheck source=/dev/null
+source "$CURRENT_DIR/util.sh"
+
+[ -d "$CONFIG_DIR" ] || (mkdir -p "$CONFIG_DIR")
+
+cluster_name="global-hub-olmv1"
+GH_NAMESPACE="multicluster-global-hub"
+REGISTRY="localhost:5001"
+INITIAL_VERSION="5.0.0"
+
+start=$(date +%s)
+
+# ── 1. Create KinD cluster ──────────────────────────────────────────────────
+echo -e "${YELLOW}=== Phase 1: Creating KinD cluster ===${NC}"
+kind_cluster "$cluster_name" "kindest/node:v1.32.2"
+install_crds "$cluster_name" false
+enable_service_ca "$cluster_name" "$TEST_DIR/manifest"
+
+# ── 2. Start local Docker registry on the kind network ──────────────────────
+echo -e "${YELLOW}=== Phase 2: Starting local registry ===${NC}"
+start_local_registry
+
+# ── 3. Install OLMv0 (for Strimzi coexistence) ─────────────────────────────
+echo -e "${YELLOW}=== Phase 3: Installing OLMv0 ===${NC}"
+enable_olm "$cluster_name"
+
+# ── 4. Install OLMv1 (cert-manager + operator-controller + catalogd) ───────
+echo -e "${YELLOW}=== Phase 4: Installing OLMv1 ===${NC}"
+install_olmv1 "$cluster_name"
+
+# ── 5. Build operator, manager, agent images ────────────────────────────────
+echo -e "${YELLOW}=== Phase 5: Building component images ===${NC}"
+cd "$PROJECT_DIR" || exit
+MULTICLUSTER_GLOBAL_HUB_OPERATOR_IMAGE_REF="${REGISTRY}/ghub-operator:v${INITIAL_VERSION}"
+MULTICLUSTER_GLOBAL_HUB_MANAGER_IMAGE_REF="${REGISTRY}/ghub-manager:v${INITIAL_VERSION}"
+MULTICLUSTER_GLOBAL_HUB_AGENT_IMAGE_REF="${REGISTRY}/ghub-agent:v${INITIAL_VERSION}"
+
+docker build . -t "$MULTICLUSTER_GLOBAL_HUB_OPERATOR_IMAGE_REF" -f operator/Dockerfile
+docker build . -t "$MULTICLUSTER_GLOBAL_HUB_MANAGER_IMAGE_REF" -f manager/Dockerfile
+docker build . -t "$MULTICLUSTER_GLOBAL_HUB_AGENT_IMAGE_REF" -f agent/Dockerfile
+
+docker push "$MULTICLUSTER_GLOBAL_HUB_OPERATOR_IMAGE_REF"
+docker push "$MULTICLUSTER_GLOBAL_HUB_MANAGER_IMAGE_REF"
+docker push "$MULTICLUSTER_GLOBAL_HUB_AGENT_IMAGE_REF"
+
+# Also load into kind so the operator can pull manager/agent images
+kind load docker-image "$MULTICLUSTER_GLOBAL_HUB_OPERATOR_IMAGE_REF" --name "$cluster_name"
+kind load docker-image "$MULTICLUSTER_GLOBAL_HUB_MANAGER_IMAGE_REF" --name "$cluster_name"
+kind load docker-image "$MULTICLUSTER_GLOBAL_HUB_AGENT_IMAGE_REF" --name "$cluster_name"
+
+# Update manager.yaml to reference built images with IfNotPresent
+sed -i -e "s;quay.io/stolostron/multicluster-global-hub-manager:latest;${MULTICLUSTER_GLOBAL_HUB_MANAGER_IMAGE_REF};" ./operator/config/manager/manager.yaml
+sed -i -e "s;quay.io/stolostron/multicluster-global-hub-agent:latest;${MULTICLUSTER_GLOBAL_HUB_AGENT_IMAGE_REF};" ./operator/config/manager/manager.yaml
+sed -i -e "s;imagePullPolicy: Always;imagePullPolicy: IfNotPresent;" ./operator/config/manager/manager.yaml
+
+# ── 6. Build OLM bundle ─────────────────────────────────────────────────────
+echo -e "${YELLOW}=== Phase 6: Building OLM bundle ===${NC}"
+cd "$PROJECT_DIR/operator" || exit
+VERSION="${INITIAL_VERSION}" RELEASE_LINE="5.0" make bundle || true
+# Build and push the bundle image
+cat > bundle.Dockerfile <<'BEOF'
+FROM scratch
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=multicluster-global-hub-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=release-5.0
+LABEL operators.operatorframework.io.bundle.channel.default.v1=release-5.0
+COPY bundle/manifests /manifests/
+COPY bundle/metadata /metadata/
+BEOF
+docker build -f bundle.Dockerfile -t "${REGISTRY}/ghub-bundle:v${INITIAL_VERSION}" .
+docker push "${REGISTRY}/ghub-bundle:v${INITIAL_VERSION}"
+rm -f bundle.Dockerfile
+
+# ── 7. Build FBC catalog ────────────────────────────────────────────────────
+echo -e "${YELLOW}=== Phase 7: Building File-Based Catalog ===${NC}"
+cd "$PROJECT_DIR" || exit
+build_fbc_catalog "$INITIAL_VERSION" "" "$REGISTRY"
+
+# ── 8. Create ClusterCatalog ────────────────────────────────────────────────
+echo -e "${YELLOW}=== Phase 8: Creating ClusterCatalog ===${NC}"
+create_cluster_catalog "$INITIAL_VERSION" "$REGISTRY" "$cluster_name"
+
+# ── 9. Install Global Hub operator via ClusterExtension ─────────────────────
+echo -e "${YELLOW}=== Phase 9: Installing operator via ClusterExtension ===${NC}"
+install_operator_clusterextension "$GH_NAMESPACE" "$cluster_name"
+
+# ── 10. Create MulticlusterGlobalHub CR ─────────────────────────────────────
+echo -e "${YELLOW}=== Phase 10: Deploying MulticlusterGlobalHub ===${NC}"
+global_hub_node_ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "${cluster_name}-control-plane")
+
+cat <<EOF | kubectl apply --context "$cluster_name" -f -
+apiVersion: operator.open-cluster-management.io/v1alpha4
+kind: MulticlusterGlobalHub
+metadata:
+  annotations:
+    global-hub.open-cluster-management.io/strimzi-catalog-source-name: operatorhubio-catalog
+    global-hub.open-cluster-management.io/strimzi-catalog-source-namespace: olm
+    global-hub.open-cluster-management.io/kafka-use-nodeport: ""
+    global-hub.open-cluster-management.io/kind-cluster-ip: "${global_hub_node_ip}"
+  name: multiclusterglobalhub
+  namespace: ${GH_NAMESPACE}
+spec:
+  availabilityConfig: Basic
+  dataLayer:
+    kafka:
+      topics:
+        specTopic: gh-spec
+        statusTopic: gh-event.*
+      storageSize: 1Gi
+    postgres:
+      retention: 18m
+      storageSize: 1Gi
+  enableMetrics: false
+  imagePullPolicy: IfNotPresent
+EOF
+
+# Trap exit for debug on failure
+trap 'on_error' EXIT
+on_error() {
+  echo "Error occurred. Printing debug info..."
+
+  echo "=== ClusterExtension ==="
+  kubectl get clusterextension -oyaml --context "$cluster_name" || true
+
+  echo "=== ClusterCatalog ==="
+  kubectl get clustercatalog -oyaml --context "$cluster_name" || true
+
+  echo "=== Pods ==="
+  kubectl get pod -n "$GH_NAMESPACE" --context "$cluster_name" || true
+
+  echo "=== MCGH ==="
+  kubectl get mcgh -n "$GH_NAMESPACE" -oyaml --context "$cluster_name" || true
+
+  echo "=== Operator Logs ==="
+  kubectl logs deploy/multicluster-global-hub-operator -n "$GH_NAMESPACE" --context "$cluster_name" --tail=50 || true
+
+  echo "=== Deployments ==="
+  kubectl get deploy -n "$GH_NAMESPACE" --context "$cluster_name" || true
+}
+
+# ── 11. Wait for components ─────────────────────────────────────────────────
+echo -e "${YELLOW}=== Phase 11: Waiting for components ===${NC}"
+wait_cmd "kubectl get deploy/multicluster-global-hub-operator -n $GH_NAMESPACE --context $cluster_name"
+wait_cmd "kubectl get deploy/multicluster-global-hub-manager -n $GH_NAMESPACE --context $cluster_name"
+kubectl wait deploy/multicluster-global-hub-manager -n "$GH_NAMESPACE" --for condition=Available=True --timeout=180s --context "$cluster_name"
+
+# Restore default behavior
+trap - EXIT
+
+echo -e "${GREEN}=== OLMv1 E2E setup complete in $(($(date +%s) - start)) seconds ===${NC}"
+echo -e "${GREEN}Operator installed via: ClusterExtension${NC}"
+echo -e "${GREEN}Catalog served via:     ClusterCatalog (catalogd)${NC}"
+echo -e "${GREEN}OLMv0 coexistence:      Strimzi Kafka via Subscription${NC}"

--- a/test/script/olmv1_e2e_upgrade.sh
+++ b/test/script/olmv1_e2e_upgrade.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+set -euo pipefail
+
+CURRENT_DIR=$(
+  cd "$(dirname "$0")" || exit
+  pwd
+)
+# shellcheck source=/dev/null
+source "$CURRENT_DIR/util.sh"
+
+cluster_name="global-hub-olmv1"
+GH_NAMESPACE="multicluster-global-hub"
+REGISTRY="localhost:5001"
+OLD_VERSION="5.0.0"
+NEW_VERSION="5.0.1"
+
+echo -e "${YELLOW}=== OLMv1 Upgrade Test: v${OLD_VERSION} → v${NEW_VERSION} ===${NC}"
+
+# ── 1. Verify current version ──────────────────────────────────────────────
+echo -e "${YELLOW}Verifying current operator version...${NC}"
+current_version=$(verify_operator_version "$cluster_name")
+echo -e "Current version: ${current_version}"
+
+# ── 2. Build bundle v5.0.1 ─────────────────────────────────────────────────
+echo -e "${YELLOW}Building bundle v${NEW_VERSION}...${NC}"
+cd "$PROJECT_DIR/operator" || exit
+
+# Save original bundle and build the new version
+cp -r bundle bundle-backup
+
+VERSION="${NEW_VERSION}" RELEASE_LINE="5.0" make bundle || true
+
+# Update CSV replaces field for upgrade edge
+sed -i "/^  name: multicluster-global-hub-operator.v${NEW_VERSION}/a\\  replaces: multicluster-global-hub-operator.v${OLD_VERSION}" \
+  bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml 2>/dev/null || true
+
+# Build and push the new bundle image
+cat > bundle.Dockerfile <<'BEOF'
+FROM scratch
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=multicluster-global-hub-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=release-5.0
+LABEL operators.operatorframework.io.bundle.channel.default.v1=release-5.0
+COPY bundle/manifests /manifests/
+COPY bundle/metadata /metadata/
+BEOF
+docker build -f bundle.Dockerfile -t "${REGISTRY}/ghub-bundle:v${NEW_VERSION}" .
+docker push "${REGISTRY}/ghub-bundle:v${NEW_VERSION}"
+rm -f bundle.Dockerfile
+
+# Restore original bundle
+rm -rf bundle
+mv bundle-backup bundle
+
+# ── 3. Build upgrade catalog (contains both versions) ──────────────────────
+echo -e "${YELLOW}Building upgrade catalog...${NC}"
+cd "$PROJECT_DIR" || exit
+build_fbc_catalog_upgrade "$NEW_VERSION" "$OLD_VERSION" "$REGISTRY"
+
+# ── 4. Update ClusterCatalog to trigger upgrade ────────────────────────────
+echo -e "${YELLOW}Updating ClusterCatalog to trigger upgrade...${NC}"
+update_cluster_catalog "$NEW_VERSION" "$REGISTRY" "$cluster_name"
+
+# ── 5. Wait for upgrade to complete ────────────────────────────────────────
+echo -e "${YELLOW}Waiting for operator upgrade...${NC}"
+# operator-controller detects the new catalog content and upgrades
+kubectl wait clusterextension/multicluster-global-hub-operator \
+  --for=condition=Installed=True --timeout=300s --context "$cluster_name"
+
+# ── 6. Verify new version ──────────────────────────────────────────────────
+echo -e "${YELLOW}Verifying upgraded version...${NC}"
+new_version=$(verify_operator_version "$cluster_name")
+echo -e "Upgraded version: ${new_version}"
+
+# ── 7. Verify components are still healthy ──────────────────────────────────
+echo -e "${YELLOW}Verifying components are healthy post-upgrade...${NC}"
+wait_cmd "kubectl get deploy/multicluster-global-hub-operator -n $GH_NAMESPACE --context $cluster_name"
+kubectl wait deploy/multicluster-global-hub-operator -n "$GH_NAMESPACE" \
+  --for=condition=Available=True --timeout=120s --context "$cluster_name"
+
+wait_cmd "kubectl get deploy/multicluster-global-hub-manager -n $GH_NAMESPACE --context $cluster_name"
+kubectl wait deploy/multicluster-global-hub-manager -n "$GH_NAMESPACE" \
+  --for=condition=Available=True --timeout=120s --context "$cluster_name"
+
+echo -e "${GREEN}=== Upgrade test passed: v${OLD_VERSION} → v${NEW_VERSION} ===${NC}"

--- a/test/script/util.sh
+++ b/test/script/util.sh
@@ -645,6 +645,269 @@ enable_olm() {
   ./install.sh v0.28.0
 }
 
+# OLMv1 component versions
+export CERT_MANAGER_VERSION=${CERT_MANAGER_VERSION:-v1.16.2}
+export OLMV1_VERSION=${OLMV1_VERSION:-v1.2.1}
+
+install_olmv1() {
+  local context="$1"
+  echo -e "${YELLOW}Installing OLMv1 components on ${context}${NC}"
+  kubectl config use-context "$context"
+
+  # cert-manager is a prerequisite for catalogd and operator-controller
+  echo -e "${YELLOW}Installing cert-manager ${CERT_MANAGER_VERSION}${NC}"
+  kubectl apply -f "https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml"
+  kubectl wait --for=condition=Available deploy --all -n cert-manager --timeout=120s
+
+  # Install operator-controller (includes catalogd)
+  echo -e "${YELLOW}Installing operator-controller ${OLMV1_VERSION}${NC}"
+  kubectl apply -f "https://github.com/operator-framework/operator-controller/releases/download/${OLMV1_VERSION}/operator-controller.yaml"
+  kubectl wait --for=condition=Available deploy --all -n olmv1-system --timeout=120s
+
+  echo -e "${GREEN}OLMv1 components installed successfully${NC}"
+}
+
+start_local_registry() {
+  local registry_name="${1:-kind-registry}"
+  if docker inspect "$registry_name" &>/dev/null; then
+    echo -e "${YELLOW}Registry ${registry_name} already running${NC}"
+    return 0
+  fi
+  echo -e "${YELLOW}Starting local Docker registry: ${registry_name}${NC}"
+  docker run -d --name "$registry_name" --network kind -p 5001:5000 registry:2
+  echo -e "${GREEN}Local registry started at localhost:5001${NC}"
+}
+
+stop_local_registry() {
+  local registry_name="${1:-kind-registry}"
+  docker stop "$registry_name" 2>/dev/null && docker rm "$registry_name" 2>/dev/null || true
+}
+
+build_fbc_catalog() {
+  local version="$1"
+  local replaces="${2:-}"
+  local registry="${3:-localhost:5001}"
+  local catalog_dir
+  catalog_dir=$(mktemp -d)
+  local bundle_img="${registry}/ghub-bundle:v${version}"
+  local catalog_img="${registry}/ghub-catalog:v${version}"
+
+  echo -e "${YELLOW}Building FBC catalog for version ${version}${NC}"
+
+  # Render the bundle image into FBC JSON
+  opm render "$bundle_img" -o yaml > "${catalog_dir}/catalog.yaml"
+
+  # Append package and channel entries
+  local channel_entry="    - name: multicluster-global-hub-operator.v${version}"
+  if [[ -n "$replaces" ]]; then
+    channel_entry="${channel_entry}
+      replaces: ${replaces}"
+  fi
+
+  cat >> "${catalog_dir}/catalog.yaml" <<EOF
+---
+schema: olm.package
+name: multicluster-global-hub-operator
+defaultChannel: release-5.0
+---
+schema: olm.channel
+package: multicluster-global-hub-operator
+name: release-5.0
+entries:
+${channel_entry}
+EOF
+
+  opm validate "${catalog_dir}"
+
+  # Build catalog image with opm serve as entrypoint
+  cat > "${catalog_dir}/Dockerfile" <<DEOF
+FROM registry.access.redhat.com/ubi9/ubi-micro:latest
+COPY catalog.yaml /configs/catalog.yaml
+LABEL operators.operatorframework.io.index.configs.v1=/configs
+DEOF
+
+  docker build -t "$catalog_img" "$catalog_dir"
+  docker push "$catalog_img"
+  rm -rf "$catalog_dir"
+
+  echo -e "${GREEN}FBC catalog image pushed: ${catalog_img}${NC}"
+}
+
+build_fbc_catalog_upgrade() {
+  local new_version="$1"
+  local old_version="$2"
+  local registry="${3:-localhost:5001}"
+  local catalog_dir
+  catalog_dir=$(mktemp -d)
+  local old_bundle_img="${registry}/ghub-bundle:v${old_version}"
+  local new_bundle_img="${registry}/ghub-bundle:v${new_version}"
+  local catalog_img="${registry}/ghub-catalog:v${new_version}"
+
+  echo -e "${YELLOW}Building upgrade FBC catalog: v${old_version} → v${new_version}${NC}"
+
+  # Render both bundle images into FBC
+  opm render "$old_bundle_img" -o yaml > "${catalog_dir}/catalog.yaml"
+  echo "---" >> "${catalog_dir}/catalog.yaml"
+  opm render "$new_bundle_img" -o yaml >> "${catalog_dir}/catalog.yaml"
+
+  # Append package and channel with upgrade edge
+  cat >> "${catalog_dir}/catalog.yaml" <<EOF
+---
+schema: olm.package
+name: multicluster-global-hub-operator
+defaultChannel: release-5.0
+---
+schema: olm.channel
+package: multicluster-global-hub-operator
+name: release-5.0
+entries:
+    - name: multicluster-global-hub-operator.v${old_version}
+    - name: multicluster-global-hub-operator.v${new_version}
+      replaces: multicluster-global-hub-operator.v${old_version}
+EOF
+
+  opm validate "${catalog_dir}"
+
+  cat > "${catalog_dir}/Dockerfile" <<DEOF
+FROM registry.access.redhat.com/ubi9/ubi-micro:latest
+COPY catalog.yaml /configs/catalog.yaml
+LABEL operators.operatorframework.io.index.configs.v1=/configs
+DEOF
+
+  docker build -t "$catalog_img" "$catalog_dir"
+  docker push "$catalog_img"
+  rm -rf "$catalog_dir"
+
+  echo -e "${GREEN}Upgrade catalog image pushed: ${catalog_img}${NC}"
+}
+
+create_cluster_catalog() {
+  local version="$1"
+  local registry="${2:-localhost:5001}"
+  local catalog_img="${registry}/ghub-catalog:v${version}"
+  local context="${3:-}"
+
+  echo -e "${YELLOW}Creating ClusterCatalog for ${catalog_img}${NC}"
+
+  local ctx_flag=""
+  if [[ -n "$context" ]]; then
+    ctx_flag="--context $context"
+  fi
+
+  kubectl apply $ctx_flag -f - <<EOF
+apiVersion: olm.operatorframework.io/v1
+kind: ClusterCatalog
+metadata:
+  name: global-hub-catalog
+spec:
+  source:
+    type: Image
+    image:
+      ref: ${catalog_img}
+      pollInterval: 10s
+EOF
+
+  kubectl wait $ctx_flag clustercatalog/global-hub-catalog --for=condition=Serving=True --timeout=120s
+  echo -e "${GREEN}ClusterCatalog is serving${NC}"
+}
+
+update_cluster_catalog() {
+  local version="$1"
+  local registry="${2:-localhost:5001}"
+  local catalog_img="${registry}/ghub-catalog:v${version}"
+  local context="${3:-}"
+
+  echo -e "${YELLOW}Updating ClusterCatalog to ${catalog_img}${NC}"
+
+  local ctx_flag=""
+  if [[ -n "$context" ]]; then
+    ctx_flag="--context $context"
+  fi
+
+  kubectl patch $ctx_flag clustercatalog/global-hub-catalog --type=merge -p \
+    "{\"spec\":{\"source\":{\"image\":{\"ref\":\"${catalog_img}\"}}}}"
+
+  sleep 5
+  kubectl wait $ctx_flag clustercatalog/global-hub-catalog --for=condition=Serving=True --timeout=120s
+  echo -e "${GREEN}ClusterCatalog updated and serving${NC}"
+}
+
+install_operator_clusterextension() {
+  local namespace="${1:-multicluster-global-hub}"
+  local context="${2:-}"
+
+  echo -e "${YELLOW}Installing Global Hub operator via ClusterExtension${NC}"
+
+  local ctx_flag=""
+  if [[ -n "$context" ]]; then
+    ctx_flag="--context $context"
+  fi
+
+  kubectl create namespace "$namespace" $ctx_flag --dry-run=client -o yaml | kubectl apply $ctx_flag -f -
+
+  # ServiceAccount for the installer
+  kubectl apply $ctx_flag -f - <<EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: global-hub-installer
+  namespace: ${namespace}
+EOF
+
+  # ClusterRoleBinding
+  kubectl apply $ctx_flag -f - <<EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: global-hub-installer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: global-hub-installer
+    namespace: ${namespace}
+EOF
+
+  # ClusterExtension
+  kubectl apply $ctx_flag -f - <<EOF
+apiVersion: olm.operatorframework.io/v1
+kind: ClusterExtension
+metadata:
+  name: multicluster-global-hub-operator
+spec:
+  namespace: ${namespace}
+  serviceAccount:
+    name: global-hub-installer
+  source:
+    sourceType: Catalog
+    catalog:
+      packageName: multicluster-global-hub-operator
+      channels:
+        - release-5.0
+EOF
+
+  echo -e "${YELLOW}Waiting for ClusterExtension to be installed...${NC}"
+  kubectl wait $ctx_flag clusterextension/multicluster-global-hub-operator \
+    --for=condition=Installed=True --timeout=300s
+  echo -e "${GREEN}Global Hub operator installed via ClusterExtension${NC}"
+}
+
+verify_operator_version() {
+  local context="${1:-}"
+  local ctx_flag=""
+  if [[ -n "$context" ]]; then
+    ctx_flag="--context $context"
+  fi
+
+  kubectl get $ctx_flag clusterextension/multicluster-global-hub-operator \
+    -o jsonpath='{.status.install.bundle.version}' 2>/dev/null || \
+  kubectl get $ctx_flag clusterextension/multicluster-global-hub-operator \
+    -o jsonpath='{.status.installedBundle.version}' 2>/dev/null || \
+  echo "unknown"
+}
+
 wait_secret_ready() {
   secretName=$1
   secretNamespace=$2


### PR DESCRIPTION
## Summary
- Add comprehensive OLMv1 test infrastructure for Global Hub operator validation
- Install and upgrade operator via ClusterExtension (OLMv1) instead of Subscription (OLMv0)
- Build and serve File-Based Catalogs via catalogd
- Demonstrate OLMv0/OLMv1 coexistence (Strimzi via OLMv0, Global Hub via OLMv1)
- Validate full component bring-up (Kafka, Postgres, Manager, Grafana)

## Related issue(s)
Jira: ACM-39126 (part of epic ACM-31637)

## Implementation Details

### Helper Functions Added to test/script/util.sh
- install_olmv1() - Install cert-manager, catalogd, operator-controller
- start_local_registry() / stop_local_registry() - Docker registry on kind network
- build_fbc_catalog() / build_fbc_catalog_upgrade() - File-Based Catalog with opm
- create_cluster_catalog() / update_cluster_catalog() - ClusterCatalog CR management  
- install_operator_clusterextension() - Operator install via ClusterExtension
- verify_operator_version() - Extract operator version from status

### Test Scripts
- olmv1_e2e_setup.sh: KinD cluster, OLMv0+OLMv1 install, images, catalog, operator
- olmv1_e2e_upgrade.sh: v5.0.0 → v5.0.1 upgrade via catalog update
- olmv1_e2e_run.sh: Validate operator, manager, Kafka, Postgres, Grafana health
- olmv1_e2e_cleanup.sh: Teardown KinD and registry

### Makefile Targets
- olmv1-e2e-setup, olmv1-e2e-run, olmv1-e2e-upgrade, olmv1-e2e-cleanup
- olmv1-e2e-test-all: Full pipeline

## Tests
- [ ] Manual testing: make olmv1-e2e-test-all
- [ ] Validates OLMv1 components (catalogd, operator-controller)
- [ ] Validates operator install via ClusterExtension
- [ ] Validates upgrade v5.0.0 → v5.0.1
- [ ] Validates component health (manager, Kafka, Postgres, Grafana)
- [ ] Validates OLMv0/OLMv1 coexistence

## Supports ACM-31637
OLM v1 GA validation requirement for Operator Framework compatibility

Signed-off-by: Mihir Lele <mlele@redhat.com>
Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>