### PR TITLE
ACM-40370: restrict migration topic ACL to active migration hubs

### DIFF
--- a/manager/pkg/migration/migration_controller.go
+++ b/manager/pkg/migration/migration_controller.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	cecontext "github.com/cloudevents/sdk-go/v2/context"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -56,8 +58,9 @@ var log = logger.DefaultZapLogger()
 type ClusterMigrationController struct {
 	client.Client
 	transport.Producer
-	EventRecorder record.EventRecorder
-	Scheme        *runtime.Scheme
+	EventRecorder  record.EventRecorder
+	Scheme         *runtime.Scheme
+	migrationTopic string
 }
 
 var migrationCtrl *ClusterMigrationController
@@ -66,11 +69,18 @@ func AddMigrationToManager(mgr ctrl.Manager, producer transport.Producer, manage
 	if migrationCtrl != nil {
 		return nil
 	}
+
+	var migrationTopic string
+	if managerConfig.TransportConfig != nil && managerConfig.TransportConfig.KafkaCredential != nil {
+		migrationTopic = managerConfig.TransportConfig.KafkaCredential.GetMigrationTopic()
+	}
+
 	migrationController := &ClusterMigrationController{
-		Client:        mgr.GetClient(),
-		Producer:      producer,
-		EventRecorder: mgr.GetEventRecorderFor("migration-event-recorder"),
-		Scheme:        mgr.GetScheme(),
+		Client:         mgr.GetClient(),
+		Producer:       producer,
+		EventRecorder:  mgr.GetEventRecorderFor("migration-event-recorder"),
+		Scheme:         mgr.GetScheme(),
+		migrationTopic: migrationTopic,
 	}
 
 	err := migrationController.SetupWithManager(mgr)
@@ -284,7 +294,7 @@ func (m *ClusterMigrationController) sendEventToTargetHub(ctx context.Context,
 	eventType := string(enum.ManagedClusterMigrationType)
 	evt := utils.ToMigrationEvent(eventType, constants.CloudEventGlobalHubClusterName, migration.Spec.To,
 		migrationId, stage, getTimeout(stage), payloadToBytes)
-	if err := m.SendEvent(ctx, evt); err != nil {
+	if err := m.sendMigrationEvent(ctx, evt); err != nil {
 		return fmt.Errorf("failed to sync managedclustermigration event(%s) from source(%s) to destination(%s) - %w",
 			eventType, constants.CloudEventGlobalHubClusterName, migration.Spec.To, err)
 	}
@@ -322,6 +332,13 @@ func getTimeout(stage string) time.Duration {
 	default:
 		return migratingTimeout
 	}
+}
+
+func (m *ClusterMigrationController) sendMigrationEvent(ctx context.Context, evt cloudevents.Event) error {
+	if m.migrationTopic != "" {
+		ctx = cecontext.WithTopic(ctx, m.migrationTopic)
+	}
+	return m.SendEvent(ctx, evt)
 }
 
 func setRetry(mcm *migrationv1alpha1.ManagedClusterMigration, stage string, condType string, hubName string) {

--- a/manager/pkg/migration/migration_initializing.go
+++ b/manager/pkg/migration/migration_initializing.go
@@ -178,11 +178,11 @@ func (m *ClusterMigrationController) handleStatusWithRollback(ctx context.Contex
 	}
 }
 
-// sendEventToSourceHub specifies the manager send the message into "From Hub" via spec path(or topic)
-// Stage is the expected state for migration, it algin with the condition states
+// sendEventToSourceHub sends a migration event to the source hub via the dedicated migration topic.
+// Stage is the expected state for migration, it aligns with the condition states:
 // 1. ResourceInitialized: request sync the klusterletconfig from source hub
 // 2. ClusterRegistered: forward bootstrap kubeconfig secret into source hub, to register into the destination hub
-// 3. ResourceDeployed: delete the resourcesailed to mark the stage ResourceDeploye from the source hub
+// 3. ResourceDeployed: delete the resources to mark the stage ResourceDeployed from the source hub
 // 4. MigrationCompleted: delete the items from the database
 func (m *ClusterMigrationController) sendEventToSourceHub(ctx context.Context, fromHub string,
 	migration *migrationv1alpha1.ManagedClusterMigration, stage string, managedClusters []string,
@@ -206,7 +206,7 @@ func (m *ClusterMigrationController) sendEventToSourceHub(ctx context.Context, f
 	eventType := string(enum.ManagedClusterMigrationType)
 	evt := utils.ToMigrationEvent(eventType, constants.CloudEventGlobalHubClusterName, fromHub,
 		migrationId, stage, getTimeout(stage), payloadBytes)
-	if err := m.SendEvent(ctx, evt); err != nil {
+	if err := m.sendMigrationEvent(ctx, evt); err != nil {
 		return fmt.Errorf("failed to sync managedclustermigration event(%s) from source(%s) to destination(%s) - %w",
 			eventType, constants.CloudEventGlobalHubClusterName, fromHub, err)
 	}
@@ -229,12 +229,12 @@ func (m *ClusterMigrationController) ensureManagedServiceAccount(ctx context.Con
 			Rotation: v1beta1.ManagedServiceAccountRotation{
 				Enabled: true,
 				// The MSA token is embedded in the bootstrap kubeconfig
-				// that is broadcast on the shared gh-spec topic to which
-				// every managed hub holds a Read ACL, so it must be
-				// short-lived. 24h comfortably covers all migration
-				// stage timeouts (5–12 min each) and matches the spec
-				// topic's default retention; the MSA itself is removed
-				// in the cleaning phase.
+				// sent via the dedicated gh-migration topic (CVE-2026-71577).
+				// Read ACL on gh-migration is granted only to hubs
+				// involved in an active migration, limiting exposure.
+				// 24h validity covers all migration stage timeouts
+				// (5–12 min each); the MSA itself is removed in the
+				// cleaning phase.
 				Validity: metav1.Duration{
 					Duration: 24 * time.Hour,
 				},

--- a/operator/pkg/controllers/transporter/migration_acl_reconciler.go
+++ b/operator/pkg/controllers/transporter/migration_acl_reconciler.go
@@ -60,17 +60,24 @@ func (r *MigrationACLReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		if apierrors.IsNotFound(err) {
 			// Migration was deleted; re-sync all managed hub KafkaUsers so revoked ACLs
 			// are cleaned up even though the trigger object's Spec.From is gone.
-			return ctrl.Result{}, r.syncAllMigrationWriteACLs(ctx, mgh, req.Namespace)
+			if err := r.syncAllMigrationACLs(ctx, mgh, req.Namespace); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{}, nil
 		}
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("get ManagedClusterMigration %s: %w", req.NamespacedName, err)
 	}
 
 	if err := r.syncMigrationWriteACLs(ctx, mgh, req.Namespace, migration.Spec.From); err != nil {
 		return ctrl.Result{}, err
 	}
+	if err := r.syncMigrationReadACLs(ctx, mgh, req.Namespace, migration.Spec.From, migration.Spec.To); err != nil {
+		return ctrl.Result{}, err
+	}
 	if migration.Status.Phase == migrationv1alpha1.PhaseDeploying {
-		migrationACLLog.Infow("synced migration write ACLs",
-			"migration", req.Name, "fromHub", migration.Spec.From, "phase", migration.Status.Phase)
+		migrationACLLog.Infow("synced migration ACLs",
+			"migration", req.Name, "fromHub", migration.Spec.From,
+			"toHub", migration.Spec.To, "phase", migration.Status.Phase)
 	}
 	return ctrl.Result{}, nil
 }
@@ -97,7 +104,38 @@ func (r *MigrationACLReconciler) syncMigrationWriteACLs(
 	return nil
 }
 
-func (r *MigrationACLReconciler) syncAllMigrationWriteACLs(
+func (r *MigrationACLReconciler) syncMigrationReadACLs(
+	ctx context.Context,
+	mgh *operatorv1alpha4.MulticlusterGlobalHub,
+	namespace string,
+	triggerFromHub, triggerToHub string,
+) error {
+	list := &migrationv1alpha1.ManagedClusterMigrationList{}
+	if err := r.List(ctx, list, client.InNamespace(namespace)); err != nil {
+		return fmt.Errorf("failed to list ManagedClusterMigration resources: %w", err)
+	}
+
+	needed := activeMigrationHubs(list)
+	hubsToSync := sets.NewString()
+	if triggerFromHub != "" {
+		hubsToSync.Insert(triggerFromHub)
+	}
+	if triggerToHub != "" {
+		hubsToSync.Insert(triggerToHub)
+	}
+	for hub := range needed {
+		hubsToSync.Insert(hub)
+	}
+	for _, hub := range hubsToSync.UnsortedList() {
+		_, grant := needed[hub]
+		if err := protocol.SyncMigrationReadACL(r.mgr, mgh, hub, grant, protocol.WithContext(ctx)); err != nil {
+			return fmt.Errorf("failed to sync migration read ACL for hub %q: %w", hub, err)
+		}
+	}
+	return nil
+}
+
+func (r *MigrationACLReconciler) syncAllMigrationACLs(
 	ctx context.Context,
 	mgh *operatorv1alpha4.MulticlusterGlobalHub,
 	namespace string,
@@ -106,7 +144,8 @@ func (r *MigrationACLReconciler) syncAllMigrationWriteACLs(
 	if err := r.List(ctx, list, client.InNamespace(namespace)); err != nil {
 		return fmt.Errorf("failed to list ManagedClusterMigration resources: %w", err)
 	}
-	needed := deployingSourceHubs(list)
+	writeNeeded := deployingSourceHubs(list)
+	readNeeded := activeMigrationHubs(list)
 
 	kafkaUsers := &kafkav1beta2.KafkaUserList{}
 	if err := r.List(ctx, kafkaUsers, client.InNamespace(namespace)); err != nil {
@@ -114,13 +153,17 @@ func (r *MigrationACLReconciler) syncAllMigrationWriteACLs(
 	}
 
 	for i := range kafkaUsers.Items {
-		fromHub, ok := managedHubFromKafkaUser(&kafkaUsers.Items[i])
+		hub, ok := managedHubFromKafkaUser(&kafkaUsers.Items[i])
 		if !ok {
 			continue
 		}
-		_, grant := needed[fromHub]
-		if err := protocol.SyncMigrationWriteACL(r.mgr, mgh, fromHub, grant, protocol.WithContext(ctx)); err != nil {
-			return fmt.Errorf("failed to sync migration write ACL for hub %q: %w", fromHub, err)
+		_, grantWrite := writeNeeded[hub]
+		if err := protocol.SyncMigrationWriteACL(r.mgr, mgh, hub, grantWrite, protocol.WithContext(ctx)); err != nil {
+			return fmt.Errorf("failed to sync migration write ACL for hub %q: %w", hub, err)
+		}
+		_, grantRead := readNeeded[hub]
+		if err := protocol.SyncMigrationReadACL(r.mgr, mgh, hub, grantRead, protocol.WithContext(ctx)); err != nil {
+			return fmt.Errorf("failed to sync migration read ACL for hub %q: %w", hub, err)
 		}
 	}
 	return nil
@@ -152,6 +195,23 @@ func hubsToSyncForMigration(fromHub string, needed map[string]struct{}) []string
 		hubs.Insert(hub)
 	}
 	return hubs.UnsortedList()
+}
+
+func activeMigrationHubs(list *migrationv1alpha1.ManagedClusterMigrationList) map[string]struct{} {
+	needed := make(map[string]struct{})
+	for i := range list.Items {
+		mcm := &list.Items[i]
+		if mcm.DeletionTimestamp != nil {
+			continue
+		}
+		switch mcm.Status.Phase {
+		case migrationv1alpha1.PhaseCompleted, migrationv1alpha1.PhaseFailed:
+			continue
+		}
+		needed[mcm.Spec.From] = struct{}{}
+		needed[mcm.Spec.To] = struct{}{}
+	}
+	return needed
 }
 
 func managedHubFromKafkaUser(user *kafkav1beta2.KafkaUser) (string, bool) {

--- a/operator/pkg/controllers/transporter/migration_acl_reconciler_test.go
+++ b/operator/pkg/controllers/transporter/migration_acl_reconciler_test.go
@@ -349,10 +349,18 @@ func newMigrationACLReconcilerFixtures(
 			),
 		},
 	}
+	kafkaUser2 := &kafkav1beta2.KafkaUser{
+		ObjectMeta: metav1.ObjectMeta{Name: "hub2-kafka-user", Namespace: "test-ns"},
+		Spec: &kafkav1beta2.KafkaUserSpec{
+			Authorization: simpleKafkaUserAuthorization(
+				utils.ReadTopicACL("gh-spec", false),
+			),
+		},
+	}
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
-		WithObjects(mgh, kafkaUser).
+		WithObjects(mgh, kafkaUser, kafkaUser2).
 		Build()
 
 	return scheme, fakeClient, mgh, kafkaUser

--- a/operator/pkg/controllers/transporter/protocol/migration_acl.go
+++ b/operator/pkg/controllers/transporter/protocol/migration_acl.go
@@ -32,3 +32,16 @@ func SyncMigrationWriteACL(
 	trans := NewStrimziTransporter(mgr, mgh, opts...)
 	return trans.SyncMigrationWriteACL(fromHub, grant)
 }
+
+// SyncMigrationReadACL grants or revokes Read+Describe on the migration topic
+// for a hub involved in an active migration.
+func SyncMigrationReadACL(
+	mgr ctrl.Manager,
+	mgh *operatorv1alpha4.MulticlusterGlobalHub,
+	hub string,
+	grant bool,
+	opts ...KafkaOption,
+) error {
+	trans := NewStrimziTransporter(mgr, mgh, opts...)
+	return trans.SyncMigrationReadACL(hub, grant)
+}

--- a/operator/pkg/controllers/transporter/protocol/strimzi_hubha_acl_test.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_hubha_acl_test.go
@@ -343,7 +343,7 @@ func TestIsObsoleteManagedHubACL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isObsoleteManagedHubACL(tt.acl, specTopic); got != tt.want {
+			if got := isObsoleteManagedHubACL(tt.acl, specTopic, "gh-migration"); got != tt.want {
 				t.Fatalf("isObsoleteManagedHubACL() = %v, want %v", got, tt.want)
 			}
 		})
@@ -353,7 +353,7 @@ func TestIsObsoleteManagedHubACL(t *testing.T) {
 func TestFilterObsoleteManagedHubACLsEmptyInput(t *testing.T) {
 	t.Parallel()
 
-	if got := filterObsoleteManagedHubACLs(nil, "gh-spec"); got != nil {
+	if got := filterObsoleteManagedHubACLs(nil, "gh-spec", "gh-migration"); got != nil {
 		t.Fatalf("filterObsoleteManagedHubACLs(nil) = %#v, want nil", got)
 	}
 }
@@ -372,7 +372,7 @@ func TestFilterObsoleteManagedHubACLPreservesHubHAWrite(t *testing.T) {
 	filtered := filterObsoleteManagedHubACLs([]kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
 		legacyACL,
 		hubHAWriteACL,
-	}, specTopic)
+	}, specTopic, "gh-migration")
 
 	if len(filtered) != 1 {
 		t.Fatalf("expected one ACL after filtering legacy combined gh-spec Write, got %d", len(filtered))

--- a/operator/pkg/controllers/transporter/protocol/strimzi_migration_acl.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_migration_acl.go
@@ -31,6 +31,10 @@ func migrationWriteACLKey(topic string) string {
 	return utils.GenerateACLKey(utils.WriteTopicACL(topic))
 }
 
+func migrationReadACLKey(topic string) string {
+	return utils.GenerateACLKey(utils.ReadTopicACL(topic, false))
+}
+
 func (k *strimziTransporter) hasMigrationWriteACL(acls []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem) bool {
 	key := migrationWriteACLKey(config.GetMigrationTopic())
 	for _, acl := range acls {
@@ -41,13 +45,45 @@ func (k *strimziTransporter) hasMigrationWriteACL(acls []kafkav1beta2.KafkaUserS
 	return false
 }
 
+func (k *strimziTransporter) hasMigrationReadACL(acls []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem) bool {
+	key := migrationReadACLKey(config.GetMigrationTopic())
+	for _, acl := range acls {
+		if utils.GenerateACLKey(acl) == key {
+			return true
+		}
+	}
+	return false
+}
+
 // SyncMigrationWriteACL grants or revokes Write on the migration topic for a source hub.
 func (k *strimziTransporter) SyncMigrationWriteACL(fromHub string, grant bool) error {
-	if fromHub == "" {
+	return k.syncMigrationACL(fromHub, grant, k.hasMigrationWriteACL,
+		migrationWriteACLKey, utils.WriteTopicACL)
+}
+
+// SyncMigrationReadACL grants or revokes Read+Describe on the migration topic for a hub
+// involved in an active migration.
+func (k *strimziTransporter) SyncMigrationReadACL(hub string, grant bool) error {
+	return k.syncMigrationACL(hub, grant, k.hasMigrationReadACL,
+		migrationReadACLKey, func(topic string) kafkav1beta2.KafkaUserSpecAuthorizationAclsElem {
+			return utils.ReadTopicACL(topic, false)
+		})
+}
+
+// syncMigrationACL is the shared implementation for granting/revoking a single ACL
+// type (Read or Write) on the migration topic for a given hub's KafkaUser.
+func (k *strimziTransporter) syncMigrationACL(
+	hub string,
+	grant bool,
+	hasACL func([]kafkav1beta2.KafkaUserSpecAuthorizationAclsElem) bool,
+	keyFn func(string) string,
+	aclFn func(string) kafkav1beta2.KafkaUserSpecAuthorizationAclsElem,
+) error {
+	if hub == "" {
 		return nil
 	}
 
-	userName := config.GetKafkaUserName(fromHub)
+	userName := config.GetKafkaUserName(hub)
 	kafkaUser := &kafkav1beta2.KafkaUser{}
 	err := k.manager.GetClient().Get(k.ctx, types.NamespacedName{
 		Name:      userName,
@@ -57,14 +93,14 @@ func (k *strimziTransporter) SyncMigrationWriteACL(fromHub string, grant bool) e
 		if !grant {
 			return nil
 		}
-		return fmt.Errorf("kafka user %s not found for migration write ACL", userName)
+		return fmt.Errorf("kafka user %s not found for migration ACL", userName)
 	}
 	if err != nil {
-		return err
+		return fmt.Errorf("get KafkaUser %s/%s: %w", k.kafkaClusterNamespace, userName, err)
 	}
 
 	migrationTopic := config.GetMigrationTopic()
-	desiredWriteACL := utils.WriteTopicACL(migrationTopic)
+	desiredACL := aclFn(migrationTopic)
 
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		latestKafkaUser := &kafkav1beta2.KafkaUser{}
@@ -76,19 +112,19 @@ func (k *strimziTransporter) SyncMigrationWriteACL(fromHub string, grant bool) e
 		}
 
 		currentACLs := currentKafkaUserACLs(latestKafkaUser)
-		if k.hasMigrationWriteACL(currentACLs) == grant {
+		if hasACL(currentACLs) == grant {
 			return nil
 		}
 
 		updatedACLs := make([]kafkav1beta2.KafkaUserSpecAuthorizationAclsElem, 0, len(currentACLs))
 		for _, acl := range currentACLs {
-			if utils.GenerateACLKey(acl) == migrationWriteACLKey(migrationTopic) {
+			if utils.GenerateACLKey(acl) == keyFn(migrationTopic) {
 				continue
 			}
 			updatedACLs = append(updatedACLs, acl)
 		}
 		if grant {
-			updatedACLs = append(updatedACLs, desiredWriteACL)
+			updatedACLs = append(updatedACLs, desiredACL)
 		}
 
 		if len(updatedACLs) == 0 {

--- a/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
@@ -390,11 +390,8 @@ func managedHubUserACLs(clusterTopic *transport.ClusterTopic, consumerGroupID st
 			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
 			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
 		}),
-		// consume migration deploying bundles from the dedicated migration topic
-		utils.GetTopicACL(clusterTopic.MigrationTopic, []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
-			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
-			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
-		}),
+		// Migration topic ACLs (read + write) are granted dynamically by the
+		// MigrationACLReconciler only to hubs involved in an active migration.
 		// report status into gh: allow the current hub to write messages to the specific status topic
 		utils.GetTopicACL(clusterTopic.StatusTopic, []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
 			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite,
@@ -446,7 +443,8 @@ func (k *strimziTransporter) EnsureUser(clusterName string) (string, error) {
 			return err
 		}
 		// combine the acls of kafkaUser and the desired acls of desiredKafkaUser
-		existingACLs := filterObsoleteManagedHubACLs(currentKafkaUserACLs(latestKafkaUser), clusterTopic.SpecTopic)
+		existingACLs := filterObsoleteManagedHubACLs(currentKafkaUserACLs(latestKafkaUser),
+			clusterTopic.SpecTopic, clusterTopic.MigrationTopic)
 		updatedKafkaUser.Spec.Authorization.Acls = combineACLs(existingACLs,
 			desiredKafkaUser.Spec.Authorization.Acls)
 
@@ -465,7 +463,7 @@ func (k *strimziTransporter) EnsureUser(clusterName string) (string, error) {
 
 func filterObsoleteManagedHubACLs(
 	acls []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem,
-	specTopic string,
+	specTopic, migrationTopic string,
 ) []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem {
 	if len(acls) == 0 {
 		return nil
@@ -473,7 +471,7 @@ func filterObsoleteManagedHubACLs(
 
 	filtered := make([]kafkav1beta2.KafkaUserSpecAuthorizationAclsElem, 0, len(acls))
 	for _, acl := range acls {
-		if isObsoleteManagedHubACL(acl, specTopic) {
+		if isObsoleteManagedHubACL(acl, specTopic, migrationTopic) {
 			continue
 		}
 		filtered = append(filtered, acl)
@@ -481,7 +479,7 @@ func filterObsoleteManagedHubACLs(
 	return filtered
 }
 
-func isObsoleteManagedHubACL(acl kafkav1beta2.KafkaUserSpecAuthorizationAclsElem, specTopic string) bool {
+func isObsoleteManagedHubACL(acl kafkav1beta2.KafkaUserSpecAuthorizationAclsElem, specTopic, migrationTopic string) bool {
 	if acl.Resource.Name == nil {
 		return false
 	}
@@ -490,15 +488,30 @@ func isObsoleteManagedHubACL(acl kafkav1beta2.KafkaUserSpecAuthorizationAclsElem
 	case kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeGroup:
 		return *acl.Resource.Name == "*"
 	case kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic:
-		if *acl.Resource.Name != specTopic {
-			return false
+		if *acl.Resource.Name == specTopic {
+			// Legacy managed-hub ACL bundled Describe+Read+Write on gh-spec.
+			// Write-only entries are managed by the Hub HA ACL watcher.
+			return topicACLHasLegacyCombinedWrite(acl.Operations)
 		}
-		// Legacy managed-hub ACL bundled Describe+Read+Write on gh-spec.
-		// Write-only entries are managed by the Hub HA ACL watcher.
-		return topicACLHasLegacyCombinedWrite(acl.Operations)
+		if *acl.Resource.Name == migrationTopic {
+			// CVE-2026-71577: strip legacy static Read+Describe on the migration topic.
+			// Write-only ACLs are preserved (managed by MigrationACLReconciler).
+			return !topicACLIsWriteOnly(acl.Operations)
+		}
 	}
 
 	return false
+}
+
+func topicACLIsWriteOnly(
+	operations []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem,
+) bool {
+	for _, op := range operations {
+		if op != kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite {
+			return false
+		}
+	}
+	return len(operations) > 0
 }
 
 func topicACLHasLegacyCombinedWrite(

--- a/operator/pkg/controllers/transporter/protocol/strimzi_transporter_test.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_transporter_test.go
@@ -617,8 +617,10 @@ func TestManagedHubUserACLs(t *testing.T) {
 	}
 	acls := managedHubUserACLs(clusterTopic, "hub1")
 
-	if len(acls) != 4 {
-		t.Fatalf("expected 4 ACLs, got %d", len(acls))
+	// 3 ACLs: consumer-group, gh-spec (read-only), gh-status (write).
+	// Migration topic ACLs are granted dynamically by MigrationACLReconciler.
+	if len(acls) != 3 {
+		t.Fatalf("expected 3 ACLs, got %d", len(acls))
 	}
 
 	groupACL, ok := findGroupACL(acls, "hub1")
@@ -650,20 +652,10 @@ func TestManagedHubUserACLs(t *testing.T) {
 		},
 	)
 
-	migrationACL, ok := findTopicACL(acls, clusterTopic.MigrationTopic)
-	if !ok {
-		t.Fatal("expected gh-migration topic ACL")
+	// Migration topic ACL must NOT be statically granted (CVE-2026-71577).
+	if _, ok := findTopicACL(acls, clusterTopic.MigrationTopic); ok {
+		t.Fatal("migration topic ACL must not be statically granted; it is managed dynamically")
 	}
-	assertACLContract(
-		t, migrationACL,
-		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic,
-		clusterTopic.MigrationTopic,
-		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypeLiteral,
-		[]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
-			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
-			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
-		},
-	)
 
 	statusACL, ok := findTopicACL(acls, clusterTopic.StatusTopic)
 	if !ok {
@@ -696,9 +688,10 @@ func TestCombineManagedHubACLsUpgrade(t *testing.T) {
 			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite,
 		}),
 		utils.WriteTopicACL(clusterTopic.MigrationTopic),
+		utils.ReadTopicACL(clusterTopic.MigrationTopic, false),
 	}
 
-	merged := combineACLs(filterObsoleteManagedHubACLs(legacyACLs, clusterTopic.SpecTopic),
+	merged := combineACLs(filterObsoleteManagedHubACLs(legacyACLs, clusterTopic.SpecTopic, clusterTopic.MigrationTopic),
 		managedHubUserACLs(clusterTopic, "hub1"))
 
 	hasWildcardGroup, specOps, migrationOps := collectManagedHubACLTopicOps(merged, clusterTopic)
@@ -741,27 +734,20 @@ func TestCombineManagedHubACLsUpgrade(t *testing.T) {
 		}
 	}
 
-	migrationReadACL, ok := findTopicACLWithOperations(
+	// Migration Read ACL must NOT be statically granted after upgrade (CVE-2026-71577).
+	// It is managed dynamically by MigrationACLReconciler.
+	_, hasStaticMigrationRead := findTopicACLWithOperations(
 		merged, clusterTopic.MigrationTopic,
 		[]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
 			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
 			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
 		},
 	)
-	if !ok {
-		t.Fatal("expected gh-migration Describe+Read ACL after upgrade")
+	if hasStaticMigrationRead {
+		t.Fatal("migration topic Read ACL must not be statically granted after upgrade")
 	}
-	assertACLContract(
-		t, migrationReadACL,
-		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic,
-		clusterTopic.MigrationTopic,
-		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypeLiteral,
-		[]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
-			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
-			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
-		},
-	)
 
+	// Migration Write ACL from the MigrationACLReconciler must be preserved.
 	migrationWriteACL, ok := findTopicACLWithOperations(
 		merged, clusterTopic.MigrationTopic,
 		[]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
@@ -780,8 +766,8 @@ func TestCombineManagedHubACLsUpgrade(t *testing.T) {
 			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite,
 		},
 	)
-	if !containsOperation(migrationOps, kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead) {
-		t.Fatal("managed hub must retain Read on gh-migration after upgrade")
+	if containsOperation(migrationOps, kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead) {
+		t.Fatal("migration topic Read ACL must not be statically retained after upgrade (CVE-2026-71577)")
 	}
 }
 

--- a/test/integration/operator/controllers/transporter_test.go
+++ b/test/integration/operator/controllers/transporter_test.go
@@ -520,7 +520,7 @@ func expectManagedHubKafkaUserACLs(
 	clusterName string,
 	consumerGroupPrefix string,
 ) {
-	Expect(len(kafkaUser.Spec.Authorization.Acls)).To(Equal(4), "managed hub KafkaUser should have four ACL entries")
+	Expect(len(kafkaUser.Spec.Authorization.Acls)).To(Equal(3), "managed hub KafkaUser should have three ACL entries")
 
 	aclByTopic := map[string][]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{}
 	consumerGroupACLs := []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{}
@@ -547,11 +547,10 @@ func expectManagedHubKafkaUserACLs(
 	Expect(specOps).NotTo(ContainElement(kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite),
 		"gh-spec ACL must not grant Write to managed hubs")
 
-	migrationOps := aclByTopic[config.GetMigrationTopic()]
-	Expect(migrationOps).To(ConsistOf(
-		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
-		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
-	), "gh-migration ACL should grant Describe and Read for managed hub consumers")
+	// Migration topic Read ACL must NOT be statically granted (CVE-2026-71577).
+	// It is managed dynamically by MigrationACLReconciler.
+	Expect(aclByTopic).NotTo(HaveKey(config.GetMigrationTopic()),
+		"migration topic ACL must not be statically granted; it is managed dynamically")
 
 	statusOps := aclByTopic[config.GetStatusTopic(clusterName)]
 	Expect(statusOps).To(Equal([]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{


### PR DESCRIPTION
## Summary

- Remove static Read+Describe ACL on `gh-migration` from every managed-hub KafkaUser; migration topic ACLs are now granted dynamically by the `MigrationACLReconciler` only to hubs involved in an active migration.
- Route all migration events (bootstrap kubeconfigs, deploying bundles) through the dedicated `gh-migration` topic via `cecontext.WithTopic`, so they are never exposed on the shared `gh-spec` topic.
- Refactor `SyncMigrationWriteACL` into a shared `syncMigrationACL` implementation and add `SyncMigrationReadACL` for dynamic Read ACL management.

## Why this fix is needed

During `ManagedClusterMigration`, the manager sends a bootstrap kubeconfig containing an MSA bearer token to the source hub. Two issues made this a security risk:

1. **Every hub could read migration data.** Every managed hub's KafkaUser was given a permanent Read+Describe ACL on the `gh-migration` topic at provisioning time. Hubs completely uninvolved in any migration could consume messages and see bootstrap kubeconfigs meant for other hubs.

2. **Migration events also went on the shared `gh-spec` topic.** `sendEventToSourceHub` and `sendEventToTargetHub` called `m.SendEvent()` directly, which publishes to `gh-spec` — the default producer topic that every hub has Read access to.

A compromised managed hub could passively consume either topic, intercept bootstrap kubeconfigs for other hubs, extract the MSA token, and use it to impersonate the destination hub.

## What changed and why all three changes are required together

| Change | Why it's needed |
|--------|----------------|
| **Remove static Read ACL** from `managedHubUserACLs` | Root cause — every hub having permanent Read on `gh-migration` means a compromised hub can always read migration data. Without this, the Kafka broker can't enforce isolation. |
| **Add dynamic Read ACL** via `MigrationACLReconciler` | Hubs involved in a migration still need to read `gh-migration`. `activeMigrationHubs()` grants Read only to `Spec.From` and `Spec.To` hubs during active phases, and revokes it on completion/failure/deletion. |
| **Route events to `gh-migration`** via `cecontext.WithTopic()` | Even with dynamic ACLs on `gh-migration`, if events are still published to `gh-spec`, the fix is incomplete — every hub reads `gh-spec` for normal operations. |

Without **all three** changes together, the vulnerability remains open:

- Keep static Read ACL + route to `gh-migration` → every hub still has Read on `gh-migration`
- Remove static Read ACL + keep events on `gh-spec` → events with bootstrap kubeconfigs are on `gh-spec` which every hub reads
- Remove static Read ACL + route to `gh-migration` + no dynamic grant → migration source/target hubs can't receive events, migration breaks

## Files changed

| File | Change |
|------|--------|
| `strimzi_transporter.go` | Remove static `gh-migration` Read+Describe ACL from `managedHubUserACLs()` |
| `strimzi_migration_acl.go` | Add `SyncMigrationReadACL`, `hasMigrationReadACL`; refactor into shared `syncMigrationACL` |
| `migration_acl.go` | Add public `SyncMigrationReadACL` wrapper |
| `migration_acl_reconciler.go` | Add `syncMigrationReadACLs`, `syncAllMigrationACLs`, `activeMigrationHubs` |
| `migration_acl_reconciler_test.go` | Add `hub2-kafka-user` fixture for Read ACL sync tests |
| `migration_controller.go` | Add `migrationTopic` field, `sendMigrationEvent` helper with `cecontext.WithTopic` |
| `migration_initializing.go` | Use `sendMigrationEvent` instead of `SendEvent`; update MSA comment |
| `strimzi_transporter_test.go` | Update `TestManagedHubUserACLs` and `TestCombineManagedHubACLsUpgrade` to assert dynamic ACL behavior |

## Test plan
- [x] `TestManagedHubUserACLs` — verifies static ACLs no longer include migration topic
- [x] `TestCombineManagedHubACLsUpgrade` — verifies legacy migration Read ACL is removed on upgrade
- [x] `TestMigrationACLReconcilerReconcileDeployingGrantsACL` — verifies dynamic Write ACL grant
- [x] `TestMigrationACLReconcilerReconcileCompletedRevokesACL` — verifies ACL revocation on completion
- [x] `TestMigrationACLReconcilerReconcileNotFound` — verifies cleanup on migration deletion
- [x] All manager migration controller tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)