### PR TITLE
ACM-34442: scope agent ClusterRole (remove impersonate)

### DIFF
--- a/operator/pkg/controllers/agent/addon/manifests/templates/agent/multicluster-global-hub-agent-clusterrole.yaml
+++ b/operator/pkg/controllers/agent/addon/manifests/templates/agent/multicluster-global-hub-agent-clusterrole.yaml
@@ -99,8 +99,9 @@ rules:
   - watch
 # Migration target syncer creates ClusterRole/ClusterRoleBinding named
 # global-hub-migration-<msa>-sar and global-hub-migration-<msa>-registration.
-# resourceNames cannot be used: names include the migration MSA and Kubernetes
-# does not allow resourceNames with create/list/watch.
+# resourceNames cannot constrain create. list/watch can be constrained only when
+# the request includes a matching metadata.name field selector. A static
+# allow-list is not possible because the MSA name is chosen per migration.
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/operator/pkg/controllers/agent/addon/manifests/templates/agent/multicluster-global-hub-agent-clusterrole.yaml
+++ b/operator/pkg/controllers/agent/addon/manifests/templates/agent/multicluster-global-hub-agent-clusterrole.yaml
@@ -58,6 +58,8 @@ rules:
   - list
   - watch
   - update
+# Cluster-wide secrets/namespaces stay: migration writes bootstrap kubeconfig
+# into multicluster-engine and deploying resources into cluster namespaces.
 - apiGroups:
   - ""
   resources:
@@ -84,14 +86,6 @@ rules:
   - update
   - delete
 - apiGroups:
-  - ""
-  resources:
-  - users
-  - groups
-  - serviceaccounts
-  verbs:
-  - impersonate
-- apiGroups:
   - "coordination.k8s.io"
   resources:
   - leases
@@ -103,13 +97,15 @@ rules:
   - patch
   - update
   - watch
+# Migration target syncer creates ClusterRole/ClusterRoleBinding named
+# global-hub-migration-<msa>-sar and global-hub-migration-<msa>-registration.
+# resourceNames cannot be used: names include the migration MSA and Kubernetes
+# does not allow resourceNames with create/list/watch.
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings
   - clusterroles
-  - rolebindings
-  - roles
   verbs:
   - create
   - delete

--- a/operator/pkg/controllers/agent/manifests/clusterrole.yaml
+++ b/operator/pkg/controllers/agent/manifests/clusterrole.yaml
@@ -73,6 +73,8 @@ rules:
   - managedclusters/accept
   verbs:
   - update
+# Cluster-wide secrets/namespaces stay: migration writes bootstrap kubeconfig
+# into multicluster-engine and deploying resources into cluster namespaces.
 - apiGroups:
   - ""
   resources:
@@ -99,14 +101,6 @@ rules:
   - update
   - delete
 - apiGroups:
-  - ""
-  resources:
-  - users
-  - groups
-  - serviceaccounts
-  verbs:
-  - impersonate
-- apiGroups:
   - "coordination.k8s.io"
   resources:
   - leases
@@ -118,13 +112,15 @@ rules:
   - patch
   - update
   - watch
+# Migration target syncer creates ClusterRole/ClusterRoleBinding named
+# global-hub-migration-<msa>-sar and global-hub-migration-<msa>-registration.
+# resourceNames cannot be used: names include the migration MSA and Kubernetes
+# does not allow resourceNames with create/list/watch.
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings
   - clusterroles
-  - rolebindings
-  - roles
   verbs:
   - create
   - delete

--- a/operator/pkg/controllers/agent/manifests/clusterrole.yaml
+++ b/operator/pkg/controllers/agent/manifests/clusterrole.yaml
@@ -114,8 +114,9 @@ rules:
   - watch
 # Migration target syncer creates ClusterRole/ClusterRoleBinding named
 # global-hub-migration-<msa>-sar and global-hub-migration-<msa>-registration.
-# resourceNames cannot be used: names include the migration MSA and Kubernetes
-# does not allow resourceNames with create/list/watch.
+# resourceNames cannot constrain create. list/watch can be constrained only when
+# the request includes a matching metadata.name field selector. A static
+# allow-list is not possible because the MSA name is chosen per migration.
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/operator/pkg/controllers/agent/rbaccheck/clusterrole_test.go
+++ b/operator/pkg/controllers/agent/rbaccheck/clusterrole_test.go
@@ -71,7 +71,8 @@ func TestAgentClusterRolePhase5RBAC(t *testing.T) {
 				}
 				if contains(rule.APIGroups, rbacv1.GroupName) &&
 					contains(rule.Resources, "clusterroles") &&
-					contains(rule.Resources, "clusterrolebindings") {
+					contains(rule.Resources, "clusterrolebindings") &&
+					contains(rule.Verbs, "create") {
 					hasMigrationRBAC = true
 				}
 			}

--- a/operator/pkg/controllers/agent/rbaccheck/clusterrole_test.go
+++ b/operator/pkg/controllers/agent/rbaccheck/clusterrole_test.go
@@ -19,8 +19,10 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	"sigs.k8s.io/yaml"
 )
 
 func TestAgentClusterRolePhase5RBAC(t *testing.T) {
@@ -46,17 +48,42 @@ func TestAgentClusterRolePhase5RBAC(t *testing.T) {
 			if err != nil {
 				t.Fatalf("read %s: %v", file, err)
 			}
-			content := string(raw)
 
-			if strings.Contains(content, "impersonate") {
-				t.Errorf("%s still grants impersonate", file)
+			role := &rbacv1.ClusterRole{}
+			if err := yaml.Unmarshal(raw, role); err != nil {
+				t.Fatalf("unmarshal %s: %v", file, err)
 			}
-			if strings.Contains(content, "\n  - roles\n") || strings.Contains(content, "\n  - rolebindings\n") {
-				t.Errorf("%s still grants cluster-wide roles/rolebindings", file)
+
+			hasMigrationRBAC := false
+			for _, rule := range role.Rules {
+				if contains(rule.Verbs, "impersonate") || contains(rule.Verbs, "*") {
+					t.Errorf("%s grants impersonate (verbs=%v resources=%v)",
+						file, rule.Verbs, rule.Resources)
+				}
+				if contains(rule.Resources, "roles") ||
+					contains(rule.Resources, "rolebindings") ||
+					contains(rule.Resources, "*") {
+					t.Errorf("%s grants cluster-wide roles/rolebindings (resources=%v)",
+						file, rule.Resources)
+				}
+				if contains(rule.APIGroups, rbacv1.GroupName) &&
+					contains(rule.Resources, "clusterroles") &&
+					contains(rule.Resources, "clusterrolebindings") {
+					hasMigrationRBAC = true
+				}
 			}
-			if !strings.Contains(content, "clusterroles") || !strings.Contains(content, "clusterrolebindings") {
-				t.Errorf("%s must keep clusterroles/clusterrolebindings for migration bootstrap", file)
+			if !hasMigrationRBAC {
+				t.Errorf("%s must keep rbac.authorization.k8s.io clusterroles/clusterrolebindings for migration bootstrap", file)
 			}
 		})
 	}
+}
+
+func contains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }

--- a/operator/pkg/controllers/agent/rbaccheck/clusterrole_test.go
+++ b/operator/pkg/controllers/agent/rbaccheck/clusterrole_test.go
@@ -54,7 +54,8 @@ func TestAgentClusterRolePhase5RBAC(t *testing.T) {
 				t.Fatalf("unmarshal %s: %v", file, err)
 			}
 
-			hasMigrationRBAC := false
+			hasClusterRoleCreate := false
+			hasClusterRoleBindingCreate := false
 			for _, rule := range role.Rules {
 				if contains(rule.Verbs, "impersonate") || contains(rule.Verbs, "*") {
 					t.Errorf("%s grants impersonate (verbs=%v resources=%v)",
@@ -69,15 +70,17 @@ func TestAgentClusterRolePhase5RBAC(t *testing.T) {
 					t.Errorf("%s grants roles/rolebindings for apiGroups=%v (resources=%v)",
 						file, rule.APIGroups, rule.Resources)
 				}
-				if contains(rule.APIGroups, rbacv1.GroupName) &&
-					contains(rule.Resources, "clusterroles") &&
-					contains(rule.Resources, "clusterrolebindings") &&
-					contains(rule.Verbs, "create") {
-					hasMigrationRBAC = true
+				if contains(rule.APIGroups, rbacv1.GroupName) && contains(rule.Verbs, "create") {
+					if contains(rule.Resources, "clusterroles") {
+						hasClusterRoleCreate = true
+					}
+					if contains(rule.Resources, "clusterrolebindings") {
+						hasClusterRoleBindingCreate = true
+					}
 				}
 			}
-			if !hasMigrationRBAC {
-				t.Errorf("%s must keep rbac.authorization.k8s.io clusterroles/clusterrolebindings for migration bootstrap", file)
+			if !hasClusterRoleCreate || !hasClusterRoleBindingCreate {
+				t.Errorf("%s must keep create on rbac.authorization.k8s.io clusterroles and clusterrolebindings for migration bootstrap", file)
 			}
 		})
 	}

--- a/operator/pkg/controllers/agent/rbaccheck/clusterrole_test.go
+++ b/operator/pkg/controllers/agent/rbaccheck/clusterrole_test.go
@@ -66,8 +66,8 @@ func TestAgentClusterRolePhase5RBAC(t *testing.T) {
 				}
 				if (contains(rule.APIGroups, rbacv1.GroupName) || contains(rule.APIGroups, "*")) &&
 					(contains(rule.Resources, "roles") || contains(rule.Resources, "rolebindings")) {
-					t.Errorf("%s grants rbac.authorization.k8s.io roles/rolebindings (resources=%v)",
-						file, rule.Resources)
+					t.Errorf("%s grants roles/rolebindings for apiGroups=%v (resources=%v)",
+						file, rule.APIGroups, rule.Resources)
 				}
 				if contains(rule.APIGroups, rbacv1.GroupName) &&
 					contains(rule.Resources, "clusterroles") &&

--- a/operator/pkg/controllers/agent/rbaccheck/clusterrole_test.go
+++ b/operator/pkg/controllers/agent/rbaccheck/clusterrole_test.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rbaccheck
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestAgentClusterRolePhase5RBAC(t *testing.T) {
+	t.Parallel()
+
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	agentDir := filepath.Join(filepath.Dir(thisFile), "..")
+
+	files := []string{
+		filepath.Join(agentDir, "manifests", "clusterrole.yaml"),
+		filepath.Join(agentDir, "addon", "manifests", "templates", "agent",
+			"multicluster-global-hub-agent-clusterrole.yaml"),
+	}
+
+	for _, file := range files {
+		t.Run(filepath.Base(filepath.Dir(file))+"/"+filepath.Base(file), func(t *testing.T) {
+			t.Parallel()
+
+			raw, err := os.ReadFile(file)
+			if err != nil {
+				t.Fatalf("read %s: %v", file, err)
+			}
+			content := string(raw)
+
+			if strings.Contains(content, "impersonate") {
+				t.Errorf("%s still grants impersonate", file)
+			}
+			if strings.Contains(content, "\n  - roles\n") || strings.Contains(content, "\n  - rolebindings\n") {
+				t.Errorf("%s still grants cluster-wide roles/rolebindings", file)
+			}
+			if !strings.Contains(content, "clusterroles") || !strings.Contains(content, "clusterrolebindings") {
+				t.Errorf("%s must keep clusterroles/clusterrolebindings for migration bootstrap", file)
+			}
+		})
+	}
+}

--- a/operator/pkg/controllers/agent/rbaccheck/clusterrole_test.go
+++ b/operator/pkg/controllers/agent/rbaccheck/clusterrole_test.go
@@ -60,10 +60,13 @@ func TestAgentClusterRolePhase5RBAC(t *testing.T) {
 					t.Errorf("%s grants impersonate (verbs=%v resources=%v)",
 						file, rule.Verbs, rule.Resources)
 				}
-				if contains(rule.Resources, "roles") ||
-					contains(rule.Resources, "rolebindings") ||
-					contains(rule.Resources, "*") {
-					t.Errorf("%s grants cluster-wide roles/rolebindings (resources=%v)",
+				if contains(rule.Resources, "*") {
+					t.Errorf("%s grants wildcard resources (resources=%v apiGroups=%v)",
+						file, rule.Resources, rule.APIGroups)
+				}
+				if (contains(rule.APIGroups, rbacv1.GroupName) || contains(rule.APIGroups, "*")) &&
+					(contains(rule.Resources, "roles") || contains(rule.Resources, "rolebindings")) {
+					t.Errorf("%s grants rbac.authorization.k8s.io roles/rolebindings (resources=%v)",
 						file, rule.Resources)
 				}
 				if contains(rule.APIGroups, rbacv1.GroupName) &&


### PR DESCRIPTION
Fixes: [ACM-34442](https://redhat.atlassian.net/browse/ACM-34442)

## Summary

- [ACM-34442](https://redhat.atlassian.net/browse/ACM-34442) Phase 5 (FIND-004): remove unused cluster-wide `impersonate` from the managed-hub agent ClusterRole
- Drop unused `roles` / `rolebindings` verbs (agent never creates namespaced Role or RoleBinding)
- Keep `clusterroles` / `clusterrolebindings` so migration can still create `global-hub-migration-<msa>-sar` and `global-hub-migration-<msa>-registration`
- Keep cluster-wide `secrets` / `namespaces`: bootstrap kubeconfig is written to `multicluster-engine`, and deploying copies resources into cluster namespaces

## Context

Phases 1–4 are on `main`:

- [#2564](https://github.com/stolostron/multicluster-global-hub/pull/2564) — Phase 1 status identity
- [#2623](https://github.com/stolostron/multicluster-global-hub/pull/2623) — Phase 2 agent spec validation
- [#2624](https://github.com/stolostron/multicluster-global-hub/pull/2624) — Phase 3 `gh-migration` topic
- [#2761](https://github.com/stolostron/multicluster-global-hub/pull/2761) — Phase 4 `gh-spec` Read-only ACL

This PR is blast-radius reduction after those Kafka fixes. 
`resourceNames` is not applied: Kubernetes does not allow `resourceNames` with `create`/`list`/`watch`, and migration RBAC object names include the MSA name.

Operator ClusterRole `impersonate` in `operator/config/rbac/role.yaml` is unchanged (operator permissions, not the agent).

## Test plan

- [ ] `go test ./operator/pkg/controllers/agent/rbaccheck/ -count=1`
- [ ] Confirm addon and standalone agent ClusterRoles no longer include `impersonate`
- [ ] Cluster migration still creates SAR and registration ClusterRoleBindings on the target hub


Made with [Cursor](https://cursor.com)

[ACM-34442]: https://redhat.atlassian.net/browse/ACM-34442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-34442]: https://redhat.atlassian.net/browse/ACM-34442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Security Improvements

* Reduced agent permissions by removing the ability to impersonate users, groups, and service accounts.
* Limited access management to cluster roles and cluster role bindings, removing unnecessary namespace-scoped role permissions.
* Retained permissions required for migration activities and resource deployment.

## Tests

* Added regression coverage to verify permission boundaries and help prevent unauthorized access from being reintroduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->