### PR TITLE
ACM-40367: CVE-2026-71577 restrict migration topic ACL to active migration hubs [GH 1.5]

### DIFF
--- a/manager/pkg/migration/migration_controller.go
+++ b/manager/pkg/migration/migration_controller.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	cecontext "github.com/cloudevents/sdk-go/v2/context"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -49,15 +51,22 @@ type ClusterMigrationController struct {
 	transport.Producer
 	BootstrapSecret *corev1.Secret
 	managerConfigs  *configs.ManagerConfig
+	migrationTopic  string
 }
 
 func NewMigrationController(client client.Client, producer transport.Producer,
 	managerConfig *configs.ManagerConfig,
 ) *ClusterMigrationController {
+	var migrationTopic string
+	if managerConfig.TransportConfig != nil && managerConfig.TransportConfig.KafkaCredential != nil {
+		migrationTopic = managerConfig.TransportConfig.KafkaCredential.GetMigrationTopic()
+	}
+
 	return &ClusterMigrationController{
 		Client:         client,
 		Producer:       producer,
 		managerConfigs: managerConfig,
+		migrationTopic: migrationTopic,
 	}
 }
 
@@ -369,9 +378,16 @@ func (m *ClusterMigrationController) sendEventToDestinationHub(ctx context.Conte
 
 	eventType := constants.MigrationTargetMsgKey
 	evt := utils.ToCloudEvent(eventType, constants.CloudEventGlobalHubClusterName, migration.Spec.To, payloadToBytes)
-	if err := m.Producer.SendEvent(ctx, evt); err != nil {
+	if err := m.sendMigrationEvent(ctx, evt); err != nil {
 		return fmt.Errorf("failed to sync managedclustermigration event(%s) from source(%s) to destination(%s) - %w",
 			eventType, constants.CloudEventGlobalHubClusterName, migration.Spec.To, err)
 	}
 	return nil
+}
+
+func (m *ClusterMigrationController) sendMigrationEvent(ctx context.Context, evt cloudevents.Event) error {
+	if m.migrationTopic != "" {
+		ctx = cecontext.WithTopic(ctx, m.migrationTopic)
+	}
+	return m.SendEvent(ctx, evt)
 }

--- a/manager/pkg/migration/migration_initializing.go
+++ b/manager/pkg/migration/migration_initializing.go
@@ -249,11 +249,11 @@ func (m *ClusterMigrationController) UpdateCondition(
 	return nil
 }
 
-// sendEventToSourceHub specifies the manager send the message into "From Hub" via spec path(or topic)
-// Stage is the expected state for migration, it algin with the condition states
+// sendEventToSourceHub sends a migration event to the source hub via the dedicated migration topic.
+// Stage is the expected state for migration, it aligns with the condition states:
 // 1. ResourceInitialized: request sync the klusterletconfig from source hub
 // 2. ClusterRegistered: forward bootstrap kubeconfig secret into source hub, to register into the destination hub
-// 3. ResourceDeployed: delete the resourcesailed to mark the stage ResourceDeploye from the source hub
+// 3. ResourceDeployed: delete the resources to mark the stage ResourceDeployed from the source hub
 // 4. MigrationCompleted: delete the items from the database
 func (m *ClusterMigrationController) sendEventToSourceHub(ctx context.Context, fromHub string,
 	migration *migrationv1alpha1.ManagedClusterMigration, stage string, managedClusters []string,
@@ -276,7 +276,7 @@ func (m *ClusterMigrationController) sendEventToSourceHub(ctx context.Context, f
 
 	eventType := constants.MigrationSourceMsgKey
 	evt := utils.ToCloudEvent(eventType, constants.CloudEventGlobalHubClusterName, fromHub, payloadBytes)
-	if err := m.Producer.SendEvent(ctx, evt); err != nil {
+	if err := m.sendMigrationEvent(ctx, evt); err != nil {
 		return fmt.Errorf("failed to sync managedclustermigration event(%s) from source(%s) to destination(%s) - %w",
 			eventType, constants.CloudEventGlobalHubClusterName, fromHub, err)
 	}
@@ -329,12 +329,12 @@ func (m *ClusterMigrationController) ensureManagedServiceAccount(ctx context.Con
 			Rotation: v1beta1.ManagedServiceAccountRotation{
 				Enabled: true,
 				// The MSA token is embedded in the bootstrap kubeconfig
-				// that is broadcast on the shared gh-spec topic to which
-				// every managed hub holds a Read ACL, so it must be
-				// short-lived. 24h comfortably covers all migration
-				// stage timeouts (5–12 min each) and matches the spec
-				// topic's default retention; the MSA itself is removed
-				// in the cleaning phase.
+				// sent via the dedicated gh-migration topic.
+				// Read ACL on gh-migration is granted only to hubs
+				// involved in an active migration, limiting exposure.
+				// 24h validity covers all migration stage timeouts
+				// (5–12 min each); the MSA itself is removed in the
+				// cleaning phase.
 				Validity: metav1.Duration{
 					Duration: 24 * time.Hour,
 				},

--- a/operator/pkg/controllers/transporter/migration_acl_reconciler.go
+++ b/operator/pkg/controllers/transporter/migration_acl_reconciler.go
@@ -60,17 +60,24 @@ func (r *MigrationACLReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		if apierrors.IsNotFound(err) {
 			// Migration was deleted; re-sync all managed hub KafkaUsers so revoked ACLs
 			// are cleaned up even though the trigger object's Spec.From is gone.
-			return ctrl.Result{}, r.syncAllMigrationWriteACLs(ctx, mgh, req.Namespace)
+			if err := r.syncAllMigrationACLs(ctx, mgh, req.Namespace); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{}, nil
 		}
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("get ManagedClusterMigration %s: %w", req.NamespacedName, err)
 	}
 
 	if err := r.syncMigrationWriteACLs(ctx, mgh, req.Namespace, migration.Spec.From); err != nil {
 		return ctrl.Result{}, err
 	}
+	if err := r.syncMigrationReadACLs(ctx, mgh, req.Namespace, migration.Spec.From, migration.Spec.To); err != nil {
+		return ctrl.Result{}, err
+	}
 	if migration.Status.Phase == migrationv1alpha1.PhaseDeploying {
-		migrationACLLog.Infow("synced migration write ACLs",
-			"migration", req.Name, "fromHub", migration.Spec.From, "phase", migration.Status.Phase)
+		migrationACLLog.Infow("synced migration ACLs",
+			"migration", req.Name, "fromHub", migration.Spec.From,
+			"toHub", migration.Spec.To, "phase", migration.Status.Phase)
 	}
 	return ctrl.Result{}, nil
 }
@@ -97,7 +104,38 @@ func (r *MigrationACLReconciler) syncMigrationWriteACLs(
 	return nil
 }
 
-func (r *MigrationACLReconciler) syncAllMigrationWriteACLs(
+func (r *MigrationACLReconciler) syncMigrationReadACLs(
+	ctx context.Context,
+	mgh *operatorv1alpha4.MulticlusterGlobalHub,
+	namespace string,
+	triggerFromHub, triggerToHub string,
+) error {
+	list := &migrationv1alpha1.ManagedClusterMigrationList{}
+	if err := r.List(ctx, list, client.InNamespace(namespace)); err != nil {
+		return fmt.Errorf("failed to list ManagedClusterMigration resources: %w", err)
+	}
+
+	needed := activeMigrationHubs(list)
+	hubsToSync := sets.NewString()
+	if triggerFromHub != "" {
+		hubsToSync.Insert(triggerFromHub)
+	}
+	if triggerToHub != "" {
+		hubsToSync.Insert(triggerToHub)
+	}
+	for hub := range needed {
+		hubsToSync.Insert(hub)
+	}
+	for _, hub := range hubsToSync.UnsortedList() {
+		_, grant := needed[hub]
+		if err := protocol.SyncMigrationReadACL(r.mgr, mgh, hub, grant, protocol.WithContext(ctx)); err != nil {
+			return fmt.Errorf("failed to sync migration read ACL for hub %q: %w", hub, err)
+		}
+	}
+	return nil
+}
+
+func (r *MigrationACLReconciler) syncAllMigrationACLs(
 	ctx context.Context,
 	mgh *operatorv1alpha4.MulticlusterGlobalHub,
 	namespace string,
@@ -106,7 +144,8 @@ func (r *MigrationACLReconciler) syncAllMigrationWriteACLs(
 	if err := r.List(ctx, list, client.InNamespace(namespace)); err != nil {
 		return fmt.Errorf("failed to list ManagedClusterMigration resources: %w", err)
 	}
-	needed := deployingSourceHubs(list)
+	writeNeeded := deployingSourceHubs(list)
+	readNeeded := activeMigrationHubs(list)
 
 	kafkaUsers := &kafkav1beta2.KafkaUserList{}
 	if err := r.List(ctx, kafkaUsers, client.InNamespace(namespace)); err != nil {
@@ -114,13 +153,17 @@ func (r *MigrationACLReconciler) syncAllMigrationWriteACLs(
 	}
 
 	for i := range kafkaUsers.Items {
-		fromHub, ok := managedHubFromKafkaUser(&kafkaUsers.Items[i])
+		hub, ok := managedHubFromKafkaUser(&kafkaUsers.Items[i])
 		if !ok {
 			continue
 		}
-		_, grant := needed[fromHub]
-		if err := protocol.SyncMigrationWriteACL(r.mgr, mgh, fromHub, grant, protocol.WithContext(ctx)); err != nil {
-			return fmt.Errorf("failed to sync migration write ACL for hub %q: %w", fromHub, err)
+		_, grantWrite := writeNeeded[hub]
+		if err := protocol.SyncMigrationWriteACL(r.mgr, mgh, hub, grantWrite, protocol.WithContext(ctx)); err != nil {
+			return fmt.Errorf("failed to sync migration write ACL for hub %q: %w", hub, err)
+		}
+		_, grantRead := readNeeded[hub]
+		if err := protocol.SyncMigrationReadACL(r.mgr, mgh, hub, grantRead, protocol.WithContext(ctx)); err != nil {
+			return fmt.Errorf("failed to sync migration read ACL for hub %q: %w", hub, err)
 		}
 	}
 	return nil
@@ -152,6 +195,23 @@ func hubsToSyncForMigration(fromHub string, needed map[string]struct{}) []string
 		hubs.Insert(hub)
 	}
 	return hubs.UnsortedList()
+}
+
+func activeMigrationHubs(list *migrationv1alpha1.ManagedClusterMigrationList) map[string]struct{} {
+	needed := make(map[string]struct{})
+	for i := range list.Items {
+		mcm := &list.Items[i]
+		if mcm.DeletionTimestamp != nil {
+			continue
+		}
+		switch mcm.Status.Phase {
+		case migrationv1alpha1.PhaseCompleted, migrationv1alpha1.PhaseFailed:
+			continue
+		}
+		needed[mcm.Spec.From] = struct{}{}
+		needed[mcm.Spec.To] = struct{}{}
+	}
+	return needed
 }
 
 func managedHubFromKafkaUser(user *kafkav1beta2.KafkaUser) (string, bool) {

--- a/operator/pkg/controllers/transporter/migration_acl_reconciler_test.go
+++ b/operator/pkg/controllers/transporter/migration_acl_reconciler_test.go
@@ -349,10 +349,18 @@ func newMigrationACLReconcilerFixtures(
 			),
 		},
 	}
+	kafkaUser2 := &kafkav1beta2.KafkaUser{
+		ObjectMeta: metav1.ObjectMeta{Name: "hub2-kafka-user", Namespace: "test-ns"},
+		Spec: &kafkav1beta2.KafkaUserSpec{
+			Authorization: simpleKafkaUserAuthorization(
+				utils.ReadTopicACL("gh-spec", false),
+			),
+		},
+	}
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
-		WithObjects(mgh, kafkaUser).
+		WithObjects(mgh, kafkaUser, kafkaUser2).
 		Build()
 
 	return scheme, fakeClient, mgh, kafkaUser

--- a/operator/pkg/controllers/transporter/protocol/migration_acl.go
+++ b/operator/pkg/controllers/transporter/protocol/migration_acl.go
@@ -32,3 +32,16 @@ func SyncMigrationWriteACL(
 	trans := NewStrimziTransporter(mgr, mgh, opts...)
 	return trans.SyncMigrationWriteACL(fromHub, grant)
 }
+
+// SyncMigrationReadACL grants or revokes Read+Describe on the migration topic
+// for a hub involved in an active migration.
+func SyncMigrationReadACL(
+	mgr ctrl.Manager,
+	mgh *operatorv1alpha4.MulticlusterGlobalHub,
+	hub string,
+	grant bool,
+	opts ...KafkaOption,
+) error {
+	trans := NewStrimziTransporter(mgr, mgh, opts...)
+	return trans.SyncMigrationReadACL(hub, grant)
+}

--- a/operator/pkg/controllers/transporter/protocol/strimzi_migration_acl.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_migration_acl.go
@@ -31,6 +31,10 @@ func migrationWriteACLKey(topic string) string {
 	return utils.GenerateACLKey(utils.WriteTopicACL(topic))
 }
 
+func migrationReadACLKey(topic string) string {
+	return utils.GenerateACLKey(utils.ReadTopicACL(topic, false))
+}
+
 func (k *strimziTransporter) hasMigrationWriteACL(acls []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem) bool {
 	key := migrationWriteACLKey(config.GetMigrationTopic())
 	for _, acl := range acls {
@@ -41,13 +45,45 @@ func (k *strimziTransporter) hasMigrationWriteACL(acls []kafkav1beta2.KafkaUserS
 	return false
 }
 
+func (k *strimziTransporter) hasMigrationReadACL(acls []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem) bool {
+	key := migrationReadACLKey(config.GetMigrationTopic())
+	for _, acl := range acls {
+		if utils.GenerateACLKey(acl) == key {
+			return true
+		}
+	}
+	return false
+}
+
 // SyncMigrationWriteACL grants or revokes Write on the migration topic for a source hub.
 func (k *strimziTransporter) SyncMigrationWriteACL(fromHub string, grant bool) error {
-	if fromHub == "" {
+	return k.syncMigrationACL(fromHub, grant, k.hasMigrationWriteACL,
+		migrationWriteACLKey, utils.WriteTopicACL)
+}
+
+// SyncMigrationReadACL grants or revokes Read+Describe on the migration topic for a hub
+// involved in an active migration.
+func (k *strimziTransporter) SyncMigrationReadACL(hub string, grant bool) error {
+	return k.syncMigrationACL(hub, grant, k.hasMigrationReadACL,
+		migrationReadACLKey, func(topic string) kafkav1beta2.KafkaUserSpecAuthorizationAclsElem {
+			return utils.ReadTopicACL(topic, false)
+		})
+}
+
+// syncMigrationACL is the shared implementation for granting/revoking a single ACL
+// type (Read or Write) on the migration topic for a given hub's KafkaUser.
+func (k *strimziTransporter) syncMigrationACL(
+	hub string,
+	grant bool,
+	hasACL func([]kafkav1beta2.KafkaUserSpecAuthorizationAclsElem) bool,
+	keyFn func(string) string,
+	aclFn func(string) kafkav1beta2.KafkaUserSpecAuthorizationAclsElem,
+) error {
+	if hub == "" {
 		return nil
 	}
 
-	userName := config.GetKafkaUserName(fromHub)
+	userName := config.GetKafkaUserName(hub)
 	kafkaUser := &kafkav1beta2.KafkaUser{}
 	err := k.manager.GetClient().Get(k.ctx, types.NamespacedName{
 		Name:      userName,
@@ -57,14 +93,14 @@ func (k *strimziTransporter) SyncMigrationWriteACL(fromHub string, grant bool) e
 		if !grant {
 			return nil
 		}
-		return fmt.Errorf("kafka user %s not found for migration write ACL", userName)
+		return fmt.Errorf("kafka user %s not found for migration ACL", userName)
 	}
 	if err != nil {
-		return err
+		return fmt.Errorf("get KafkaUser %s/%s: %w", k.kafkaClusterNamespace, userName, err)
 	}
 
 	migrationTopic := config.GetMigrationTopic()
-	desiredWriteACL := utils.WriteTopicACL(migrationTopic)
+	desiredACL := aclFn(migrationTopic)
 
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		latestKafkaUser := &kafkav1beta2.KafkaUser{}
@@ -76,19 +112,19 @@ func (k *strimziTransporter) SyncMigrationWriteACL(fromHub string, grant bool) e
 		}
 
 		currentACLs := currentKafkaUserACLs(latestKafkaUser)
-		if k.hasMigrationWriteACL(currentACLs) == grant {
+		if hasACL(currentACLs) == grant {
 			return nil
 		}
 
 		updatedACLs := make([]kafkav1beta2.KafkaUserSpecAuthorizationAclsElem, 0, len(currentACLs))
 		for _, acl := range currentACLs {
-			if utils.GenerateACLKey(acl) == migrationWriteACLKey(migrationTopic) {
+			if utils.GenerateACLKey(acl) == keyFn(migrationTopic) {
 				continue
 			}
 			updatedACLs = append(updatedACLs, acl)
 		}
 		if grant {
-			updatedACLs = append(updatedACLs, desiredWriteACL)
+			updatedACLs = append(updatedACLs, desiredACL)
 		}
 
 		if len(updatedACLs) == 0 {

--- a/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
@@ -344,11 +344,8 @@ func managedHubUserACLs(clusterTopic *transport.ClusterTopic, consumerGroupID st
 			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
 			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
 		}),
-		// consume migration deploying bundles from the dedicated migration topic
-		utils.GetTopicACL(clusterTopic.MigrationTopic, []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
-			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
-			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
-		}),
+		// Migration topic ACLs (read + write) are granted dynamically by the
+		// MigrationACLReconciler only to hubs involved in an active migration.
 		// report status into gh: allow the current hub to write messages to the specific status topic
 		utils.GetTopicACL(clusterTopic.StatusTopic, []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
 			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite,
@@ -400,7 +397,8 @@ func (k *strimziTransporter) EnsureUser(clusterName string) (string, error) {
 			return err
 		}
 		// combine the acls of kafkaUser and the desired acls of desiredKafkaUser
-		existingACLs := filterObsoleteManagedHubACLs(currentKafkaUserACLs(latestKafkaUser), clusterTopic.SpecTopic)
+		existingACLs := filterObsoleteManagedHubACLs(currentKafkaUserACLs(latestKafkaUser),
+			clusterTopic.SpecTopic, clusterTopic.MigrationTopic)
 		updatedKafkaUser.Spec.Authorization.Acls = combineACLs(existingACLs,
 			desiredKafkaUser.Spec.Authorization.Acls)
 
@@ -419,7 +417,7 @@ func (k *strimziTransporter) EnsureUser(clusterName string) (string, error) {
 
 func filterObsoleteManagedHubACLs(
 	acls []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem,
-	specTopic string,
+	specTopic, migrationTopic string,
 ) []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem {
 	if len(acls) == 0 {
 		return nil
@@ -427,7 +425,7 @@ func filterObsoleteManagedHubACLs(
 
 	filtered := make([]kafkav1beta2.KafkaUserSpecAuthorizationAclsElem, 0, len(acls))
 	for _, acl := range acls {
-		if isObsoleteManagedHubACL(acl, specTopic) {
+		if isObsoleteManagedHubACL(acl, specTopic, migrationTopic) {
 			continue
 		}
 		filtered = append(filtered, acl)
@@ -435,7 +433,10 @@ func filterObsoleteManagedHubACLs(
 	return filtered
 }
 
-func isObsoleteManagedHubACL(acl kafkav1beta2.KafkaUserSpecAuthorizationAclsElem, specTopic string) bool {
+func isObsoleteManagedHubACL(
+	acl kafkav1beta2.KafkaUserSpecAuthorizationAclsElem,
+	specTopic, migrationTopic string,
+) bool {
 	if acl.Resource.Name == nil {
 		return false
 	}
@@ -444,13 +445,30 @@ func isObsoleteManagedHubACL(acl kafkav1beta2.KafkaUserSpecAuthorizationAclsElem
 	case kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeGroup:
 		return *acl.Resource.Name == "*"
 	case kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic:
-		if *acl.Resource.Name != specTopic {
-			return false
+		if *acl.Resource.Name == specTopic {
+			// Legacy managed-hub ACL bundled Describe+Read+Write on gh-spec.
+			// Write-only entries are managed by the Hub HA ACL watcher.
+			return topicACLHasLegacyCombinedWrite(acl.Operations)
 		}
-		return topicACLHasLegacyCombinedWrite(acl.Operations)
+		if *acl.Resource.Name == migrationTopic {
+			// Strip legacy static Read+Describe on the migration topic.
+			// Write-only ACLs are preserved (managed by MigrationACLReconciler).
+			return !topicACLIsWriteOnly(acl.Operations)
+		}
 	}
 
 	return false
+}
+
+func topicACLIsWriteOnly(
+	operations []kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem,
+) bool {
+	for _, op := range operations {
+		if op != kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite {
+			return false
+		}
+	}
+	return len(operations) > 0
 }
 
 func topicACLHasLegacyCombinedWrite(

--- a/operator/pkg/controllers/transporter/protocol/strimzi_transporter_test.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_transporter_test.go
@@ -328,8 +328,10 @@ func TestManagedHubUserACLs(t *testing.T) {
 	}
 	acls := managedHubUserACLs(clusterTopic, "hub1")
 
-	if len(acls) != 4 {
-		t.Fatalf("expected 4 ACLs, got %d", len(acls))
+	// 3 ACLs: consumer-group, gh-spec (read-only), gh-status (write).
+	// Migration topic ACLs are granted dynamically by MigrationACLReconciler.
+	if len(acls) != 3 {
+		t.Fatalf("expected 3 ACLs, got %d", len(acls))
 	}
 
 	groupACL, ok := findGroupACL(acls, "hub1")
@@ -361,20 +363,10 @@ func TestManagedHubUserACLs(t *testing.T) {
 		},
 	)
 
-	migrationACL, ok := findTopicACL(acls, clusterTopic.MigrationTopic)
-	if !ok {
-		t.Fatal("expected gh-migration topic ACL")
+	// Migration topic ACL must NOT be statically granted.
+	if _, ok := findTopicACL(acls, clusterTopic.MigrationTopic); ok {
+		t.Fatal("migration topic ACL must not be statically granted; it is managed dynamically")
 	}
-	assertACLContract(
-		t, migrationACL,
-		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic,
-		clusterTopic.MigrationTopic,
-		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypeLiteral,
-		[]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
-			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
-			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
-		},
-	)
 
 	statusACL, ok := findTopicACL(acls, clusterTopic.StatusTopic)
 	if !ok {
@@ -407,9 +399,10 @@ func TestCombineManagedHubACLsUpgrade(t *testing.T) {
 			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite,
 		}),
 		utils.WriteTopicACL(clusterTopic.MigrationTopic),
+		utils.ReadTopicACL(clusterTopic.MigrationTopic, false),
 	}
 
-	merged := combineACLs(filterObsoleteManagedHubACLs(legacyACLs, clusterTopic.SpecTopic),
+	merged := combineACLs(filterObsoleteManagedHubACLs(legacyACLs, clusterTopic.SpecTopic, clusterTopic.MigrationTopic),
 		managedHubUserACLs(clusterTopic, "hub1"))
 
 	hasWildcardGroup, specOps, migrationOps := collectManagedHubACLTopicOps(merged, clusterTopic)
@@ -452,27 +445,20 @@ func TestCombineManagedHubACLsUpgrade(t *testing.T) {
 		}
 	}
 
-	migrationReadACL, ok := findTopicACLWithOperations(
+	// Migration Read ACL must NOT be statically granted after upgrade.
+	// It is managed dynamically by MigrationACLReconciler.
+	_, hasStaticMigrationRead := findTopicACLWithOperations(
 		merged, clusterTopic.MigrationTopic,
 		[]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
 			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
 			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
 		},
 	)
-	if !ok {
-		t.Fatal("expected gh-migration Describe+Read ACL after upgrade")
+	if hasStaticMigrationRead {
+		t.Fatal("migration topic Read ACL must not be statically granted after upgrade")
 	}
-	assertACLContract(
-		t, migrationReadACL,
-		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourceTypeTopic,
-		clusterTopic.MigrationTopic,
-		kafkav1beta2.KafkaUserSpecAuthorizationAclsElemResourcePatternTypeLiteral,
-		[]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
-			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
-			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
-		},
-	)
 
+	// Migration Write ACL from the MigrationACLReconciler must be preserved.
 	migrationWriteACL, ok := findTopicACLWithOperations(
 		merged, clusterTopic.MigrationTopic,
 		[]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{
@@ -491,8 +477,8 @@ func TestCombineManagedHubACLsUpgrade(t *testing.T) {
 			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite,
 		},
 	)
-	if !containsOperation(migrationOps, kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead) {
-		t.Fatal("managed hub must retain Read on gh-migration after upgrade")
+	if containsOperation(migrationOps, kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead) {
+		t.Fatal("migration topic Read ACL must not be statically retained after upgrade")
 	}
 }
 

--- a/test/integration/operator/controllers/transporter_test.go
+++ b/test/integration/operator/controllers/transporter_test.go
@@ -393,7 +393,7 @@ var _ = Describe("transporter", Ordered, func() {
 
 		err = runtimeClient.Get(ctx, client.ObjectKeyFromObject(kafkaUser), kafkaUser)
 		Expect(err).To(Succeed())
-		Expect(4).To(Equal(len(kafkaUser.Spec.Authorization.Acls)))
+		Expect(3).To(Equal(len(kafkaUser.Spec.Authorization.Acls)))
 
 		aclByTopic := map[string][]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{}
 		consumerGroupACLs := []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{}
@@ -414,11 +414,8 @@ var _ = Describe("transporter", Ordered, func() {
 		))
 		Expect(specOps).NotTo(ContainElement(kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemWrite))
 
-		migrationOps := aclByTopic[config.GetMigrationTopic()]
-		Expect(migrationOps).To(ConsistOf(
-			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemDescribe,
-			kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElemRead,
-		))
+		// Migration topic Read ACL must NOT be statically granted.
+		Expect(aclByTopic).NotTo(HaveKey(config.GetMigrationTopic()))
 
 		statusOps := aclByTopic[config.GetStatusTopic(clusterName)]
 		Expect(statusOps).To(Equal([]kafkav1beta2.KafkaUserSpecAuthorizationAclsElemOperationsElem{


### PR DESCRIPTION
Fixes
[ACM-40367](https://redhat.atlassian.net/browse/ACM-40367)

## Summary
- Backport of #2780 to release-2.14 (GH 1.5)
- Remove static Read+Describe ACL on `gh-migration` from `managedHubUserACLs`; migration topic ACLs are now granted dynamically by `MigrationACLReconciler` only to hubs involved in an active migration
- Route migration events through the dedicated `gh-migration` topic via `cecontext.WithTopic` instead of the shared `gh-spec` topic
- Strip legacy static migration Read ACLs during KafkaUser upgrade reconciliation

**Note:** This branch uses a different migration controller structure (`NewMigrationController` factory) — the `sendMigrationEvent` helper and `migrationTopic` field were adapted to fit the existing pattern.

## Test plan
- [ ] Verify unit tests pass (`make unit-tests-operator`)
- [ ] Verify integration tests pass (`make integration-test/operator`)
- [ ] Confirm managed hub KafkaUsers have 3 ACLs (spec Read+Describe, status Write, consumer-group Read) — no static migration Read ACL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ACM-40367]: https://redhat.atlassian.net/browse/ACM-40367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ