### PR TITLE
ACM-34442: BYO Kafka per-hub credentials and ACL guide

### DIFF
--- a/agent/cmd/main.go
+++ b/agent/cmd/main.go
@@ -181,6 +181,10 @@ func completeConfig(ctx context.Context, c client.Client, agentConfig *configs.A
 		return fmt.Errorf("flag consumer-worker-pool-size should be in the scope [1, 100]")
 	}
 
+	if agentConfig.TransportConfig != nil {
+		agentConfig.TransportConfig.LeafHubName = agentConfig.LeafHubName
+	}
+
 	configs.SetAgentConfig(agentConfig)
 	return nil
 }

--- a/agent/cmd/main_test.go
+++ b/agent/cmd/main_test.go
@@ -101,6 +101,7 @@ func TestCompleteConfig(t *testing.T) {
 				MetricsAddress:   "0.0.0.0:8384",
 				TransportConfig: &transport.TransportInternalConfig{
 					TransportType: string(transport.Kafka),
+					LeafHubName:   "123",
 					KafkaCredential: &transport.KafkaConfig{
 						ConsumerGroupID: "test-hub",
 					},
@@ -137,6 +138,7 @@ func TestCompleteConfig(t *testing.T) {
 				MetricsAddress:   "0.0.0.0:8384",
 				TransportConfig: &transport.TransportInternalConfig{
 					TransportType: string(transport.Kafka),
+					LeafHubName:   "hub1",
 				},
 			},
 		},

--- a/doc/README.md
+++ b/doc/README.md
@@ -28,6 +28,7 @@ The multicluster global hub is useful when a single hub cluster cannot manage th
     - [Grafana dashboards](#grafana-dashboards)
     - [Cronjobs and Metrics](#cronjobs-and-metrics)
   - [Built-in PostgreSQL Configuration](./global_hub_builtin_postgresql.md)
+  - [Bring your own Kafka, Postgres, and Grafana](./byo.md)
   - [Troubleshooting](./troubleshooting.md)
   - [Development preview features](./dev-preview.md)
   - [Known issues](#known-issues)

--- a/doc/byo.md
+++ b/doc/byo.md
@@ -64,8 +64,8 @@ Grant ACLs that match the built-in Strimzi transporter. Do **not** grant every m
 
 | Principal | `gh-spec` | `gh-migration` | Status topic |
 |-----------|-----------|----------------|--------------|
-| Global hub manager (`global-hub-kafka-user`) | Describe, Read, **Write** | Describe, Read, **Write** | Describe, Read on `gh-status` (or on each custom status topic) |
-| Managed hub `{hub}-kafka-user` | Describe, **Read** (no Write) | Describe, Read; **Write** only while that hub is an active migration source | Describe, Read, **Write** on `gh-status` (or that hub's custom status topic) |
+| Global hub manager (`global-hub-kafka-user`) | Describe, Read, **Write** | Describe, Read, **Write** | Describe, Read on the configured status topic |
+| Managed hub `{hub}-kafka-user` | Describe, **Read** (no Write) | Describe, Read; **Write** only while that hub is an active migration source | Describe, Read, **Write** on the configured status topic |
 | Consumer group | Per-hub literal group name | Per-hub literal group name | Per-hub literal group name (not `*`) |
 
 Notes:
@@ -74,7 +74,7 @@ Notes:
 - During cluster migration, the source hub publishes deploying bundles to `gh-migration`. The target hub agent consumes from `gh-migration` as well as `gh-spec`.
 - Grant **Write** on `gh-migration` to the source managed hub only for the duration of an active migration, then revoke it. With built-in Strimzi Kafka, the operator applies and removes that ACL automatically; with BYO Kafka, you must update ACLs yourself or through your Kafka administration tooling.
 - For more information about cluster migration, see [Managed Cluster Migration](./migration/global_hub_cluster_migration.md).
-- Built-in Strimzi Kafka uses per-hub status topics such as `gh-status.<cluster-name>` with a prefix ACL on `gh-status`. BYO Kafka uses the shared topic `gh-status` with a literal ACL unless you override `statusTopic`.
+- Built-in Strimzi Kafka uses per-hub status topics such as `gh-status.<cluster-name>` with a prefix ACL on `gh-status`. BYO Kafka always uses one shared status topic (`gh-status` by default, or the configured `statusTopic`) for every managed hub.
 
 Example Strimzi `KafkaUser` ACL entries for the global hub manager transport user (BYO defaults shown):
 

--- a/doc/byo.md
+++ b/doc/byo.md
@@ -2,29 +2,53 @@ Multicluster global hub depends on the middleware (Kafka, Postgres) and observab
 
 ## Bring your own Kafka
 
-If you have your own Kafka, you can use it as the transport for multicluster global hub. You need to create a secret `multicluster-global-hub-transport` in `multicluster-global-hub` namespace. The secret contains the following fields:
+If you have your own Kafka, you can use it as the transport for multicluster global hub.
 
-- `bootstrap.servers`: Required, the Kafka bootstrap servers.
-- `ca.crt`: Required, if you use the `KafkaUser` custom resource to configure authentication credentials, see [User authentication](https://strimzi.io/docs/operators/latest/deploying.html#con-securing-client-authentication-str) in the STRIMZI documentation for the steps to extract the `ca.crt` certificate from the secret.
-- `client.crt`: Required, see [User authentication](https://strimzi.io/docs/operators/latest/deploying.html#con-securing-client-authentication-str) in the STRIMZI documentation for the steps to extract the `user.crt` certificate from the secret.
-- `client.key`: Required, see [User authentication](https://strimzi.io/docs/operators/latest/deploying.html#con-securing-client-authentication-str) in the STRIMZI documentation for the steps to extract the `user.key` from the secret.
+### Transport secrets
 
-You can create the secret by running the following command:
+Create Kafka client secrets in the `multicluster-global-hub` namespace.
+
+| Secret | Used by | Required |
+|--------|---------|----------|
+| `multicluster-global-hub-transport` | Global Hub manager | Yes |
+| `multicluster-global-hub-transport-<clusterName>` | Managed hub named `<clusterName>` | Recommended |
+
+Each secret contains:
+
+- `bootstrap_server`: Required. The Kafka bootstrap servers.
+- `ca.crt`: Required. If you use the `KafkaUser` custom resource to configure authentication credentials, see [User authentication](https://strimzi.io/docs/operators/latest/deploying.html#con-securing-client-authentication-str) in the Strimzi documentation for the steps to extract the `ca.crt` certificate from the secret.
+- `client.crt`: Required. See [User authentication](https://strimzi.io/docs/operators/latest/deploying.html#con-securing-client-authentication-str) for the steps to extract the `user.crt` certificate from the secret.
+- `client.key`: Required. See [User authentication](https://strimzi.io/docs/operators/latest/deploying.html#con-securing-client-authentication-str) for the steps to extract the `user.key` from the secret.
+
+Give **each managed hub a distinct client certificate**. Shared client certificates across hubs are not isolated by Kafka ACLs. The operator rejects two per-hub secrets that contain the same `client.crt`. The agent also fails to start when a BYO client certificate CommonName is `{other-hub}-kafka-user` and that name does not match the local hub.
+
+If a per-hub secret is not present, the operator falls back to the shared `multicluster-global-hub-transport` secret (legacy). That mode cannot enforce per-hub Kafka write isolation.
+
+Create the manager secret:
+
 ```bash
 kubectl create secret generic multicluster-global-hub-transport -n multicluster-global-hub \
     --from-literal=bootstrap_server=<kafka-bootstrap-server-address> \
     --from-file=ca.crt=<CA-cert-for-kafka-server> \
     --from-file=client.crt=<Client-cert-for-kafka-server> \
-    --from-file=client.key=<Client-key-for-kafka-server> 
+    --from-file=client.key=<Client-key-for-kafka-server>
 ```
 
-*Prerequisite:*  See the following requirements for bringing your own Kafka: 
+Create a per-hub secret for a managed hub named `hub1`:
+
+```bash
+kubectl create secret generic multicluster-global-hub-transport-hub1 -n multicluster-global-hub \
+    --from-literal=bootstrap_server=<kafka-bootstrap-server-address> \
+    --from-file=ca.crt=<CA-cert-for-kafka-server> \
+    --from-file=client.crt=<hub1-client-cert> \
+    --from-file=client.key=<hub1-client-key>
+```
+
+*Prerequisite:*
 
 - Unless you configured your Kafka to automatically create topics, you must manually create the transport topics `gh-spec`, `gh-migration`, and `gh-status`. By default, all managed hubs publish status to the shared topic `gh-status`. If you set a different `statusTopic` in `spec.dataLayer.kafka.topics`, create that topic instead. See [Kafka topics and ACLs](#kafka-topics-and-acls) below.
-
-- Kafka 3.3 or later is tested.\
-
-- Suggest to have persistent volume for your Kafka.
+- Kafka 3.3 or later is tested.
+- Persistent volume is recommended for Kafka.
 
 ### Kafka topics and ACLs
 
@@ -36,22 +60,23 @@ Global Hub uses three Kafka topics for transport:
 | `gh-migration` | Cluster migration deploying-phase bundles (source hub to target hub) |
 | `gh-status` | Status and compliance events from managed hubs to the global hub manager (shared topic by default) |
 
-When you manage Kafka ACLs yourself, grant permissions for your deployment:
+Grant ACLs that match the built-in Strimzi transporter. Do **not** grant every managed hub Read+Write on both spec and status topics.
 
 | Principal | `gh-spec` | `gh-migration` | Status topic |
 |-----------|-----------|----------------|--------------|
-| Global hub manager | Describe, Read, **Write** | Describe, Read, **Write** | Describe, Read on `gh-status` (or on each custom status topic) |
-| Managed hub agent | Describe, Read, Write | Describe, Read; **Write** on the source hub only while a cluster migration is in the Deploying phase | Describe, Read, **Write** on `gh-status` (or on a custom status topic if configured) |
+| Global hub manager (`global-hub-kafka-user`) | Describe, Read, **Write** | Describe, Read, **Write** | Describe, Read on `gh-status` (or on each custom status topic) |
+| Managed hub `{hub}-kafka-user` | Describe, **Read** (no Write) | Describe, Read; **Write** only while that hub is an active migration source | Describe, Read, **Write** on `gh-status` (or that hub's custom status topic) |
+| Consumer group | Per-hub literal group name | Per-hub literal group name | Per-hub literal group name (not `*`) |
 
 Notes:
 
-- The global hub manager publishes to `gh-spec`. Managed hub agents consume from `gh-spec`.
+- The global hub manager publishes to `gh-spec`. Managed hub agents consume from `gh-spec` and must not produce to it.
 - During cluster migration, the source hub publishes deploying bundles to `gh-migration`. The target hub agent consumes from `gh-migration` as well as `gh-spec`.
-- Grant **Write** on `gh-migration` to the source managed hub only for the duration of an active migration Deploying phase, then revoke it. With built-in Strimzi Kafka, the operator applies and removes that ACL automatically; with BYO Kafka, you must update ACLs yourself or through your Kafka administration tooling.
+- Grant **Write** on `gh-migration` to the source managed hub only for the duration of an active migration, then revoke it. With built-in Strimzi Kafka, the operator applies and removes that ACL automatically; with BYO Kafka, you must update ACLs yourself or through your Kafka administration tooling.
 - For more information about cluster migration, see [Managed Cluster Migration](./migration/global_hub_cluster_migration.md).
 - Built-in Strimzi Kafka uses per-hub status topics such as `gh-status.<cluster-name>` with a prefix ACL on `gh-status`. BYO Kafka uses the shared topic `gh-status` with a literal ACL unless you override `statusTopic`.
 
-Example Strimzi `KafkaUser` ACL entries for the global hub transport user (BYO defaults shown):
+Example Strimzi `KafkaUser` ACL entries for the global hub manager transport user (BYO defaults shown):
 
 ```yaml
 # gh-spec — manager publishes policy/spec sync
@@ -60,7 +85,7 @@ Example Strimzi `KafkaUser` ACL entries for the global hub transport user (BYO d
     type: topic
     name: gh-spec
     patternType: literal
-# gh-migration — manager oversight; source hub writes during migration Deploying
+# gh-migration — manager oversight; source hub writes during migration
 - operations: [Describe, Read, Write]
   resource:
     type: topic
@@ -74,7 +99,28 @@ Example Strimzi `KafkaUser` ACL entries for the global hub transport user (BYO d
     patternType: literal
 ```
 
-Managed hub agents also need **Read** on `gh-spec` and `gh-migration`, **Write** on `gh-status` (or on a custom status topic), and temporary **Write** on `gh-migration` when that hub is the source of an in-progress migration.
+Example managed-hub `KafkaUser` ACL entries:
+
+```yaml
+# gh-spec — consume spec/policy only
+- operations: [Describe, Read]
+  resource:
+    type: topic
+    name: gh-spec
+    patternType: literal
+# gh-migration — read always; add Write only while this hub is a migration source
+- operations: [Describe, Read]
+  resource:
+    type: topic
+    name: gh-migration
+    patternType: literal
+# gh-status — publish this hub's status
+- operations: [Describe, Read, Write]
+  resource:
+    type: topic
+    name: gh-status
+    patternType: literal
+```
 
 ## Bring your own Postgres
 

--- a/operator/pkg/controllers/agent/addon/default_agent_controller.go
+++ b/operator/pkg/controllers/agent/addon/default_agent_controller.go
@@ -46,7 +46,7 @@ type DefaultAgentController struct {
 // Assert whether a secret is associated with or affects the addon
 func targetAddonSecret(obj client.Object) bool {
 	if obj.GetName() == config.GetImagePullSecretName() ||
-		obj.GetName() == constants.GHTransportSecretName ||
+		constants.IsGHTransportSecret(obj.GetName()) ||
 		obj.GetLabels() != nil && obj.GetLabels()["strimzi.io/cluster"] == operatortrans.KafkaClusterName &&
 			obj.GetLabels()["strimzi.io/kind"] == "KafkaUser" {
 		return true

--- a/operator/pkg/controllers/transporter/protocol/byo_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/byo_transporter.go
@@ -83,8 +83,7 @@ func (s *BYOTransporter) EnsureUser(clusterName string) (string, error) {
 	if secretName == s.sharedSecretName() {
 		s.log.Info("BYO Kafka is using the shared transport secret; " +
 			"provide a per-hub secret for isolated credentials")
-	}
-	if err := s.validateDistinctClientCerts(clusterName, secret.Data[transportSecretClientCertKey]); err != nil {
+	} else if err := s.validateDistinctClientCerts(clusterName, secret.Data[transportSecretClientCertKey]); err != nil {
 		return "", err
 	}
 	return config.GetKafkaUserName(clusterName), nil
@@ -109,11 +108,11 @@ func (s *BYOTransporter) Prune(clusterName string) error {
 }
 
 func (s *BYOTransporter) GetConnCredential(clusterName string) (*transport.KafkaConfig, error) {
-	kafkaSecret, _, err := s.getTransportSecret(clusterName)
+	kafkaSecret, secretName, err := s.getTransportSecret(clusterName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get BYO Kafka transport secret: %w", err)
 	}
-	if !isManagerCluster(clusterName) {
+	if !isManagerCluster(clusterName) && secretName != s.sharedSecretName() {
 		if err := s.validateDistinctClientCerts(clusterName, kafkaSecret.Data[transportSecretClientCertKey]); err != nil {
 			return nil, err
 		}
@@ -199,7 +198,7 @@ func (s *BYOTransporter) validateDistinctClientCerts(clusterName string, clientC
 	for i := range secretList.Items {
 		secret := &secretList.Items[i]
 		otherCluster := constants.ClusterNameFromGHTransportSecret(secret.Name)
-		if otherCluster == "" || otherCluster == clusterName {
+		if otherCluster == "" || otherCluster == clusterName || isManagerCluster(otherCluster) {
 			continue
 		}
 		otherCert := secret.Data[transportSecretClientCertKey]

--- a/operator/pkg/controllers/transporter/protocol/byo_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/byo_transporter.go
@@ -1,6 +1,23 @@
+/*
+Copyright Contributors to the Open Cluster Management project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package protocol
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"fmt"
@@ -8,10 +25,12 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 )
@@ -24,28 +43,52 @@ type BYOTransporter struct {
 	runtimeClient client.Client
 }
 
-// create the transport with secret(BYO case), it should meet the following conditions
-// 1. name: "multicluster-global-hub-transport"
-// 2. properties: "bootstrap_server", "ca.crt", "client.crt" and "client.key"
+var byoTransporter *BYOTransporter
+
+// NewBYOTransporter creates the transport from customer-provided Kafka secrets.
+// The manager uses the shared secret "multicluster-global-hub-transport".
+// Each managed hub may supply "multicluster-global-hub-transport-<clusterName>"
+// so Kafka ACLs can bind a distinct client certificate to that hub. When the
+// per-hub secret is absent, the shared secret is used (legacy BYO).
 func NewBYOTransporter(ctx context.Context, namespacedName types.NamespacedName,
 	c client.Client,
 ) *BYOTransporter {
-	transporterConstructMu.Lock()
-	defer transporterConstructMu.Unlock()
-
-	t := &BYOTransporter{
-		log:           logger.ZaprLogger(),
-		ctx:           ctx,
-		runtimeClient: c,
-		name:          namespacedName.Name,
-		namespace:     namespacedName.Namespace,
+	if byoTransporter == nil {
+		byoTransporter = &BYOTransporter{
+			log: logger.ZaprLogger(),
+		}
+		config.SetTransporter(byoTransporter)
 	}
-	config.SetTransporter(t)
-	return t
+	byoTransporter.ctx = ctx
+	byoTransporter.runtimeClient = c
+	byoTransporter.name = namespacedName.Name
+	byoTransporter.namespace = namespacedName.Namespace
+	return byoTransporter
 }
 
+// EnsureUser validates that a BYO transport secret exists for the cluster and
+// that per-hub client certificates are distinct. Kafka users and ACLs remain
+// customer-managed; see doc/byo.md. Missing secrets are logged, not rejected,
+// so addon install can proceed before credentials are created.
 func (s *BYOTransporter) EnsureUser(clusterName string) (string, error) {
-	return "", nil
+	if clusterName == "" {
+		return "", nil
+	}
+	secret, secretName, err := s.getTransportSecret(clusterName)
+	if err != nil {
+		s.log.Info("BYO Kafka transport secret not found; provide a per-hub or shared secret",
+			"cluster", clusterName, "error", err)
+		return config.GetKafkaUserName(clusterName), nil
+	}
+	if secretName == s.sharedSecretName() {
+		s.log.Info("BYO Kafka is using the shared transport secret; "+
+			"provide a per-hub secret for isolated credentials",
+			"cluster", clusterName, "secret", secretName)
+	}
+	if err := s.validateDistinctClientCerts(clusterName, secret.Data[filepath.Join("client.crt")]); err != nil {
+		return "", err
+	}
+	return config.GetKafkaUserName(clusterName), nil
 }
 
 func (s *BYOTransporter) EnsureTopic(clusterName string) (*transport.ClusterTopic, error) {
@@ -66,13 +109,14 @@ func (s *BYOTransporter) Prune(clusterName string) error {
 }
 
 func (s *BYOTransporter) GetConnCredential(clusterName string) (*transport.KafkaConfig, error) {
-	kafkaSecret := &corev1.Secret{}
-	err := s.runtimeClient.Get(s.ctx, types.NamespacedName{
-		Name:      s.name,
-		Namespace: s.namespace,
-	}, kafkaSecret)
+	kafkaSecret, _, err := s.getTransportSecret(clusterName)
 	if err != nil {
 		return nil, err
+	}
+	if clusterName != "" {
+		if err := s.validateDistinctClientCerts(clusterName, kafkaSecret.Data[filepath.Join("client.crt")]); err != nil {
+			return nil, err
+		}
 	}
 
 	mgh, err := config.GetMulticlusterGlobalHub(context.Background(), s.runtimeClient)
@@ -97,4 +141,72 @@ func (s *BYOTransporter) GetConnCredential(clusterName string) (*transport.Kafka
 		ClientCert:     base64.StdEncoding.EncodeToString(kafkaSecret.Data[filepath.Join("client.crt")]),
 		ClientKey:      base64.StdEncoding.EncodeToString(kafkaSecret.Data[filepath.Join("client.key")]),
 	}, nil
+}
+
+func (s *BYOTransporter) sharedSecretName() string {
+	if s.name != "" {
+		return s.name
+	}
+	return constants.GHTransportSecretName
+}
+
+func (s *BYOTransporter) getTransportSecret(clusterName string) (*corev1.Secret, string, error) {
+	if clusterName != "" {
+		perHubName := constants.GHTransportSecretNameForCluster(clusterName)
+		perHubSecret := &corev1.Secret{}
+		err := s.runtimeClient.Get(s.ctx, types.NamespacedName{
+			Name:      perHubName,
+			Namespace: s.namespace,
+		}, perHubSecret)
+		if err == nil {
+			return perHubSecret, perHubName, nil
+		}
+		if !apierrors.IsNotFound(err) {
+			return nil, "", err
+		}
+	}
+
+	sharedName := s.sharedSecretName()
+	sharedSecret := &corev1.Secret{}
+	err := s.runtimeClient.Get(s.ctx, types.NamespacedName{
+		Name:      sharedName,
+		Namespace: s.namespace,
+	}, sharedSecret)
+	if err != nil {
+		if apierrors.IsNotFound(err) && clusterName != "" {
+			return nil, "", fmt.Errorf("BYO Kafka secret %q or %q not found in namespace %q",
+				constants.GHTransportSecretNameForCluster(clusterName), sharedName, s.namespace)
+		}
+		return nil, "", err
+	}
+	return sharedSecret, sharedName, nil
+}
+
+func (s *BYOTransporter) validateDistinctClientCerts(clusterName string, clientCert []byte) error {
+	if clusterName == "" || len(clientCert) == 0 {
+		return nil
+	}
+
+	secretList := &corev1.SecretList{}
+	if err := s.runtimeClient.List(s.ctx, secretList, client.InNamespace(s.namespace)); err != nil {
+		return fmt.Errorf("failed to list BYO transport secrets: %w", err)
+	}
+
+	for i := range secretList.Items {
+		secret := &secretList.Items[i]
+		otherCluster := constants.ClusterNameFromGHTransportSecret(secret.Name)
+		if otherCluster == "" || otherCluster == clusterName {
+			continue
+		}
+		otherCert := secret.Data[filepath.Join("client.crt")]
+		if len(otherCert) == 0 {
+			continue
+		}
+		if bytes.Equal(clientCert, otherCert) {
+			return fmt.Errorf("BYO Kafka client cert for hub %q is identical to hub %q; "+
+				"each hub must have a distinct client certificate (secret %s)",
+				clusterName, otherCluster, secret.Name)
+		}
+	}
+	return nil
 }

--- a/operator/pkg/controllers/transporter/protocol/byo_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/byo_transporter.go
@@ -76,7 +76,7 @@ func (s *BYOTransporter) EnsureUser(clusterName string) (string, error) {
 			s.log.Info("BYO Kafka transport secret not found; provide a per-hub or shared secret")
 			return config.GetKafkaUserName(clusterName), nil
 		}
-		return "", err
+		return "", fmt.Errorf("failed to get BYO Kafka transport secret: %w", err)
 	}
 	if secretName == s.sharedSecretName() {
 		s.log.Info("BYO Kafka is using the shared transport secret; " +

--- a/operator/pkg/controllers/transporter/protocol/byo_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/byo_transporter.go
@@ -73,16 +73,14 @@ func (s *BYOTransporter) EnsureUser(clusterName string) (string, error) {
 	secret, secretName, err := s.getTransportSecret(clusterName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			s.log.Info("BYO Kafka transport secret not found; provide a per-hub or shared secret",
-				"cluster", clusterName)
+			s.log.Info("BYO Kafka transport secret not found; provide a per-hub or shared secret")
 			return config.GetKafkaUserName(clusterName), nil
 		}
 		return "", err
 	}
 	if secretName == s.sharedSecretName() {
-		s.log.Info("BYO Kafka is using the shared transport secret; "+
-			"provide a per-hub secret for isolated credentials",
-			"cluster", clusterName, "secret", secretName)
+		s.log.Info("BYO Kafka is using the shared transport secret; " +
+			"provide a per-hub secret for isolated credentials")
 	}
 	if err := s.validateDistinctClientCerts(clusterName, secret.Data[filepath.Join("client.crt")]); err != nil {
 		return "", err

--- a/operator/pkg/controllers/transporter/protocol/byo_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/byo_transporter.go
@@ -1,18 +1,17 @@
-/*
-Copyright Contributors to the Open Cluster Management project.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package protocol
 
@@ -43,8 +42,6 @@ type BYOTransporter struct {
 	runtimeClient client.Client
 }
 
-var byoTransporter *BYOTransporter
-
 // NewBYOTransporter creates the transport from customer-provided Kafka secrets.
 // The manager uses the shared secret "multicluster-global-hub-transport".
 // Each managed hub may supply "multicluster-global-hub-transport-<clusterName>"
@@ -53,32 +50,34 @@ var byoTransporter *BYOTransporter
 func NewBYOTransporter(ctx context.Context, namespacedName types.NamespacedName,
 	c client.Client,
 ) *BYOTransporter {
-	if byoTransporter == nil {
-		byoTransporter = &BYOTransporter{
-			log: logger.ZaprLogger(),
-		}
-		config.SetTransporter(byoTransporter)
+	transporter := &BYOTransporter{
+		log:           logger.ZaprLogger(),
+		ctx:           ctx,
+		runtimeClient: c,
+		name:          namespacedName.Name,
+		namespace:     namespacedName.Namespace,
 	}
-	byoTransporter.ctx = ctx
-	byoTransporter.runtimeClient = c
-	byoTransporter.name = namespacedName.Name
-	byoTransporter.namespace = namespacedName.Namespace
-	return byoTransporter
+	config.SetTransporter(transporter)
+	return transporter
 }
 
 // EnsureUser validates that a BYO transport secret exists for the cluster and
 // that per-hub client certificates are distinct. Kafka users and ACLs remain
-// customer-managed; see doc/byo.md. Missing secrets are logged, not rejected,
-// so addon install can proceed before credentials are created.
+// customer-managed; see doc/byo.md. A missing secret is logged, not rejected,
+// so addon install can proceed before credentials are created. Other API
+// errors are returned to the caller.
 func (s *BYOTransporter) EnsureUser(clusterName string) (string, error) {
-	if clusterName == "" {
+	if isManagerCluster(clusterName) {
 		return "", nil
 	}
 	secret, secretName, err := s.getTransportSecret(clusterName)
 	if err != nil {
-		s.log.Info("BYO Kafka transport secret not found; provide a per-hub or shared secret",
-			"cluster", clusterName, "error", err)
-		return config.GetKafkaUserName(clusterName), nil
+		if apierrors.IsNotFound(err) {
+			s.log.Info("BYO Kafka transport secret not found; provide a per-hub or shared secret",
+				"cluster", clusterName)
+			return config.GetKafkaUserName(clusterName), nil
+		}
+		return "", err
 	}
 	if secretName == s.sharedSecretName() {
 		s.log.Info("BYO Kafka is using the shared transport secret; "+
@@ -95,7 +94,8 @@ func (s *BYOTransporter) EnsureTopic(clusterName string) (*transport.ClusterTopi
 	return &transport.ClusterTopic{
 		SpecTopic:      config.GetSpecTopic(),
 		MigrationTopic: config.GetMigrationTopic(),
-		StatusTopic:    config.GetStatusTopic(clusterName),
+		// BYO Kafka uses one configured status topic for every hub.
+		StatusTopic: config.GetStatusTopic(""),
 	}, nil
 }
 
@@ -113,13 +113,13 @@ func (s *BYOTransporter) GetConnCredential(clusterName string) (*transport.Kafka
 	if err != nil {
 		return nil, err
 	}
-	if clusterName != "" {
+	if !isManagerCluster(clusterName) {
 		if err := s.validateDistinctClientCerts(clusterName, kafkaSecret.Data[filepath.Join("client.crt")]); err != nil {
 			return nil, err
 		}
 	}
 
-	mgh, err := config.GetMulticlusterGlobalHub(context.Background(), s.runtimeClient)
+	mgh, err := config.GetMulticlusterGlobalHub(s.ctx, s.runtimeClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get mgh: %w", err)
 	}
@@ -133,7 +133,7 @@ func (s *BYOTransporter) GetConnCredential(clusterName string) (*transport.Kafka
 		BootstrapServer: string(kafkaSecret.Data[filepath.Join("bootstrap_server")]),
 		ConsumerGroupID: config.GetConsumerGroupID(mgh.Spec.DataLayerSpec.Kafka.ConsumerGroupPrefix, clusterName),
 
-		// for the byo case, the status topic isn't change by the clusterName
+		// BYO status topic is shared; clusterName does not change it
 		StatusTopic:    config.GetStatusTopic(""),
 		SpecTopic:      config.GetSpecTopic(),
 		MigrationTopic: config.GetMigrationTopic(),
@@ -141,6 +141,10 @@ func (s *BYOTransporter) GetConnCredential(clusterName string) (*transport.Kafka
 		ClientCert:     base64.StdEncoding.EncodeToString(kafkaSecret.Data[filepath.Join("client.crt")]),
 		ClientKey:      base64.StdEncoding.EncodeToString(kafkaSecret.Data[filepath.Join("client.key")]),
 	}, nil
+}
+
+func isManagerCluster(clusterName string) bool {
+	return clusterName == "" || clusterName == constants.CloudEventGlobalHubClusterName
 }
 
 func (s *BYOTransporter) sharedSecretName() string {
@@ -151,7 +155,7 @@ func (s *BYOTransporter) sharedSecretName() string {
 }
 
 func (s *BYOTransporter) getTransportSecret(clusterName string) (*corev1.Secret, string, error) {
-	if clusterName != "" {
+	if !isManagerCluster(clusterName) {
 		perHubName := constants.GHTransportSecretNameForCluster(clusterName)
 		perHubSecret := &corev1.Secret{}
 		err := s.runtimeClient.Get(s.ctx, types.NamespacedName{
@@ -173,9 +177,9 @@ func (s *BYOTransporter) getTransportSecret(clusterName string) (*corev1.Secret,
 		Namespace: s.namespace,
 	}, sharedSecret)
 	if err != nil {
-		if apierrors.IsNotFound(err) && clusterName != "" {
-			return nil, "", fmt.Errorf("BYO Kafka secret %q or %q not found in namespace %q",
-				constants.GHTransportSecretNameForCluster(clusterName), sharedName, s.namespace)
+		if apierrors.IsNotFound(err) && !isManagerCluster(clusterName) {
+			return nil, "", fmt.Errorf("BYO Kafka secret %q or %q not found in namespace %q: %w",
+				constants.GHTransportSecretNameForCluster(clusterName), sharedName, s.namespace, err)
 		}
 		return nil, "", err
 	}
@@ -183,7 +187,7 @@ func (s *BYOTransporter) getTransportSecret(clusterName string) (*corev1.Secret,
 }
 
 func (s *BYOTransporter) validateDistinctClientCerts(clusterName string, clientCert []byte) error {
-	if clusterName == "" || len(clientCert) == 0 {
+	if isManagerCluster(clusterName) || len(clientCert) == 0 {
 		return nil
 	}
 

--- a/operator/pkg/controllers/transporter/protocol/byo_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/byo_transporter.go
@@ -34,6 +34,8 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 )
 
+const transportSecretClientCertKey = "client.crt"
+
 type BYOTransporter struct {
 	ctx           context.Context
 	log           logr.Logger
@@ -82,7 +84,7 @@ func (s *BYOTransporter) EnsureUser(clusterName string) (string, error) {
 		s.log.Info("BYO Kafka is using the shared transport secret; " +
 			"provide a per-hub secret for isolated credentials")
 	}
-	if err := s.validateDistinctClientCerts(clusterName, secret.Data[filepath.Join("client.crt")]); err != nil {
+	if err := s.validateDistinctClientCerts(clusterName, secret.Data[transportSecretClientCertKey]); err != nil {
 		return "", err
 	}
 	return config.GetKafkaUserName(clusterName), nil
@@ -109,10 +111,10 @@ func (s *BYOTransporter) Prune(clusterName string) error {
 func (s *BYOTransporter) GetConnCredential(clusterName string) (*transport.KafkaConfig, error) {
 	kafkaSecret, _, err := s.getTransportSecret(clusterName)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get BYO Kafka transport secret: %w", err)
 	}
 	if !isManagerCluster(clusterName) {
-		if err := s.validateDistinctClientCerts(clusterName, kafkaSecret.Data[filepath.Join("client.crt")]); err != nil {
+		if err := s.validateDistinctClientCerts(clusterName, kafkaSecret.Data[transportSecretClientCertKey]); err != nil {
 			return nil, err
 		}
 	}
@@ -136,7 +138,7 @@ func (s *BYOTransporter) GetConnCredential(clusterName string) (*transport.Kafka
 		SpecTopic:      config.GetSpecTopic(),
 		MigrationTopic: config.GetMigrationTopic(),
 		CACert:         base64.StdEncoding.EncodeToString(kafkaSecret.Data[filepath.Join("ca.crt")]),
-		ClientCert:     base64.StdEncoding.EncodeToString(kafkaSecret.Data[filepath.Join("client.crt")]),
+		ClientCert:     base64.StdEncoding.EncodeToString(kafkaSecret.Data[transportSecretClientCertKey]),
 		ClientKey:      base64.StdEncoding.EncodeToString(kafkaSecret.Data[filepath.Join("client.key")]),
 	}, nil
 }
@@ -200,14 +202,12 @@ func (s *BYOTransporter) validateDistinctClientCerts(clusterName string, clientC
 		if otherCluster == "" || otherCluster == clusterName {
 			continue
 		}
-		otherCert := secret.Data[filepath.Join("client.crt")]
+		otherCert := secret.Data[transportSecretClientCertKey]
 		if len(otherCert) == 0 {
 			continue
 		}
 		if bytes.Equal(clientCert, otherCert) {
-			return fmt.Errorf("BYO Kafka client cert for hub %q is identical to hub %q; "+
-				"each hub must have a distinct client certificate (secret %s)",
-				clusterName, otherCluster, secret.Name)
+			return fmt.Errorf("BYO Kafka client certificates on per-hub transport secrets must not be identical")
 		}
 	}
 	return nil

--- a/operator/pkg/controllers/transporter/protocol/byo_transporter_test.go
+++ b/operator/pkg/controllers/transporter/protocol/byo_transporter_test.go
@@ -263,4 +263,23 @@ func TestGetConnCredentialMissingSecret(t *testing.T) {
 	if err == nil {
 		t.Fatal("GetConnCredential(hub1) expected missing secret error")
 	}
+	if !strings.Contains(err.Error(), "failed to get BYO Kafka transport secret") {
+		t.Fatalf("GetConnCredential() error = %v, want wrapped lookup error", err)
+	}
+}
+
+func TestGetConnCredentialRejectsIdenticalPerHubCerts(t *testing.T) {
+	ns := utils.GetDefaultNamespace()
+	same := "duplicate-cert"
+	hub1 := byoSecret(constants.GHTransportSecretNameForCluster("hub1"), ns, same)
+	hub2 := byoSecret(constants.GHTransportSecretNameForCluster("hub2"), ns, same)
+	trans := newBYOTransporter(t, byoMGH(ns), hub1, hub2)
+
+	_, err := trans.GetConnCredential("hub1")
+	if err == nil {
+		t.Fatal("GetConnCredential(hub1) expected identical-cert error")
+	}
+	if !strings.Contains(err.Error(), "identical") {
+		t.Fatalf("GetConnCredential() error = %v, want identical cert message", err)
+	}
 }

--- a/operator/pkg/controllers/transporter/protocol/byo_transporter_test.go
+++ b/operator/pkg/controllers/transporter/protocol/byo_transporter_test.go
@@ -1,29 +1,32 @@
-/*
-Copyright Contributors to the Open Cluster Management project.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package protocol
 
 import (
 	"context"
+	"encoding/base64"
 	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
@@ -31,10 +34,6 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
-
-func resetBYOTransporter() {
-	byoTransporter = nil
-}
 
 func byoSecret(name, namespace, cert string) *corev1.Secret {
 	return &corev1.Secret{
@@ -67,54 +66,110 @@ func byoMGH(namespace string) *v1alpha4.MulticlusterGlobalHub {
 	}
 }
 
-func TestGetConnCredentialPrefersPerHubSecret(t *testing.T) {
-	resetBYOTransporter()
-	t.Cleanup(resetBYOTransporter)
-
+func newBYOTransporter(t *testing.T, objects ...client.Object) *BYOTransporter {
+	t.Helper()
 	ns := utils.GetDefaultNamespace()
-	shared := byoSecret(constants.GHTransportSecretName, ns, "shared-cert")
-	hub1 := byoSecret(constants.GHTransportSecretNameForCluster("hub1"), ns, "hub1-cert")
 	c := fake.NewClientBuilder().WithScheme(config.GetRuntimeScheme()).
-		WithObjects(byoMGH(ns), shared, hub1).Build()
-
-	trans := NewBYOTransporter(context.Background(), types.NamespacedName{
+		WithObjects(objects...).Build()
+	return NewBYOTransporter(context.Background(), types.NamespacedName{
 		Name:      constants.GHTransportSecretName,
 		Namespace: ns,
 	}, c)
+}
+
+type getErrorClient struct {
+	client.Client
+	err error
+}
+
+func (c getErrorClient) Get(ctx context.Context, key types.NamespacedName, obj client.Object,
+	opts ...client.GetOption,
+) error {
+	if c.err != nil {
+		return c.err
+	}
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
+func TestNewBYOTransporterReturnsIsolatedInstance(t *testing.T) {
+	ns := utils.GetDefaultNamespace()
+	c := fake.NewClientBuilder().WithScheme(config.GetRuntimeScheme()).
+		WithObjects(byoMGH(ns)).Build()
+
+	first := NewBYOTransporter(context.Background(), types.NamespacedName{
+		Name:      constants.GHTransportSecretName,
+		Namespace: ns,
+	}, c)
+	second := NewBYOTransporter(context.Background(), types.NamespacedName{
+		Name:      "other-transport",
+		Namespace: "other-ns",
+	}, c)
+	if first == second {
+		t.Fatal("NewBYOTransporter must return a distinct instance per call")
+	}
+	if first.namespace == second.namespace || first.name == second.name {
+		t.Fatal("NewBYOTransporter must not rewrite fields on a shared instance")
+	}
+}
+
+func TestGetConnCredentialPrefersPerHubSecret(t *testing.T) {
+	ns := utils.GetDefaultNamespace()
+	shared := byoSecret(constants.GHTransportSecretName, ns, "shared-cert")
+	hub1 := byoSecret(constants.GHTransportSecretNameForCluster("hub1"), ns, "hub1-cert")
+	trans := newBYOTransporter(t, byoMGH(ns), shared, hub1)
 
 	conn, err := trans.GetConnCredential("hub1")
 	if err != nil {
 		t.Fatalf("GetConnCredential(hub1) error = %v", err)
 	}
-	if conn.ClientCert == "" {
-		t.Fatal("expected per-hub client cert")
+	decoded, err := base64.StdEncoding.DecodeString(conn.ClientCert)
+	if err != nil {
+		t.Fatalf("decode client cert: %v", err)
+	}
+	if string(decoded) != "hub1-cert" {
+		t.Fatalf("client cert = %q, want hub1-cert", decoded)
 	}
 	if !strings.Contains(conn.ConsumerGroupID, "hub1") {
 		t.Fatalf("ConsumerGroupID = %q, want hub1", conn.ConsumerGroupID)
 	}
 
-	sharedConn, err := trans.GetConnCredential("")
+	sharedConn, err := trans.GetConnCredential(constants.CloudEventGlobalHubClusterName)
 	if err != nil {
-		t.Fatalf("GetConnCredential() error = %v", err)
+		t.Fatalf("GetConnCredential(global-hub) error = %v", err)
 	}
-	if sharedConn.ClientCert == conn.ClientCert {
-		t.Fatal("manager shared secret must not reuse the per-hub client cert")
+	sharedDecoded, err := base64.StdEncoding.DecodeString(sharedConn.ClientCert)
+	if err != nil {
+		t.Fatalf("decode shared client cert: %v", err)
+	}
+	if string(sharedDecoded) != "shared-cert" {
+		t.Fatalf("manager client cert = %q, want shared-cert", sharedDecoded)
+	}
+}
+
+func TestGetConnCredentialManagerIgnoresGlobalHubNamedSecret(t *testing.T) {
+	ns := utils.GetDefaultNamespace()
+	shared := byoSecret(constants.GHTransportSecretName, ns, "manager-cert")
+	spoof := byoSecret(constants.GHTransportSecretNameForCluster(
+		constants.CloudEventGlobalHubClusterName), ns, "spoof-cert")
+	trans := newBYOTransporter(t, byoMGH(ns), shared, spoof)
+
+	conn, err := trans.GetConnCredential(constants.CloudEventGlobalHubClusterName)
+	if err != nil {
+		t.Fatalf("GetConnCredential(global-hub) error = %v", err)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(conn.ClientCert)
+	if err != nil {
+		t.Fatalf("decode client cert: %v", err)
+	}
+	if string(decoded) != "manager-cert" {
+		t.Fatalf("manager must use the shared secret, got cert %q", decoded)
 	}
 }
 
 func TestGetConnCredentialFallsBackToSharedSecret(t *testing.T) {
-	resetBYOTransporter()
-	t.Cleanup(resetBYOTransporter)
-
 	ns := utils.GetDefaultNamespace()
 	shared := byoSecret(constants.GHTransportSecretName, ns, "shared-cert")
-	c := fake.NewClientBuilder().WithScheme(config.GetRuntimeScheme()).
-		WithObjects(byoMGH(ns), shared).Build()
-
-	trans := NewBYOTransporter(context.Background(), types.NamespacedName{
-		Name:      constants.GHTransportSecretName,
-		Namespace: ns,
-	}, c)
+	trans := newBYOTransporter(t, byoMGH(ns), shared)
 
 	conn, err := trans.GetConnCredential("hub2")
 	if err != nil {
@@ -126,20 +181,11 @@ func TestGetConnCredentialFallsBackToSharedSecret(t *testing.T) {
 }
 
 func TestEnsureUserRejectsIdenticalPerHubCerts(t *testing.T) {
-	resetBYOTransporter()
-	t.Cleanup(resetBYOTransporter)
-
 	ns := utils.GetDefaultNamespace()
 	same := "duplicate-cert"
 	hub1 := byoSecret(constants.GHTransportSecretNameForCluster("hub1"), ns, same)
 	hub2 := byoSecret(constants.GHTransportSecretNameForCluster("hub2"), ns, same)
-	c := fake.NewClientBuilder().WithScheme(config.GetRuntimeScheme()).
-		WithObjects(byoMGH(ns), hub1, hub2).Build()
-
-	trans := NewBYOTransporter(context.Background(), types.NamespacedName{
-		Name:      constants.GHTransportSecretName,
-		Namespace: ns,
-	}, c)
+	trans := newBYOTransporter(t, byoMGH(ns), hub1, hub2)
 
 	_, err := trans.EnsureUser("hub1")
 	if err == nil {
@@ -151,19 +197,10 @@ func TestEnsureUserRejectsIdenticalPerHubCerts(t *testing.T) {
 }
 
 func TestEnsureUserAllowsDistinctPerHubCerts(t *testing.T) {
-	resetBYOTransporter()
-	t.Cleanup(resetBYOTransporter)
-
 	ns := utils.GetDefaultNamespace()
 	hub1 := byoSecret(constants.GHTransportSecretNameForCluster("hub1"), ns, "hub1-cert")
 	hub2 := byoSecret(constants.GHTransportSecretNameForCluster("hub2"), ns, "hub2-cert")
-	c := fake.NewClientBuilder().WithScheme(config.GetRuntimeScheme()).
-		WithObjects(byoMGH(ns), hub1, hub2).Build()
-
-	trans := NewBYOTransporter(context.Background(), types.NamespacedName{
-		Name:      constants.GHTransportSecretName,
-		Namespace: ns,
-	}, c)
+	trans := newBYOTransporter(t, byoMGH(ns), hub1, hub2)
 
 	user, err := trans.EnsureUser("hub1")
 	if err != nil {
@@ -175,17 +212,8 @@ func TestEnsureUserAllowsDistinctPerHubCerts(t *testing.T) {
 }
 
 func TestEnsureUserSucceedsWithoutSecret(t *testing.T) {
-	resetBYOTransporter()
-	t.Cleanup(resetBYOTransporter)
-
 	ns := utils.GetDefaultNamespace()
-	c := fake.NewClientBuilder().WithScheme(config.GetRuntimeScheme()).
-		WithObjects(byoMGH(ns)).Build()
-
-	trans := NewBYOTransporter(context.Background(), types.NamespacedName{
-		Name:      constants.GHTransportSecretName,
-		Namespace: ns,
-	}, c)
+	trans := newBYOTransporter(t, byoMGH(ns))
 
 	user, err := trans.EnsureUser("hub1")
 	if err != nil {
@@ -196,18 +224,32 @@ func TestEnsureUserSucceedsWithoutSecret(t *testing.T) {
 	}
 }
 
-func TestGetConnCredentialMissingSecret(t *testing.T) {
-	resetBYOTransporter()
-	t.Cleanup(resetBYOTransporter)
-
+func TestEnsureUserReturnsAPIError(t *testing.T) {
 	ns := utils.GetDefaultNamespace()
-	c := fake.NewClientBuilder().WithScheme(config.GetRuntimeScheme()).
+	base := fake.NewClientBuilder().WithScheme(config.GetRuntimeScheme()).
 		WithObjects(byoMGH(ns)).Build()
-
+	forbidden := apierrors.NewForbidden(
+		schema.GroupResource{Group: "", Resource: "secrets"},
+		constants.GHTransportSecretNameForCluster("hub1"),
+		nil,
+	)
 	trans := NewBYOTransporter(context.Background(), types.NamespacedName{
 		Name:      constants.GHTransportSecretName,
 		Namespace: ns,
-	}, c)
+	}, getErrorClient{Client: base, err: forbidden})
+
+	_, err := trans.EnsureUser("hub1")
+	if err == nil {
+		t.Fatal("EnsureUser(hub1) expected API error")
+	}
+	if !apierrors.IsForbidden(err) {
+		t.Fatalf("EnsureUser() error = %v, want forbidden", err)
+	}
+}
+
+func TestGetConnCredentialMissingSecret(t *testing.T) {
+	ns := utils.GetDefaultNamespace()
+	trans := newBYOTransporter(t, byoMGH(ns))
 
 	_, err := trans.GetConnCredential("hub1")
 	if err == nil {

--- a/operator/pkg/controllers/transporter/protocol/byo_transporter_test.go
+++ b/operator/pkg/controllers/transporter/protocol/byo_transporter_test.go
@@ -1,0 +1,216 @@
+/*
+Copyright Contributors to the Open Cluster Management project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package protocol
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
+)
+
+func resetBYOTransporter() {
+	byoTransporter = nil
+}
+
+func byoSecret(name, namespace, cert string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			"bootstrap_server": []byte("kafka.example:443"),
+			"ca.crt":           []byte("ca-" + cert),
+			"client.crt":       []byte(cert),
+			"client.key":       []byte("key-" + cert),
+		},
+	}
+}
+
+func byoMGH(namespace string) *v1alpha4.MulticlusterGlobalHub {
+	return &v1alpha4.MulticlusterGlobalHub{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mgh",
+			Namespace: namespace,
+		},
+		Spec: v1alpha4.MulticlusterGlobalHubSpec{
+			DataLayerSpec: v1alpha4.DataLayerSpec{
+				Kafka: v1alpha4.KafkaSpec{
+					ConsumerGroupPrefix: "gh-",
+				},
+			},
+		},
+	}
+}
+
+func TestGetConnCredentialPrefersPerHubSecret(t *testing.T) {
+	resetBYOTransporter()
+	t.Cleanup(resetBYOTransporter)
+
+	ns := utils.GetDefaultNamespace()
+	shared := byoSecret(constants.GHTransportSecretName, ns, "shared-cert")
+	hub1 := byoSecret(constants.GHTransportSecretNameForCluster("hub1"), ns, "hub1-cert")
+	c := fake.NewClientBuilder().WithScheme(config.GetRuntimeScheme()).
+		WithObjects(byoMGH(ns), shared, hub1).Build()
+
+	trans := NewBYOTransporter(context.Background(), types.NamespacedName{
+		Name:      constants.GHTransportSecretName,
+		Namespace: ns,
+	}, c)
+
+	conn, err := trans.GetConnCredential("hub1")
+	if err != nil {
+		t.Fatalf("GetConnCredential(hub1) error = %v", err)
+	}
+	if conn.ClientCert == "" {
+		t.Fatal("expected per-hub client cert")
+	}
+	if !strings.Contains(conn.ConsumerGroupID, "hub1") {
+		t.Fatalf("ConsumerGroupID = %q, want hub1", conn.ConsumerGroupID)
+	}
+
+	sharedConn, err := trans.GetConnCredential("")
+	if err != nil {
+		t.Fatalf("GetConnCredential() error = %v", err)
+	}
+	if sharedConn.ClientCert == conn.ClientCert {
+		t.Fatal("manager shared secret must not reuse the per-hub client cert")
+	}
+}
+
+func TestGetConnCredentialFallsBackToSharedSecret(t *testing.T) {
+	resetBYOTransporter()
+	t.Cleanup(resetBYOTransporter)
+
+	ns := utils.GetDefaultNamespace()
+	shared := byoSecret(constants.GHTransportSecretName, ns, "shared-cert")
+	c := fake.NewClientBuilder().WithScheme(config.GetRuntimeScheme()).
+		WithObjects(byoMGH(ns), shared).Build()
+
+	trans := NewBYOTransporter(context.Background(), types.NamespacedName{
+		Name:      constants.GHTransportSecretName,
+		Namespace: ns,
+	}, c)
+
+	conn, err := trans.GetConnCredential("hub2")
+	if err != nil {
+		t.Fatalf("GetConnCredential(hub2) fallback error = %v", err)
+	}
+	if conn.BootstrapServer != "kafka.example:443" {
+		t.Fatalf("BootstrapServer = %q", conn.BootstrapServer)
+	}
+}
+
+func TestEnsureUserRejectsIdenticalPerHubCerts(t *testing.T) {
+	resetBYOTransporter()
+	t.Cleanup(resetBYOTransporter)
+
+	ns := utils.GetDefaultNamespace()
+	same := "duplicate-cert"
+	hub1 := byoSecret(constants.GHTransportSecretNameForCluster("hub1"), ns, same)
+	hub2 := byoSecret(constants.GHTransportSecretNameForCluster("hub2"), ns, same)
+	c := fake.NewClientBuilder().WithScheme(config.GetRuntimeScheme()).
+		WithObjects(byoMGH(ns), hub1, hub2).Build()
+
+	trans := NewBYOTransporter(context.Background(), types.NamespacedName{
+		Name:      constants.GHTransportSecretName,
+		Namespace: ns,
+	}, c)
+
+	_, err := trans.EnsureUser("hub1")
+	if err == nil {
+		t.Fatal("EnsureUser(hub1) expected identical-cert error")
+	}
+	if !strings.Contains(err.Error(), "identical") {
+		t.Fatalf("EnsureUser() error = %v, want identical cert message", err)
+	}
+}
+
+func TestEnsureUserAllowsDistinctPerHubCerts(t *testing.T) {
+	resetBYOTransporter()
+	t.Cleanup(resetBYOTransporter)
+
+	ns := utils.GetDefaultNamespace()
+	hub1 := byoSecret(constants.GHTransportSecretNameForCluster("hub1"), ns, "hub1-cert")
+	hub2 := byoSecret(constants.GHTransportSecretNameForCluster("hub2"), ns, "hub2-cert")
+	c := fake.NewClientBuilder().WithScheme(config.GetRuntimeScheme()).
+		WithObjects(byoMGH(ns), hub1, hub2).Build()
+
+	trans := NewBYOTransporter(context.Background(), types.NamespacedName{
+		Name:      constants.GHTransportSecretName,
+		Namespace: ns,
+	}, c)
+
+	user, err := trans.EnsureUser("hub1")
+	if err != nil {
+		t.Fatalf("EnsureUser(hub1) error = %v", err)
+	}
+	if user != "hub1-kafka-user" {
+		t.Fatalf("EnsureUser() = %q, want hub1-kafka-user", user)
+	}
+}
+
+func TestEnsureUserSucceedsWithoutSecret(t *testing.T) {
+	resetBYOTransporter()
+	t.Cleanup(resetBYOTransporter)
+
+	ns := utils.GetDefaultNamespace()
+	c := fake.NewClientBuilder().WithScheme(config.GetRuntimeScheme()).
+		WithObjects(byoMGH(ns)).Build()
+
+	trans := NewBYOTransporter(context.Background(), types.NamespacedName{
+		Name:      constants.GHTransportSecretName,
+		Namespace: ns,
+	}, c)
+
+	user, err := trans.EnsureUser("hub1")
+	if err != nil {
+		t.Fatalf("EnsureUser(hub1) without secret error = %v", err)
+	}
+	if user != "hub1-kafka-user" {
+		t.Fatalf("EnsureUser() = %q, want hub1-kafka-user", user)
+	}
+}
+
+func TestGetConnCredentialMissingSecret(t *testing.T) {
+	resetBYOTransporter()
+	t.Cleanup(resetBYOTransporter)
+
+	ns := utils.GetDefaultNamespace()
+	c := fake.NewClientBuilder().WithScheme(config.GetRuntimeScheme()).
+		WithObjects(byoMGH(ns)).Build()
+
+	trans := NewBYOTransporter(context.Background(), types.NamespacedName{
+		Name:      constants.GHTransportSecretName,
+		Namespace: ns,
+	}, c)
+
+	_, err := trans.GetConnCredential("hub1")
+	if err == nil {
+		t.Fatal("GetConnCredential(hub1) expected missing secret error")
+	}
+}

--- a/operator/pkg/controllers/transporter/protocol/byo_transporter_test.go
+++ b/operator/pkg/controllers/transporter/protocol/byo_transporter_test.go
@@ -283,3 +283,31 @@ func TestGetConnCredentialRejectsIdenticalPerHubCerts(t *testing.T) {
 		t.Fatalf("GetConnCredential() error = %v, want identical cert message", err)
 	}
 }
+
+func TestEnsureUserAllowsSharedFallbackMatchingPerHubCert(t *testing.T) {
+	ns := utils.GetDefaultNamespace()
+	same := "shared-cert"
+	shared := byoSecret(constants.GHTransportSecretName, ns, same)
+	hub1 := byoSecret(constants.GHTransportSecretNameForCluster("hub1"), ns, same)
+	trans := newBYOTransporter(t, byoMGH(ns), shared, hub1)
+
+	if _, err := trans.EnsureUser("hub2"); err != nil {
+		t.Fatalf("EnsureUser(hub2) shared fallback error = %v", err)
+	}
+	if _, err := trans.GetConnCredential("hub2"); err != nil {
+		t.Fatalf("GetConnCredential(hub2) shared fallback error = %v", err)
+	}
+}
+
+func TestEnsureUserIgnoresManagerNamedSecretDuplicates(t *testing.T) {
+	ns := utils.GetDefaultNamespace()
+	hub1 := byoSecret(constants.GHTransportSecretNameForCluster("hub1"), ns, "hub1-cert")
+	managerNamed := byoSecret(constants.GHTransportSecretNameForCluster(
+		constants.CloudEventGlobalHubClusterName,
+	), ns, "hub1-cert")
+	trans := newBYOTransporter(t, byoMGH(ns), hub1, managerNamed)
+
+	if _, err := trans.EnsureUser("hub1"); err != nil {
+		t.Fatalf("EnsureUser(hub1) error = %v", err)
+	}
+}

--- a/operator/pkg/controllers/transporter/protocol/byo_transporter_test.go
+++ b/operator/pkg/controllers/transporter/protocol/byo_transporter_test.go
@@ -157,7 +157,8 @@ func TestGetConnCredentialManagerIgnoresGlobalHubNamedSecret(t *testing.T) {
 	ns := utils.GetDefaultNamespace()
 	shared := byoSecret(constants.GHTransportSecretName, ns, "manager-cert")
 	spoof := byoSecret(constants.GHTransportSecretNameForCluster(
-		constants.CloudEventGlobalHubClusterName), ns, "spoof-cert")
+		constants.CloudEventGlobalHubClusterName,
+	), ns, "spoof-cert")
 	trans := newBYOTransporter(t, byoMGH(ns), shared, spoof)
 
 	conn, err := trans.GetConnCredential(constants.CloudEventGlobalHubClusterName)

--- a/operator/pkg/controllers/transporter/protocol/byo_transporter_test.go
+++ b/operator/pkg/controllers/transporter/protocol/byo_transporter_test.go
@@ -132,17 +132,24 @@ func TestGetConnCredentialPrefersPerHubSecret(t *testing.T) {
 	if !strings.Contains(conn.ConsumerGroupID, "hub1") {
 		t.Fatalf("ConsumerGroupID = %q, want hub1", conn.ConsumerGroupID)
 	}
+}
 
-	sharedConn, err := trans.GetConnCredential(constants.CloudEventGlobalHubClusterName)
+func TestGetConnCredentialManagerUsesSharedSecret(t *testing.T) {
+	ns := utils.GetDefaultNamespace()
+	shared := byoSecret(constants.GHTransportSecretName, ns, "shared-cert")
+	hub1 := byoSecret(constants.GHTransportSecretNameForCluster("hub1"), ns, "hub1-cert")
+	trans := newBYOTransporter(t, byoMGH(ns), shared, hub1)
+
+	conn, err := trans.GetConnCredential(constants.CloudEventGlobalHubClusterName)
 	if err != nil {
 		t.Fatalf("GetConnCredential(global-hub) error = %v", err)
 	}
-	sharedDecoded, err := base64.StdEncoding.DecodeString(sharedConn.ClientCert)
+	decoded, err := base64.StdEncoding.DecodeString(conn.ClientCert)
 	if err != nil {
-		t.Fatalf("decode shared client cert: %v", err)
+		t.Fatalf("decode client cert: %v", err)
 	}
-	if string(sharedDecoded) != "shared-cert" {
-		t.Fatalf("manager client cert = %q, want shared-cert", sharedDecoded)
+	if string(decoded) != "shared-cert" {
+		t.Fatalf("manager client cert = %q, want shared-cert", decoded)
 	}
 }
 

--- a/operator/pkg/controllers/transporter/transport_reconciler.go
+++ b/operator/pkg/controllers/transporter/transport_reconciler.go
@@ -153,7 +153,7 @@ func networkPolicyCond(obj client.Object) bool {
 }
 
 func secretCond(obj client.Object) bool {
-	if WatchedSecret.Has(obj.GetName()) {
+	if WatchedSecret.Has(obj.GetName()) || constants.IsGHTransportSecret(obj.GetName()) {
 		return true
 	}
 	if obj.GetLabels()[StrimziClusterLabel] == protocol.KafkaClusterName &&

--- a/operator/pkg/controllers/transporter/transport_reconciler_test.go
+++ b/operator/pkg/controllers/transporter/transport_reconciler_test.go
@@ -65,6 +65,16 @@ func TestSecretPredicate(t *testing.T) {
 			wantBool: true,
 		},
 		{
+			name: "per-hub BYO transport secret should match",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.GHTransportSecretNameForCluster("hub1"),
+					Namespace: utils.GetDefaultNamespace(),
+				},
+			},
+			wantBool: true,
+		},
+		{
 			name: "kafka user secret with strimzi labels should match",
 			obj: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -220,6 +230,15 @@ func TestSecretCond(t *testing.T) {
 			obj: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: constants.GHTransportSecretName,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "per-hub BYO transport secret name matches",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: constants.GHTransportSecretNameForCluster("hub1"),
 				},
 			},
 			expected: true,

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,5 +1,7 @@
 package constants
 
+import "strings"
+
 // global hub common constants
 const (
 	// GHDefaultNamespace defines default namespace for ACM hub and Global hub operator and manager
@@ -115,6 +117,31 @@ const (
 	KafkaCertSecretName       = "kafka-certs-secret"                // #nosec G101
 	GHDefaultStorageRetention = "18m"                               // 18 months
 )
+
+// GHTransportSecretNameForCluster is the BYO Kafka secret for a managed hub.
+// The shared secret GHTransportSecretName is used for the manager (empty clusterName).
+func GHTransportSecretNameForCluster(clusterName string) string {
+	if clusterName == "" {
+		return GHTransportSecretName
+	}
+	return GHTransportSecretName + "-" + clusterName
+}
+
+// IsGHTransportSecret reports whether name is the shared BYO transport secret
+// or a per-hub secret named multicluster-global-hub-transport-<cluster>.
+func IsGHTransportSecret(name string) bool {
+	return name == GHTransportSecretName || strings.HasPrefix(name, GHTransportSecretName+"-")
+}
+
+// ClusterNameFromGHTransportSecret returns the hub name encoded in a per-hub
+// BYO transport secret, or empty for the shared secret / unrelated names.
+func ClusterNameFromGHTransportSecret(name string) string {
+	prefix := GHTransportSecretName + "-"
+	if !strings.HasPrefix(name, prefix) {
+		return ""
+	}
+	return strings.TrimPrefix(name, prefix)
+}
 
 // the global hub transport config secret for manager and agent
 const (

--- a/pkg/transport/controller/controller.go
+++ b/pkg/transport/controller/controller.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport/config"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport/consumer"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport/identity"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport/producer"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport/requester"
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
@@ -252,6 +253,12 @@ func (c *TransportCtrl) ReconcileKafkaCredential(ctx context.Context, secret *co
 	kafkaConn, err := utils.GetKafkaCredentialBySecret(secret, c.runtimeClient)
 	if err != nil {
 		return false, err
+	}
+	if !c.inManager && c.transportConfig != nil && c.transportConfig.LeafHubName != "" &&
+		kafkaConn.ClientSecretName == "" {
+		if err := identity.ValidateBYOClientCert(c.transportConfig.LeafHubName, kafkaConn.ClientCert); err != nil {
+			return false, err
+		}
 	}
 	err = c.ResyncKafkaClientSecret(ctx, kafkaConn, secret)
 	if err != nil {

--- a/pkg/transport/identity/identity.go
+++ b/pkg/transport/identity/identity.go
@@ -18,6 +18,9 @@ limitations under the License.
 package identity
 
 import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
 	"strings"
 
 	kafka_confluent "github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2"
@@ -125,6 +128,50 @@ func LeafHubForStatusEvent(evt *cloudevents.Event) (string, bool) {
 	}
 
 	return evt.Source(), true
+}
+
+// HubFromClientCertCN maps an mTLS certificate CommonName to a hub name when
+// the CN follows the KafkaUser convention "{hub}-kafka-user".
+func HubFromClientCertCN(commonName string) string {
+	return HubFromKafkaUser(commonName)
+}
+
+// ValidateBYOClientCert rejects a BYO Kafka client certificate whose CN is a
+// KafkaUser for a different hub. Custom CNs (for example global-hub-byo-user)
+// are allowed so existing shared-secret BYO installs keep working until they
+// switch to per-hub secrets.
+func ValidateBYOClientCert(leafHubName, clientCertPEM string) error {
+	if leafHubName == "" || clientCertPEM == "" {
+		return nil
+	}
+
+	cn, err := commonNameFromPEMX509(clientCertPEM)
+	if err != nil {
+		return fmt.Errorf("failed to parse BYO Kafka client certificate: %w", err)
+	}
+	if cn == "" {
+		return nil
+	}
+
+	certHub := HubFromClientCertCN(cn)
+	if certHub == "" || certHub == leafHubName {
+		return nil
+	}
+
+	return fmt.Errorf("BYO Kafka client certificate CN %q belongs to hub %q, not %q",
+		cn, certHub, leafHubName)
+}
+
+func commonNameFromPEMX509(certPEM string) (string, error) {
+	block, _ := pem.Decode([]byte(certPEM))
+	if block == nil {
+		return "", fmt.Errorf("no PEM certificate found")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return "", err
+	}
+	return cert.Subject.CommonName, nil
 }
 
 // EnrichManagerStatusEvent sets authedhub from the Kafka status topic when the pattern

--- a/pkg/transport/identity/identity.go
+++ b/pkg/transport/identity/identity.go
@@ -158,8 +158,7 @@ func ValidateBYOClientCert(leafHubName, clientCertPEM string) error {
 		return nil
 	}
 
-	return fmt.Errorf("BYO Kafka client certificate CN %q belongs to hub %q, not %q",
-		cn, certHub, leafHubName)
+	return fmt.Errorf("BYO Kafka client certificate does not belong to this hub")
 }
 
 func commonNameFromPEMX509(certPEM string) (string, error) {

--- a/pkg/transport/identity/identity_test.go
+++ b/pkg/transport/identity/identity_test.go
@@ -17,7 +17,14 @@ limitations under the License.
 package identity
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"testing"
+	"time"
 
 	kafka_confluent "github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -140,4 +147,63 @@ func TestEnrichManagerStatusEvent(t *testing.T) {
 	t.Run("nil event is no-op", func(t *testing.T) {
 		EnrichManagerStatusEvent(nil, "^gh-status.*")
 	})
+}
+
+func TestValidateBYOClientCert(t *testing.T) {
+	t.Run("empty inputs are no-op", func(t *testing.T) {
+		if err := ValidateBYOClientCert("", "cert"); err != nil {
+			t.Fatalf("ValidateBYOClientCert() = %v", err)
+		}
+		if err := ValidateBYOClientCert("hub1", ""); err != nil {
+			t.Fatalf("ValidateBYOClientCert() = %v", err)
+		}
+	})
+
+	t.Run("matching kafka user CN is accepted", func(t *testing.T) {
+		certPEM := mustTestCertPEM(t, "hub1-kafka-user")
+		if err := ValidateBYOClientCert("hub1", certPEM); err != nil {
+			t.Fatalf("ValidateBYOClientCert() = %v", err)
+		}
+	})
+
+	t.Run("mismatched kafka user CN is rejected", func(t *testing.T) {
+		certPEM := mustTestCertPEM(t, "hub2-kafka-user")
+		err := ValidateBYOClientCert("hub1", certPEM)
+		if err == nil {
+			t.Fatal("expected mismatch error")
+		}
+	})
+
+	t.Run("custom BYO CN is accepted", func(t *testing.T) {
+		certPEM := mustTestCertPEM(t, "global-hub-byo-user")
+		if err := ValidateBYOClientCert("hub1", certPEM); err != nil {
+			t.Fatalf("ValidateBYOClientCert() custom CN = %v", err)
+		}
+	})
+
+	t.Run("manager kafka user on agent is rejected", func(t *testing.T) {
+		certPEM := mustTestCertPEM(t, "global-hub-kafka-user")
+		if err := ValidateBYOClientCert("hub1", certPEM); err == nil {
+			t.Fatal("expected rejection of global-hub-kafka-user on a managed hub")
+		}
+	})
+}
+
+func mustTestCertPEM(t *testing.T, commonName string) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: commonName},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("CreateCertificate: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
 }

--- a/pkg/transport/type.go
+++ b/pkg/transport/type.go
@@ -43,6 +43,9 @@ type TransportInternalConfig struct {
 	RestfulCredential *RestfulConfig
 	Extends           map[string]interface{}
 	FailureThreshold  int
+	// LeafHubName is set on the agent so BYO Kafka client certs can be checked
+	// against the local hub identity. Empty on the manager.
+	LeafHubName string
 }
 
 // KafkaInternalConfig specifics the configuration for the global hub manager, agent, or even inventory

--- a/test/Makefile
+++ b/test/Makefile
@@ -26,7 +26,7 @@ e2e-test-all: tidy vendor
 	sh ./test/script/e2e_run.sh -f "e2e-test-transport-identity" -v $(VERBOSE)
 	sh ./test/script/e2e_run.sh -f "e2e-test-transport-migration-topic" -v $(VERBOSE)
 
-e2e-test-cluster e2e-test-local-agent e2e-test-localpolicy e2e-test-grafana e2e-test-migration e2e-test-hubha e2e-test-transport-identity e2e-test-transport-migration-topic: tidy vendor
+e2e-test-cluster e2e-test-local-agent e2e-test-localpolicy e2e-test-grafana e2e-test-migration e2e-test-hubha e2e-test-transport-identity e2e-test-transport-migration-topic e2e-test-transport-byo: tidy vendor
 	./test/script/e2e_run.sh -f $@ -v $(VERBOSE)
 
 e2e-prow-tests: 

--- a/test/Makefile
+++ b/test/Makefile
@@ -26,8 +26,11 @@ e2e-test-all: tidy vendor
 	sh ./test/script/e2e_run.sh -f "e2e-test-transport-identity" -v $(VERBOSE)
 	sh ./test/script/e2e_run.sh -f "e2e-test-transport-migration-topic" -v $(VERBOSE)
 
-e2e-test-cluster e2e-test-local-agent e2e-test-localpolicy e2e-test-grafana e2e-test-migration e2e-test-hubha e2e-test-transport-identity e2e-test-transport-migration-topic e2e-test-transport-byo: tidy vendor
+e2e-test-cluster e2e-test-local-agent e2e-test-localpolicy e2e-test-grafana e2e-test-migration e2e-test-hubha e2e-test-transport-identity e2e-test-transport-migration-topic: tidy vendor
 	./test/script/e2e_run.sh -f $@ -v $(VERBOSE)
+
+e2e-test-transport-byo: tidy vendor
+	sh ./test/script/e2e_run_byo.sh
 
 e2e-prow-tests: 
 	./test/script/e2e_prow.sh

--- a/test/e2e/transport_byo_test.go
+++ b/test/e2e/transport_byo_test.go
@@ -16,6 +16,7 @@
 package tests
 
 import (
+	"context"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
@@ -39,6 +40,7 @@ import (
 const (
 	byoPerHubBootstrapMarker = "e2e-byo-per-hub-marker:443"
 	byoIdenticalCertLog      = "must not be identical"
+	byoAPITimeout            = 30 * time.Second
 )
 
 var _ = Describe("Transport BYO Kafka E2E", Serial, Label("e2e-test-transport-byo"), Ordered, func() {
@@ -60,12 +62,12 @@ var _ = Describe("Transport BYO Kafka E2E", Serial, Label("e2e-test-transport-by
 
 		var err error
 		sourceHubClient, err = testClients.RuntimeClient(sourceHubName, agentScheme)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "expected a kube client for the source managed hub")
 
 		shared, err := byoSharedTransportSecret()
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "expected the shared BYO transport secret")
 		sharedBootstrap = string(shared.Data["bootstrap_server"])
-		Expect(sharedBootstrap).NotTo(BeEmpty())
+		Expect(sharedBootstrap).NotTo(BeEmpty(), "shared BYO transport secret must set bootstrap_server")
 	})
 
 	AfterAll(func() {
@@ -76,15 +78,17 @@ var _ = Describe("Transport BYO Kafka E2E", Serial, Label("e2e-test-transport-by
 		deleteBYOPerHubSecret(targetHubName)
 	})
 
-	It("keeps shared-secret fallback and allows a custom client certificate CN", func() {
+	It("allows a custom client certificate CN on the shared BYO secret", func() {
 		shared, err := byoSharedTransportSecret()
-		Expect(err).NotTo(HaveOccurred())
-		Expect(shared.Data["client.crt"]).NotTo(BeEmpty())
+		Expect(err).NotTo(HaveOccurred(), "expected the shared BYO transport secret")
+		Expect(shared.Data["client.crt"]).NotTo(BeEmpty(), "shared BYO transport secret must set client.crt")
 
 		cn := pemCertificateCommonName(shared.Data["client.crt"])
 		Expect(identity.HubFromClientCertCN(cn)).To(BeEmpty(),
 			"shared BYO client cert CN must be a custom name, not {hub}-kafka-user")
+	})
 
+	It("starts the managed hub agent with shared-secret fallback", func() {
 		Eventually(func() error {
 			return managedHubAgentKafkaReady(sourceHubClient, sourceHubName)
 		}, 2*time.Minute, 5*time.Second).Should(Succeed(),
@@ -106,7 +110,8 @@ var _ = Describe("Transport BYO Kafka E2E", Serial, Label("e2e-test-transport-by
 					return fmt.Errorf("waiting for shared-secret bootstrap to be restored")
 				}
 				return nil
-			}, 2*time.Minute, 5*time.Second).Should(Succeed())
+			}, 2*time.Minute, 5*time.Second).Should(Succeed(),
+				"agent transport must fall back to the shared BYO secret after per-hub cleanup")
 		})
 
 		Eventually(func() error {
@@ -137,15 +142,21 @@ var _ = Describe("Transport BYO Kafka E2E", Serial, Label("e2e-test-transport-by
 	})
 })
 
+func byoAPIContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, byoAPITimeout)
+}
+
 func byoSharedTransportSecret() (*corev1.Secret, error) {
+	apiCtx, cancel := byoAPIContext()
+	defer cancel()
 	return testClients.KubeClient().CoreV1().Secrets(testOptions.GlobalHub.Namespace).Get(
-		ctx, constants.GHTransportSecretName, metav1.GetOptions{},
+		apiCtx, constants.GHTransportSecretName, metav1.GetOptions{},
 	)
 }
 
 func createBYOPerHubSecret(clusterName string, mutate func(*corev1.Secret)) {
 	shared, err := byoSharedTransportSecret()
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred(), "expected the shared BYO transport secret as a template")
 
 	data := make(map[string][]byte, len(shared.Data))
 	for key, value := range shared.Data {
@@ -167,28 +178,34 @@ func createBYOPerHubSecret(clusterName string, mutate func(*corev1.Secret)) {
 	}
 
 	kube := testClients.KubeClient().CoreV1().Secrets(testOptions.GlobalHub.Namespace)
-	_, err = kube.Create(ctx, secret, metav1.CreateOptions{})
+	apiCtx, cancel := byoAPIContext()
+	defer cancel()
+	_, err = kube.Create(apiCtx, secret, metav1.CreateOptions{})
 	if apierrors.IsAlreadyExists(err) {
-		existing, getErr := kube.Get(ctx, secret.Name, metav1.GetOptions{})
-		Expect(getErr).NotTo(HaveOccurred())
+		existing, getErr := kube.Get(apiCtx, secret.Name, metav1.GetOptions{})
+		Expect(getErr).NotTo(HaveOccurred(), "expected existing per-hub BYO secret")
 		existing.Data = secret.Data
-		_, err = kube.Update(ctx, existing, metav1.UpdateOptions{})
+		_, err = kube.Update(apiCtx, existing, metav1.UpdateOptions{})
 	}
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred(), "expected to create or update the per-hub BYO secret")
 }
 
 func deleteBYOPerHubSecret(clusterName string) {
+	apiCtx, cancel := byoAPIContext()
+	defer cancel()
 	err := testClients.KubeClient().CoreV1().Secrets(testOptions.GlobalHub.Namespace).Delete(
-		ctx, constants.GHTransportSecretNameForCluster(clusterName), metav1.DeleteOptions{},
+		apiCtx, constants.GHTransportSecretNameForCluster(clusterName), metav1.DeleteOptions{},
 	)
 	if err != nil && !apierrors.IsNotFound(err) {
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "expected to delete leftover per-hub BYO secret")
 	}
 }
 
 func managedHubAgentKafkaConfig(hubClient client.Client) (*transport.KafkaConfig, error) {
+	apiCtx, cancel := byoAPIContext()
+	defer cancel()
 	secret := &corev1.Secret{}
-	if err := hubClient.Get(ctx, types.NamespacedName{
+	if err := hubClient.Get(apiCtx, types.NamespacedName{
 		Name:      constants.GHTransportConfigSecret,
 		Namespace: constants.GHAgentNamespace,
 	}, secret); err != nil {
@@ -219,12 +236,14 @@ func pemCertificateCommonName(certPEM []byte) string {
 	block, _ := pem.Decode(certPEM)
 	Expect(block).NotTo(BeNil(), "shared BYO client.crt must be PEM")
 	cert, err := x509.ParseCertificate(block.Bytes)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred(), "shared BYO client.crt must parse as x509")
 	return cert.Subject.CommonName
 }
 
 func operatorLogsContain(substr string) error {
-	pods, err := testClients.KubeClient().CoreV1().Pods(testOptions.GlobalHub.Namespace).List(ctx, metav1.ListOptions{
+	apiCtx, cancel := byoAPIContext()
+	defer cancel()
+	pods, err := testClients.KubeClient().CoreV1().Pods(testOptions.GlobalHub.Namespace).List(apiCtx, metav1.ListOptions{
 		LabelSelector: "name=multicluster-global-hub-operator",
 	})
 	if err != nil {
@@ -239,7 +258,7 @@ func operatorLogsContain(substr string) error {
 		logs, logErr := testClients.KubeClient().CoreV1().Pods(testOptions.GlobalHub.Namespace).
 			GetLogs(pods.Items[i].Name, &corev1.PodLogOptions{
 				Container: "multicluster-global-hub-operator",
-			}).DoRaw(ctx)
+			}).DoRaw(apiCtx)
 		if logErr != nil {
 			return logErr
 		}

--- a/test/e2e/transport_byo_test.go
+++ b/test/e2e/transport_byo_test.go
@@ -139,7 +139,8 @@ var _ = Describe("Transport BYO Kafka E2E", Serial, Label("e2e-test-transport-by
 
 func byoSharedTransportSecret() (*corev1.Secret, error) {
 	return testClients.KubeClient().CoreV1().Secrets(testOptions.GlobalHub.Namespace).Get(
-		ctx, constants.GHTransportSecretName, metav1.GetOptions{})
+		ctx, constants.GHTransportSecretName, metav1.GetOptions{},
+	)
 }
 
 func createBYOPerHubSecret(clusterName string, mutate func(*corev1.Secret)) {
@@ -178,7 +179,8 @@ func createBYOPerHubSecret(clusterName string, mutate func(*corev1.Secret)) {
 
 func deleteBYOPerHubSecret(clusterName string) {
 	err := testClients.KubeClient().CoreV1().Secrets(testOptions.GlobalHub.Namespace).Delete(
-		ctx, constants.GHTransportSecretNameForCluster(clusterName), metav1.DeleteOptions{})
+		ctx, constants.GHTransportSecretNameForCluster(clusterName), metav1.DeleteOptions{},
+	)
 	if err != nil && !apierrors.IsNotFound(err) {
 		Expect(err).NotTo(HaveOccurred())
 	}

--- a/test/e2e/transport_byo_test.go
+++ b/test/e2e/transport_byo_test.go
@@ -1,0 +1,250 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport/identity"
+	pkgutils "github.com/stolostron/multicluster-global-hub/pkg/utils"
+)
+
+const (
+	byoPerHubBootstrapMarker = "e2e-byo-per-hub-marker:443"
+	byoIdenticalCertLog      = "must not be identical"
+)
+
+var _ = Describe("Transport BYO Kafka E2E", Serial, Label("e2e-test-transport-byo"), Ordered, func() {
+	var (
+		sourceHubName   string
+		targetHubName   string
+		sourceHubClient client.Client
+		sharedBootstrap string
+	)
+
+	BeforeAll(func() {
+		if isBYO != "true" {
+			Skip("BYO Kafka e2e requires ISBYO=true")
+		}
+		Expect(len(managedHubNames)).To(BeNumerically(">=", 2),
+			"BYO Kafka e2e requires two regional hubs")
+		sourceHubName = managedHubNames[0]
+		targetHubName = managedHubNames[1]
+
+		var err error
+		sourceHubClient, err = testClients.RuntimeClient(sourceHubName, agentScheme)
+		Expect(err).NotTo(HaveOccurred())
+
+		shared, err := byoSharedTransportSecret()
+		Expect(err).NotTo(HaveOccurred())
+		sharedBootstrap = string(shared.Data["bootstrap_server"])
+		Expect(sharedBootstrap).NotTo(BeEmpty())
+	})
+
+	AfterAll(func() {
+		if isBYO != "true" {
+			return
+		}
+		deleteBYOPerHubSecret(sourceHubName)
+		deleteBYOPerHubSecret(targetHubName)
+	})
+
+	It("keeps shared-secret fallback and allows a custom client certificate CN", func() {
+		shared, err := byoSharedTransportSecret()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(shared.Data["client.crt"]).NotTo(BeEmpty())
+
+		cn := pemCertificateCommonName(shared.Data["client.crt"])
+		Expect(identity.HubFromClientCertCN(cn)).To(BeEmpty(),
+			"shared BYO client cert CN must be a custom name, not {hub}-kafka-user")
+
+		Eventually(func() error {
+			return managedHubAgentKafkaReady(sourceHubClient, sourceHubName)
+		}, 2*time.Minute, 5*time.Second).Should(Succeed(),
+			"managed hub agent must start with the shared BYO transport secret")
+	})
+
+	It("selects a per-hub transport secret over the shared secret", func() {
+		createBYOPerHubSecret(sourceHubName, func(secret *corev1.Secret) {
+			secret.Data["bootstrap_server"] = []byte(byoPerHubBootstrapMarker)
+		})
+		DeferCleanup(func() {
+			deleteBYOPerHubSecret(sourceHubName)
+			Eventually(func() error {
+				cfg, err := managedHubAgentKafkaConfig(sourceHubClient)
+				if err != nil {
+					return err
+				}
+				if cfg.BootstrapServer != sharedBootstrap {
+					return fmt.Errorf("waiting for shared-secret bootstrap to be restored")
+				}
+				return nil
+			}, 2*time.Minute, 5*time.Second).Should(Succeed())
+		})
+
+		Eventually(func() error {
+			cfg, err := managedHubAgentKafkaConfig(sourceHubClient)
+			if err != nil {
+				return err
+			}
+			if cfg.BootstrapServer != byoPerHubBootstrapMarker {
+				return fmt.Errorf("agent transport still uses shared bootstrap")
+			}
+			return nil
+		}, 2*time.Minute, 5*time.Second).Should(Succeed(),
+			"agent transport credentials must come from the per-hub BYO secret")
+	})
+
+	It("rejects identical client certificates on two per-hub secrets", func() {
+		createBYOPerHubSecret(sourceHubName, nil)
+		createBYOPerHubSecret(targetHubName, nil)
+		DeferCleanup(func() {
+			deleteBYOPerHubSecret(sourceHubName)
+			deleteBYOPerHubSecret(targetHubName)
+		})
+
+		Eventually(func() error {
+			return operatorLogsContain(byoIdenticalCertLog)
+		}, 2*time.Minute, 5*time.Second).Should(Succeed(),
+			"operator must reject identical client certificates on per-hub BYO secrets")
+	})
+})
+
+func byoSharedTransportSecret() (*corev1.Secret, error) {
+	return testClients.KubeClient().CoreV1().Secrets(testOptions.GlobalHub.Namespace).Get(
+		ctx, constants.GHTransportSecretName, metav1.GetOptions{})
+}
+
+func createBYOPerHubSecret(clusterName string, mutate func(*corev1.Secret)) {
+	shared, err := byoSharedTransportSecret()
+	Expect(err).NotTo(HaveOccurred())
+
+	data := make(map[string][]byte, len(shared.Data))
+	for key, value := range shared.Data {
+		copied := make([]byte, len(value))
+		copy(copied, value)
+		data[key] = copied
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.GHTransportSecretNameForCluster(clusterName),
+			Namespace: testOptions.GlobalHub.Namespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: data,
+	}
+	if mutate != nil {
+		mutate(secret)
+	}
+
+	kube := testClients.KubeClient().CoreV1().Secrets(testOptions.GlobalHub.Namespace)
+	_, err = kube.Create(ctx, secret, metav1.CreateOptions{})
+	if apierrors.IsAlreadyExists(err) {
+		existing, getErr := kube.Get(ctx, secret.Name, metav1.GetOptions{})
+		Expect(getErr).NotTo(HaveOccurred())
+		existing.Data = secret.Data
+		_, err = kube.Update(ctx, existing, metav1.UpdateOptions{})
+	}
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func deleteBYOPerHubSecret(clusterName string) {
+	err := testClients.KubeClient().CoreV1().Secrets(testOptions.GlobalHub.Namespace).Delete(
+		ctx, constants.GHTransportSecretNameForCluster(clusterName), metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		Expect(err).NotTo(HaveOccurred())
+	}
+}
+
+func managedHubAgentKafkaConfig(hubClient client.Client) (*transport.KafkaConfig, error) {
+	secret := &corev1.Secret{}
+	if err := hubClient.Get(ctx, types.NamespacedName{
+		Name:      constants.GHTransportConfigSecret,
+		Namespace: constants.GHAgentNamespace,
+	}, secret); err != nil {
+		return nil, fmt.Errorf("get agent transport-config secret: %w", err)
+	}
+	cfg, err := pkgutils.GetKafkaCredentialBySecret(secret, hubClient)
+	if err != nil {
+		return nil, fmt.Errorf("parse agent transport-config: %w", err)
+	}
+	return cfg, nil
+}
+
+func managedHubAgentKafkaReady(hubClient client.Client, hubName string) error {
+	cfg, err := managedHubAgentKafkaConfig(hubClient)
+	if err != nil {
+		return err
+	}
+	if cfg.ClientCert == "" {
+		return fmt.Errorf("agent transport-config is missing a client certificate")
+	}
+	if err := checkDeployAvailable(hubClient, constants.GHAgentNamespace, "multicluster-global-hub-agent"); err != nil {
+		return fmt.Errorf("agent on hub %s: %w", hubName, err)
+	}
+	return nil
+}
+
+func pemCertificateCommonName(certPEM []byte) string {
+	block, _ := pem.Decode(certPEM)
+	Expect(block).NotTo(BeNil(), "shared BYO client.crt must be PEM")
+	cert, err := x509.ParseCertificate(block.Bytes)
+	Expect(err).NotTo(HaveOccurred())
+	return cert.Subject.CommonName
+}
+
+func operatorLogsContain(substr string) error {
+	pods, err := testClients.KubeClient().CoreV1().Pods(testOptions.GlobalHub.Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "name=multicluster-global-hub-operator",
+	})
+	if err != nil {
+		return err
+	}
+	if len(pods.Items) == 0 {
+		return fmt.Errorf("operator pod not found")
+	}
+
+	var combined strings.Builder
+	for i := range pods.Items {
+		logs, logErr := testClients.KubeClient().CoreV1().Pods(testOptions.GlobalHub.Namespace).
+			GetLogs(pods.Items[i].Name, &corev1.PodLogOptions{
+				Container: "multicluster-global-hub-operator",
+			}).DoRaw(ctx)
+		if logErr != nil {
+			return logErr
+		}
+		combined.Write(logs)
+	}
+	if !strings.Contains(combined.String(), substr) {
+		return fmt.Errorf("operator logs do not yet report identical per-hub client certificates")
+	}
+	return nil
+}

--- a/test/script/e2e_run_byo.sh
+++ b/test/script/e2e_run_byo.sh
@@ -84,11 +84,11 @@ kubectl create secret generic "$transport_secret" -n "${target_namespace}" --kub
 echo "transport secret is ready in ${target_namespace} namespace!"
 
 ## run e2e
-bash "$CURRENT_DIR/e2e_run.sh" -n ${target_namespace} -f "e2e-test-localpolicy,e2e-test-grafana,e2e-test-local-agent,e2e-test-transport-byo"
+bash "$CURRENT_DIR/e2e_run.sh" -n "${target_namespace}" -f "e2e-test-localpolicy,e2e-test-grafana,e2e-test-local-agent,e2e-test-transport-byo"
 
 # Clean up MulticlusterGlobalHub resources before migration tests
 echo "Cleaning up BYO test resources..."
-kubectl delete multiclusterglobalhubs --all -n ${target_namespace} --kubeconfig "${GH_KUBECONFIG}" --ignore-not-found=true
-kubectl delete service multicluster-global-hub-manager-nonk8s-service -n ${target_namespace} --kubeconfig "${GH_KUBECONFIG}" --ignore-not-found=true
+kubectl delete multiclusterglobalhubs --all -n "${target_namespace}" --kubeconfig "${GH_KUBECONFIG}" --ignore-not-found=true
+kubectl delete service multicluster-global-hub-manager-nonk8s-service -n "${target_namespace}" --kubeconfig "${GH_KUBECONFIG}" --ignore-not-found=true
 
 unset ISBYO

--- a/test/script/e2e_run_byo.sh
+++ b/test/script/e2e_run_byo.sh
@@ -84,7 +84,7 @@ kubectl create secret generic "$transport_secret" -n "${target_namespace}" --kub
 echo "transport secret is ready in ${target_namespace} namespace!"
 
 ## run e2e
-bash "$CURRENT_DIR/e2e_run.sh" -n ${target_namespace} -f "e2e-test-localpolicy,e2e-test-grafana,e2e-test-local-agent"
+bash "$CURRENT_DIR/e2e_run.sh" -n ${target_namespace} -f "e2e-test-localpolicy,e2e-test-grafana,e2e-test-local-agent,e2e-test-transport-byo"
 
 # Clean up MulticlusterGlobalHub resources before migration tests
 echo "Cleaning up BYO test resources..."


### PR DESCRIPTION
Fixes: [ACM-34442](https://redhat.atlassian.net/browse/ACM-34442)

## Summary

- Prefer per-hub BYO Kafka secrets `multicluster-global-hub-transport-<clusterName>` so each managed hub can use a distinct client certificate
- Reject identical `client.crt` values across per-hub secrets, and fail agent start when a BYO client certificate CN is `{other-hub}-kafka-user`
- Update [BYO Kafka docs](https://github.com/stolostron/multicluster-global-hub/blob/main/doc/byo.md) so managed hubs are Read-only on `gh-spec` (Strimzi-equivalent ACL table)

## Context

Phase 6 of the [ACM-34442](https://redhat.atlassian.net/browse/ACM-34442) transport-identity series. Phases 1–5 are already on `main`:

- [#2564](https://github.com/stolostron/multicluster-global-hub/pull/2564) — manager status identity
- [#2623](https://github.com/stolostron/multicluster-global-hub/pull/2623) — agent spec source validation
- [#2624](https://github.com/stolostron/multicluster-global-hub/pull/2624) — dedicated `gh-migration` topic
- [#2761](https://github.com/stolostron/multicluster-global-hub/pull/2761) — managed-hub Kafka ACLs on `gh-spec`
- [#2782](https://github.com/stolostron/multicluster-global-hub/pull/2782) — agent ClusterRole scope

The shared `multicluster-global-hub-transport` secret remains the manager credential and a legacy fallback for hubs without a per-hub secret.

Related:

- [ACM-34442](https://redhat.atlassian.net/browse/ACM-34442)
- [#2782](https://github.com/stolostron/multicluster-global-hub/pull/2782) — Phase 5

## Test plan

- [ ] Confirm a managed hub with `multicluster-global-hub-transport-<cluster>` uses that secret's client cert
- [ ] Confirm two per-hub secrets with the same `client.crt` are rejected
- [ ] Confirm legacy shared-secret BYO still starts (custom CN such as `global-hub-byo-user`)
- [ ] Confirm agent start fails when the client cert CN is `{other-hub}-kafka-user`
- [ ] Review `doc/byo.md` ACL table: managed hubs Read-only on `gh-spec`, Write on status, migration Write only while a source hub


Made with [Cursor](https://cursor.com)

[ACM-34442]: https://redhat.atlassian.net/browse/ACM-34442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-34442]: https://redhat.atlassian.net/browse/ACM-34442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-34442]: https://redhat.atlassian.net/browse/ACM-34442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate BYO Kafka transport credentials for each managed hub, with shared-credential fallback.
  * Added client-certificate validation to ensure certificates match the correct hub and are not improperly reused.
  * Improved recognition, reconciliation, and configuration of shared and per-hub transport secrets.
  * Added support for shared BYO Kafka status topics.

* **Documentation**
  * Expanded Quick Start guidance and Kafka prerequisites, certificate, secret, and ACL documentation.

* **Tests**
  * Added unit and end-to-end coverage for BYO Kafka credentials, certificates, secrets, and transport readiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->