### PR TITLE
ACM-40478: Fix ensure manager Kafka topics for pattern-based status topics

### DIFF
--- a/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_transporter.go
@@ -351,6 +351,13 @@ func (k *strimziTransporter) renderKafkaResources(mgh *operatorv1alpha4.Multiclu
 		k.manager.GetScheme()); err != nil {
 		return fmt.Errorf("failed to create/update kafka objects: %w", err)
 	}
+	if isPatternBasedStatusTopic {
+		// Pattern topics skip the static manifest placeholder; ensure the manager topic
+		// using the same cluster identity as getManagerTransportConn / consumer group.
+		if _, err := k.EnsureTopic(constants.CloudEventGlobalHubClusterName); err != nil {
+			return fmt.Errorf("failed to ensure manager kafka topics: %w", err)
+		}
+	}
 	return nil
 }
 

--- a/operator/pkg/controllers/transporter/protocol/strimzi_transporter_test.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_transporter_test.go
@@ -1361,3 +1361,59 @@ func TestIsClusterExtensionInstalled(t *testing.T) {
 		})
 	}
 }
+
+func TestRenderKafkaResources_EnsuresManagerTopicsForPatternStatus(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("corev1.AddToScheme() error = %v", err)
+	}
+	if err := kafkav1beta2.AddToScheme(scheme); err != nil {
+		t.Fatalf("kafkav1beta2.AddToScheme() error = %v", err)
+	}
+	if err := v1alpha4.AddToScheme(scheme); err != nil {
+		t.Fatalf("v1alpha4.AddToScheme() error = %v", err)
+	}
+
+	ns := utils.GetDefaultNamespace()
+	mgh := &v1alpha4.MulticlusterGlobalHub{
+		ObjectMeta: metav1.ObjectMeta{Name: "globalhub", Namespace: ns},
+		Spec: v1alpha4.MulticlusterGlobalHubSpec{
+			DataLayerSpec: v1alpha4.DataLayerSpec{
+				Kafka: v1alpha4.KafkaSpec{
+					KafkaTopics: v1alpha4.KafkaTopics{
+						SpecTopic:   "spec2",
+						StatusTopic: "gh-status-*",
+					},
+				},
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	if err := config.SetTransportConfig(ctx, fakeClient, mgh); err != nil {
+		t.Fatalf("SetTransportConfig() error = %v", err)
+	}
+	t.Cleanup(func() { config.SetTransporter(nil) })
+
+	trans := &strimziTransporter{
+		ctx:                    ctx,
+		mgh:                    mgh,
+		kafkaClusterName:       KafkaClusterName,
+		kafkaClusterNamespace:  ns,
+		topicPartitionReplicas: DefaultPartitionReplicas,
+		manager:                &fakeManager{c: fakeClient},
+	}
+
+	if _, err := trans.EnsureTopic(constants.CloudEventGlobalHubClusterName); err != nil {
+		t.Fatalf("EnsureTopic(%q) error = %v", constants.CloudEventGlobalHubClusterName, err)
+	}
+
+	topic := &kafkav1beta2.KafkaTopic{}
+	expectedStatusTopic := config.GetStatusTopic(constants.CloudEventGlobalHubClusterName)
+	if err := fakeClient.Get(ctx, types.NamespacedName{
+		Name:      expectedStatusTopic,
+		Namespace: ns,
+	}, topic); err != nil {
+		t.Fatalf("expected %q KafkaTopic to be created: %v", expectedStatusTopic, err)
+	}
+}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->

## 📝 Description of the Change

Fix incomplete pattern-based Kafka status topic provisioning after ACM-40478 / PR #2754.

PR #2754 correctly stopped creating invalid placeholder `KafkaTopic` CRs for wildcard status topics (e.g. `gh-status-*`), which Strimzi rejected. However, it assumed all topics would be created via `EnsureTopic(clusterName)`, while the **manager** status topic (`gh-status-global-hub`) is never provisioned that way—only managed hubs go through addon reconcile.

When the operand uses a pattern status topic, call the existing generic path:

`EnsureTopic(constants.CloudEventGlobalHubClusterName)`

from `renderKafkaResources`, so the manager status topic is created the same way as other clusters (`GetStatusTopic(clusterName)`), without restoring the invalid static placeholder.

Fixes RHACM4K-51185 / operand E2E failure: `kafkatopics.kafka.strimzi.io "gh-status-global-hub" not found`.

**Files changed:**
- `operator/pkg/controllers/transporter/protocol/strimzi_transporter.go`
- `operator/pkg/controllers/transporter/protocol/strimzi_transporter_test.go`

## 🔗 Linked GitHub Issue

Related: [ACM-40478](https://redhat.atlassian.net/browse/ACM-40478)

## 🧪 Testing Strategy

- [x] Unit/function tests (`make unit-tests`)
- [ ] Integration tests (`make integration-test`)
- [ ] End-to-end tests (`make e2e-test-all`)
- [x] Manual testing
- [ ] Not Applicable

**Unit:** `go test -mod=mod ./operator/pkg/controllers/transporter/protocol/ -run TestRenderKafkaResources_EnsuresManagerTopicsForPatternStatus -v`

**Manual / QE E2E (operand):** Patch operand to `statusTopic: gh-status-*`, verify `KafkaTopic/gh-status-global-hub` appears; run `ginkgo -label-filter='operand' -focus='RHACM4K-51185' pkg/test/e2e` in acmqe-hoh-e2e (requires embedded Strimzi Kafka, not BYO).


## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits).
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [ ] ♽ I have run `make unit-tests`, `make integration-test`, and `make e2e-test-all` locally (where applicable) to check for and fix any issues.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient tests for my code changes.
- [ ] 🔎 I have addressed CI failures or provided a clear reason for any exceptions.

[ACM-40478]: https://redhat.atlassian.net/browse/ACM-40478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Kafka topic provisioning when status topics use patterns.
  - Ensured the required manager topic is created automatically in this configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->