### PR TITLE
ACM-40365: CVE-2026-71577 restrict migration topic ACL to active migration hubs (#2780)

### DIFF
--- a/operator/pkg/controllers/transporter/migration_acl_reconciler.go
+++ b/operator/pkg/controllers/transporter/migration_acl_reconciler.go
@@ -60,12 +60,18 @@ func (r *MigrationACLReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		if apierrors.IsNotFound(err) {
 			// Migration was deleted; re-sync all managed hub KafkaUsers so revoked ACLs
 			// are cleaned up even though the trigger object's Spec.From is gone.
-			return ctrl.Result{}, r.syncAllMigrationWriteACLs(ctx, mgh, req.Namespace)
+			if err := r.syncAllMigrationACLs(ctx, mgh, req.Namespace); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{}, nil
 		}
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("get ManagedClusterMigration %s: %w", req.NamespacedName, err)
 	}
 
 	if err := r.syncMigrationWriteACLs(ctx, mgh, req.Namespace, migration.Spec.From); err != nil {
+		return ctrl.Result{}, err
+	}
+	if err := r.syncMigrationReadACLs(ctx, mgh, req.Namespace, migration.Spec.From, migration.Spec.To); err != nil {
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{}, nil
@@ -93,7 +99,38 @@ func (r *MigrationACLReconciler) syncMigrationWriteACLs(
 	return nil
 }
 
-func (r *MigrationACLReconciler) syncAllMigrationWriteACLs(
+func (r *MigrationACLReconciler) syncMigrationReadACLs(
+	ctx context.Context,
+	mgh *operatorv1alpha4.MulticlusterGlobalHub,
+	namespace string,
+	triggerFromHub, triggerToHub string,
+) error {
+	list := &migrationv1alpha1.ManagedClusterMigrationList{}
+	if err := r.List(ctx, list, client.InNamespace(namespace)); err != nil {
+		return fmt.Errorf("failed to list ManagedClusterMigration resources: %w", err)
+	}
+
+	needed := activeMigrationHubs(list)
+	hubsToSync := sets.NewString()
+	if triggerFromHub != "" {
+		hubsToSync.Insert(triggerFromHub)
+	}
+	if triggerToHub != "" {
+		hubsToSync.Insert(triggerToHub)
+	}
+	for hub := range needed {
+		hubsToSync.Insert(hub)
+	}
+	for _, hub := range hubsToSync.UnsortedList() {
+		_, grant := needed[hub]
+		if err := protocol.SyncMigrationReadACL(r.mgr, mgh, hub, grant, protocol.WithContext(ctx)); err != nil {
+			return fmt.Errorf("failed to sync migration read ACL for hub %q: %w", hub, err)
+		}
+	}
+	return nil
+}
+
+func (r *MigrationACLReconciler) syncAllMigrationACLs(
 	ctx context.Context,
 	mgh *operatorv1alpha4.MulticlusterGlobalHub,
 	namespace string,
@@ -102,7 +139,8 @@ func (r *MigrationACLReconciler) syncAllMigrationWriteACLs(
 	if err := r.List(ctx, list, client.InNamespace(namespace)); err != nil {
 		return fmt.Errorf("failed to list ManagedClusterMigration resources: %w", err)
 	}
-	needed := deployingSourceHubs(list)
+	writeNeeded := deployingSourceHubs(list)
+	readNeeded := activeMigrationHubs(list)
 
 	kafkaUsers := &kafkav1beta2.KafkaUserList{}
 	if err := r.List(ctx, kafkaUsers, client.InNamespace(namespace)); err != nil {
@@ -110,13 +148,17 @@ func (r *MigrationACLReconciler) syncAllMigrationWriteACLs(
 	}
 
 	for i := range kafkaUsers.Items {
-		fromHub, ok := managedHubFromKafkaUser(&kafkaUsers.Items[i])
+		hub, ok := managedHubFromKafkaUser(&kafkaUsers.Items[i])
 		if !ok {
 			continue
 		}
-		_, grant := needed[fromHub]
-		if err := protocol.SyncMigrationWriteACL(r.mgr, mgh, fromHub, grant, protocol.WithContext(ctx)); err != nil {
-			return fmt.Errorf("failed to sync migration write ACL for hub %q: %w", fromHub, err)
+		_, grantWrite := writeNeeded[hub]
+		if err := protocol.SyncMigrationWriteACL(r.mgr, mgh, hub, grantWrite, protocol.WithContext(ctx)); err != nil {
+			return fmt.Errorf("failed to sync migration write ACL for hub %q: %w", hub, err)
+		}
+		_, grantRead := readNeeded[hub]
+		if err := protocol.SyncMigrationReadACL(r.mgr, mgh, hub, grantRead, protocol.WithContext(ctx)); err != nil {
+			return fmt.Errorf("failed to sync migration read ACL for hub %q: %w", hub, err)
 		}
 	}
 	return nil
@@ -150,6 +192,19 @@ func hubsToSyncForMigration(fromHub string, needed map[string]struct{}) []string
 		hubs.Insert(hub)
 	}
 	return hubs.UnsortedList()
+}
+
+func activeMigrationHubs(list *migrationv1alpha1.ManagedClusterMigrationList) map[string]struct{} {
+	needed := make(map[string]struct{})
+	for i := range list.Items {
+		mcm := &list.Items[i]
+		if mcm.DeletionTimestamp != nil {
+			continue
+		}
+		needed[mcm.Spec.From] = struct{}{}
+		needed[mcm.Spec.To] = struct{}{}
+	}
+	return needed
 }
 
 func managedHubFromKafkaUser(user *kafkav1beta2.KafkaUser) (string, bool) {

--- a/operator/pkg/controllers/transporter/migration_acl_reconciler_test.go
+++ b/operator/pkg/controllers/transporter/migration_acl_reconciler_test.go
@@ -362,10 +362,18 @@ func newMigrationACLReconcilerFixtures(
 			),
 		},
 	}
+	kafkaUser2 := &kafkav1beta2.KafkaUser{
+		ObjectMeta: metav1.ObjectMeta{Name: "hub2-kafka-user", Namespace: "test-ns"},
+		Spec: &kafkav1beta2.KafkaUserSpec{
+			Authorization: simpleKafkaUserAuthorization(
+				protocol.ReadTopicACL("gh-spec", false),
+			),
+		},
+	}
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
-		WithObjects(mgh, kafkaUser).
+		WithObjects(mgh, kafkaUser, kafkaUser2).
 		Build()
 
 	return scheme, fakeClient, mgh, kafkaUser

--- a/operator/pkg/controllers/transporter/protocol/migration_acl.go
+++ b/operator/pkg/controllers/transporter/protocol/migration_acl.go
@@ -32,3 +32,16 @@ func SyncMigrationWriteACL(
 	trans := NewStrimziTransporter(mgr, mgh, opts...)
 	return trans.SyncMigrationWriteACL(fromHub, grant)
 }
+
+// SyncMigrationReadACL grants or revokes Read+Describe on the migration topic
+// for a hub involved in an active migration.
+func SyncMigrationReadACL(
+	mgr ctrl.Manager,
+	mgh *operatorv1alpha4.MulticlusterGlobalHub,
+	hub string,
+	grant bool,
+	opts ...KafkaOption,
+) error {
+	trans := NewStrimziTransporter(mgr, mgh, opts...)
+	return trans.SyncMigrationReadACL(hub, grant)
+}

--- a/operator/pkg/controllers/transporter/protocol/strimzi_migration_acl.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_migration_acl.go
@@ -30,6 +30,10 @@ func migrationWriteACLKey(topic string) string {
 	return GenerateACLKey(WriteTopicACL(topic))
 }
 
+func migrationReadACLKey(topic string) string {
+	return GenerateACLKey(ReadTopicACL(topic, false))
+}
+
 func (k *strimziTransporter) hasMigrationWriteACL(acls []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem) bool {
 	key := migrationWriteACLKey(config.GetMigrationTopic())
 	for _, acl := range acls {
@@ -40,13 +44,45 @@ func (k *strimziTransporter) hasMigrationWriteACL(acls []kafkav1beta2.KafkaUserS
 	return false
 }
 
+func (k *strimziTransporter) hasMigrationReadACL(acls []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem) bool {
+	key := migrationReadACLKey(config.GetMigrationTopic())
+	for _, acl := range acls {
+		if GenerateACLKey(acl) == key {
+			return true
+		}
+	}
+	return false
+}
+
 // SyncMigrationWriteACL grants or revokes Write on the migration topic for a source hub.
 func (k *strimziTransporter) SyncMigrationWriteACL(fromHub string, grant bool) error {
-	if fromHub == "" {
+	return k.syncMigrationACL(fromHub, grant, k.hasMigrationWriteACL,
+		migrationWriteACLKey, WriteTopicACL)
+}
+
+// SyncMigrationReadACL grants or revokes Read+Describe on the migration topic for a hub
+// involved in an active migration.
+func (k *strimziTransporter) SyncMigrationReadACL(hub string, grant bool) error {
+	return k.syncMigrationACL(hub, grant, k.hasMigrationReadACL,
+		migrationReadACLKey, func(topic string) kafkav1beta2.KafkaUserSpecAuthorizationAclsElem {
+			return ReadTopicACL(topic, false)
+		})
+}
+
+// syncMigrationACL is the shared implementation for granting/revoking a single ACL
+// type (Read or Write) on the migration topic for a given hub's KafkaUser.
+func (k *strimziTransporter) syncMigrationACL(
+	hub string,
+	grant bool,
+	hasACL func([]kafkav1beta2.KafkaUserSpecAuthorizationAclsElem) bool,
+	keyFn func(string) string,
+	aclFn func(string) kafkav1beta2.KafkaUserSpecAuthorizationAclsElem,
+) error {
+	if hub == "" {
 		return nil
 	}
 
-	userName := config.GetKafkaUserName(fromHub)
+	userName := config.GetKafkaUserName(hub)
 	kafkaUser := &kafkav1beta2.KafkaUser{}
 	err := k.manager.GetClient().Get(k.ctx, types.NamespacedName{
 		Name:      userName,
@@ -56,14 +92,14 @@ func (k *strimziTransporter) SyncMigrationWriteACL(fromHub string, grant bool) e
 		if !grant {
 			return nil
 		}
-		return fmt.Errorf("kafka user %s not found for migration write ACL", userName)
+		return fmt.Errorf("kafka user %s not found for migration ACL", userName)
 	}
 	if err != nil {
-		return err
+		return fmt.Errorf("get KafkaUser %s/%s: %w", k.kafkaClusterNamespace, userName, err)
 	}
 
 	migrationTopic := config.GetMigrationTopic()
-	desiredWriteACL := WriteTopicACL(migrationTopic)
+	desiredACL := aclFn(migrationTopic)
 
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		latestKafkaUser := &kafkav1beta2.KafkaUser{}
@@ -75,19 +111,19 @@ func (k *strimziTransporter) SyncMigrationWriteACL(fromHub string, grant bool) e
 		}
 
 		currentACLs := currentKafkaUserACLs(latestKafkaUser)
-		if k.hasMigrationWriteACL(currentACLs) == grant {
+		if hasACL(currentACLs) == grant {
 			return nil
 		}
 
 		updatedACLs := make([]kafkav1beta2.KafkaUserSpecAuthorizationAclsElem, 0, len(currentACLs))
 		for _, acl := range currentACLs {
-			if GenerateACLKey(acl) == migrationWriteACLKey(migrationTopic) {
+			if GenerateACLKey(acl) == keyFn(migrationTopic) {
 				continue
 			}
 			updatedACLs = append(updatedACLs, acl)
 		}
 		if grant {
-			updatedACLs = append(updatedACLs, desiredWriteACL)
+			updatedACLs = append(updatedACLs, desiredACL)
 		}
 
 		if len(updatedACLs) == 0 {

--- a/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
@@ -431,7 +431,6 @@ func (k *strimziTransporter) EnsureUser(clusterName string) (string, error) {
 	simpleACLs := []kafkav1beta2.KafkaUserSpecAuthorizationAclsElem{
 		ConsumeGroupReadACL(),
 		ReadTopicACL(clusterTopic.SpecTopic, false),
-		ReadTopicACL(clusterTopic.MigrationTopic, false),
 		WriteTopicACL(clusterTopic.StatusTopic),
 	}
 

--- a/test/integration/operator/controllers/transporter_test.go
+++ b/test/integration/operator/controllers/transporter_test.go
@@ -388,7 +388,16 @@ var _ = Describe("transporter", Ordered, func() {
 		err = runtimeClient.Get(ctx, client.ObjectKeyFromObject(kafkaUser), kafkaUser)
 		Expect(err).To(Succeed())
 		// utils.PrettyPrint(kafkaUser.Spec.Authorization)
-		Expect(4).To(Equal(len(kafkaUser.Spec.Authorization.Acls)))
+		Expect(3).To(Equal(len(kafkaUser.Spec.Authorization.Acls)))
+
+		aclByTopic := make(map[string]bool)
+		for _, acl := range kafkaUser.Spec.Authorization.Acls {
+			if acl.Resource.Name != nil {
+				aclByTopic[*acl.Resource.Name] = true
+			}
+		}
+		// Migration topic Read ACL must NOT be statically granted.
+		Expect(aclByTopic).NotTo(HaveKey(config.GetMigrationTopic()))
 
 		// topic: create
 		clusterTopic, err := trans.EnsureTopic(clusterName)


### PR DESCRIPTION
Fixes
[ACM-40365](https://redhat.atlassian.net/browse/ACM-40365)

## Summary
- Backport of #2780 to release-2.13 (GH 1.4)
- Remove static Read+Describe ACL on `gh-migration` from inline `simpleACLs`; migration topic ACLs are now granted dynamically by `MigrationACLReconciler` only to hubs involved in an active migration
- Add `SyncMigrationReadACL` alongside existing `SyncMigrationWriteACL`, refactored into shared `syncMigrationACL`
- Add `syncMigrationReadACLs`, `syncAllMigrationACLs`, and `activeMigrationHubs` to `MigrationACLReconciler`
- Adapted for release-2.13: no Phase-based filtering (all non-deleted migrations are active), ACL helpers in `protocol` package directly

## Test plan
- [ ] Integration test updated: ACL count 4→3, migration topic absence assertion added
- [ ] Verify `EnsureUser` no longer grants static Read ACL on migration topic
- [ ] Verify `MigrationACLReconciler` dynamically grants/revokes Read ACLs for active migrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ACM-40365]: https://redhat.atlassian.net/browse/ACM-40365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ