### PR TITLE
ACM-34442: BYO Kafka per-hub credentials and ACL guide for GH 1.6

### DIFF
--- a/agent/cmd/main.go
+++ b/agent/cmd/main.go
@@ -195,6 +195,10 @@ func completeConfig(ctx context.Context, c client.Client, agentConfig *configs.A
 		return fmt.Errorf("flag consumer-worker-pool-size should be in the scope [1, 100]")
 	}
 
+	if agentConfig.TransportConfig != nil {
+		agentConfig.TransportConfig.LeafHubName = agentConfig.LeafHubName
+	}
+
 	configs.SetAgentConfig(agentConfig)
 	return nil
 }

--- a/agent/cmd/main_test.go
+++ b/agent/cmd/main_test.go
@@ -101,6 +101,7 @@ func TestCompleteConfig(t *testing.T) {
 				MetricsAddress:   "0.0.0.0:8384",
 				TransportConfig: &transport.TransportInternalConfig{
 					TransportType: string(transport.Kafka),
+					LeafHubName:   "123",
 					KafkaCredential: &transport.KafkaConfig{
 						ConsumerGroupID: "test-hub",
 					},
@@ -114,6 +115,7 @@ func TestCompleteConfig(t *testing.T) {
 				DeployMode:  string(constants.DefaultMode),
 				TransportConfig: &transport.TransportInternalConfig{
 					TransportType: string(transport.Kafka),
+					LeafHubName:   "hub1",
 				},
 			},
 			fakeClient:     fake.NewClientBuilder().WithScheme(config.GetRuntimeScheme()).WithObjects().Build(),
@@ -127,6 +129,7 @@ func TestCompleteConfig(t *testing.T) {
 				SpecWorkPoolSize: 5,
 				TransportConfig: &transport.TransportInternalConfig{
 					TransportType: string(transport.Kafka),
+					LeafHubName:   "hub1",
 				},
 			},
 			fakeClient: fake.NewClientBuilder().WithScheme(config.GetRuntimeScheme()).WithObjects().Build(),
@@ -137,6 +140,7 @@ func TestCompleteConfig(t *testing.T) {
 				MetricsAddress:   "0.0.0.0:8384",
 				TransportConfig: &transport.TransportInternalConfig{
 					TransportType: string(transport.Kafka),
+					LeafHubName:   "hub1",
 				},
 			},
 		},

--- a/doc/README.md
+++ b/doc/README.md
@@ -28,6 +28,7 @@ The multicluster global hub is useful when a single hub cluster cannot manage th
     - [Grafana dashboards](#grafana-dashboards)
     - [Cronjobs and Metrics](#cronjobs-and-metrics)
   - [Built-in PostgreSQL Configuration](./global_hub_builtin_postgresql.md)
+  - [Bring your own Kafka, Postgres, and Grafana](./byo.md)
   - [Troubleshooting](./troubleshooting.md)
   - [Development preview features](./dev-preview.md)
   - [Known issues](#known-issues)

--- a/doc/byo.md
+++ b/doc/byo.md
@@ -2,29 +2,125 @@ Multicluster global hub depends on the middleware (Kafka, Postgres) and observab
 
 ## Bring your own Kafka
 
-If you have your own Kafka, you can use it as the transport for multicluster global hub. You need to create a secret `multicluster-global-hub-transport` in `multicluster-global-hub` namespace. The secret contains the following fields:
+If you have your own Kafka, you can use it as the transport for multicluster global hub.
 
-- `bootstrap.servers`: Required, the Kafka bootstrap servers.
-- `ca.crt`: Required, if you use the `KafkaUser` custom resource to configure authentication credentials, see [User authentication](https://strimzi.io/docs/operators/latest/deploying.html#con-securing-client-authentication-str) in the STRIMZI documentation for the steps to extract the `ca.crt` certificate from the secret.
-- `client.crt`: Required, see [User authentication](https://strimzi.io/docs/operators/latest/deploying.html#con-securing-client-authentication-str) in the STRIMZI documentation for the steps to extract the `user.crt` certificate from the secret.
-- `client.key`: Required, see [User authentication](https://strimzi.io/docs/operators/latest/deploying.html#con-securing-client-authentication-str) in the STRIMZI documentation for the steps to extract the `user.key` from the secret.
+### Transport secrets
 
-You can create the secret by running the following command:
+Create Kafka client secrets in the `multicluster-global-hub` namespace.
+
+| Secret | Used by | Required |
+|--------|---------|----------|
+| `multicluster-global-hub-transport` | Global Hub manager | Yes |
+| `multicluster-global-hub-transport-<clusterName>` | Managed hub named `<clusterName>` | Recommended |
+
+Each secret contains:
+
+- `bootstrap_server`: Required. The Kafka bootstrap servers.
+- `ca.crt`: Required. If you use the `KafkaUser` custom resource to configure authentication credentials, see [User authentication](https://strimzi.io/docs/operators/latest/deploying.html#con-securing-client-authentication-str) in the Strimzi documentation for the steps to extract the `ca.crt` certificate from the secret.
+- `client.crt`: Required. See [User authentication](https://strimzi.io/docs/operators/latest/deploying.html#con-securing-client-authentication-str) for the steps to extract the `user.crt` certificate from the secret.
+- `client.key`: Required. See [User authentication](https://strimzi.io/docs/operators/latest/deploying.html#con-securing-client-authentication-str) for the steps to extract the `user.key` from the secret.
+
+Give **each managed hub a distinct client certificate**. Shared client certificates across hubs are not isolated by Kafka ACLs. The operator rejects two per-hub secrets that contain the same `client.crt`. The agent also fails to start when a BYO client certificate CommonName is `{other-hub}-kafka-user` and that name does not match the local hub.
+
+If a per-hub secret is not present, the operator falls back to the shared `multicluster-global-hub-transport` secret (legacy). That mode cannot enforce per-hub Kafka write isolation.
+
+Create the manager secret:
+
 ```bash
 kubectl create secret generic multicluster-global-hub-transport -n multicluster-global-hub \
     --from-literal=bootstrap_server=<kafka-bootstrap-server-address> \
     --from-file=ca.crt=<CA-cert-for-kafka-server> \
     --from-file=client.crt=<Client-cert-for-kafka-server> \
-    --from-file=client.key=<Client-key-for-kafka-server> 
+    --from-file=client.key=<Client-key-for-kafka-server>
 ```
 
-*Prerequisite:*  See the following requirements for bringing your own Kafka: 
+Create a per-hub secret for a managed hub named `hub1`:
 
-- Unless you configured your Kafka to automatically create topics, you must manually create two topics for spec and status(The default topics are `gh-spec` and `gh-status`). When you create these topics, ensure that the Kafka user can to read and write data to the these topics. And also make sure the topic names in the Global Hub operand is aligned with the topics you created.
+```bash
+kubectl create secret generic multicluster-global-hub-transport-hub1 -n multicluster-global-hub \
+    --from-literal=bootstrap_server=<kafka-bootstrap-server-address> \
+    --from-file=ca.crt=<CA-cert-for-kafka-server> \
+    --from-file=client.crt=<hub1-client-cert> \
+    --from-file=client.key=<hub1-client-key>
+```
 
-- Kafka 3.3 or later is tested.\
+*Prerequisite:*
 
-- Suggest to have persistent volume for your Kafka.
+- Unless you configured your Kafka to automatically create topics, you must manually create the transport topics `gh-spec`, `gh-migration`, and `gh-status`. By default, all managed hubs publish status to the shared topic `gh-status`. If you set a different `statusTopic` in `spec.dataLayer.kafka.topics`, create that topic instead. See [Kafka topics and ACLs](#kafka-topics-and-acls) below.
+- Kafka 3.3 or later is tested.
+- Persistent volume is recommended for Kafka.
+
+### Kafka topics and ACLs
+
+Global Hub uses three Kafka topics for transport:
+
+| Topic | Purpose |
+|-------|---------|
+| `gh-spec` | Policy and spec sync from the global hub manager to managed hub agents |
+| `gh-migration` | Cluster migration deploying-phase bundles (source hub to target hub) |
+| `gh-status` | Status and compliance events from managed hubs to the global hub manager (shared topic by default) |
+
+Grant ACLs that match the built-in Strimzi transporter. Do **not** grant every managed hub Read+Write on both spec and status topics.
+
+| Principal | `gh-spec` | `gh-migration` | Status topic |
+|-----------|-----------|----------------|--------------|
+| Global hub manager (`global-hub-kafka-user`) | Describe, Read, **Write** | Describe, Read, **Write** | Describe, Read on the configured status topic |
+| Managed hub `{hub}-kafka-user` | Describe, **Read** (no Write) | Describe, Read; **Write** only while that hub is an active migration source | Describe, Read, **Write** on the configured status topic |
+| Consumer group | Per-hub literal group name | Per-hub literal group name | Per-hub literal group name (not `*`) |
+
+Notes:
+
+- The global hub manager publishes to `gh-spec`. Managed hub agents consume from `gh-spec` and must not produce to it.
+- During cluster migration, the source hub publishes deploying bundles to `gh-migration`. The target hub agent consumes from `gh-migration` as well as `gh-spec`.
+- Grant **Write** on `gh-migration` to the source managed hub only for the duration of an active migration, then revoke it. With built-in Strimzi Kafka, the operator applies and removes that ACL automatically; with BYO Kafka, you must update ACLs yourself or through your Kafka administration tooling.
+- For more information about cluster migration, see [Managed Cluster Migration](./migration/global_hub_cluster_migration.md).
+- Built-in Strimzi Kafka uses per-hub status topics such as `gh-status.<cluster-name>` with a prefix ACL on `gh-status`. BYO Kafka always uses one shared status topic (`gh-status` by default, or the configured `statusTopic`) for every managed hub.
+
+Example Strimzi `KafkaUser` ACL entries for the global hub manager transport user (BYO defaults shown):
+
+```yaml
+# gh-spec — manager publishes policy/spec sync
+- operations: [Describe, Read, Write]
+  resource:
+    type: topic
+    name: gh-spec
+    patternType: literal
+# gh-migration — manager oversight; source hub writes during migration
+- operations: [Describe, Read, Write]
+  resource:
+    type: topic
+    name: gh-migration
+    patternType: literal
+# gh-status — manager consumes status from the shared BYO topic (use literal unless you override statusTopic)
+- operations: [Describe, Read]
+  resource:
+    type: topic
+    name: gh-status
+    patternType: literal
+```
+
+Example managed-hub `KafkaUser` ACL entries:
+
+```yaml
+# gh-spec — consume spec/policy only
+- operations: [Describe, Read]
+  resource:
+    type: topic
+    name: gh-spec
+    patternType: literal
+# gh-migration — read always; add Write only while this hub is a migration source
+- operations: [Describe, Read]
+  resource:
+    type: topic
+    name: gh-migration
+    patternType: literal
+# gh-status — publish this hub's status
+- operations: [Describe, Read, Write]
+  resource:
+    type: topic
+    name: gh-status
+    patternType: literal
+```
 
 ## Bring your own Postgres
 

--- a/doc/byo.md
+++ b/doc/byo.md
@@ -48,7 +48,7 @@ kubectl create secret generic multicluster-global-hub-transport-hub1 -n multiclu
 
 - Unless you configured your Kafka to automatically create topics, you must manually create the transport topics `gh-spec`, `gh-migration`, and `gh-status`. By default, all managed hubs publish status to the shared topic `gh-status`. If you set a different `statusTopic` in `spec.dataLayer.kafka.topics`, create that topic instead. See [Kafka topics and ACLs](#kafka-topics-and-acls) below.
 - Enable simple ACL authorization on the Kafka cluster so those ACLs take effect (Strimzi: `spec.kafka.authorization.type: simple`).
-- Kafka 3.3 or later is tested.
+- Kafka 3.3 and later is supported. Versions before 3.3 are unsupported. End-to-end tests use Kafka 4.0.0.
 - Persistent volume is recommended for Kafka.
 
 ### Kafka topics and ACLs
@@ -62,7 +62,7 @@ spec:
       type: simple
 ```
 
-Without a broker authorizer, KafkaUser (or equivalent) ACLs are ignored and authenticated clients can still read and write all topics.
+Without a broker authorizer, Kafka cannot enforce manually configured ACLs, so authenticated clients can still read and write all topics. A Strimzi `KafkaUser` that defines ACL rules while authorization is disabled is marked `NotReady` with an authorization-disabled error; those ACLs are not silently ignored.
 
 Global Hub uses three Kafka topics for transport:
 

--- a/doc/byo.md
+++ b/doc/byo.md
@@ -87,7 +87,9 @@ Notes:
 - Grant **Write** on `gh-migration` to the source managed hub only for the duration of an active migration, then revoke it. With built-in Strimzi Kafka, the operator applies and removes that ACL automatically; with BYO Kafka, you must update ACLs yourself or through your Kafka administration tooling.
 - For more information about cluster migration, see [Managed Cluster Migration](./migration/global_hub_cluster_migration.md).
 - Built-in Strimzi Kafka uses per-hub status topics such as `gh-status.<cluster-name>` with a prefix ACL on `gh-status`. BYO Kafka always uses one shared status topic (`gh-status` by default, or the configured `statusTopic`) for every managed hub.
-- Kafka consumers also need **Group Read** (FindCoordinator). Topic-only ACLs fail with `Group authorization failed` and the consumer group is never created. A shared BYO principal (single `multicluster-global-hub-transport` secret / `global-hub-byo-user`) must use Group `*` Read. Per-hub KafkaUsers should use the literal group id: `consumerGroupPrefix` + cluster name with hyphens replaced by underscores (for example `custom_qe_global_hub`).
+- Kafka consumers also need **Group Read** (FindCoordinator). Topic-only ACLs fail with `Group authorization failed` and the consumer group is never created.
+- Per-hub KafkaUsers (`{hub}-kafka-user`) must use the **literal** group id: `consumerGroupPrefix` + cluster name with hyphens replaced by underscores. With prefix `custom-qe-`, the manager group is `custom_qe_global_hub` and hub `hub1` is `custom_qe_hub1`. Do not grant Group `*` to per-hub users.
+- A shared BYO principal (single `multicluster-global-hub-transport` secret / `global-hub-byo-user`) joins both the manager group and every hub group, so that user needs Group `*` Read. See the labeled shared-BYO example below.
 
 Example Strimzi `KafkaUser` ACL entries for the global hub manager transport user (BYO defaults shown):
 
@@ -110,16 +112,15 @@ Example Strimzi `KafkaUser` ACL entries for the global hub manager transport use
     type: topic
     name: gh-status
     patternType: literal
-# consumer group — FindCoordinator / group join
-# Shared BYO user: "*". Per-hub user: literal "{prefix}{cluster}" (hyphens → underscores)
+# consumer group — manager id is {prefix}global_hub (hyphens → underscores)
 - operations: [Read]
   resource:
     type: group
-    name: "*"
+    name: custom_qe_global_hub
     patternType: literal
 ```
 
-Example managed-hub `KafkaUser` ACL entries:
+Example managed-hub `KafkaUser` ACL entries (hub `hub1` with prefix `custom-qe-`):
 
 ```yaml
 # gh-spec — consume spec/policy only
@@ -140,8 +141,18 @@ Example managed-hub `KafkaUser` ACL entries:
     type: topic
     name: gh-status
     patternType: literal
-# consumer group — FindCoordinator / group join
-# Shared BYO user: "*". Per-hub user: literal "{prefix}{cluster}" (hyphens → underscores)
+# consumer group — {prefix}{hub} with hyphens replaced by underscores
+- operations: [Read]
+  resource:
+    type: group
+    name: custom_qe_hub1
+    patternType: literal
+```
+
+Example Group ACL for a **shared BYO principal** only (`global-hub-byo-user` / single transport secret). Do not use `*` on per-hub `{hub}-kafka-user` resources:
+
+```yaml
+# consumer group — shared BYO user joins manager + every hub group
 - operations: [Read]
   resource:
     type: group

--- a/doc/byo.md
+++ b/doc/byo.md
@@ -87,6 +87,7 @@ Notes:
 - Grant **Write** on `gh-migration` to the source managed hub only for the duration of an active migration, then revoke it. With built-in Strimzi Kafka, the operator applies and removes that ACL automatically; with BYO Kafka, you must update ACLs yourself or through your Kafka administration tooling.
 - For more information about cluster migration, see [Managed Cluster Migration](./migration/global_hub_cluster_migration.md).
 - Built-in Strimzi Kafka uses per-hub status topics such as `gh-status.<cluster-name>` with a prefix ACL on `gh-status`. BYO Kafka always uses one shared status topic (`gh-status` by default, or the configured `statusTopic`) for every managed hub.
+- Kafka consumers also need **Group Read** (FindCoordinator). Topic-only ACLs fail with `Group authorization failed` and the consumer group is never created. A shared BYO principal (single `multicluster-global-hub-transport` secret / `global-hub-byo-user`) must use Group `*` Read. Per-hub KafkaUsers should use the literal group id: `consumerGroupPrefix` + cluster name with hyphens replaced by underscores (for example `custom_qe_global_hub`).
 
 Example Strimzi `KafkaUser` ACL entries for the global hub manager transport user (BYO defaults shown):
 
@@ -108,6 +109,13 @@ Example Strimzi `KafkaUser` ACL entries for the global hub manager transport use
   resource:
     type: topic
     name: gh-status
+    patternType: literal
+# consumer group — FindCoordinator / group join
+# Shared BYO user: "*". Per-hub user: literal "{prefix}{cluster}" (hyphens → underscores)
+- operations: [Read]
+  resource:
+    type: group
+    name: "*"
     patternType: literal
 ```
 
@@ -131,6 +139,13 @@ Example managed-hub `KafkaUser` ACL entries:
   resource:
     type: topic
     name: gh-status
+    patternType: literal
+# consumer group — FindCoordinator / group join
+# Shared BYO user: "*". Per-hub user: literal "{prefix}{cluster}" (hyphens → underscores)
+- operations: [Read]
+  resource:
+    type: group
+    name: "*"
     patternType: literal
 ```
 

--- a/doc/byo.md
+++ b/doc/byo.md
@@ -47,10 +47,22 @@ kubectl create secret generic multicluster-global-hub-transport-hub1 -n multiclu
 *Prerequisite:*
 
 - Unless you configured your Kafka to automatically create topics, you must manually create the transport topics `gh-spec`, `gh-migration`, and `gh-status`. By default, all managed hubs publish status to the shared topic `gh-status`. If you set a different `statusTopic` in `spec.dataLayer.kafka.topics`, create that topic instead. See [Kafka topics and ACLs](#kafka-topics-and-acls) below.
+- Enable simple ACL authorization on the Kafka cluster so those ACLs take effect (Strimzi: `spec.kafka.authorization.type: simple`).
 - Kafka 3.3 or later is tested.
 - Persistent volume is recommended for Kafka.
 
 ### Kafka topics and ACLs
+
+Enable simple ACL authorization on the Kafka cluster before granting the ACLs below. With Strimzi or AMQ Streams, set:
+
+```yaml
+spec:
+  kafka:
+    authorization:
+      type: simple
+```
+
+Without a broker authorizer, KafkaUser (or equivalent) ACLs are ignored and authenticated clients can still read and write all topics.
 
 Global Hub uses three Kafka topics for transport:
 

--- a/operator/pkg/controllers/agent/addon/default_agent_controller.go
+++ b/operator/pkg/controllers/agent/addon/default_agent_controller.go
@@ -338,6 +338,7 @@ func (r *DefaultAgentController) reconcileAddonAndResources(ctx context.Context,
 	return EnsureTransportResource(cluster.Name)
 }
 
+// EnsureTransportResource ensures Kafka user and topic resources for the managed hub.
 func EnsureTransportResource(clusterName string) error {
 	// create kafka resource: user and topic
 	trans := config.GetTransporter()

--- a/operator/pkg/controllers/agent/addon/default_agent_controller.go
+++ b/operator/pkg/controllers/agent/addon/default_agent_controller.go
@@ -46,7 +46,7 @@ type DefaultAgentController struct {
 // Assert whether a secret is associated with or affects the addon
 func targetAddonSecret(obj client.Object) bool {
 	if obj.GetName() == config.GetImagePullSecretName() ||
-		obj.GetName() == constants.GHTransportSecretName ||
+		constants.IsGHTransportSecret(obj.GetName()) ||
 		obj.GetLabels() != nil && obj.GetLabels()["strimzi.io/cluster"] == operatortrans.KafkaClusterName &&
 			obj.GetLabels()["strimzi.io/kind"] == "KafkaUser" {
 		return true

--- a/operator/pkg/controllers/agent/local_agent_controller.go
+++ b/operator/pkg/controllers/agent/local_agent_controller.go
@@ -238,6 +238,7 @@ func GetLocalClusterName(ctx context.Context, c client.Client, namespace string)
 	return mcList.Items[0].Name, nil
 }
 
+// pruneAgentResources deletes local-agent resources and prunes transport users.
 func (s *LocalAgentController) pruneAgentResources(ctx context.Context, namespace string) error {
 	log.Debugf("prune agent resources in namespace: %v", namespace)
 	// delete deployment
@@ -268,6 +269,8 @@ func (s *LocalAgentController) pruneAgentResources(ctx context.Context, namespac
 	return nil
 }
 
+// GenerateLocalAgentCredential writes the local-agent transport secret from the
+// transporter connection. Bootstrap server and cluster ID are not logged.
 func GenerateLocalAgentCredential(ctx context.Context, c client.Client, namespace string) error {
 	log.Debugf("generate local agent credential in namespace: %v", namespace)
 	err := addon.EnsureTransportResource(clusterName)
@@ -280,7 +283,8 @@ func GenerateLocalAgentCredential(ctx context.Context, c client.Client, namespac
 	if err != nil {
 		return err
 	}
-	log.Debugf("kafkaConnection bootstrap server: %s, cluster ID: %s", kafkaConnection.BootstrapServer, kafkaConnection.ClusterID)
+	log.Debugf("generated local agent Kafka credentials: bootstrap_set=%t cluster_id_set=%t",
+		kafkaConnection.BootstrapServer != "", kafkaConnection.ClusterID != "")
 	kafkaConfigYaml, err := kafkaConnection.YamlMarshal(true)
 	if err != nil {
 		return fmt.Errorf("failed to marshalling the kafka config yaml: %w", err)
@@ -318,6 +322,7 @@ func GenerateLocalAgentCredential(ctx context.Context, c client.Client, namespac
 	return c.Update(ctx, expectedSecret)
 }
 
+// getTransportSecretName returns the local-agent transport-config secret name.
 func getTransportSecretName() string {
 	return constants.GHTransportConfigSecret + "-" + clusterName
 }

--- a/operator/pkg/controllers/transporter/protocol/byo_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/byo_transporter.go
@@ -1,6 +1,22 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package protocol
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"fmt"
@@ -8,13 +24,17 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
 	"github.com/stolostron/multicluster-global-hub/pkg/logger"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 )
+
+const transportSecretClientCertKey = "client.crt"
 
 type BYOTransporter struct {
 	ctx           context.Context
@@ -24,36 +44,57 @@ type BYOTransporter struct {
 	runtimeClient client.Client
 }
 
-var byoTransporter *BYOTransporter
-
-// create the transport with secret(BYO case), it should meet the following conditions
-// 1. name: "multicluster-global-hub-transport"
-// 2. properties: "bootstrap_server", "ca.crt", "client.crt" and "client.key"
+// NewBYOTransporter creates the transport from customer-provided Kafka secrets.
+// The manager uses the shared secret "multicluster-global-hub-transport".
+// Each managed hub may supply "multicluster-global-hub-transport-<clusterName>"
+// so Kafka ACLs can bind a distinct client certificate to that hub. When the
+// per-hub secret is absent, the shared secret is used (legacy BYO).
 func NewBYOTransporter(ctx context.Context, namespacedName types.NamespacedName,
 	c client.Client,
 ) *BYOTransporter {
-	if byoTransporter == nil {
-		byoTransporter = &BYOTransporter{
-			log:           logger.ZaprLogger(),
-			ctx:           ctx,
-			runtimeClient: c,
-		}
-		config.SetTransporter(byoTransporter)
+	transporter := &BYOTransporter{
+		log:           logger.ZaprLogger(),
+		ctx:           ctx,
+		runtimeClient: c,
+		name:          namespacedName.Name,
+		namespace:     namespacedName.Namespace,
 	}
-	byoTransporter.name = namespacedName.Name
-	byoTransporter.namespace = namespacedName.Namespace
-	return byoTransporter
+	config.SetTransporter(transporter)
+	return transporter
 }
 
+// EnsureUser validates that a BYO transport secret exists for the cluster and
+// that per-hub client certificates are distinct. Kafka users and ACLs remain
+// customer-managed; see doc/byo.md. A missing secret is logged, not rejected,
+// so addon install can proceed before credentials are created. Other API
+// errors are returned to the caller.
 func (s *BYOTransporter) EnsureUser(clusterName string) (string, error) {
-	return "", nil
+	if isManagerCluster(clusterName) {
+		return "", nil
+	}
+	secret, secretName, err := s.getTransportSecret(clusterName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			s.log.Info("BYO Kafka transport secret not found; provide a per-hub or shared secret")
+			return config.GetKafkaUserName(clusterName), nil
+		}
+		return "", fmt.Errorf("failed to get BYO Kafka transport secret: %w", err)
+	}
+	if secretName == s.sharedSecretName() {
+		s.log.Info("BYO Kafka is using the shared transport secret; " +
+			"provide a per-hub secret for isolated credentials")
+	} else if err := s.validateDistinctClientCerts(clusterName, secret.Data[transportSecretClientCertKey]); err != nil {
+		return "", err
+	}
+	return config.GetKafkaUserName(clusterName), nil
 }
 
 func (s *BYOTransporter) EnsureTopic(clusterName string) (*transport.ClusterTopic, error) {
 	return &transport.ClusterTopic{
 		SpecTopic:      config.GetSpecTopic(),
 		MigrationTopic: config.GetMigrationTopic(),
-		StatusTopic:    config.GetStatusTopic(clusterName),
+		// BYO Kafka uses one configured status topic for every hub.
+		StatusTopic: config.GetStatusTopic(""),
 	}, nil
 }
 
@@ -67,16 +108,17 @@ func (s *BYOTransporter) Prune(clusterName string) error {
 }
 
 func (s *BYOTransporter) GetConnCredential(clusterName string) (*transport.KafkaConfig, error) {
-	kafkaSecret := &corev1.Secret{}
-	err := s.runtimeClient.Get(s.ctx, types.NamespacedName{
-		Name:      s.name,
-		Namespace: s.namespace,
-	}, kafkaSecret)
+	kafkaSecret, secretName, err := s.getTransportSecret(clusterName)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get BYO Kafka transport secret: %w", err)
+	}
+	if !isManagerCluster(clusterName) && secretName != s.sharedSecretName() {
+		if err := s.validateDistinctClientCerts(clusterName, kafkaSecret.Data[transportSecretClientCertKey]); err != nil {
+			return nil, err
+		}
 	}
 
-	mgh, err := config.GetMulticlusterGlobalHub(context.Background(), s.runtimeClient)
+	mgh, err := config.GetMulticlusterGlobalHub(s.ctx, s.runtimeClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get mgh: %w", err)
 	}
@@ -90,12 +132,82 @@ func (s *BYOTransporter) GetConnCredential(clusterName string) (*transport.Kafka
 		BootstrapServer: string(kafkaSecret.Data[filepath.Join("bootstrap_server")]),
 		ConsumerGroupID: config.GetConsumerGroupID(mgh.Spec.DataLayerSpec.Kafka.ConsumerGroupPrefix, clusterName),
 
-		// for the byo case, the status topic isn't change by the clusterName
+		// BYO status topic is shared; clusterName does not change it
 		StatusTopic:    config.GetStatusTopic(""),
 		SpecTopic:      config.GetSpecTopic(),
 		MigrationTopic: config.GetMigrationTopic(),
 		CACert:         base64.StdEncoding.EncodeToString(kafkaSecret.Data[filepath.Join("ca.crt")]),
-		ClientCert:     base64.StdEncoding.EncodeToString(kafkaSecret.Data[filepath.Join("client.crt")]),
+		ClientCert:     base64.StdEncoding.EncodeToString(kafkaSecret.Data[transportSecretClientCertKey]),
 		ClientKey:      base64.StdEncoding.EncodeToString(kafkaSecret.Data[filepath.Join("client.key")]),
 	}, nil
+}
+
+func isManagerCluster(clusterName string) bool {
+	return clusterName == "" || clusterName == constants.CloudEventGlobalHubClusterName
+}
+
+func (s *BYOTransporter) sharedSecretName() string {
+	if s.name != "" {
+		return s.name
+	}
+	return constants.GHTransportSecretName
+}
+
+func (s *BYOTransporter) getTransportSecret(clusterName string) (*corev1.Secret, string, error) {
+	if !isManagerCluster(clusterName) {
+		perHubName := constants.GHTransportSecretNameForCluster(clusterName)
+		perHubSecret := &corev1.Secret{}
+		err := s.runtimeClient.Get(s.ctx, types.NamespacedName{
+			Name:      perHubName,
+			Namespace: s.namespace,
+		}, perHubSecret)
+		if err == nil {
+			return perHubSecret, perHubName, nil
+		}
+		if !apierrors.IsNotFound(err) {
+			return nil, "", err
+		}
+	}
+
+	sharedName := s.sharedSecretName()
+	sharedSecret := &corev1.Secret{}
+	err := s.runtimeClient.Get(s.ctx, types.NamespacedName{
+		Name:      sharedName,
+		Namespace: s.namespace,
+	}, sharedSecret)
+	if err != nil {
+		if apierrors.IsNotFound(err) && !isManagerCluster(clusterName) {
+			return nil, "", fmt.Errorf("BYO Kafka secret %q or %q not found in namespace %q: %w",
+				constants.GHTransportSecretNameForCluster(clusterName), sharedName, s.namespace, err)
+		}
+		return nil, "", err
+	}
+	return sharedSecret, sharedName, nil
+}
+
+func (s *BYOTransporter) validateDistinctClientCerts(clusterName string, clientCert []byte) error {
+	if isManagerCluster(clusterName) || len(clientCert) == 0 {
+		return nil
+	}
+
+	secretList := &corev1.SecretList{}
+	if err := s.runtimeClient.List(s.ctx, secretList, client.InNamespace(s.namespace)); err != nil {
+		return fmt.Errorf("failed to list BYO transport secrets: %w", err)
+	}
+
+	for i := range secretList.Items {
+		secret := &secretList.Items[i]
+		otherCluster := constants.ClusterNameFromGHTransportSecret(secret.Name)
+		if otherCluster == "" || otherCluster == clusterName || isManagerCluster(otherCluster) {
+			continue
+		}
+		otherCert := secret.Data[transportSecretClientCertKey]
+		if len(otherCert) == 0 {
+			continue
+		}
+		if bytes.Equal(clientCert, otherCert) {
+			return fmt.Errorf("BYO Kafka client certificates on per-hub transport secrets must not be identical")
+		}
+	}
+	return nil
 }

--- a/operator/pkg/controllers/transporter/protocol/byo_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/byo_transporter.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
@@ -194,13 +195,24 @@ func (s *BYOTransporter) getTransportSecret(clusterName string) (*corev1.Secret,
 }
 
 // validateDistinctClientCerts requires a non-empty client.crt on a per-hub
-// secret and rejects identical certificates across managed hubs.
+// secret and rejects identical certificates across managed hubs. Secrets that
+// only share the transport-secret name prefix are ignored unless the suffix
+// is an existing ManagedCluster name.
 func (s *BYOTransporter) validateDistinctClientCerts(clusterName string, clientCert []byte) error {
 	if isManagerCluster(clusterName) {
 		return nil
 	}
 	if len(clientCert) == 0 {
 		return fmt.Errorf("BYO Kafka per-hub transport secret is missing client.crt")
+	}
+
+	managedHubs := map[string]struct{}{}
+	mcList := &clusterv1.ManagedClusterList{}
+	if err := s.runtimeClient.List(s.ctx, mcList); err != nil {
+		return fmt.Errorf("failed to list managed clusters for BYO cert uniqueness: %w", err)
+	}
+	for i := range mcList.Items {
+		managedHubs[mcList.Items[i].Name] = struct{}{}
 	}
 
 	secretList := &corev1.SecretList{}
@@ -211,7 +223,10 @@ func (s *BYOTransporter) validateDistinctClientCerts(clusterName string, clientC
 	for i := range secretList.Items {
 		secret := &secretList.Items[i]
 		otherCluster := constants.ClusterNameFromGHTransportSecret(secret.Name)
-		if otherCluster == "" || otherCluster == clusterName || isManagerCluster(otherCluster) {
+		if _, ok := managedHubs[otherCluster]; !ok {
+			continue
+		}
+		if otherCluster == clusterName || isManagerCluster(otherCluster) {
 			continue
 		}
 		otherCert := secret.Data[transportSecretClientCertKey]

--- a/operator/pkg/controllers/transporter/protocol/byo_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/byo_transporter.go
@@ -18,7 +18,9 @@ package protocol
 import (
 	"bytes"
 	"context"
+	"crypto/x509"
 	"encoding/base64"
+	"encoding/pem"
 	"fmt"
 	"path/filepath"
 
@@ -233,9 +235,43 @@ func (s *BYOTransporter) validateDistinctClientCerts(clusterName string, clientC
 		if len(otherCert) == 0 {
 			continue
 		}
-		if bytes.Equal(clientCert, otherCert) {
+		if clientCertsEqual(clientCert, otherCert) {
 			return fmt.Errorf("BYO Kafka client certificates on per-hub transport secrets must not be identical")
 		}
 	}
 	return nil
+}
+
+// clientCertsEqual reports whether two client.crt values are the same leaf
+// certificate. Parsed PEM identity is compared by DER bytes so extra headers
+// or chain blocks cannot hide a duplicate. Unparseable values fall back to
+// raw-byte equality.
+func clientCertsEqual(a, b []byte) bool {
+	aDER, aOK := leafCertificateDER(a)
+	bDER, bOK := leafCertificateDER(b)
+	if aOK && bOK {
+		return bytes.Equal(aDER, bDER)
+	}
+	return bytes.Equal(a, b)
+}
+
+// leafCertificateDER returns the DER encoding of the first PEM certificate
+// block (the leaf). ok is false when client.crt is not a parseable PEM cert.
+func leafCertificateDER(clientCert []byte) ([]byte, bool) {
+	rest := clientCert
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			return nil, false
+		}
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, false
+		}
+		return cert.Raw, true
+	}
 }

--- a/operator/pkg/controllers/transporter/protocol/byo_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/byo_transporter.go
@@ -89,6 +89,7 @@ func (s *BYOTransporter) EnsureUser(clusterName string) (string, error) {
 	return config.GetKafkaUserName(clusterName), nil
 }
 
+// EnsureTopic returns the configured spec, status, and migration topic names.
 func (s *BYOTransporter) EnsureTopic(clusterName string) (*transport.ClusterTopic, error) {
 	return &transport.ClusterTopic{
 		SpecTopic:      config.GetSpecTopic(),
@@ -98,15 +99,19 @@ func (s *BYOTransporter) EnsureTopic(clusterName string) (*transport.ClusterTopi
 	}, nil
 }
 
+// EnsureKafka is a no-op for BYO; the customer already operates Kafka.
 func (s *BYOTransporter) EnsureKafka() (bool, error) {
 	// do nothing
 	return false, nil
 }
 
+// Prune is a no-op for BYO; Kafka users and ACLs stay customer-managed.
 func (s *BYOTransporter) Prune(clusterName string) error {
 	return nil
 }
 
+// GetConnCredential loads Kafka connection settings from the per-hub secret
+// when present, otherwise the shared transport secret.
 func (s *BYOTransporter) GetConnCredential(clusterName string) (*transport.KafkaConfig, error) {
 	kafkaSecret, secretName, err := s.getTransportSecret(clusterName)
 	if err != nil {
@@ -142,10 +147,12 @@ func (s *BYOTransporter) GetConnCredential(clusterName string) (*transport.Kafka
 	}, nil
 }
 
+// isManagerCluster reports whether clusterName is the global hub manager.
 func isManagerCluster(clusterName string) bool {
 	return clusterName == "" || clusterName == constants.CloudEventGlobalHubClusterName
 }
 
+// sharedSecretName is the customer-provided shared BYO transport secret.
 func (s *BYOTransporter) sharedSecretName() string {
 	if s.name != "" {
 		return s.name
@@ -153,6 +160,7 @@ func (s *BYOTransporter) sharedSecretName() string {
 	return constants.GHTransportSecretName
 }
 
+// getTransportSecret returns the per-hub secret when it exists, else the shared secret.
 func (s *BYOTransporter) getTransportSecret(clusterName string) (*corev1.Secret, string, error) {
 	if !isManagerCluster(clusterName) {
 		perHubName := constants.GHTransportSecretNameForCluster(clusterName)
@@ -185,9 +193,14 @@ func (s *BYOTransporter) getTransportSecret(clusterName string) (*corev1.Secret,
 	return sharedSecret, sharedName, nil
 }
 
+// validateDistinctClientCerts requires a non-empty client.crt on a per-hub
+// secret and rejects identical certificates across managed hubs.
 func (s *BYOTransporter) validateDistinctClientCerts(clusterName string, clientCert []byte) error {
-	if isManagerCluster(clusterName) || len(clientCert) == 0 {
+	if isManagerCluster(clusterName) {
 		return nil
+	}
+	if len(clientCert) == 0 {
+		return fmt.Errorf("BYO Kafka per-hub transport secret is missing client.crt")
 	}
 
 	secretList := &corev1.SecretList{}

--- a/operator/pkg/controllers/transporter/protocol/byo_transporter_test.go
+++ b/operator/pkg/controllers/transporter/protocol/byo_transporter_test.go
@@ -17,9 +17,16 @@ package protocol
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/base64"
+	"encoding/pem"
+	"math/big"
 	"strings"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -222,6 +229,25 @@ func TestEnsureUserRejectsIdenticalPerHubCerts(t *testing.T) {
 	}
 }
 
+// TestEnsureUserRejectsEquivalentLeafCerts rejects the same leaf certificate
+// encoded with extra PEM wrapping or chain blocks.
+func TestEnsureUserRejectsEquivalentLeafCerts(t *testing.T) {
+	ns := utils.GetDefaultNamespace()
+	leaf := mustBYOCertPEM(t, "shared-leaf")
+	chain := append(append([]byte("\n"), leaf...), mustBYOCertPEM(t, "intermediate")...)
+	hub1 := byoSecret(constants.GHTransportSecretNameForCluster("hub1"), ns, string(leaf))
+	hub2 := byoSecret(constants.GHTransportSecretNameForCluster("hub2"), ns, string(chain))
+	trans := newBYOTransporter(t, byoMGH(ns), hub1, hub2, byoManagedCluster("hub1"), byoManagedCluster("hub2"))
+
+	_, err := trans.EnsureUser("hub1")
+	if err == nil {
+		t.Fatal("EnsureUser(hub1) expected identical leaf certificate error")
+	}
+	if !strings.Contains(err.Error(), "identical") {
+		t.Fatalf("EnsureUser() error = %v, want identical cert message", err)
+	}
+}
+
 // TestEnsureUserAllowsDistinctPerHubCerts allows hubs with different client certificates.
 func TestEnsureUserAllowsDistinctPerHubCerts(t *testing.T) {
 	ns := utils.GetDefaultNamespace()
@@ -377,4 +403,26 @@ func TestBYOTransporterEnsureTopicIncludesMigrationTopic(t *testing.T) {
 	if topic.MigrationTopic != config.GetMigrationTopic() {
 		t.Fatalf("MigrationTopic = %q, want %q", topic.MigrationTopic, config.GetMigrationTopic())
 	}
+}
+
+// mustBYOCertPEM builds a PEM-encoded test certificate with the given CommonName.
+func mustBYOCertPEM(t *testing.T, commonName string) []byte {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: commonName},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("CreateCertificate: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
 }

--- a/operator/pkg/controllers/transporter/protocol/byo_transporter_test.go
+++ b/operator/pkg/controllers/transporter/protocol/byo_transporter_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
+// byoSecret builds a BYO Kafka transport secret for unit tests.
 func byoSecret(name, namespace, cert string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -50,6 +51,7 @@ func byoSecret(name, namespace, cert string) *corev1.Secret {
 	}
 }
 
+// byoMGH returns a MulticlusterGlobalHub with a Kafka consumer-group prefix.
 func byoMGH(namespace string) *v1alpha4.MulticlusterGlobalHub {
 	return &v1alpha4.MulticlusterGlobalHub{
 		ObjectMeta: metav1.ObjectMeta{
@@ -66,6 +68,7 @@ func byoMGH(namespace string) *v1alpha4.MulticlusterGlobalHub {
 	}
 }
 
+// newBYOTransporter builds a BYOTransporter backed by a fake client.
 func newBYOTransporter(t *testing.T, objects ...client.Object) *BYOTransporter {
 	t.Helper()
 	ns := utils.GetDefaultNamespace()
@@ -82,6 +85,7 @@ type getErrorClient struct {
 	err error
 }
 
+// Get returns the injected error so EnsureUser can surface API failures.
 func (c getErrorClient) Get(ctx context.Context, key types.NamespacedName, obj client.Object,
 	opts ...client.GetOption,
 ) error {
@@ -91,6 +95,7 @@ func (c getErrorClient) Get(ctx context.Context, key types.NamespacedName, obj c
 	return c.Client.Get(ctx, key, obj, opts...)
 }
 
+// TestNewBYOTransporterReturnsIsolatedInstance checks each call gets its own transporter.
 func TestNewBYOTransporterReturnsIsolatedInstance(t *testing.T) {
 	ns := utils.GetDefaultNamespace()
 	c := fake.NewClientBuilder().WithScheme(config.GetRuntimeScheme()).
@@ -112,6 +117,7 @@ func TestNewBYOTransporterReturnsIsolatedInstance(t *testing.T) {
 	}
 }
 
+// TestGetConnCredentialPrefersPerHubSecret checks per-hub secrets win over the shared secret.
 func TestGetConnCredentialPrefersPerHubSecret(t *testing.T) {
 	ns := utils.GetDefaultNamespace()
 	shared := byoSecret(constants.GHTransportSecretName, ns, "shared-cert")
@@ -134,6 +140,7 @@ func TestGetConnCredentialPrefersPerHubSecret(t *testing.T) {
 	}
 }
 
+// TestGetConnCredentialManagerUsesSharedSecret checks the manager always uses the shared secret.
 func TestGetConnCredentialManagerUsesSharedSecret(t *testing.T) {
 	ns := utils.GetDefaultNamespace()
 	shared := byoSecret(constants.GHTransportSecretName, ns, "shared-cert")
@@ -153,6 +160,7 @@ func TestGetConnCredentialManagerUsesSharedSecret(t *testing.T) {
 	}
 }
 
+// TestGetConnCredentialManagerIgnoresGlobalHubNamedSecret ignores a secret named for the manager hub.
 func TestGetConnCredentialManagerIgnoresGlobalHubNamedSecret(t *testing.T) {
 	ns := utils.GetDefaultNamespace()
 	shared := byoSecret(constants.GHTransportSecretName, ns, "manager-cert")
@@ -174,6 +182,7 @@ func TestGetConnCredentialManagerIgnoresGlobalHubNamedSecret(t *testing.T) {
 	}
 }
 
+// TestGetConnCredentialFallsBackToSharedSecret uses the shared secret when no per-hub secret exists.
 func TestGetConnCredentialFallsBackToSharedSecret(t *testing.T) {
 	ns := utils.GetDefaultNamespace()
 	shared := byoSecret(constants.GHTransportSecretName, ns, "shared-cert")
@@ -188,6 +197,7 @@ func TestGetConnCredentialFallsBackToSharedSecret(t *testing.T) {
 	}
 }
 
+// TestEnsureUserRejectsIdenticalPerHubCerts rejects two hubs sharing the same client certificate.
 func TestEnsureUserRejectsIdenticalPerHubCerts(t *testing.T) {
 	ns := utils.GetDefaultNamespace()
 	same := "duplicate-cert"
@@ -204,6 +214,7 @@ func TestEnsureUserRejectsIdenticalPerHubCerts(t *testing.T) {
 	}
 }
 
+// TestEnsureUserAllowsDistinctPerHubCerts allows hubs with different client certificates.
 func TestEnsureUserAllowsDistinctPerHubCerts(t *testing.T) {
 	ns := utils.GetDefaultNamespace()
 	hub1 := byoSecret(constants.GHTransportSecretNameForCluster("hub1"), ns, "hub1-cert")
@@ -219,6 +230,22 @@ func TestEnsureUserAllowsDistinctPerHubCerts(t *testing.T) {
 	}
 }
 
+// TestEnsureUserReportsMissingClientCert rejects a per-hub secret that omits client.crt.
+func TestEnsureUserReportsMissingClientCert(t *testing.T) {
+	ns := utils.GetDefaultNamespace()
+	hub1 := byoSecret(constants.GHTransportSecretNameForCluster("hub1"), ns, "")
+	trans := newBYOTransporter(t, byoMGH(ns), hub1)
+
+	_, err := trans.EnsureUser("hub1")
+	if err == nil {
+		t.Fatal("EnsureUser(hub1) expected missing client.crt error")
+	}
+	if !strings.Contains(err.Error(), "missing client.crt") {
+		t.Fatalf("EnsureUser() error = %v, want missing client.crt", err)
+	}
+}
+
+// TestEnsureUserSucceedsWithoutSecret allows addon install before the BYO secret exists.
 func TestEnsureUserSucceedsWithoutSecret(t *testing.T) {
 	ns := utils.GetDefaultNamespace()
 	trans := newBYOTransporter(t, byoMGH(ns))
@@ -232,6 +259,7 @@ func TestEnsureUserSucceedsWithoutSecret(t *testing.T) {
 	}
 }
 
+// TestEnsureUserReturnsAPIError surfaces non-NotFound secret lookup failures.
 func TestEnsureUserReturnsAPIError(t *testing.T) {
 	ns := utils.GetDefaultNamespace()
 	base := fake.NewClientBuilder().WithScheme(config.GetRuntimeScheme()).
@@ -255,6 +283,7 @@ func TestEnsureUserReturnsAPIError(t *testing.T) {
 	}
 }
 
+// TestGetConnCredentialMissingSecret errors when neither per-hub nor shared secret exists.
 func TestGetConnCredentialMissingSecret(t *testing.T) {
 	ns := utils.GetDefaultNamespace()
 	trans := newBYOTransporter(t, byoMGH(ns))
@@ -268,6 +297,7 @@ func TestGetConnCredentialMissingSecret(t *testing.T) {
 	}
 }
 
+// TestGetConnCredentialRejectsIdenticalPerHubCerts rejects duplicate per-hub client certificates.
 func TestGetConnCredentialRejectsIdenticalPerHubCerts(t *testing.T) {
 	ns := utils.GetDefaultNamespace()
 	same := "duplicate-cert"
@@ -284,6 +314,7 @@ func TestGetConnCredentialRejectsIdenticalPerHubCerts(t *testing.T) {
 	}
 }
 
+// TestEnsureUserAllowsSharedFallbackMatchingPerHubCert allows shared-secret fallback with a matching cert.
 func TestEnsureUserAllowsSharedFallbackMatchingPerHubCert(t *testing.T) {
 	ns := utils.GetDefaultNamespace()
 	same := "shared-cert"
@@ -299,6 +330,7 @@ func TestEnsureUserAllowsSharedFallbackMatchingPerHubCert(t *testing.T) {
 	}
 }
 
+// TestEnsureUserIgnoresManagerNamedSecretDuplicates ignores manager-named secrets in uniqueness checks.
 func TestEnsureUserIgnoresManagerNamedSecretDuplicates(t *testing.T) {
 	ns := utils.GetDefaultNamespace()
 	hub1 := byoSecret(constants.GHTransportSecretNameForCluster("hub1"), ns, "hub1-cert")
@@ -312,6 +344,7 @@ func TestEnsureUserIgnoresManagerNamedSecretDuplicates(t *testing.T) {
 	}
 }
 
+// TestBYOTransporterEnsureTopicIncludesMigrationTopic includes the migration topic in BYO cluster topics.
 func TestBYOTransporterEnsureTopicIncludesMigrationTopic(t *testing.T) {
 	trans := NewBYOTransporter(context.Background(), types.NamespacedName{
 		Name: constants.GHTransportSecretName, Namespace: "test-ns",

--- a/operator/pkg/controllers/transporter/protocol/byo_transporter_test.go
+++ b/operator/pkg/controllers/transporter/protocol/byo_transporter_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -65,6 +66,13 @@ func byoMGH(namespace string) *v1alpha4.MulticlusterGlobalHub {
 				},
 			},
 		},
+	}
+}
+
+// byoManagedCluster builds a ManagedCluster used to identify per-hub BYO secrets.
+func byoManagedCluster(name string) *clusterv1.ManagedCluster {
+	return &clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
 	}
 }
 
@@ -203,7 +211,7 @@ func TestEnsureUserRejectsIdenticalPerHubCerts(t *testing.T) {
 	same := "duplicate-cert"
 	hub1 := byoSecret(constants.GHTransportSecretNameForCluster("hub1"), ns, same)
 	hub2 := byoSecret(constants.GHTransportSecretNameForCluster("hub2"), ns, same)
-	trans := newBYOTransporter(t, byoMGH(ns), hub1, hub2)
+	trans := newBYOTransporter(t, byoMGH(ns), hub1, hub2, byoManagedCluster("hub1"), byoManagedCluster("hub2"))
 
 	_, err := trans.EnsureUser("hub1")
 	if err == nil {
@@ -219,7 +227,7 @@ func TestEnsureUserAllowsDistinctPerHubCerts(t *testing.T) {
 	ns := utils.GetDefaultNamespace()
 	hub1 := byoSecret(constants.GHTransportSecretNameForCluster("hub1"), ns, "hub1-cert")
 	hub2 := byoSecret(constants.GHTransportSecretNameForCluster("hub2"), ns, "hub2-cert")
-	trans := newBYOTransporter(t, byoMGH(ns), hub1, hub2)
+	trans := newBYOTransporter(t, byoMGH(ns), hub1, hub2, byoManagedCluster("hub1"), byoManagedCluster("hub2"))
 
 	user, err := trans.EnsureUser("hub1")
 	if err != nil {
@@ -242,6 +250,19 @@ func TestEnsureUserReportsMissingClientCert(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "missing client.crt") {
 		t.Fatalf("EnsureUser() error = %v, want missing client.crt", err)
+	}
+}
+
+// TestEnsureUserIgnoresUnrelatedPrefixedSecret ignores a prefixed secret that is not a ManagedCluster.
+func TestEnsureUserIgnoresUnrelatedPrefixedSecret(t *testing.T) {
+	ns := utils.GetDefaultNamespace()
+	same := "duplicate-cert"
+	hub1 := byoSecret(constants.GHTransportSecretNameForCluster("hub1"), ns, same)
+	unrelated := byoSecret(constants.GHTransportSecretName+"-not-a-managed-hub", ns, same)
+	trans := newBYOTransporter(t, byoMGH(ns), hub1, unrelated, byoManagedCluster("hub1"))
+
+	if _, err := trans.EnsureUser("hub1"); err != nil {
+		t.Fatalf("EnsureUser(hub1) unrelated prefix error = %v", err)
 	}
 }
 
@@ -303,7 +324,7 @@ func TestGetConnCredentialRejectsIdenticalPerHubCerts(t *testing.T) {
 	same := "duplicate-cert"
 	hub1 := byoSecret(constants.GHTransportSecretNameForCluster("hub1"), ns, same)
 	hub2 := byoSecret(constants.GHTransportSecretNameForCluster("hub2"), ns, same)
-	trans := newBYOTransporter(t, byoMGH(ns), hub1, hub2)
+	trans := newBYOTransporter(t, byoMGH(ns), hub1, hub2, byoManagedCluster("hub1"), byoManagedCluster("hub2"))
 
 	_, err := trans.GetConnCredential("hub1")
 	if err == nil {

--- a/operator/pkg/controllers/transporter/protocol/byo_transporter_test.go
+++ b/operator/pkg/controllers/transporter/protocol/byo_transporter_test.go
@@ -1,148 +1,326 @@
 // Copyright (c) 2026 Red Hat, Inc.
 // Copyright Contributors to the Open Cluster Management project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package protocol
 
 import (
 	"context"
+	"encoding/base64"
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	operatorv1alpha4 "github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
-	operatorconfig "github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
 	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
-func TestBYOTransporterEnsureTopicIncludesMigrationTopic(t *testing.T) {
-	restoreBYOTransporterState(t)
+func byoSecret(name, namespace, cert string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			"bootstrap_server": []byte("kafka.example:443"),
+			"ca.crt":           []byte("ca-" + cert),
+			"client.crt":       []byte(cert),
+			"client.key":       []byte("key-" + cert),
+		},
+	}
+}
 
+func byoMGH(namespace string) *v1alpha4.MulticlusterGlobalHub {
+	return &v1alpha4.MulticlusterGlobalHub{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mgh",
+			Namespace: namespace,
+		},
+		Spec: v1alpha4.MulticlusterGlobalHubSpec{
+			DataLayerSpec: v1alpha4.DataLayerSpec{
+				Kafka: v1alpha4.KafkaSpec{
+					ConsumerGroupPrefix: "gh-",
+				},
+			},
+		},
+	}
+}
+
+func newBYOTransporter(t *testing.T, objects ...client.Object) *BYOTransporter {
+	t.Helper()
+	ns := utils.GetDefaultNamespace()
+	c := fake.NewClientBuilder().WithScheme(config.GetRuntimeScheme()).
+		WithObjects(objects...).Build()
+	return NewBYOTransporter(context.Background(), types.NamespacedName{
+		Name:      constants.GHTransportSecretName,
+		Namespace: ns,
+	}, c)
+}
+
+type getErrorClient struct {
+	client.Client
+	err error
+}
+
+func (c getErrorClient) Get(ctx context.Context, key types.NamespacedName, obj client.Object,
+	opts ...client.GetOption,
+) error {
+	if c.err != nil {
+		return c.err
+	}
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
+func TestNewBYOTransporterReturnsIsolatedInstance(t *testing.T) {
+	ns := utils.GetDefaultNamespace()
+	c := fake.NewClientBuilder().WithScheme(config.GetRuntimeScheme()).
+		WithObjects(byoMGH(ns)).Build()
+
+	first := NewBYOTransporter(context.Background(), types.NamespacedName{
+		Name:      constants.GHTransportSecretName,
+		Namespace: ns,
+	}, c)
+	second := NewBYOTransporter(context.Background(), types.NamespacedName{
+		Name:      "other-transport",
+		Namespace: "other-ns",
+	}, c)
+	if first == second {
+		t.Fatal("NewBYOTransporter must return a distinct instance per call")
+	}
+	if first.namespace == second.namespace || first.name == second.name {
+		t.Fatal("NewBYOTransporter must not rewrite fields on a shared instance")
+	}
+}
+
+func TestGetConnCredentialPrefersPerHubSecret(t *testing.T) {
+	ns := utils.GetDefaultNamespace()
+	shared := byoSecret(constants.GHTransportSecretName, ns, "shared-cert")
+	hub1 := byoSecret(constants.GHTransportSecretNameForCluster("hub1"), ns, "hub1-cert")
+	trans := newBYOTransporter(t, byoMGH(ns), shared, hub1)
+
+	conn, err := trans.GetConnCredential("hub1")
+	if err != nil {
+		t.Fatalf("GetConnCredential(hub1) error = %v", err)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(conn.ClientCert)
+	if err != nil {
+		t.Fatalf("decode client cert: %v", err)
+	}
+	if string(decoded) != "hub1-cert" {
+		t.Fatalf("client cert = %q, want hub1-cert", decoded)
+	}
+	if !strings.Contains(conn.ConsumerGroupID, "hub1") {
+		t.Fatalf("ConsumerGroupID = %q, want hub1", conn.ConsumerGroupID)
+	}
+}
+
+func TestGetConnCredentialManagerUsesSharedSecret(t *testing.T) {
+	ns := utils.GetDefaultNamespace()
+	shared := byoSecret(constants.GHTransportSecretName, ns, "shared-cert")
+	hub1 := byoSecret(constants.GHTransportSecretNameForCluster("hub1"), ns, "hub1-cert")
+	trans := newBYOTransporter(t, byoMGH(ns), shared, hub1)
+
+	conn, err := trans.GetConnCredential(constants.CloudEventGlobalHubClusterName)
+	if err != nil {
+		t.Fatalf("GetConnCredential(global-hub) error = %v", err)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(conn.ClientCert)
+	if err != nil {
+		t.Fatalf("decode client cert: %v", err)
+	}
+	if string(decoded) != "shared-cert" {
+		t.Fatalf("manager client cert = %q, want shared-cert", decoded)
+	}
+}
+
+func TestGetConnCredentialManagerIgnoresGlobalHubNamedSecret(t *testing.T) {
+	ns := utils.GetDefaultNamespace()
+	shared := byoSecret(constants.GHTransportSecretName, ns, "manager-cert")
+	spoof := byoSecret(constants.GHTransportSecretNameForCluster(
+		constants.CloudEventGlobalHubClusterName,
+	), ns, "spoof-cert")
+	trans := newBYOTransporter(t, byoMGH(ns), shared, spoof)
+
+	conn, err := trans.GetConnCredential(constants.CloudEventGlobalHubClusterName)
+	if err != nil {
+		t.Fatalf("GetConnCredential(global-hub) error = %v", err)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(conn.ClientCert)
+	if err != nil {
+		t.Fatalf("decode client cert: %v", err)
+	}
+	if string(decoded) != "manager-cert" {
+		t.Fatalf("manager must use the shared secret, got cert %q", decoded)
+	}
+}
+
+func TestGetConnCredentialFallsBackToSharedSecret(t *testing.T) {
+	ns := utils.GetDefaultNamespace()
+	shared := byoSecret(constants.GHTransportSecretName, ns, "shared-cert")
+	trans := newBYOTransporter(t, byoMGH(ns), shared)
+
+	conn, err := trans.GetConnCredential("hub2")
+	if err != nil {
+		t.Fatalf("GetConnCredential(hub2) fallback error = %v", err)
+	}
+	if conn.BootstrapServer != "kafka.example:443" {
+		t.Fatalf("BootstrapServer = %q", conn.BootstrapServer)
+	}
+}
+
+func TestEnsureUserRejectsIdenticalPerHubCerts(t *testing.T) {
+	ns := utils.GetDefaultNamespace()
+	same := "duplicate-cert"
+	hub1 := byoSecret(constants.GHTransportSecretNameForCluster("hub1"), ns, same)
+	hub2 := byoSecret(constants.GHTransportSecretNameForCluster("hub2"), ns, same)
+	trans := newBYOTransporter(t, byoMGH(ns), hub1, hub2)
+
+	_, err := trans.EnsureUser("hub1")
+	if err == nil {
+		t.Fatal("EnsureUser(hub1) expected identical-cert error")
+	}
+	if !strings.Contains(err.Error(), "identical") {
+		t.Fatalf("EnsureUser() error = %v, want identical cert message", err)
+	}
+}
+
+func TestEnsureUserAllowsDistinctPerHubCerts(t *testing.T) {
+	ns := utils.GetDefaultNamespace()
+	hub1 := byoSecret(constants.GHTransportSecretNameForCluster("hub1"), ns, "hub1-cert")
+	hub2 := byoSecret(constants.GHTransportSecretNameForCluster("hub2"), ns, "hub2-cert")
+	trans := newBYOTransporter(t, byoMGH(ns), hub1, hub2)
+
+	user, err := trans.EnsureUser("hub1")
+	if err != nil {
+		t.Fatalf("EnsureUser(hub1) error = %v", err)
+	}
+	if user != "hub1-kafka-user" {
+		t.Fatalf("EnsureUser() = %q, want hub1-kafka-user", user)
+	}
+}
+
+func TestEnsureUserSucceedsWithoutSecret(t *testing.T) {
+	ns := utils.GetDefaultNamespace()
+	trans := newBYOTransporter(t, byoMGH(ns))
+
+	user, err := trans.EnsureUser("hub1")
+	if err != nil {
+		t.Fatalf("EnsureUser(hub1) without secret error = %v", err)
+	}
+	if user != "hub1-kafka-user" {
+		t.Fatalf("EnsureUser() = %q, want hub1-kafka-user", user)
+	}
+}
+
+func TestEnsureUserReturnsAPIError(t *testing.T) {
+	ns := utils.GetDefaultNamespace()
+	base := fake.NewClientBuilder().WithScheme(config.GetRuntimeScheme()).
+		WithObjects(byoMGH(ns)).Build()
+	forbidden := apierrors.NewForbidden(
+		schema.GroupResource{Group: "", Resource: "secrets"},
+		constants.GHTransportSecretNameForCluster("hub1"),
+		nil,
+	)
 	trans := NewBYOTransporter(context.Background(), types.NamespacedName{
 		Name:      constants.GHTransportSecretName,
-		Namespace: "test-ns",
-	}, fake.NewClientBuilder().Build())
+		Namespace: ns,
+	}, getErrorClient{Client: base, err: forbidden})
 
+	_, err := trans.EnsureUser("hub1")
+	if err == nil {
+		t.Fatal("EnsureUser(hub1) expected API error")
+	}
+	if !apierrors.IsForbidden(err) {
+		t.Fatalf("EnsureUser() error = %v, want forbidden", err)
+	}
+}
+
+func TestGetConnCredentialMissingSecret(t *testing.T) {
+	ns := utils.GetDefaultNamespace()
+	trans := newBYOTransporter(t, byoMGH(ns))
+
+	_, err := trans.GetConnCredential("hub1")
+	if err == nil {
+		t.Fatal("GetConnCredential(hub1) expected missing secret error")
+	}
+	if !strings.Contains(err.Error(), "failed to get BYO Kafka transport secret") {
+		t.Fatalf("GetConnCredential() error = %v, want wrapped lookup error", err)
+	}
+}
+
+func TestGetConnCredentialRejectsIdenticalPerHubCerts(t *testing.T) {
+	ns := utils.GetDefaultNamespace()
+	same := "duplicate-cert"
+	hub1 := byoSecret(constants.GHTransportSecretNameForCluster("hub1"), ns, same)
+	hub2 := byoSecret(constants.GHTransportSecretNameForCluster("hub2"), ns, same)
+	trans := newBYOTransporter(t, byoMGH(ns), hub1, hub2)
+
+	_, err := trans.GetConnCredential("hub1")
+	if err == nil {
+		t.Fatal("GetConnCredential(hub1) expected identical-cert error")
+	}
+	if !strings.Contains(err.Error(), "identical") {
+		t.Fatalf("GetConnCredential() error = %v, want identical cert message", err)
+	}
+}
+
+func TestEnsureUserAllowsSharedFallbackMatchingPerHubCert(t *testing.T) {
+	ns := utils.GetDefaultNamespace()
+	same := "shared-cert"
+	shared := byoSecret(constants.GHTransportSecretName, ns, same)
+	hub1 := byoSecret(constants.GHTransportSecretNameForCluster("hub1"), ns, same)
+	trans := newBYOTransporter(t, byoMGH(ns), shared, hub1)
+
+	if _, err := trans.EnsureUser("hub2"); err != nil {
+		t.Fatalf("EnsureUser(hub2) shared fallback error = %v", err)
+	}
+	if _, err := trans.GetConnCredential("hub2"); err != nil {
+		t.Fatalf("GetConnCredential(hub2) shared fallback error = %v", err)
+	}
+}
+
+func TestEnsureUserIgnoresManagerNamedSecretDuplicates(t *testing.T) {
+	ns := utils.GetDefaultNamespace()
+	hub1 := byoSecret(constants.GHTransportSecretNameForCluster("hub1"), ns, "hub1-cert")
+	managerNamed := byoSecret(constants.GHTransportSecretNameForCluster(
+		constants.CloudEventGlobalHubClusterName,
+	), ns, "hub1-cert")
+	trans := newBYOTransporter(t, byoMGH(ns), hub1, managerNamed)
+
+	if _, err := trans.EnsureUser("hub1"); err != nil {
+		t.Fatalf("EnsureUser(hub1) error = %v", err)
+	}
+}
+
+func TestBYOTransporterEnsureTopicIncludesMigrationTopic(t *testing.T) {
+	trans := NewBYOTransporter(context.Background(), types.NamespacedName{
+		Name: constants.GHTransportSecretName, Namespace: "test-ns",
+	}, fake.NewClientBuilder().Build())
 	topic, err := trans.EnsureTopic("hub1")
 	if err != nil {
 		t.Fatalf("EnsureTopic() error = %v", err)
 	}
-	if topic.MigrationTopic != operatorconfig.GetMigrationTopic() {
-		t.Fatalf("MigrationTopic = %q, want %q", topic.MigrationTopic, operatorconfig.GetMigrationTopic())
-	}
-	if topic.SpecTopic != operatorconfig.GetSpecTopic() {
-		t.Fatalf("SpecTopic = %q, want %q", topic.SpecTopic, operatorconfig.GetSpecTopic())
-	}
-}
-
-func TestBYOTransporterEnsureUserAndPruneAreNoOps(t *testing.T) {
-	restoreBYOTransporterState(t)
-
-	trans := NewBYOTransporter(context.Background(), types.NamespacedName{
-		Name: constants.GHTransportSecretName, Namespace: "test-ns",
-	}, fake.NewClientBuilder().Build())
-
-	if _, err := trans.EnsureUser("hub1"); err != nil {
-		t.Fatalf("EnsureUser() error = %v", err)
-	}
-	if ready, err := trans.EnsureKafka(); err != nil || ready {
-		t.Fatalf("EnsureKafka() = (%v, %v), want (false, nil)", ready, err)
-	}
-	if err := trans.Prune("hub1"); err != nil {
-		t.Fatalf("Prune() error = %v", err)
-	}
-}
-
-func TestBYOTransporterGetConnCredential(t *testing.T) {
-	restoreBYOTransporterState(t)
-
-	scheme := runtime.NewScheme()
-	if err := corev1.AddToScheme(scheme); err != nil {
-		t.Fatalf("AddToScheme: %v", err)
-	}
-	if err := operatorv1alpha4.AddToScheme(scheme); err != nil {
-		t.Fatalf("AddToScheme(MGH): %v", err)
-	}
-
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      constants.GHTransportSecretName,
-			Namespace: "test-ns",
-		},
-		Data: map[string][]byte{
-			"bootstrap_server": []byte("kafka:9093"),
-			"ca.crt":           []byte("ca-bytes"),
-			"client.crt":       []byte("cert-bytes"),
-			"client.key":       []byte("key-bytes"),
-		},
-	}
-	mgh := &operatorv1alpha4.MulticlusterGlobalHub{
-		ObjectMeta: metav1.ObjectMeta{Name: "mgh", Namespace: "test-ns"},
-	}
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(secret, mgh).
-		Build()
-
-	trans := NewBYOTransporter(context.Background(), types.NamespacedName{
-		Name: constants.GHTransportSecretName, Namespace: "test-ns",
-	}, fakeClient)
-
-	cfg, err := trans.GetConnCredential("hub1")
-	if err != nil {
-		t.Fatalf("GetConnCredential() error = %v", err)
-	}
-	if cfg.BootstrapServer != "kafka:9093" {
-		t.Fatalf("BootstrapServer = %q, want kafka:9093", cfg.BootstrapServer)
-	}
-	if cfg.MigrationTopic != operatorconfig.GetMigrationTopic() {
-		t.Fatalf("MigrationTopic = %q, want %q", cfg.MigrationTopic, operatorconfig.GetMigrationTopic())
-	}
-	if cfg.GetCACert() == "" || cfg.GetClientCert() == "" || cfg.GetClientKey() == "" {
-		t.Fatal("expected encoded cert material in KafkaConfig")
-	}
-}
-
-func TestBYOTransporterGetConnCredentialErrors(t *testing.T) {
-	restoreBYOTransporterState(t)
-
-	trans := NewBYOTransporter(context.Background(), types.NamespacedName{
-		Name: "missing-secret", Namespace: "test-ns",
-	}, fake.NewClientBuilder().Build())
-
-	if _, err := trans.GetConnCredential("hub1"); err == nil {
-		t.Fatal("GetConnCredential() expected error for missing secret")
-	}
-}
-
-func restoreBYOTransporterState(t *testing.T) {
-	t.Helper()
-
-	originalTransporter := operatorconfig.GetTransporter()
-
-	t.Cleanup(func() {
-		byoTransporter = nil
-		operatorconfig.SetTransporter(originalTransporter)
-	})
-
-	byoTransporter = nil
-	operatorconfig.SetTransporter(nil)
-
-	scheme := runtime.NewScheme()
-	if err := corev1.AddToScheme(scheme); err != nil {
-		t.Fatalf("AddToScheme: %v", err)
-	}
-	mgh := &operatorv1alpha4.MulticlusterGlobalHub{
-		ObjectMeta: metav1.ObjectMeta{Name: "mgh", Namespace: "test-ns"},
-		Spec: operatorv1alpha4.MulticlusterGlobalHubSpec{
-			DataLayerSpec: operatorv1alpha4.DataLayerSpec{Kafka: operatorv1alpha4.KafkaSpec{}},
-		},
-	}
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	if err := operatorconfig.SetTransportConfig(context.Background(), fakeClient, mgh); err != nil {
-		t.Fatalf("SetTransportConfig() error = %v", err)
+	if topic.MigrationTopic != config.GetMigrationTopic() {
+		t.Fatalf("MigrationTopic = %q, want %q", topic.MigrationTopic, config.GetMigrationTopic())
 	}
 }

--- a/operator/pkg/controllers/transporter/transport_reconciler.go
+++ b/operator/pkg/controllers/transporter/transport_reconciler.go
@@ -99,7 +99,7 @@ var secretPred = predicate.Funcs{
 }
 
 func secretCond(obj client.Object) bool {
-	if WatchedSecret.Has(obj.GetName()) {
+	if WatchedSecret.Has(obj.GetName()) || constants.IsGHTransportSecret(obj.GetName()) {
 		return true
 	}
 	if obj.GetLabels()["strimzi.io/cluster"] == protocol.KafkaClusterName &&

--- a/operator/pkg/controllers/transporter/transport_reconciler.go
+++ b/operator/pkg/controllers/transporter/transport_reconciler.go
@@ -98,6 +98,7 @@ var secretPred = predicate.Funcs{
 	},
 }
 
+// secretCond matches watched secrets, including shared and per-hub BYO transport secrets.
 func secretCond(obj client.Object) bool {
 	if WatchedSecret.Has(obj.GetName()) || constants.IsGHTransportSecret(obj.GetName()) {
 		return true

--- a/operator/pkg/controllers/transporter/transport_reconciler_test.go
+++ b/operator/pkg/controllers/transporter/transport_reconciler_test.go
@@ -52,6 +52,7 @@ func assertPredicateAllEvents(t *testing.T, pred predicate.Funcs, obj client.Obj
 	assert.Equal(t, want, pred.Delete(event.DeleteEvent{Object: obj}), "DeleteFunc")
 }
 
+// TestSecretPredicate covers create/update/delete filters for transport secrets.
 func TestSecretPredicate(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -139,6 +140,7 @@ func TestSecretPredicate(t *testing.T) {
 	}
 }
 
+// TestSecretCond matches shared and per-hub BYO transport secret names.
 func TestSecretCond(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/operator/pkg/controllers/transporter/transport_reconciler_test.go
+++ b/operator/pkg/controllers/transporter/transport_reconciler_test.go
@@ -69,6 +69,16 @@ func TestSecretPredicate(t *testing.T) {
 			wantBool: true,
 		},
 		{
+			name: "per-hub BYO transport secret should match",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.GHTransportSecretNameForCluster("hub1"),
+					Namespace: utils.GetDefaultNamespace(),
+				},
+			},
+			wantBool: true,
+		},
+		{
 			name: "kafka user secret with strimzi labels should match",
 			obj: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -140,6 +150,15 @@ func TestSecretCond(t *testing.T) {
 			obj: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: constants.GHTransportSecretName,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "per-hub BYO transport secret name matches",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: constants.GHTransportSecretNameForCluster("hub1"),
 				},
 			},
 			expected: true,

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,5 +1,7 @@
 package constants
 
+import "strings"
+
 // global hub common constants
 const (
 	// GHDefaultNamespace defines default namespace for ACM hub and Global hub operator and manager
@@ -111,6 +113,31 @@ const (
 	KafkaCertSecretName       = "kafka-certs-secret"                // #nosec G101
 	GHDefaultStorageRetention = "18m"                               // 18 months
 )
+
+// GHTransportSecretNameForCluster is the BYO Kafka secret for a managed hub.
+// The shared secret GHTransportSecretName is used for the manager (empty clusterName).
+func GHTransportSecretNameForCluster(clusterName string) string {
+	if clusterName == "" {
+		return GHTransportSecretName
+	}
+	return GHTransportSecretName + "-" + clusterName
+}
+
+// IsGHTransportSecret reports whether name is the shared BYO transport secret
+// or a per-hub secret named multicluster-global-hub-transport-<cluster>.
+func IsGHTransportSecret(name string) bool {
+	return name == GHTransportSecretName || strings.HasPrefix(name, GHTransportSecretName+"-")
+}
+
+// ClusterNameFromGHTransportSecret returns the hub name encoded in a per-hub
+// BYO transport secret, or empty for the shared secret / unrelated names.
+func ClusterNameFromGHTransportSecret(name string) string {
+	prefix := GHTransportSecretName + "-"
+	if !strings.HasPrefix(name, prefix) {
+		return ""
+	}
+	return strings.TrimPrefix(name, prefix)
+}
 
 // the global hub transport config secret for manager and agent
 const (

--- a/pkg/transport/controller/controller.go
+++ b/pkg/transport/controller/controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport/config"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport/consumer"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport/identity"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport/producer"
 	"github.com/stolostron/multicluster-global-hub/pkg/transport/requester"
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
@@ -271,6 +272,12 @@ func (c *TransportCtrl) ReconcileKafkaCredential(ctx context.Context, secret *co
 	kafkaConn, err := config.GetKafkaCredentialBySecret(secret, c.runtimeClient)
 	if err != nil {
 		return false, err
+	}
+	if !c.inManager && c.transportConfig != nil && c.transportConfig.LeafHubName != "" &&
+		kafkaConn.ClientSecretName == "" {
+		if err := identity.ValidateBYOClientCert(c.transportConfig.LeafHubName, kafkaConn.ClientCert); err != nil {
+			return false, err
+		}
 	}
 	err = c.ResyncKafkaClientSecret(ctx, kafkaConn, secret)
 	if err != nil {

--- a/pkg/transport/identity/identity.go
+++ b/pkg/transport/identity/identity.go
@@ -18,6 +18,9 @@ limitations under the License.
 package identity
 
 import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
 	"strings"
 
 	kafka_confluent "github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2"
@@ -125,6 +128,49 @@ func LeafHubForStatusEvent(evt *cloudevents.Event) (string, bool) {
 	}
 
 	return evt.Source(), true
+}
+
+// HubFromClientCertCN maps an mTLS certificate CommonName to a hub name when
+// the CN follows the KafkaUser convention "{hub}-kafka-user".
+func HubFromClientCertCN(commonName string) string {
+	return HubFromKafkaUser(commonName)
+}
+
+// ValidateBYOClientCert rejects a BYO Kafka client certificate whose CN is a
+// KafkaUser for a different hub. Custom CNs (for example global-hub-byo-user)
+// are allowed so existing shared-secret BYO installs keep working until they
+// switch to per-hub secrets.
+func ValidateBYOClientCert(leafHubName, clientCertPEM string) error {
+	if leafHubName == "" || clientCertPEM == "" {
+		return nil
+	}
+
+	cn, err := commonNameFromPEMX509(clientCertPEM)
+	if err != nil {
+		return fmt.Errorf("failed to parse BYO Kafka client certificate: %w", err)
+	}
+	if cn == "" {
+		return nil
+	}
+
+	certHub := HubFromClientCertCN(cn)
+	if certHub == "" || certHub == leafHubName {
+		return nil
+	}
+
+	return fmt.Errorf("BYO Kafka client certificate does not belong to this hub")
+}
+
+func commonNameFromPEMX509(certPEM string) (string, error) {
+	block, _ := pem.Decode([]byte(certPEM))
+	if block == nil {
+		return "", fmt.Errorf("no PEM certificate found")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return "", err
+	}
+	return cert.Subject.CommonName, nil
 }
 
 // EnrichManagerStatusEvent sets authedhub from the Kafka status topic when the pattern

--- a/pkg/transport/identity/identity.go
+++ b/pkg/transport/identity/identity.go
@@ -161,6 +161,7 @@ func ValidateBYOClientCert(leafHubName, clientCertPEM string) error {
 	return fmt.Errorf("BYO Kafka client certificate does not belong to this hub")
 }
 
+// commonNameFromPEMX509 extracts the certificate CommonName from PEM-encoded x509 data.
 func commonNameFromPEMX509(certPEM string) (string, error) {
 	block, _ := pem.Decode([]byte(certPEM))
 	if block == nil {

--- a/pkg/transport/identity/identity_test.go
+++ b/pkg/transport/identity/identity_test.go
@@ -17,7 +17,14 @@ limitations under the License.
 package identity
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"testing"
+	"time"
 
 	kafka_confluent "github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -140,4 +147,63 @@ func TestEnrichManagerStatusEvent(t *testing.T) {
 	t.Run("nil event is no-op", func(t *testing.T) {
 		EnrichManagerStatusEvent(nil, "^gh-status.*")
 	})
+}
+
+func TestValidateBYOClientCert(t *testing.T) {
+	t.Run("empty inputs are no-op", func(t *testing.T) {
+		if err := ValidateBYOClientCert("", "cert"); err != nil {
+			t.Fatalf("ValidateBYOClientCert() = %v", err)
+		}
+		if err := ValidateBYOClientCert("hub1", ""); err != nil {
+			t.Fatalf("ValidateBYOClientCert() = %v", err)
+		}
+	})
+
+	t.Run("matching kafka user CN is accepted", func(t *testing.T) {
+		certPEM := mustTestCertPEM(t, "hub1-kafka-user")
+		if err := ValidateBYOClientCert("hub1", certPEM); err != nil {
+			t.Fatalf("ValidateBYOClientCert() = %v", err)
+		}
+	})
+
+	t.Run("mismatched kafka user CN is rejected", func(t *testing.T) {
+		certPEM := mustTestCertPEM(t, "hub2-kafka-user")
+		err := ValidateBYOClientCert("hub1", certPEM)
+		if err == nil {
+			t.Fatal("expected mismatch error")
+		}
+	})
+
+	t.Run("custom BYO CN is accepted", func(t *testing.T) {
+		certPEM := mustTestCertPEM(t, "global-hub-byo-user")
+		if err := ValidateBYOClientCert("hub1", certPEM); err != nil {
+			t.Fatalf("ValidateBYOClientCert() custom CN = %v", err)
+		}
+	})
+
+	t.Run("manager kafka user on agent is rejected", func(t *testing.T) {
+		certPEM := mustTestCertPEM(t, "global-hub-kafka-user")
+		if err := ValidateBYOClientCert("hub1", certPEM); err == nil {
+			t.Fatal("expected rejection of global-hub-kafka-user on a managed hub")
+		}
+	})
+}
+
+func mustTestCertPEM(t *testing.T, commonName string) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: commonName},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("CreateCertificate: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
 }

--- a/pkg/transport/identity/identity_test.go
+++ b/pkg/transport/identity/identity_test.go
@@ -149,6 +149,7 @@ func TestEnrichManagerStatusEvent(t *testing.T) {
 	})
 }
 
+// TestValidateBYOClientCert checks CN matching for per-hub BYO client certificates.
 func TestValidateBYOClientCert(t *testing.T) {
 	t.Run("empty inputs are no-op", func(t *testing.T) {
 		if err := ValidateBYOClientCert("", "cert"); err != nil {
@@ -189,6 +190,7 @@ func TestValidateBYOClientCert(t *testing.T) {
 	})
 }
 
+// mustTestCertPEM builds a test certificate PEM with the given CommonName.
 func mustTestCertPEM(t *testing.T, commonName string) string {
 	t.Helper()
 	key, err := rsa.GenerateKey(rand.Reader, 2048)

--- a/pkg/transport/type.go
+++ b/pkg/transport/type.go
@@ -43,6 +43,9 @@ type TransportInternalConfig struct {
 	RestfulCredential *RestfulConfig
 	Extends           map[string]interface{}
 	FailureThreshold  int
+	// LeafHubName is set on the agent so BYO Kafka client certs can be checked
+	// against the local hub identity. Empty on the manager.
+	LeafHubName string
 }
 
 // KafkaInternalConfig specifics the configuration for the global hub manager, agent, or even inventory

--- a/test/Makefile
+++ b/test/Makefile
@@ -52,3 +52,6 @@ integration-test/manager: setup_envtest
 
 integration-test/operator: setup_envtest
 	KUBEBUILDER_ASSETS="$(shell ${TMP_BIN}/setup-envtest use --use-env -p path)" ${GO_TEST} `go list ./test/integration/operator/...`
+
+e2e-test-transport-byo: tidy vendor
+	sh ./test/script/e2e_run_byo.sh

--- a/test/e2e/transport_byo_test.go
+++ b/test/e2e/transport_byo_test.go
@@ -25,6 +25,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -128,6 +129,7 @@ var _ = Describe("Transport BYO Kafka E2E", Serial, Label("e2e-test-transport-by
 	})
 
 	It("rejects identical client certificates on two per-hub secrets", func() {
+		since := metav1.Now()
 		createBYOPerHubSecret(sourceHubName, nil)
 		createBYOPerHubSecret(targetHubName, nil)
 		DeferCleanup(func() {
@@ -136,16 +138,18 @@ var _ = Describe("Transport BYO Kafka E2E", Serial, Label("e2e-test-transport-by
 		})
 
 		Eventually(func() error {
-			return operatorLogsContain(byoIdenticalCertLog)
+			return operatorLogsContain(byoIdenticalCertLog, &since)
 		}, 2*time.Minute, 5*time.Second).Should(Succeed(),
 			"operator must reject identical client certificates on per-hub BYO secrets")
 	})
 })
 
+// byoAPIContext returns a short timeout for BYO secret and log API calls.
 func byoAPIContext() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(ctx, byoAPITimeout)
 }
 
+// byoSharedTransportSecret loads the shared BYO transport secret used as a template.
 func byoSharedTransportSecret() (*corev1.Secret, error) {
 	apiCtx, cancel := byoAPIContext()
 	defer cancel()
@@ -154,6 +158,7 @@ func byoSharedTransportSecret() (*corev1.Secret, error) {
 	)
 }
 
+// createBYOPerHubSecret creates or updates a per-hub BYO transport secret.
 func createBYOPerHubSecret(clusterName string, mutate func(*corev1.Secret)) {
 	shared, err := byoSharedTransportSecret()
 	Expect(err).NotTo(HaveOccurred(), "expected the shared BYO transport secret as a template")
@@ -190,6 +195,7 @@ func createBYOPerHubSecret(clusterName string, mutate func(*corev1.Secret)) {
 	Expect(err).NotTo(HaveOccurred(), "expected to create or update the per-hub BYO secret")
 }
 
+// deleteBYOPerHubSecret deletes a leftover per-hub BYO transport secret.
 func deleteBYOPerHubSecret(clusterName string) {
 	apiCtx, cancel := byoAPIContext()
 	defer cancel()
@@ -201,6 +207,7 @@ func deleteBYOPerHubSecret(clusterName string) {
 	}
 }
 
+// managedHubAgentKafkaConfig reads Kafka settings from the agent transport-config secret.
 func managedHubAgentKafkaConfig(hubClient client.Client) (*transport.KafkaConfig, error) {
 	apiCtx, cancel := byoAPIContext()
 	defer cancel()
@@ -218,6 +225,7 @@ func managedHubAgentKafkaConfig(hubClient client.Client) (*transport.KafkaConfig
 	return cfg, nil
 }
 
+// managedHubAgentKafkaReady checks agent Kafka config and a ready agent Deployment.
 func managedHubAgentKafkaReady(hubClient client.Client, hubName string) error {
 	cfg, err := managedHubAgentKafkaConfig(hubClient)
 	if err != nil {
@@ -226,12 +234,22 @@ func managedHubAgentKafkaReady(hubClient client.Client, hubName string) error {
 	if cfg.ClientCert == "" {
 		return fmt.Errorf("agent transport-config is missing a client certificate")
 	}
-	if err := checkDeployAvailable(hubClient, constants.GHAgentNamespace, "multicluster-global-hub-agent"); err != nil {
+	apiCtx, cancel := byoAPIContext()
+	defer cancel()
+	deployment := &appsv1.Deployment{}
+	if err := hubClient.Get(apiCtx, types.NamespacedName{
+		Namespace: constants.GHAgentNamespace,
+		Name:      "multicluster-global-hub-agent",
+	}, deployment); err != nil {
 		return fmt.Errorf("agent on hub %s: %w", hubName, err)
+	}
+	if deployment.Status.AvailableReplicas == 0 {
+		return fmt.Errorf("deployment: %s is not ready", deployment.Name)
 	}
 	return nil
 }
 
+// pemCertificateCommonName returns the CommonName from a PEM client certificate.
 func pemCertificateCommonName(certPEM []byte) string {
 	block, _ := pem.Decode(certPEM)
 	Expect(block).NotTo(BeNil(), "shared BYO client.crt must be PEM")
@@ -240,7 +258,8 @@ func pemCertificateCommonName(certPEM []byte) string {
 	return cert.Subject.CommonName
 }
 
-func operatorLogsContain(substr string) error {
+// operatorLogsContain reports whether operator logs since the given time contain substr.
+func operatorLogsContain(substr string, since *metav1.Time) error {
 	apiCtx, cancel := byoAPIContext()
 	defer cancel()
 	pods, err := testClients.KubeClient().CoreV1().Pods(testOptions.GlobalHub.Namespace).List(apiCtx, metav1.ListOptions{
@@ -258,11 +277,14 @@ func operatorLogsContain(substr string) error {
 		logs, logErr := testClients.KubeClient().CoreV1().Pods(testOptions.GlobalHub.Namespace).
 			GetLogs(pods.Items[i].Name, &corev1.PodLogOptions{
 				Container: "multicluster-global-hub-operator",
+				SinceTime: since,
 			}).DoRaw(apiCtx)
 		if logErr != nil {
 			return logErr
 		}
-		combined.Write(logs)
+		if _, writeErr := combined.Write(logs); writeErr != nil {
+			return writeErr
+		}
 	}
 	if !strings.Contains(combined.String(), substr) {
 		return fmt.Errorf("operator logs do not yet report identical per-hub client certificates")

--- a/test/e2e/transport_byo_test.go
+++ b/test/e2e/transport_byo_test.go
@@ -1,0 +1,271 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport"
+	transportconfig "github.com/stolostron/multicluster-global-hub/pkg/transport/config"
+	"github.com/stolostron/multicluster-global-hub/pkg/transport/identity"
+)
+
+const (
+	byoPerHubBootstrapMarker = "e2e-byo-per-hub-marker:443"
+	byoIdenticalCertLog      = "must not be identical"
+	byoAPITimeout            = 30 * time.Second
+)
+
+var _ = Describe("Transport BYO Kafka E2E", Serial, Label("e2e-test-transport-byo"), Ordered, func() {
+	var (
+		sourceHubName   string
+		targetHubName   string
+		sourceHubClient client.Client
+		sharedBootstrap string
+	)
+
+	BeforeAll(func() {
+		if isBYO != "true" {
+			Skip("BYO Kafka e2e requires ISBYO=true")
+		}
+		Expect(len(managedHubNames)).To(BeNumerically(">=", 2),
+			"BYO Kafka e2e requires two regional hubs")
+		sourceHubName = managedHubNames[0]
+		targetHubName = managedHubNames[1]
+
+		var err error
+		sourceHubClient, err = testClients.RuntimeClient(sourceHubName, agentScheme)
+		Expect(err).NotTo(HaveOccurred(), "expected a kube client for the source managed hub")
+
+		shared, err := byoSharedTransportSecret()
+		Expect(err).NotTo(HaveOccurred(), "expected the shared BYO transport secret")
+		sharedBootstrap = string(shared.Data["bootstrap_server"])
+		Expect(sharedBootstrap).NotTo(BeEmpty(), "shared BYO transport secret must set bootstrap_server")
+	})
+
+	AfterAll(func() {
+		if isBYO != "true" {
+			return
+		}
+		deleteBYOPerHubSecret(sourceHubName)
+		deleteBYOPerHubSecret(targetHubName)
+	})
+
+	It("allows a custom client certificate CN on the shared BYO secret", func() {
+		shared, err := byoSharedTransportSecret()
+		Expect(err).NotTo(HaveOccurred(), "expected the shared BYO transport secret")
+		Expect(shared.Data["client.crt"]).NotTo(BeEmpty(), "shared BYO transport secret must set client.crt")
+
+		cn := pemCertificateCommonName(shared.Data["client.crt"])
+		Expect(identity.HubFromClientCertCN(cn)).To(BeEmpty(),
+			"shared BYO client cert CN must be a custom name, not {hub}-kafka-user")
+	})
+
+	It("starts the managed hub agent with shared-secret fallback", func() {
+		Eventually(func() error {
+			return managedHubAgentKafkaReady(sourceHubClient, sourceHubName)
+		}, 2*time.Minute, 5*time.Second).Should(Succeed(),
+			"managed hub agent must start with the shared BYO transport secret")
+	})
+
+	It("selects a per-hub transport secret over the shared secret", func() {
+		createBYOPerHubSecret(sourceHubName, func(secret *corev1.Secret) {
+			secret.Data["bootstrap_server"] = []byte(byoPerHubBootstrapMarker)
+		})
+		DeferCleanup(func() {
+			deleteBYOPerHubSecret(sourceHubName)
+			Eventually(func() error {
+				cfg, err := managedHubAgentKafkaConfig(sourceHubClient)
+				if err != nil {
+					return err
+				}
+				if cfg.BootstrapServer != sharedBootstrap {
+					return fmt.Errorf("waiting for shared-secret bootstrap to be restored")
+				}
+				return nil
+			}, 2*time.Minute, 5*time.Second).Should(Succeed(),
+				"agent transport must fall back to the shared BYO secret after per-hub cleanup")
+		})
+
+		Eventually(func() error {
+			cfg, err := managedHubAgentKafkaConfig(sourceHubClient)
+			if err != nil {
+				return err
+			}
+			if cfg.BootstrapServer != byoPerHubBootstrapMarker {
+				return fmt.Errorf("agent transport still uses shared bootstrap")
+			}
+			return nil
+		}, 2*time.Minute, 5*time.Second).Should(Succeed(),
+			"agent transport credentials must come from the per-hub BYO secret")
+	})
+
+	It("rejects identical client certificates on two per-hub secrets", func() {
+		createBYOPerHubSecret(sourceHubName, nil)
+		createBYOPerHubSecret(targetHubName, nil)
+		DeferCleanup(func() {
+			deleteBYOPerHubSecret(sourceHubName)
+			deleteBYOPerHubSecret(targetHubName)
+		})
+
+		Eventually(func() error {
+			return operatorLogsContain(byoIdenticalCertLog)
+		}, 2*time.Minute, 5*time.Second).Should(Succeed(),
+			"operator must reject identical client certificates on per-hub BYO secrets")
+	})
+})
+
+func byoAPIContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, byoAPITimeout)
+}
+
+func byoSharedTransportSecret() (*corev1.Secret, error) {
+	apiCtx, cancel := byoAPIContext()
+	defer cancel()
+	return testClients.KubeClient().CoreV1().Secrets(testOptions.GlobalHub.Namespace).Get(
+		apiCtx, constants.GHTransportSecretName, metav1.GetOptions{},
+	)
+}
+
+func createBYOPerHubSecret(clusterName string, mutate func(*corev1.Secret)) {
+	shared, err := byoSharedTransportSecret()
+	Expect(err).NotTo(HaveOccurred(), "expected the shared BYO transport secret as a template")
+
+	data := make(map[string][]byte, len(shared.Data))
+	for key, value := range shared.Data {
+		copied := make([]byte, len(value))
+		copy(copied, value)
+		data[key] = copied
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.GHTransportSecretNameForCluster(clusterName),
+			Namespace: testOptions.GlobalHub.Namespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: data,
+	}
+	if mutate != nil {
+		mutate(secret)
+	}
+
+	kube := testClients.KubeClient().CoreV1().Secrets(testOptions.GlobalHub.Namespace)
+	apiCtx, cancel := byoAPIContext()
+	defer cancel()
+	_, err = kube.Create(apiCtx, secret, metav1.CreateOptions{})
+	if apierrors.IsAlreadyExists(err) {
+		existing, getErr := kube.Get(apiCtx, secret.Name, metav1.GetOptions{})
+		Expect(getErr).NotTo(HaveOccurred(), "expected existing per-hub BYO secret")
+		existing.Data = secret.Data
+		_, err = kube.Update(apiCtx, existing, metav1.UpdateOptions{})
+	}
+	Expect(err).NotTo(HaveOccurred(), "expected to create or update the per-hub BYO secret")
+}
+
+func deleteBYOPerHubSecret(clusterName string) {
+	apiCtx, cancel := byoAPIContext()
+	defer cancel()
+	err := testClients.KubeClient().CoreV1().Secrets(testOptions.GlobalHub.Namespace).Delete(
+		apiCtx, constants.GHTransportSecretNameForCluster(clusterName), metav1.DeleteOptions{},
+	)
+	if err != nil && !apierrors.IsNotFound(err) {
+		Expect(err).NotTo(HaveOccurred(), "expected to delete leftover per-hub BYO secret")
+	}
+}
+
+func managedHubAgentKafkaConfig(hubClient client.Client) (*transport.KafkaConfig, error) {
+	apiCtx, cancel := byoAPIContext()
+	defer cancel()
+	secret := &corev1.Secret{}
+	if err := hubClient.Get(apiCtx, types.NamespacedName{
+		Name:      constants.GHTransportConfigSecret,
+		Namespace: constants.GHAgentNamespace,
+	}, secret); err != nil {
+		return nil, fmt.Errorf("get agent transport-config secret: %w", err)
+	}
+	cfg, err := transportconfig.GetKafkaCredentialBySecret(secret, hubClient)
+	if err != nil {
+		return nil, fmt.Errorf("parse agent transport-config: %w", err)
+	}
+	return cfg, nil
+}
+
+func managedHubAgentKafkaReady(hubClient client.Client, hubName string) error {
+	cfg, err := managedHubAgentKafkaConfig(hubClient)
+	if err != nil {
+		return err
+	}
+	if cfg.ClientCert == "" {
+		return fmt.Errorf("agent transport-config is missing a client certificate")
+	}
+	if err := checkDeployAvailable(hubClient, constants.GHAgentNamespace, "multicluster-global-hub-agent"); err != nil {
+		return fmt.Errorf("agent on hub %s: %w", hubName, err)
+	}
+	return nil
+}
+
+func pemCertificateCommonName(certPEM []byte) string {
+	block, _ := pem.Decode(certPEM)
+	Expect(block).NotTo(BeNil(), "shared BYO client.crt must be PEM")
+	cert, err := x509.ParseCertificate(block.Bytes)
+	Expect(err).NotTo(HaveOccurred(), "shared BYO client.crt must parse as x509")
+	return cert.Subject.CommonName
+}
+
+func operatorLogsContain(substr string) error {
+	apiCtx, cancel := byoAPIContext()
+	defer cancel()
+	pods, err := testClients.KubeClient().CoreV1().Pods(testOptions.GlobalHub.Namespace).List(apiCtx, metav1.ListOptions{
+		LabelSelector: "name=multicluster-global-hub-operator",
+	})
+	if err != nil {
+		return err
+	}
+	if len(pods.Items) == 0 {
+		return fmt.Errorf("operator pod not found")
+	}
+
+	var combined strings.Builder
+	for i := range pods.Items {
+		logs, logErr := testClients.KubeClient().CoreV1().Pods(testOptions.GlobalHub.Namespace).
+			GetLogs(pods.Items[i].Name, &corev1.PodLogOptions{
+				Container: "multicluster-global-hub-operator",
+			}).DoRaw(apiCtx)
+		if logErr != nil {
+			return logErr
+		}
+		combined.Write(logs)
+	}
+	if !strings.Contains(combined.String(), substr) {
+		return fmt.Errorf("operator logs do not yet report identical per-hub client certificates")
+	}
+	return nil
+}

--- a/test/e2e/transport_byo_test.go
+++ b/test/e2e/transport_byo_test.go
@@ -283,7 +283,7 @@ func operatorLogsContain(substr string, since *metav1.Time) error {
 			return logErr
 		}
 		if _, writeErr := combined.Write(logs); writeErr != nil {
-			return writeErr
+			return fmt.Errorf("append operator logs: %w", writeErr)
 		}
 	}
 	if !strings.Contains(combined.String(), substr) {

--- a/test/script/e2e_run_byo.sh
+++ b/test/script/e2e_run_byo.sh
@@ -84,7 +84,7 @@ kubectl create secret generic "$transport_secret" -n "${target_namespace}" --kub
 echo "transport secret is ready in ${target_namespace} namespace!"
 
 ## run e2e
-bash "$CURRENT_DIR/e2e_run.sh" -n ${target_namespace} -f "e2e-test-localpolicy,e2e-test-grafana,e2e-test-local-agent"
+bash "$CURRENT_DIR/e2e_run.sh" -n ${target_namespace} -f "e2e-test-localpolicy,e2e-test-grafana,e2e-test-transport-byo,e2e-test-local-agent"
 
 # Clean up BYO namespace before transport suites. The operator only reconciles when exactly
 # one MulticlusterGlobalHub exists cluster-wide; leaving the mgh operand blocks transport-identity.

--- a/test/script/e2e_run_byo.sh
+++ b/test/script/e2e_run_byo.sh
@@ -84,7 +84,7 @@ kubectl create secret generic "$transport_secret" -n "${target_namespace}" --kub
 echo "transport secret is ready in ${target_namespace} namespace!"
 
 ## run e2e
-bash "$CURRENT_DIR/e2e_run.sh" -n ${target_namespace} -f "e2e-test-localpolicy,e2e-test-grafana,e2e-test-transport-byo,e2e-test-local-agent"
+bash "$CURRENT_DIR/e2e_run.sh" -n "${target_namespace}" -f "e2e-test-localpolicy,e2e-test-grafana,e2e-test-transport-byo,e2e-test-local-agent"
 
 # Clean up BYO namespace before transport suites. The operator only reconciles when exactly
 # one MulticlusterGlobalHub exists cluster-wide; leaving the mgh operand blocks transport-identity.

--- a/test/script/util.sh
+++ b/test/script/util.sh
@@ -278,6 +278,34 @@ join_cluster() {
   fi
 }
 
+# sync_grc_git_repo clones and checks out a GRC dependency under a file lock so
+# parallel e2e setup jobs do not corrupt shared working-tree checkouts.
+sync_grc_git_repo() {
+  local repo_name=$1
+  local repo_url=$2
+  local lock_file="${CURRENT_DIR}/.${repo_name}.lock"
+
+  (
+    flock -x 200
+    if [ ! -d "$repo_name" ]; then
+      echo "Cloning $repo_name repository..."
+      if ! git clone "$repo_url"; then
+        echo -e "${RED}Failed to clone $repo_name repository${NC}"
+        exit 1
+      fi
+    fi
+    cd "$repo_name" || exit 1
+    if ! git checkout "$GRC_VERSION" 2>/dev/null; then
+      echo -e "${RED}Failed to checkout $GRC_VERSION, fetching updates...${NC}"
+      if ! git fetch origin && git checkout "$GRC_VERSION"; then
+        echo -e "${RED}Failed to checkout $GRC_VERSION after fetch${NC}"
+        exit 1
+      fi
+    fi
+    cd "${CURRENT_DIR}" || exit 1
+  ) 200>"$lock_file"
+}
+
 init_policy() {
   echo -e "${CYAN} Init Policy $1:$2 $NC"
   local hub=$1
@@ -293,25 +321,7 @@ init_policy() {
   PROPAGATOR_GIT_HTTP_PATH="https://github.com/open-cluster-management-io/governance-policy-propagator.git"
   propagator="governance-policy-propagator"
 
-  # Clone repository if it doesn't exist
-  if [ ! -d $propagator ]; then
-    echo "Cloning $propagator repository..."
-    if ! git clone $PROPAGATOR_GIT_HTTP_PATH; then
-      echo -e "${RED}Failed to clone $propagator repository${NC}"
-      exit 1
-    fi
-  fi
-
-  # Always ensure we're on the correct version
-  cd $propagator || exit 1
-  if ! git checkout $GRC_VERSION 2>/dev/null; then
-    echo -e "${RED}Failed to checkout $GRC_VERSION, fetching updates...${NC}"
-    if ! git fetch origin && git checkout $GRC_VERSION; then
-      echo -e "${RED}Failed to checkout $GRC_VERSION after fetch${NC}"
-      exit 1
-    fi
-  fi
-  cd ../ || exit 1
+  sync_grc_git_repo "$propagator" "$PROPAGATOR_GIT_HTTP_PATH" || exit 1
 
   # Verify required CRD files exist
   required_crds=(
@@ -371,24 +381,7 @@ init_policy() {
   POLICY_ADDON_GIT_HTTP_PATH="https://github.com/open-cluster-management-io/governance-policy-framework-addon.git"
   policy_addon=governance-policy-framework-addon
 
-  # Clone repository if it doesn't exist
-  if [ ! -d $policy_addon ]; then
-    if ! git clone $POLICY_ADDON_GIT_HTTP_PATH; then
-      echo -e "${RED}Failed to clone $policy_addon repository${NC}"
-      exit 1
-    fi
-  fi
-
-  # Always ensure we're on the correct version
-  cd $policy_addon || exit 1
-  if ! git checkout $GRC_VERSION 2>/dev/null; then
-    echo -e "${RED}Failed to checkout $GRC_VERSION, fetching updates...${NC}"
-    if ! git fetch origin && git checkout $GRC_VERSION; then
-      echo -e "${RED}Failed to checkout $GRC_VERSION after fetch${NC}"
-      exit 1
-    fi
-  fi
-  cd ../ || exit 1
+  sync_grc_git_repo "$policy_addon" "$POLICY_ADDON_GIT_HTTP_PATH" || exit 1
 
   retry "(kubectl --context $cluster apply -f $policy_addon/deploy/operator.yaml -n $MANAGED_NAMESPACE) && (kubectl --context $cluster get deploy/$policy_addon -n $MANAGED_NAMESPACE)" 10
 
@@ -401,24 +394,7 @@ init_policy() {
   config_policy="config-policy-controller"
   CONFIG_POLICY_GIT_HTTP_PATH="https://github.com/open-cluster-management-io/config-policy-controller.git"
 
-  # Clone repository if it doesn't exist
-  if [ ! -d $config_policy ]; then
-    if ! git clone $CONFIG_POLICY_GIT_HTTP_PATH; then
-      echo -e "${RED}Failed to clone $config_policy repository${NC}"
-      exit 1
-    fi
-  fi
-
-  # Always ensure we're on the correct version
-  cd $config_policy || exit 1
-  if ! git checkout $GRC_VERSION 2>/dev/null; then
-    echo -e "${RED}Failed to checkout $GRC_VERSION, fetching updates...${NC}"
-    if ! git fetch origin && git checkout $GRC_VERSION; then
-      echo -e "${RED}Failed to checkout $GRC_VERSION after fetch${NC}"
-      exit 1
-    fi
-  fi
-  cd ../ || exit 1
+  sync_grc_git_repo "$config_policy" "$CONFIG_POLICY_GIT_HTTP_PATH" || exit 1
 
   kubectl --context "$cluster" apply -f ${config_policy}/deploy/crds/policy.open-cluster-management.io_configurationpolicies.yaml
   # kubectl --context "$cluster" apply -f ${GIT_PATH}/crds/policy.open-cluster-management.io_operatorpolicies.yaml

--- a/test/script/util.sh
+++ b/test/script/util.sh
@@ -297,7 +297,11 @@ sync_grc_git_repo() {
     cd "$repo_name" || exit 1
     if ! git checkout "$GRC_VERSION" 2>/dev/null; then
       echo -e "${RED}Failed to checkout $GRC_VERSION, fetching updates...${NC}"
-      if ! git fetch origin && git checkout "$GRC_VERSION"; then
+      if ! git fetch origin; then
+        echo -e "${RED}Failed to fetch $repo_name${NC}"
+        exit 1
+      fi
+      if ! git checkout "$GRC_VERSION"; then
         echo -e "${RED}Failed to checkout $GRC_VERSION after fetch${NC}"
         exit 1
       fi

--- a/tools/generate-kafka-config.sh
+++ b/tools/generate-kafka-config.sh
@@ -19,12 +19,20 @@ Available options:
   global_hub_namespace       The namespace of the Global Hub operator. Default is 'multicluster-global-hub'.
   kafka_cluster_name         The Kafka cluster name. Default is 'kafka'.
 
+Environment:
+
+  CONSUMER_GROUP_PREFIX      Optional. Same as spec.dataLayer.kafka.consumerGroupPrefix.
+                             Prepended to cluster_name for the KafkaUser Group ACL.
+                             The resulting id has hyphens replaced with underscores.
+
 EOF
   exit
 }
 
 # create a KafkaUser CR
 createKafkaUser() {
+  # Literal group id matches GetConsumerGroupID(prefix, clusterName).
+  group_id=$(printf '%s%s' "${CONSUMER_GROUP_PREFIX:-}" "$1" | tr '-' '_')
   cat <<EOF | kubectl apply -f -
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaUser
@@ -42,7 +50,7 @@ spec:
       operations:
       - Read
       resource:
-        name: '*'
+        name: ${group_id}
         patternType: literal
         type: group
     - host: '*'


### PR DESCRIPTION
Fixes: [ACM-34442](https://redhat.atlassian.net/browse/ACM-34442), [ACM-38863](https://redhat.atlassian.net/browse/ACM-38863)

## Summary

- Backport [ACM-34442](https://redhat.atlassian.net/browse/ACM-34442) phase 6 BYO Kafka per-hub credentials to `release-2.15` (Global Hub 1.6)
- Prefer per-hub transport secrets `multicluster-global-hub-transport-<clusterName>` so Kafka ACLs can isolate managed hubs; shared secret remains the manager credential and legacy fallback
- Reject identical `client.crt` values across per-hub secrets, and fail agent start when a BYO client certificate CN is `{other-hub}-kafka-user`
- Document Strimzi-equivalent BYO ACLs (managed hubs Read-only on `gh-spec`) and pick up the `gh-migration` topic/ACL guidance from [#2686](https://github.com/stolostron/multicluster-global-hub/pull/2686)

## Context

Phase 6 of the [ACM-34442](https://redhat.atlassian.net/browse/ACM-34442) transport-identity series. This change is already on `main` in [#2807](https://github.com/stolostron/multicluster-global-hub/pull/2807). The BYO `gh-migration` topic docs from [#2686](https://github.com/stolostron/multicluster-global-hub/pull/2686) (`787f59ff`) are on `main` only today; this backport includes them in `doc/byo.md`.

Related:

- [stolostron/multicluster-global-hub#2807](https://github.com/stolostron/multicluster-global-hub/pull/2807) — phase 6 on `main`
- [stolostron/multicluster-global-hub#2686](https://github.com/stolostron/multicluster-global-hub/pull/2686) — BYO `gh-migration` topic docs
- [stolostron/multicluster-global-hub#2808](https://github.com/stolostron/multicluster-global-hub/pull/2808) — 1.8 backport
- [ACM-34442](https://redhat.atlassian.net/browse/ACM-34442) — parent
- [ACM-38863](https://redhat.atlassian.net/browse/ACM-38863) — GH 1.6 tracker

## Test plan

- [ ] Confirm a managed hub with `multicluster-global-hub-transport-<cluster>` uses that secret's client cert
- [ ] Confirm two per-hub secrets with the same `client.crt` are rejected
- [ ] Confirm legacy shared-secret BYO still starts (custom CN such as `global-hub-byo-user`)
- [ ] Confirm agent start fails when the client cert CN is `{other-hub}-kafka-user`
- [ ] Review `doc/byo.md`: create `gh-spec`, `gh-migration`, and `gh-status`; managed hubs Read-only on `gh-spec`; migration Write only while a source hub

Made with [Cursor](https://cursor.com)

[ACM-34442]: https://redhat.atlassian.net/browse/ACM-34442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-38863]: https://redhat.atlassian.net/browse/ACM-38863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-34442]: https://redhat.atlassian.net/browse/ACM-34442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-34442]: https://redhat.atlassian.net/browse/ACM-34442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-34442]: https://redhat.atlassian.net/browse/ACM-34442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared and per-managed-hub BYO Kafka credentials, with per-hub precedence and shared-secret fallback.
  * Added client certificate validation for hub association and duplicate certificate detection.
  * Improved Kafka consumer-group access configuration with optional group prefixes.
  * Reduced sensitive transport details in controller logs.

* **Documentation**
  * Expanded BYO Kafka, Postgres, and Grafana setup guidance.
  * Added BYO infrastructure guidance to Quick Start navigation.

* **Tests**
  * Added comprehensive BYO Kafka certificate, fallback, permissions, and end-to-end coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->