### PR TITLE
[release-2.13] ACM-34442: scope agent ClusterRole (remove impersonate)

### DIFF
--- a/operator/pkg/controllers/agent/manifests/templates/agent/multicluster-global-hub-agent-clusterrole.yaml
+++ b/operator/pkg/controllers/agent/manifests/templates/agent/multicluster-global-hub-agent-clusterrole.yaml
@@ -89,6 +89,8 @@ rules:
   - list
   - watch
   - update
+# Cluster-wide secrets/namespaces stay: migration writes bootstrap kubeconfig
+# into multicluster-engine and deploying resources into cluster namespaces.
 - apiGroups:
   - ""
   resources:
@@ -115,14 +117,6 @@ rules:
   - update
   - delete
 - apiGroups:
-  - ""
-  resources:
-  - users
-  - groups
-  - serviceaccounts
-  verbs:
-  - impersonate
-- apiGroups:
   - "coordination.k8s.io"
   resources:
   - leases
@@ -134,13 +128,16 @@ rules:
   - patch
   - update
   - watch
+# Migration target syncer creates ClusterRole/ClusterRoleBinding named
+# global-hub-migration-<msa>-sar and global-hub-migration-<msa>-registration.
+# resourceNames cannot constrain create. list/watch can be constrained only when
+# the request includes a matching metadata.name field selector. A static
+# allow-list is not possible because the MSA name is chosen per migration.
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings
   - clusterroles
-  - rolebindings
-  - roles
   verbs:
   - create
   - delete

--- a/operator/pkg/controllers/agent/rbaccheck/clusterrole_test.go
+++ b/operator/pkg/controllers/agent/rbaccheck/clusterrole_test.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rbaccheck
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	"sigs.k8s.io/yaml"
+)
+
+func TestAgentClusterRolePhase5RBAC(t *testing.T) {
+	t.Parallel()
+
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	agentDir := filepath.Join(filepath.Dir(thisFile), "..")
+
+	files := []string{
+		filepath.Join(agentDir, "manifests", "templates", "agent",
+			"multicluster-global-hub-agent-clusterrole.yaml"),
+	}
+
+	for _, file := range files {
+		t.Run(filepath.Base(filepath.Dir(file))+"/"+filepath.Base(file), func(t *testing.T) {
+			t.Parallel()
+
+			raw, err := os.ReadFile(file)
+			if err != nil {
+				t.Fatalf("read %s: %v", file, err)
+			}
+
+			role := &rbacv1.ClusterRole{}
+			if err := yaml.Unmarshal(stripGoTemplateDirectives(raw), role); err != nil {
+				t.Fatalf("unmarshal %s: %v", file, err)
+			}
+
+			hasClusterRoleCreate := false
+			hasClusterRoleBindingCreate := false
+			for _, rule := range role.Rules {
+				if contains(rule.Verbs, "impersonate") || contains(rule.Verbs, "*") {
+					t.Errorf("%s grants impersonate (verbs=%v resources=%v)",
+						file, rule.Verbs, rule.Resources)
+				}
+				if contains(rule.Resources, "*") {
+					t.Errorf("%s grants wildcard resources (resources=%v apiGroups=%v)",
+						file, rule.Resources, rule.APIGroups)
+				}
+				if (contains(rule.APIGroups, rbacv1.GroupName) || contains(rule.APIGroups, "*")) &&
+					(contains(rule.Resources, "roles") || contains(rule.Resources, "rolebindings")) {
+					t.Errorf("%s grants roles/rolebindings for apiGroups=%v (resources=%v)",
+						file, rule.APIGroups, rule.Resources)
+				}
+				if contains(rule.APIGroups, rbacv1.GroupName) && contains(rule.Verbs, "create") {
+					if contains(rule.Resources, "clusterroles") {
+						hasClusterRoleCreate = true
+					}
+					if contains(rule.Resources, "clusterrolebindings") {
+						hasClusterRoleBindingCreate = true
+					}
+				}
+			}
+			if !hasClusterRoleCreate || !hasClusterRoleBindingCreate {
+				t.Errorf("%s must keep create on rbac.authorization.k8s.io clusterroles and clusterrolebindings for migration bootstrap", file)
+			}
+		})
+	}
+}
+
+func contains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func stripGoTemplateDirectives(raw []byte) []byte {
+	lines := strings.Split(string(raw), "\n")
+	filtered := make([]string, 0, len(lines))
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "{{") {
+			continue
+		}
+		filtered = append(filtered, line)
+	}
+	return []byte(strings.Join(filtered, "\n"))
+}


### PR DESCRIPTION
## Summary

Backport of #2782 (ACM-34442 Phase 5) to `release-2.13` (GH 1.4).

- Remove unused `impersonate` from the agent ClusterRole template
- Drop namespaced `roles` / `rolebindings` (no in-tree caller; migration uses cluster-scoped RBAC)
- Keep cluster-wide `secrets` / `namespaces` and migration `clusterroles` / `clusterrolebindings` with `create`
- Add `rbaccheck/clusterrole_test.go` — adapted for the legacy `manifests/templates/agent/` path and Go template wrappers on this branch

Related: [ACM-34442](https://redhat.atlassian.net/browse/ACM-34442), [ACM-38861](https://redhat.atlassian.net/browse/ACM-38861)

/assign birsanv

## Test plan

- [x] `go test ./operator/pkg/controllers/agent/rbaccheck/...`
- [ ] CI format / bundle / e2e on release-2.13

Made with [Cursor](https://cursor.com)

[ACM-34442]: https://redhat.atlassian.net/browse/ACM-34442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-38861]: https://redhat.atlassian.net/browse/ACM-38861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ