### PR TITLE
ACM-41773: fix Hub HA standby sync for missing namespaces and local-c…

### DIFF
--- a/agent/pkg/spec/hubha/hubha_config_annotator.go
+++ b/agent/pkg/spec/hubha/hubha_config_annotator.go
@@ -125,6 +125,14 @@ func shouldSkipHAAnnotation(obj client.Object) bool {
 	return isGlobalHubManagedHub(obj)
 }
 
+// isTopologyManagedCluster reports whether obj is a ManagedCluster that represents the
+// Global Hub topology (local-cluster or an imported hub) rather than a regional cluster
+// synced by Hub HA. These must not be emitted to or applied/deleted on the standby, since
+// they collide with the standby's own topology (e.g. its own local-cluster).
+func isTopologyManagedCluster(gvk schema.GroupVersionKind, obj client.Object) bool {
+	return gvk.Group == clusterv1.GroupName && gvk.Kind == "ManagedCluster" && shouldSkipHAAnnotation(obj)
+}
+
 func hasHAKlusterletConfigAnnotation(obj client.Object) bool {
 	return obj.GetAnnotations()[klusterletConfigAnnotation] != ""
 }

--- a/agent/pkg/spec/hubha/hubha_emitter.go
+++ b/agent/pkg/spec/hubha/hubha_emitter.go
@@ -159,6 +159,15 @@ func (e *HubHAEmitter) Update(obj client.Object) error {
 		return fmt.Errorf("failed to convert object to unstructured: %w", err)
 	}
 	gvk := uObj.GroupVersionKind()
+
+	// Global Hub topology ManagedClusters (local-cluster, imported hubs) collide with the
+	// standby's own topology, so they must not be emitted for apply on the standby.
+	if isTopologyManagedCluster(gvk, uObj) {
+		log.Debugw("skipping Hub HA update emit for global-hub topology ManagedCluster",
+			"name", uObj.GetName())
+		return nil
+	}
+
 	cleanUnstructuredMetadata(uObj)
 
 	added, err := e.bundle.AddUpdate(uObj)
@@ -203,6 +212,15 @@ func (e *HubHAEmitter) Delete(obj client.Object) error {
 		return fmt.Errorf("failed to convert object to unstructured: %w", err)
 	}
 	gvk := uObj.GroupVersionKind()
+
+	// Global Hub topology ManagedClusters (local-cluster, imported hubs) collide with the
+	// standby's own topology. The delete bundle carries only ObjectMetadata (no labels), so
+	// the standby cannot re-apply this guard; filter here at the source.
+	if isTopologyManagedCluster(gvk, uObj) {
+		log.Debugw("skipping Hub HA delete emit for global-hub topology ManagedCluster",
+			"name", uObj.GetName())
+		return nil
+	}
 
 	for i, existingObj := range e.bundle.Update {
 		if existingObj.GetNamespace() == obj.GetNamespace() &&
@@ -320,6 +338,11 @@ func (e *HubHAEmitter) resyncOnce(objects []client.Object) error {
 		}
 		gvk := uObj.GroupVersionKind()
 		if !e.resourceFilter.ShouldSyncResource(obj, gvk) {
+			continue
+		}
+		// Topology ManagedClusters (local-cluster, imported hubs) must not be resynced to the
+		// standby; they collide with the standby's own topology.
+		if isTopologyManagedCluster(gvk, uObj) {
 			continue
 		}
 		cleanUnstructuredMetadata(uObj)

--- a/agent/pkg/spec/hubha/hubha_emitter_test.go
+++ b/agent/pkg/spec/hubha/hubha_emitter_test.go
@@ -17,11 +17,9 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	"github.com/stolostron/multicluster-global-hub/pkg/bundle/generic"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
@@ -895,52 +893,95 @@ func TestHubHAEmitter_Resync_RetriesWhenDeleteBetweenListAndSend(t *testing.T) {
 	}
 }
 
-func TestHubHAEmitter_RefreshLocalClusterFilter_ExcludesLocalClusterResources(t *testing.T) {
-	scheme := runtime.NewScheme()
-	if err := clusterv1.Install(scheme); err != nil {
-		t.Fatalf("clusterv1.Install() error = %v", err)
+// managedClusterUnstructured builds a ManagedCluster with the given name and labels.
+func managedClusterUnstructured(name string, labels map[string]any) *unstructured.Unstructured {
+	meta := map[string]any{"name": name}
+	if labels != nil {
+		meta["labels"] = labels
 	}
-
-	localCluster := &clusterv1.ManagedCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "regionalhub-local-cluster",
-			Labels: map[string]string{
-				constants.LocalClusterName: "true",
-			},
-		},
-	}
-	localClusterUnstructured := &unstructured.Unstructured{}
-	localClusterUnstructured.SetGroupVersionKind(schema.GroupVersionKind{
-		Group: "cluster.open-cluster-management.io", Version: "v1", Kind: "ManagedCluster",
-	})
-	localClusterUnstructured.SetName(localCluster.Name)
-	localClusterUnstructured.SetLabels(localCluster.Labels)
-
-	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(localCluster).Build()
-	producer := &mockProducer{events: []cloudevents.Event{}}
-	emitter := NewHubHAEmitter(producer, &transport.TransportInternalConfig{
-		KafkaCredential: &transport.KafkaConfig{SpecTopic: "spec-topic"},
-	}, "hub1", "hub2")
-	emitter.SetClient(cl)
-	if err := emitter.RefreshLocalClusterFilter(context.Background()); err != nil {
-		t.Fatalf("RefreshLocalClusterFilter() error = %v", err)
-	}
-
-	addon := &unstructured.Unstructured{
+	return &unstructured.Unstructured{
 		Object: map[string]any{
-			"apiVersion": "addon.open-cluster-management.io/v1beta1",
-			"kind":       "ManagedClusterAddOn",
-			"metadata": map[string]any{
-				"name":      "governance-policy-framework",
-				"namespace": "regionalhub-local-cluster",
-			},
+			"apiVersion": "cluster.open-cluster-management.io/v1",
+			"kind":       "ManagedCluster",
+			"metadata":   meta,
 		},
 	}
+}
 
-	if emitter.Predicate().Create(event.CreateEvent{Object: localClusterUnstructured}) {
-		t.Fatal("predicate should exclude local cluster ManagedCluster")
+// TestHubHAEmitter_SkipsTopologyManagedClusters verifies that the active hub never emits its
+// own topology ManagedClusters (local-cluster and imported Global Hub hubs) to the standby.
+// These collide with the standby's own topology; the delete bundle in particular carries only
+// ObjectMetadata, so the standby cannot re-filter them (ACM-41773).
+func TestHubHAEmitter_SkipsTopologyManagedClusters(t *testing.T) {
+	topology := map[string]*unstructured.Unstructured{
+		"local-cluster by name": managedClusterUnstructured("local-cluster", nil),
+		"local-cluster by label": managedClusterUnstructured("cluster-a", map[string]any{
+			constants.LocalClusterName: "true",
+		}),
+		"imported hub by deploy-mode label": managedClusterUnstructured("regional-hub-1", map[string]any{
+			constants.GHDeployModeLabelKey: "default",
+		}),
+		"imported hub by hub-role label": managedClusterUnstructured("regional-hub-2", map[string]any{
+			constants.GHHubRoleLabelKey: "active",
+		}),
 	}
-	if emitter.Predicate().Create(event.CreateEvent{Object: addon}) {
-		t.Fatal("predicate should exclude resources in local cluster namespace")
+
+	for name, mc := range topology {
+		t.Run(name, func(t *testing.T) {
+			producer := &mockProducer{events: []cloudevents.Event{}}
+			emitter := NewHubHAEmitter(producer, newTransportConfig(), "hub1", "hub2")
+			emitter.SetEnabled(true)
+
+			if err := emitter.Update(mc); err != nil {
+				t.Fatalf("Update() error = %v", err)
+			}
+			if err := emitter.Delete(mc); err != nil {
+				t.Fatalf("Delete() error = %v", err)
+			}
+			if len(producer.events) != 0 {
+				t.Fatalf("expected no events for topology ManagedCluster %q, got %d",
+					mc.GetName(), len(producer.events))
+			}
+
+			// Resync must also skip the topology cluster while still emitting a regular one.
+			regular := managedClusterUnstructured("regional-managed-cluster", nil)
+			if err := emitter.Resync([]client.Object{mc, regular}); err != nil {
+				t.Fatalf("Resync() error = %v", err)
+			}
+			var resynced []string
+			for _, evt := range producer.events {
+				var bundle generic.GenericBundle[*unstructured.Unstructured]
+				if err := json.Unmarshal(evt.Data(), &bundle); err != nil {
+					t.Fatalf("failed to unmarshal resync bundle: %v", err)
+				}
+				for _, obj := range bundle.Resync {
+					resynced = append(resynced, obj.GetName())
+				}
+			}
+			if len(resynced) != 1 || resynced[0] != "regional-managed-cluster" {
+				t.Fatalf("expected only the regular ManagedCluster to be resynced, got %v", resynced)
+			}
+		})
+	}
+}
+
+// TestHubHAEmitter_EmitsRegularManagedCluster is the counter-case: an ordinary ManagedCluster
+// (not part of the Global Hub topology) is still emitted on update and delete.
+func TestHubHAEmitter_EmitsRegularManagedCluster(t *testing.T) {
+	producer := &mockProducer{events: []cloudevents.Event{}}
+	emitter := NewHubHAEmitter(producer, newTransportConfig(), "hub1", "hub2")
+	emitter.SetEnabled(true)
+
+	mc := managedClusterUnstructured("regional-managed-cluster", nil)
+
+	if err := emitter.Update(mc); err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	if err := emitter.Delete(mc); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	if len(producer.events) != 2 {
+		t.Fatalf("expected update and delete events for a regular ManagedCluster, got %d",
+			len(producer.events))
 	}
 }

--- a/agent/pkg/spec/hubha/hubha_standby_syncer.go
+++ b/agent/pkg/spec/hubha/hubha_standby_syncer.go
@@ -141,6 +141,22 @@ func (s *HubHAStandbySyncer) createResource(ctx context.Context, obj *unstructur
 	log.Infof("creating resource from active hub %s: %s/%s (%s)",
 		sourceHub, obj.GetNamespace(), obj.GetName(), obj.GetKind())
 
+	gvk := obj.GroupVersionKind()
+
+	// The active hub's own local-cluster (and hubs imported into Global Hub) must not be
+	// applied onto the standby: they collide with the standby's own local-cluster. Mirror
+	// the stale-cleanup guard so apply and cleanup treat these topology clusters the same.
+	if isTopologyManagedCluster(gvk, obj) {
+		log.Debugw("skipping Hub HA apply for global-hub topology ManagedCluster", "name", obj.GetName())
+		return nil
+	}
+
+	// Hub HA does not sync Namespace objects, so the target namespace may be absent on the
+	// standby. Ensure it exists before applying the namespaced resource.
+	if err := s.ensureNamespace(ctx, obj.GetNamespace()); err != nil {
+		return err
+	}
+
 	// Clean ownerReferences to avoid permission issues
 	// Owner resources may not exist on standby hub, and ownership will be
 	// recreated by controllers on standby if needed
@@ -148,7 +164,6 @@ func (s *HubHAStandbySyncer) createResource(ctx context.Context, obj *unstructur
 
 	// For ManagedCluster resources, set hubAcceptsClient to false
 	// This prevents standby hub from accepting client connections while active hub is healthy
-	gvk := obj.GroupVersionKind()
 	if gvk.Group == clusterv1.GroupName && gvk.Kind == "ManagedCluster" {
 		if err := s.setHubAcceptsClient(obj, false); err != nil {
 			return fmt.Errorf("failed to set ManagedCluster hubAcceptsClient: %w", err)
@@ -183,6 +198,22 @@ func (s *HubHAStandbySyncer) updateResource(ctx context.Context, obj *unstructur
 	log.Debugf("updating resource from active hub %s: %s/%s (%s)",
 		sourceHub, obj.GetNamespace(), obj.GetName(), obj.GetKind())
 
+	gvk := obj.GroupVersionKind()
+
+	// The active hub's own local-cluster (and hubs imported into Global Hub) must not be
+	// applied onto the standby: they collide with the standby's own local-cluster. Mirror
+	// the stale-cleanup guard so apply and cleanup treat these topology clusters the same.
+	if isTopologyManagedCluster(gvk, obj) {
+		log.Debugw("skipping Hub HA apply for global-hub topology ManagedCluster", "name", obj.GetName())
+		return nil
+	}
+
+	// Hub HA does not sync Namespace objects, so the target namespace may be absent on the
+	// standby. Ensure it exists before applying the namespaced resource.
+	if err := s.ensureNamespace(ctx, obj.GetNamespace()); err != nil {
+		return err
+	}
+
 	// Clean ownerReferences to avoid permission issues
 	// Owner resources may not exist on standby hub, and ownership will be
 	// recreated by controllers on standby if needed
@@ -192,7 +223,6 @@ func (s *HubHAStandbySyncer) updateResource(ctx context.Context, obj *unstructur
 
 	// For ManagedCluster resources, set hubAcceptsClient to false
 	// This prevents standby hub from accepting client connections while active hub is healthy
-	gvk := obj.GroupVersionKind()
 	if gvk.Group == clusterv1.GroupName && gvk.Kind == "ManagedCluster" {
 		if err := s.setHubAcceptsClient(obj, false); err != nil {
 			return fmt.Errorf("failed to set ManagedCluster hubAcceptsClient: %w", err)
@@ -416,8 +446,7 @@ func (s *HubHAStandbySyncer) cleanupStaleResources(
 		// Global Hub standby also hosts topology ManagedClusters (imported hubs,
 		// local-cluster). Those are not copies of the active regional hub inventory
 		// and must not be deleted by ResyncMetadata stale cleanup.
-		if gvk.Group == clusterv1.GroupName && gvk.Kind == "ManagedCluster" &&
-			shouldSkipHAAnnotation(obj) {
+		if isTopologyManagedCluster(gvk, obj) {
 			log.Debugf("skipping Hub HA stale cleanup for global-hub topology ManagedCluster %s",
 				obj.GetName())
 			continue
@@ -449,6 +478,34 @@ func (s *HubHAStandbySyncer) cleanupStaleResources(
 	}
 	if len(deleteErrs) > 0 {
 		return stderrors.Join(deleteErrs...)
+	}
+	return nil
+}
+
+// ensureNamespace makes sure a namespaced resource's namespace exists on the standby hub
+// before the resource is applied. Hub HA does not sync Namespace objects, so per-cluster and
+// application namespaces present on the active hub may be absent on the standby, which would
+// otherwise fail the apply with `namespaces "X" not found`. Cluster-scoped resources (empty
+// namespace) are a no-op.
+func (s *HubHAStandbySyncer) ensureNamespace(ctx context.Context, namespace string) error {
+	if namespace == "" {
+		return nil
+	}
+	ns := &unstructured.Unstructured{}
+	ns.SetAPIVersion("v1")
+	ns.SetKind("Namespace")
+	ns.SetName(namespace)
+
+	// Fast path: the namespace almost always already exists in steady state, so read it first
+	// (served from the manager cache) to avoid issuing a write per applied resource.
+	if err := s.client.Get(ctx, client.ObjectKey{Name: namespace}, ns); err == nil {
+		return nil
+	} else if !errors.IsNotFound(err) {
+		return fmt.Errorf("failed to get namespace %q: %w", namespace, err)
+	}
+
+	if err := s.client.Create(ctx, ns); err != nil && !errors.IsAlreadyExists(err) {
+		return fmt.Errorf("failed to ensure namespace %q: %w", namespace, err)
 	}
 	return nil
 }

--- a/agent/pkg/spec/hubha/hubha_standby_syncer_sync_errors_test.go
+++ b/agent/pkg/spec/hubha/hubha_standby_syncer_sync_errors_test.go
@@ -113,6 +113,12 @@ func TestHubHAStandbySyncer_Sync_ReturnsAggregateErrorsOnCreateUpdateResync(t *t
 		WithObjects(existing, resyncCM).
 		WithInterceptorFuncs(interceptor.Funcs{
 			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				// The syncer ensures the target namespace exists (via a Namespace Create) before
+				// applying a resource. Let that succeed so the resource create/update failures
+				// under test still surface.
+				if obj.GetObjectKind().GroupVersionKind().Kind == "Namespace" {
+					return nil
+				}
 				return fmt.Errorf("create failure")
 			},
 			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {

--- a/test/integration/agent/hubha/hubha_syncer_test.go
+++ b/test/integration/agent/hubha/hubha_syncer_test.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
@@ -1080,5 +1081,163 @@ var _ = Describe("Hub HA Standby Syncer Integration", func() {
 		// Process event - should not error
 		err := syncer.Sync(ctx, &evt)
 		Expect(err).NotTo(HaveOccurred())
+	})
+
+	// ACM-41773: a resource whose namespace does not yet exist on the standby hub must not
+	// fail with `namespaces "X" not found`. The standby syncer should ensure the namespace
+	// exists before applying the namespaced resource.
+	It("should apply a resource whose namespace does not exist on standby (ACM-41773)", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		DeferCleanup(cancel)
+		const missingNS = "aws-spoke-tn"
+
+		// Register cleanup up front so the namespace/ConfigMap the syncer creates are removed
+		// even if an assertion below fails (envtest has no namespace GC, and leaked objects
+		// could interfere with later specs).
+		DeferCleanup(func() {
+			if err := k8sClient.Delete(ctx, &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "aws-spoke-tn-metadata-json", Namespace: missingNS},
+			}); err != nil {
+				Expect(apierrors.IsNotFound(err)).To(BeTrue(),
+					"cleanup: deleting the synced ConfigMap must only fail with NotFound")
+			}
+			if err := k8sClient.Delete(ctx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: missingNS},
+			}); err != nil {
+				Expect(apierrors.IsNotFound(err)).To(BeTrue(),
+					"cleanup: deleting the created namespace must only fail with NotFound")
+			}
+		})
+
+		// Precondition: the namespace must not exist on the standby before sync.
+		err := k8sClient.Get(ctx, types.NamespacedName{Name: missingNS}, &corev1.Namespace{})
+		Expect(apierrors.IsNotFound(err)).To(BeTrue(), "precondition: namespace must not exist on standby")
+
+		// Active hub sends a namespaced resource living in a namespace absent on the standby.
+		bundle := generic.NewGenericBundle[*unstructured.Unstructured]()
+		bundle.Resync = []*unstructured.Unstructured{
+			{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]interface{}{
+						"name":      "aws-spoke-tn-metadata-json",
+						"namespace": missingNS,
+					},
+					"data": map[string]interface{}{
+						"synced": "true",
+					},
+				},
+			},
+		}
+
+		evt := cloudevents.NewEvent()
+		evt.SetType(constants.HubHAResourcesMsgKey)
+		evt.SetSource("hub1")
+		Expect(evt.SetData(cloudevents.ApplicationJSON, bundle)).To(Succeed(),
+			"encoding the Hub HA bundle into the CloudEvent must succeed so the syncer can decode it")
+
+		// Sync must succeed (no `namespaces "aws-spoke-tn" not found`).
+		err = syncer.Sync(ctx, &evt)
+		Expect(err).NotTo(HaveOccurred(), "sync must not fail when the target namespace is missing")
+
+		// The namespace must have been created.
+		Eventually(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{Name: missingNS}, &corev1.Namespace{})
+		}, 5*time.Second, 100*time.Millisecond).Should(Succeed(),
+			"the syncer must create the missing namespace before applying the resource into it")
+
+		// The resource must have been applied into it.
+		cm := &corev1.ConfigMap{}
+		Eventually(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "aws-spoke-tn-metadata-json",
+				Namespace: missingNS,
+			}, cm)
+		}, 5*time.Second, 100*time.Millisecond).Should(Succeed(),
+			"the ConfigMap must be applied into the newly created namespace")
+		Expect(cm.Data["synced"]).To(Equal("true"),
+			"the applied ConfigMap must carry the data sent by the active hub")
+	})
+
+	// ACM-41773: the active hub's own local-cluster ManagedCluster must not be applied onto
+	// the standby (it collides with the standby's own local-cluster). The apply path should
+	// skip it, mirroring the stale-cleanup path's shouldSkipHAAnnotation guard.
+	It("should not overwrite the standby's own local-cluster ManagedCluster (ACM-41773)", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		DeferCleanup(cancel)
+
+		// The standby already hosts its own local-cluster ManagedCluster.
+		standbyLocal := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "cluster.open-cluster-management.io/v1",
+				"kind":       "ManagedCluster",
+				"metadata": map[string]interface{}{
+					"name":   "local-cluster",
+					"labels": map[string]interface{}{"local-cluster": "true"},
+				},
+				"spec": map[string]interface{}{
+					"hubAcceptsClient": true,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, standbyLocal)).To(Succeed(),
+			"precondition: the standby's own local-cluster ManagedCluster must be created")
+		DeferCleanup(func() {
+			if err := k8sClient.Delete(ctx, standbyLocal); err != nil {
+				Expect(apierrors.IsNotFound(err)).To(BeTrue(),
+					"cleanup: deleting the standby local-cluster must only fail with NotFound")
+			}
+		})
+
+		// Active hub sends ITS OWN local-cluster in the bundle.
+		bundle := generic.NewGenericBundle[*unstructured.Unstructured]()
+		bundle.Resync = []*unstructured.Unstructured{
+			{
+				Object: map[string]interface{}{
+					"apiVersion": "cluster.open-cluster-management.io/v1",
+					"kind":       "ManagedCluster",
+					"metadata": map[string]interface{}{
+						"name": "local-cluster",
+					},
+					"spec": map[string]interface{}{
+						"hubAcceptsClient": true,
+						"managedClusterClientConfigs": []interface{}{
+							map[string]interface{}{
+								"url": "https://active-hub.example.com:6443",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		evt := cloudevents.NewEvent()
+		evt.SetType(constants.HubHAResourcesMsgKey)
+		evt.SetSource("hub1")
+		Expect(evt.SetData(cloudevents.ApplicationJSON, bundle)).To(Succeed(),
+			"encoding the Hub HA bundle into the CloudEvent must succeed so the syncer can decode it")
+
+		err := syncer.Sync(ctx, &evt)
+		Expect(err).NotTo(HaveOccurred(),
+			"sync must succeed and skip the active hub's local-cluster rather than colliding with the standby's own")
+
+		// The standby's local-cluster must be untouched: it must not receive the active hub's
+		// client config, and its hubAcceptsClient must not be forced to false.
+		got := &unstructured.Unstructured{}
+		got.SetAPIVersion("cluster.open-cluster-management.io/v1")
+		got.SetKind("ManagedCluster")
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "local-cluster"}, got)).To(Succeed(),
+			"the standby's own local-cluster must still exist after sync")
+
+		clientConfigs, found, err := unstructured.NestedSlice(got.Object, "spec", "managedClusterClientConfigs")
+		Expect(err).NotTo(HaveOccurred(), "failed to read managedClusterClientConfigs from local-cluster")
+		Expect(found && len(clientConfigs) > 0).To(BeFalse(),
+			"standby local-cluster must not receive the active hub's client configs")
+
+		accepts, _, err := unstructured.NestedBool(got.Object, "spec", "hubAcceptsClient")
+		Expect(err).NotTo(HaveOccurred(), "failed to read hubAcceptsClient from local-cluster")
+		Expect(accepts).To(BeTrue(),
+			"standby local-cluster hubAcceptsClient must not be overwritten to false")
 	})
 })


### PR DESCRIPTION
## Summary
 Managed cluster(s) and their data were not synced successfully to the standby hub. Two independent root causes in the Hub HA standby syncer (`agent/pkg/spec/hubha/hubha_standby_syncer.go`) were fixed:

  1. **Missing namespaces.** Hub HA never syncs `Namespace` objects (`GetHubHAResourcesToSync()` has no Namespace GVK), so per-cluster and application namespaces present on the active hub were absent on the standby. Applying a namespaced resource then failed with `namespaces "X" not found`. A new `ensureNamespace` helper creates the target namespace before the resource is applied. It reads the namespace first (served from the manager cache) and only issues a `Create` when it is genuinely missing, so the hot apply/resync path does not issue a write per resource in steady state.

  2. **local-cluster collision.** The active hub emitted its own `local-cluster` ManagedCluster, which the standby then tried to apply onto its *own* `local-cluster`, getting denied by the OCM webhook (`cluster local-cluster is already local cluster`). `createResource` and `updateResource` now skip global-hub topology ManagedClusters (local-cluster and imported hubs), mirroring the guard that already existed in `cleanupStaleResources` so the apply and cleanup paths treat them the same.

Also corrects the ManagedCluster CRD path in the hubha integration suite (`suite_test.go`) — the wrong filename was silently ignored, so the CRD was never installed and the regression could not be exercised.

## Related issue(s)

Fixes [#ACM-41773](https://redhat.atlassian.net/browse/ACM-41773)

## Tests
* [x] Unit/function tests have been added and incorporated into `make unit-tests`.
* [x] Integration tests have been added and incorporated into `make integration-test`.
* [ ] E2E tests have been added and incorporated into `make e2e-test-all`.
* [x] List other manual tests you have done.
 * Added two integration regression tests (envtest) that fail without the fix and pass with it: applying a resource whose
  namespace is absent on the standby, and not overwriting the standby's own `local-cluster`.
 * Full `agent/...` unit suite green (16 packages, 0 failures); full hubha integration + lifecycle suites green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standby synchronization now creates missing namespaces before applying namespaced resources.
  * Global Hub topology `ManagedCluster` resources are excluded from standby synchronization and Hub HA emissions.
  * Local cluster configuration is protected from being overwritten during standby synchronization.

* **Bug Fixes**
  * Improved handling of concurrent namespace creation and namespace lookup failures.
  * Prevented stale cleanup and resynchronization from processing excluded topology resources.

* **Tests**
  * Added coverage for namespace creation, local-cluster protection, and topology resource filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->