### PR TITLE
ACM-41771: Exclude regional local cluster from Hub HA pre-stage sync

### DIFF
--- a/agent/pkg/spec/hubha/hubha_config_annotator.go
+++ b/agent/pkg/spec/hubha/hubha_config_annotator.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/configs"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
 var klusterletConfigGVK = schema.GroupVersionKind{
@@ -118,7 +119,7 @@ func isActiveHub() bool {
 
 // shouldSkipHAAnnotation is true for local-cluster and hubs imported into Global Hub.
 func shouldSkipHAAnnotation(obj client.Object) bool {
-	if isLocalManagedCluster(obj) {
+	if utils.IsLocalManagedCluster(obj) {
 		return true
 	}
 	return isGlobalHubManagedHub(obj)
@@ -126,13 +127,6 @@ func shouldSkipHAAnnotation(obj client.Object) bool {
 
 func hasHAKlusterletConfigAnnotation(obj client.Object) bool {
 	return obj.GetAnnotations()[klusterletConfigAnnotation] != ""
-}
-
-func isLocalManagedCluster(obj client.Object) bool {
-	if obj.GetLabels()[constants.LocalClusterName] == "true" {
-		return true
-	}
-	return obj.GetName() == constants.LocalClusterName
 }
 
 func isGlobalHubManagedHub(obj client.Object) bool {

--- a/agent/pkg/spec/hubha/hubha_config_annotator_test.go
+++ b/agent/pkg/spec/hubha/hubha_config_annotator_test.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/stolostron/multicluster-global-hub/agent/pkg/configs"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
 func newAnnotatorTestScheme(t *testing.T) *runtime.Scheme {
@@ -357,11 +358,11 @@ func TestFindHAKlusterletConfigName(t *testing.T) {
 }
 
 func TestIsLocalManagedCluster(t *testing.T) {
-	assert.True(t, isLocalManagedCluster(&clusterv1.ManagedCluster{
+	assert.True(t, utils.IsLocalManagedCluster(&clusterv1.ManagedCluster{
 		ObjectMeta: metav1.ObjectMeta{Name: constants.LocalClusterName},
 	}), "name local-cluster should be treated as local")
 
-	assert.True(t, isLocalManagedCluster(&clusterv1.ManagedCluster{
+	assert.True(t, utils.IsLocalManagedCluster(&clusterv1.ManagedCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "acm-local-cluster",
 			Labels: map[string]string{
@@ -370,7 +371,7 @@ func TestIsLocalManagedCluster(t *testing.T) {
 		},
 	}), "local-cluster=true label should be treated as local")
 
-	assert.False(t, isLocalManagedCluster(&clusterv1.ManagedCluster{
+	assert.False(t, utils.IsLocalManagedCluster(&clusterv1.ManagedCluster{
 		ObjectMeta: metav1.ObjectMeta{Name: "ks"},
 	}), "regular managed cluster should not be treated as local")
 }

--- a/agent/pkg/spec/hubha/hubha_emitter.go
+++ b/agent/pkg/spec/hubha/hubha_emitter.go
@@ -93,6 +93,27 @@ func (e *HubHAEmitter) SetClient(c client.Client) {
 	e.client = c
 }
 
+// RefreshLocalClusterFilter resolves this hub's local cluster name and configures
+// the resource filter to exclude it from Hub HA pre-stage sync.
+func (e *HubHAEmitter) RefreshLocalClusterFilter(ctx context.Context) error {
+	e.mu.Lock()
+	cl := e.client
+	e.mu.Unlock()
+	if cl == nil {
+		return nil
+	}
+
+	name, err := utils.ResolveLocalClusterManagedClusterName(ctx, cl)
+	if err != nil {
+		return fmt.Errorf("failed to resolve local cluster name for Hub HA filter: %w", err)
+	}
+
+	e.mu.Lock()
+	e.resourceFilter.SetLocalClusterName(name)
+	e.mu.Unlock()
+	return nil
+}
+
 // SetEnabled controls whether the emitter sends events.
 // Set to true when the hub is in active role; false when standby or transitioning.
 func (e *HubHAEmitter) SetEnabled(enabled bool) {

--- a/agent/pkg/spec/hubha/hubha_emitter_test.go
+++ b/agent/pkg/spec/hubha/hubha_emitter_test.go
@@ -17,9 +17,11 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	"github.com/stolostron/multicluster-global-hub/pkg/bundle/generic"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
@@ -890,5 +892,55 @@ func TestHubHAEmitter_Resync_RetriesWhenDeleteBetweenListAndSend(t *testing.T) {
 	}
 	if sawResyncOfDeleted {
 		t.Fatal("stale snapshot must not resync or inventory-mark deleted object to-delete")
+	}
+}
+
+func TestHubHAEmitter_RefreshLocalClusterFilter_ExcludesLocalClusterResources(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := clusterv1.Install(scheme); err != nil {
+		t.Fatalf("clusterv1.Install() error = %v", err)
+	}
+
+	localCluster := &clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "regionalhub-local-cluster",
+			Labels: map[string]string{
+				constants.LocalClusterName: "true",
+			},
+		},
+	}
+	localClusterUnstructured := &unstructured.Unstructured{}
+	localClusterUnstructured.SetGroupVersionKind(schema.GroupVersionKind{
+		Group: "cluster.open-cluster-management.io", Version: "v1", Kind: "ManagedCluster",
+	})
+	localClusterUnstructured.SetName(localCluster.Name)
+	localClusterUnstructured.SetLabels(localCluster.Labels)
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(localCluster).Build()
+	producer := &mockProducer{events: []cloudevents.Event{}}
+	emitter := NewHubHAEmitter(producer, &transport.TransportInternalConfig{
+		KafkaCredential: &transport.KafkaConfig{SpecTopic: "spec-topic"},
+	}, "hub1", "hub2")
+	emitter.SetClient(cl)
+	if err := emitter.RefreshLocalClusterFilter(context.Background()); err != nil {
+		t.Fatalf("RefreshLocalClusterFilter() error = %v", err)
+	}
+
+	addon := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "addon.open-cluster-management.io/v1beta1",
+			"kind":       "ManagedClusterAddOn",
+			"metadata": map[string]any{
+				"name":      "governance-policy-framework",
+				"namespace": "regionalhub-local-cluster",
+			},
+		},
+	}
+
+	if emitter.Predicate().Create(event.CreateEvent{Object: localClusterUnstructured}) {
+		t.Fatal("predicate should exclude local cluster ManagedCluster")
+	}
+	if emitter.Predicate().Create(event.CreateEvent{Object: addon}) {
+		t.Fatal("predicate should exclude resources in local cluster namespace")
 	}
 }

--- a/agent/pkg/spec/hubha/hubha_standby_syncer.go
+++ b/agent/pkg/spec/hubha/hubha_standby_syncer.go
@@ -132,6 +132,12 @@ func (s *HubHAStandbySyncer) Sync(ctx context.Context, evt *cloudevents.Event) e
 func (s *HubHAStandbySyncer) createResource(ctx context.Context, obj *unstructured.Unstructured,
 	sourceHub string,
 ) error {
+	if shouldSkipHubHAResourceApply(obj) {
+		log.Debugf("skipping Hub HA create for local cluster resource %s/%s (%s) from active hub %s",
+			obj.GetNamespace(), obj.GetName(), obj.GetKind(), sourceHub)
+		return nil
+	}
+
 	log.Infof("creating resource from active hub %s: %s/%s (%s)",
 		sourceHub, obj.GetNamespace(), obj.GetName(), obj.GetKind())
 
@@ -168,6 +174,12 @@ func (s *HubHAStandbySyncer) createResource(ctx context.Context, obj *unstructur
 func (s *HubHAStandbySyncer) updateResource(ctx context.Context, obj *unstructured.Unstructured,
 	sourceHub string,
 ) error {
+	if shouldSkipHubHAResourceApply(obj) {
+		log.Debugf("skipping Hub HA update for local cluster resource %s/%s (%s) from active hub %s",
+			obj.GetNamespace(), obj.GetName(), obj.GetKind(), sourceHub)
+		return nil
+	}
+
 	log.Debugf("updating resource from active hub %s: %s/%s (%s)",
 		sourceHub, obj.GetNamespace(), obj.GetName(), obj.GetKind())
 
@@ -458,4 +470,12 @@ func (s *HubHAStandbySyncer) setHubAcceptsClient(obj *unstructured.Unstructured,
 
 	log.Debugf("adjusted ManagedCluster %s hubAcceptsClient to %v", obj.GetName(), hubAcceptsClient)
 	return nil
+}
+
+func shouldSkipHubHAResourceApply(obj *unstructured.Unstructured) bool {
+	gvk := obj.GroupVersionKind()
+	if gvk.Group == clusterv1.GroupName && gvk.Kind == "ManagedCluster" {
+		return utils.IsLocalManagedCluster(obj)
+	}
+	return false
 }

--- a/agent/pkg/spec/hubha/hubha_standby_syncer_test.go
+++ b/agent/pkg/spec/hubha/hubha_standby_syncer_test.go
@@ -1245,6 +1245,47 @@ func TestHubHAStandbySyncer_Sync_ResyncMetadata_PreservesGlobalHubTopologyManage
 	}
 }
 
+func TestHubHAStandbySyncer_SkipsLocalClusterManagedClusterApply(t *testing.T) {
+	scheme := newTestScheme()
+	cl := fake.NewClientBuilder().WithScheme(scheme).Build()
+	syncer := NewHubHAStandbySyncer(cl)
+
+	localCluster := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": managedClusterAPIVersion,
+			"kind":       "ManagedCluster",
+			"metadata": map[string]interface{}{
+				"name": "regionalhub-local-cluster",
+				"labels": map[string]interface{}{
+					constants.LocalClusterName: "true",
+				},
+			},
+		},
+	}
+
+	bundle := generic.NewGenericBundle[*unstructured.Unstructured]()
+	bundle.Update = []*unstructured.Unstructured{localCluster}
+
+	evt := cloudevents.NewEvent()
+	evt.SetType(constants.HubHAResourcesMsgKey)
+	evt.SetSource("hub1")
+	if err := evt.SetData(cloudevents.ApplicationJSON, bundle); err != nil {
+		t.Fatalf("SetData() error = %v", err)
+	}
+	if err := syncer.Sync(context.Background(), &evt); err != nil {
+		t.Fatalf("Sync() error = %v", err)
+	}
+
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion(managedClusterAPIVersion)
+	obj.SetKind("ManagedCluster")
+	if err := cl.Get(context.Background(), types.NamespacedName{Name: "regionalhub-local-cluster"}, obj); err == nil {
+		t.Fatal("local cluster ManagedCluster should not be created on standby hub")
+	} else if !errors.IsNotFound(err) {
+		t.Fatalf("expected NotFound, got: %v", err)
+	}
+}
+
 // atomicInt is a tiny counter for interceptor tests without importing sync/atomic in assertions.
 type atomicInt struct{ v int }
 

--- a/agent/pkg/status/syncers/hubha/hubha_controller.go
+++ b/agent/pkg/status/syncers/hubha/hubha_controller.go
@@ -202,6 +202,10 @@ func (c *hubHALifecycleController) enableSyncer(ctx context.Context, standbyHub 
 		log.Infof("Hub HA resource syncer started, watching %d GVKs", len(activeGVKs))
 	}
 
+	if err := c.emitter.RefreshLocalClusterFilter(ctx); err != nil {
+		return fmt.Errorf("failed to refresh Hub HA local cluster filter: %w", err)
+	}
+
 	c.emitter.SetEnabled(true)
 
 	if !c.registered {

--- a/agent/pkg/status/syncers/hubha/hubha_controller_test.go
+++ b/agent/pkg/status/syncers/hubha/hubha_controller_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -36,6 +37,9 @@ func buildScheme(t *testing.T) *runtime.Scheme {
 	s := runtime.NewScheme()
 	if err := corev1.AddToScheme(s); err != nil {
 		t.Fatalf("failed to add corev1 to test scheme: %v", err)
+	}
+	if err := clusterv1.Install(s); err != nil {
+		t.Fatalf("failed to add clusterv1 to test scheme: %v", err)
 	}
 	return s
 }

--- a/pkg/utils/hubha_resource_filter.go
+++ b/pkg/utils/hubha_resource_filter.go
@@ -1,7 +1,10 @@
 package utils
 
 import (
+	"sync"
+
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
@@ -11,6 +14,9 @@ import (
 type HubHAResourceFilter struct {
 	// Required label keys for secrets and configmaps
 	requiredSecretConfigMapLabels []string
+	// localClusterName is the ManagedCluster name for this hub's local cluster.
+	localClusterName string
+	mu               sync.RWMutex
 }
 
 // NewHubHAResourceFilter creates a new resource filter for Hub HA
@@ -24,12 +30,24 @@ func NewHubHAResourceFilter() *HubHAResourceFilter {
 	}
 }
 
+// SetLocalClusterName configures the local cluster ManagedCluster name used to
+// exclude hub-local inventory from Hub HA pre-stage sync.
+func (f *HubHAResourceFilter) SetLocalClusterName(name string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.localClusterName = name
+}
+
 // ShouldSyncResource determines if a resource should be synced for Hub HA
 // This is called per-object to filter individual resource instances
 func (f *HubHAResourceFilter) ShouldSyncResource(obj client.Object, gvk schema.GroupVersionKind) bool {
 	// Exclude resources explicitly marked to be excluded from backup
 	labels := obj.GetLabels()
 	if labels != nil && labels["velero.io/exclude-from-backup"] == "true" {
+		return false
+	}
+
+	if f.shouldExcludeLocalClusterResource(obj, gvk) {
 		return false
 	}
 
@@ -59,6 +77,21 @@ func (f *HubHAResourceFilter) shouldSyncSecretOrConfigMap(obj client.Object) boo
 		}
 	}
 
+	return false
+}
+
+func (f *HubHAResourceFilter) shouldExcludeLocalClusterResource(
+	obj client.Object, gvk schema.GroupVersionKind,
+) bool {
+	if gvk.Group == clusterv1.GroupName && gvk.Kind == "ManagedCluster" {
+		return IsLocalManagedCluster(obj)
+	}
+	f.mu.RLock()
+	localClusterName := f.localClusterName
+	f.mu.RUnlock()
+	if localClusterName != "" && obj.GetNamespace() == localClusterName {
+		return true
+	}
 	return false
 }
 

--- a/pkg/utils/hubha_resource_filter_test.go
+++ b/pkg/utils/hubha_resource_filter_test.go
@@ -10,12 +10,12 @@ import (
 )
 
 func TestHubHAResourceFilter_ShouldSyncResource(t *testing.T) {
-	filter := NewHubHAResourceFilter()
-
 	tests := []struct {
 		name           string
 		gvk            schema.GroupVersionKind
 		labels         map[string]string
+		namespace      string
+		localCluster   string
 		expectedResult bool
 	}{
 		{
@@ -48,6 +48,30 @@ func TestHubHAResourceFilter_ShouldSyncResource(t *testing.T) {
 			labels: map[string]string{
 				"velero.io/exclude-from-backup": "true",
 			},
+			expectedResult: false,
+		},
+		{
+			name: "local cluster ManagedCluster should not be synced",
+			gvk: schema.GroupVersionKind{
+				Group:   "cluster.open-cluster-management.io",
+				Version: "v1",
+				Kind:    "ManagedCluster",
+			},
+			labels: map[string]string{
+				constants.LocalClusterName: "true",
+			},
+			expectedResult: false,
+		},
+		{
+			name: "resource in local cluster namespace should not be synced",
+			gvk: schema.GroupVersionKind{
+				Group:   "addon.open-cluster-management.io",
+				Version: "v1beta1",
+				Kind:    "ManagedClusterAddOn",
+			},
+			labels:         nil,
+			namespace:      "regionalhub-local-cluster",
+			localCluster:   "regionalhub-local-cluster",
 			expectedResult: false,
 		},
 		{
@@ -118,8 +142,16 @@ func TestHubHAResourceFilter_ShouldSyncResource(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			filter := NewHubHAResourceFilter()
+			if tt.localCluster != "" {
+				filter.SetLocalClusterName(tt.localCluster)
+			}
+
 			obj := &unstructured.Unstructured{}
 			obj.SetGroupVersionKind(tt.gvk)
+			if tt.namespace != "" {
+				obj.SetNamespace(tt.namespace)
+			}
 			if tt.labels != nil {
 				obj.SetLabels(tt.labels)
 			}

--- a/pkg/utils/local_cluster.go
+++ b/pkg/utils/local_cluster.go
@@ -13,6 +13,18 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 )
 
+// IsLocalManagedCluster reports whether obj is the hub's local ManagedCluster.
+func IsLocalManagedCluster(obj client.Object) bool {
+	if obj == nil {
+		return false
+	}
+	labels := obj.GetLabels()
+	if labels != nil && labels[constants.LocalClusterName] == "true" {
+		return true
+	}
+	return obj.GetName() == constants.LocalClusterName
+}
+
 // ResolveLocalClusterManagedClusterName returns the ManagedCluster name for the
 // cluster labeled local-cluster=true. When no such cluster exists, it falls back
 // to constants.LocalClusterName for environments where the local cluster is

--- a/test/integration/agent/hubha/lifecycle/suite_test.go
+++ b/test/integration/agent/hubha/lifecycle/suite_test.go
@@ -69,7 +69,7 @@ var _ = BeforeSuite(func() {
 				filepath.Join("..", "..", "..", "..", "manifest", "crd",
 					"0000_00_cluster.open-cluster-management.io_placements.crd.yaml"),
 				filepath.Join("..", "..", "..", "..", "manifest", "crd",
-					"0000_02_clusters.open-cluster-management.io_managedclusters.crd.yaml"),
+					"0000_00_cluster.open-cluster-management.io_managedclusters.crd.yaml"),
 			},
 		},
 		ErrorIfCRDPathMissing: false,

--- a/test/integration/agent/hubha/suite_test.go
+++ b/test/integration/agent/hubha/suite_test.go
@@ -71,7 +71,7 @@ var _ = BeforeSuite(func() {
 				filepath.Join("..", "..", "..", "manifest", "crd",
 					"0000_00_cluster.open-cluster-management.io_placements.crd.yaml"),
 				filepath.Join("..", "..", "..", "manifest", "crd",
-					"0000_02_clusters.open-cluster-management.io_managedclusters.crd.yaml"),
+					"0000_00_cluster.open-cluster-management.io_managedclusters.crd.yaml"),
 			},
 		},
 		ErrorIfCRDPathMissing: false, // Some CRDs might not exist in test env


### PR DESCRIPTION
## Summary

- Exclude the hub's local cluster `ManagedCluster` and namespace-scoped resources from Hub HA pre-stage sync on the active hub
- Resolve the local cluster name at sync enable time and configure `HubHAResourceFilter` so resources in that namespace are not emitted
- Skip applying local cluster `ManagedCluster` on the standby hub as defense in depth

Fixes [ACM-41771](https://redhat.atlassian.net/browse/ACM-41771).

## Problem

When a regional hub is active in Hub HA, its local cluster (e.g. `regionalhub-local-cluster`) was synced to the standby Global Hub. That caused admission webhook errors (`cannot create another local cluster`) and failures for namespaced addons (`namespace not found`).

## Test plan

- [x] `go test -mod=mod ./pkg/utils/... ./agent/pkg/spec/hubha/... ./agent/pkg/status/syncers/hubha/...`
- [ ] Manual verification on QA: standby agent logs show no local-cluster sync errors after labeling active hub

[ACM-41771]: https://redhat.atlassian.net/browse/ACM-41771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved high-availability synchronization to consistently identify and exclude the local cluster.
  * Prevented local-cluster resources and resources in its namespace from being synchronized or applied.
  * Added safer handling when the local cluster cannot be resolved before synchronization starts.

* **Tests**
  * Added coverage for local-cluster detection, filtering, and standby synchronization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->