### PR TITLE
ACM-42643: Add Tekton files for Global Hub 5.2 release

### DIFF
--- a/.tekton/multicluster-global-hub-agent-globalhub-5-2-pull-request.yaml
+++ b/.tekton/multicluster-global-hub-agent-globalhub-5-2-pull-request.yaml
@@ -1,0 +1,66 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/stolostron/multicluster-global-hub?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" &&
+      (target_branch == "main" || target_branch == "release-5.2") && (".tekton/multicluster-global-hub-agent-[!b]*.yaml".pathChanged() || "go.{mod,sum}".pathChanged() || "{pkg,agent}/***".pathChanged() || "librdkafka".pathChanged() || "rpms.in.yaml".pathChanged() || "rpms.lock.yaml".pathChanged())
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: release-globalhub-5-2
+    appstudio.openshift.io/component: multicluster-global-hub-agent-globalhub-5-2
+    pipelines.appstudio.openshift.io/type: build
+  name: multicluster-global-hub-agent-globalhub-5-2-on-pull-request
+  namespace: acm-multicluster-glo-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-agent-globalhub-5-2:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux/arm64
+  - name: dockerfile
+    value: agent/Containerfile.agent
+  - name: path-context
+    value: .
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '[ {"type": "gomod", "path": "."}, {"type": "rpm", "path": "."} ]'
+  - name: build-args
+    value:
+      - "GIT_COMMIT={{revision}}"
+      - "RELEASE_CPE=cpe:/a:redhat:multicluster_globalhub:5.2::el9"
+      - "RELEASE_VERSION=release-5.2"
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: "https://github.com/stolostron/konflux-build-catalog.git"
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: pipelines/common-base.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-multicluster-global-hub-agent-globalhub-5-2
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/multicluster-global-hub-agent-globalhub-5-2-push.yaml
+++ b/.tekton/multicluster-global-hub-agent-globalhub-5-2-push.yaml
@@ -1,0 +1,76 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/build-nudge-files: "konflux-patch.sh"
+    build.appstudio.openshift.io/repo: https://github.com/stolostron/multicluster-global-hub?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-5.2" && (".tekton/multicluster-global-hub-agent-[!b]*.yaml".pathChanged() || "go.{mod,sum}".pathChanged() || "{pkg,agent}/***".pathChanged() || "librdkafka".pathChanged() || "rpms.in.yaml".pathChanged() || "rpms.lock.yaml".pathChanged())
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: release-globalhub-5-2
+    appstudio.openshift.io/component: multicluster-global-hub-agent-globalhub-5-2
+    pipelines.appstudio.openshift.io/type: build
+  name: multicluster-global-hub-agent-globalhub-5-2-on-push
+  namespace: acm-multicluster-glo-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-agent-globalhub-5-2:{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux/arm64
+  - name: dockerfile
+    value: agent/Containerfile.agent
+  - name: path-context
+    value: .
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '[ {"type": "gomod", "path": "."}, {"type": "rpm", "path": "."} ]'
+  - name: build-args
+    value:
+      - "GIT_COMMIT={{revision}}"
+      - "RELEASE_CPE=cpe:/a:redhat:multicluster_globalhub:5.2::el9"
+      - "RELEASE_VERSION=release-5.2"
+  - name: send-slack-notification
+    value: "true"
+  - name: konflux-application-name
+    value: "release-globalhub-5-2"
+  - name: slack-webhook-url-secret-name
+    # See details: https://konflux.pages.redhat.com/docs/users/patterns/slack-notifications.html
+    value: "slack-notify-webhook"
+  - name: slack-webhook-url-secret-key
+    value: "slack-webhook-url"
+  - name: slack-group-id
+    # Will mention the user in the slack message when the pipeline run failed; this is not required.
+    # Please make sure replace the value with component owner's slack member id.
+    value: "S09JCE3DF9N"
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: "https://github.com/stolostron/konflux-build-catalog.git"
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: pipelines/common-base.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-multicluster-global-hub-agent-globalhub-5-2
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/multicluster-global-hub-manager-globalhub-5-2-pull-request.yaml
+++ b/.tekton/multicluster-global-hub-manager-globalhub-5-2-pull-request.yaml
@@ -1,0 +1,66 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/stolostron/multicluster-global-hub?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" &&
+      (target_branch == "main" || target_branch == "release-5.2") && (".tekton/multicluster-global-hub-manager-[!b]*.yaml".pathChanged() || "go.{mod,sum}".pathChanged() || "{pkg,manager}/***".pathChanged() || "librdkafka".pathChanged() || "rpms.in.yaml".pathChanged() || "rpms.lock.yaml".pathChanged())
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: release-globalhub-5-2
+    appstudio.openshift.io/component: multicluster-global-hub-manager-globalhub-5-2
+    pipelines.appstudio.openshift.io/type: build
+  name: multicluster-global-hub-manager-globalhub-5-2-on-pull-request
+  namespace: acm-multicluster-glo-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-manager-globalhub-5-2:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux/arm64
+  - name: dockerfile
+    value: manager/Containerfile.manager
+  - name: path-context
+    value: .
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '[ {"type": "gomod", "path": "."}, {"type": "rpm", "path": "."} ]'
+  - name: build-args
+    value:
+      - "GIT_COMMIT={{revision}}"
+      - "RELEASE_CPE=cpe:/a:redhat:multicluster_globalhub:5.2::el9"
+      - "RELEASE_VERSION=release-5.2"
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: "https://github.com/stolostron/konflux-build-catalog.git"
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: pipelines/common-base.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-multicluster-global-hub-manager-globalhub-5-2
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/multicluster-global-hub-manager-globalhub-5-2-push.yaml
+++ b/.tekton/multicluster-global-hub-manager-globalhub-5-2-push.yaml
@@ -1,0 +1,76 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/build-nudge-files: "konflux-patch.sh"
+    build.appstudio.openshift.io/repo: https://github.com/stolostron/multicluster-global-hub?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-5.2" && (".tekton/multicluster-global-hub-manager-[!b]*.yaml".pathChanged() || "go.{mod,sum}".pathChanged() || "{pkg,manager}/***".pathChanged() || "librdkafka".pathChanged() || "rpms.in.yaml".pathChanged() || "rpms.lock.yaml".pathChanged())
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: release-globalhub-5-2
+    appstudio.openshift.io/component: multicluster-global-hub-manager-globalhub-5-2
+    pipelines.appstudio.openshift.io/type: build
+  name: multicluster-global-hub-manager-globalhub-5-2-on-push
+  namespace: acm-multicluster-glo-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-manager-globalhub-5-2:{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux/arm64
+  - name: dockerfile
+    value: manager/Containerfile.manager
+  - name: path-context
+    value: .
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '[ {"type": "gomod", "path": "."}, {"type": "rpm", "path": "."} ]'
+  - name: build-args
+    value:
+      - "GIT_COMMIT={{revision}}"
+      - "RELEASE_CPE=cpe:/a:redhat:multicluster_globalhub:5.2::el9"
+      - "RELEASE_VERSION=release-5.2"
+  - name: send-slack-notification
+    value: "true"
+  - name: konflux-application-name
+    value: "release-globalhub-5-2"
+  - name: slack-webhook-url-secret-name
+    # See details: https://konflux.pages.redhat.com/docs/users/patterns/slack-notifications.html
+    value: "slack-notify-webhook"
+  - name: slack-webhook-url-secret-key
+    value: "slack-webhook-url"
+  - name: slack-group-id
+    # Will mention the user in the slack message when the pipeline run failed; this is not required.
+    # Please make sure replace the value with component owner's slack member id.
+    value: "S09JCE3DF9N"
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: "https://github.com/stolostron/konflux-build-catalog.git"
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: pipelines/common-base.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-multicluster-global-hub-manager-globalhub-5-2
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/multicluster-global-hub-operator-globalhub-5-2-pull-request.yaml
+++ b/.tekton/multicluster-global-hub-operator-globalhub-5-2-pull-request.yaml
@@ -1,0 +1,66 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/stolostron/multicluster-global-hub?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" &&
+      (target_branch == "main" || target_branch == "release-5.2") && (".tekton/multicluster-global-hub-operator-[!b]*.yaml".pathChanged() || "go.{mod,sum}".pathChanged() || "{pkg,operator}/***".pathChanged())
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: release-globalhub-5-2
+    appstudio.openshift.io/component: multicluster-global-hub-operator-globalhub-5-2
+    pipelines.appstudio.openshift.io/type: build
+  name: multicluster-global-hub-operator-globalhub-5-2-on-pull-request
+  namespace: acm-multicluster-glo-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-operator-globalhub-5-2:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux/arm64
+  - name: dockerfile
+    value: operator/Containerfile.operator
+  - name: path-context
+    value: .
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '[ {"type": "gomod", "path": "."} ]'
+  - name: build-args
+    value:
+      - "GIT_COMMIT={{revision}}"
+      - "RELEASE_CPE=cpe:/a:redhat:multicluster_globalhub:5.2::el9"
+      - "RELEASE_VERSION=release-5.2"
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: "https://github.com/stolostron/konflux-build-catalog.git"
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: pipelines/common-base.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-multicluster-global-hub-operator-globalhub-5-2
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/multicluster-global-hub-operator-globalhub-5-2-push.yaml
+++ b/.tekton/multicluster-global-hub-operator-globalhub-5-2-push.yaml
@@ -1,0 +1,76 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/build-nudge-files: "konflux-patch.sh"
+    build.appstudio.openshift.io/repo: https://github.com/stolostron/multicluster-global-hub?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-5.2" && (".tekton/multicluster-global-hub-operator-[!b]*.yaml".pathChanged() || "go.{mod,sum}".pathChanged() || "{pkg,operator}/***".pathChanged())
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: release-globalhub-5-2
+    appstudio.openshift.io/component: multicluster-global-hub-operator-globalhub-5-2
+    pipelines.appstudio.openshift.io/type: build
+  name: multicluster-global-hub-operator-globalhub-5-2-on-push
+  namespace: acm-multicluster-glo-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/multicluster-global-hub-operator-globalhub-5-2:{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux/arm64
+  - name: dockerfile
+    value: operator/Containerfile.operator
+  - name: path-context
+    value: .
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '[ {"type": "gomod", "path": "."} ]'
+  - name: build-args
+    value:
+      - "GIT_COMMIT={{revision}}"
+      - "RELEASE_CPE=cpe:/a:redhat:multicluster_globalhub:5.2::el9"
+      - "RELEASE_VERSION=release-5.2"
+  - name: send-slack-notification
+    value: "true"
+  - name: konflux-application-name
+    value: "release-globalhub-5-2"
+  - name: slack-webhook-url-secret-name
+    # See details: https://konflux.pages.redhat.com/docs/users/patterns/slack-notifications.html
+    value: "slack-notify-webhook"
+  - name: slack-webhook-url-secret-key
+    value: "slack-webhook-url"
+  - name: slack-group-id
+    # Will mention the user in the slack message when the pipeline run failed; this is not required.
+    # Please make sure replace the value with component owner's slack member id.
+    value: "S09JCE3DF9N"
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: "https://github.com/stolostron/konflux-build-catalog.git"
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: pipelines/common-base.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-multicluster-global-hub-operator-globalhub-5-2
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
## Summary

Add Tekton pipeline configurations for Global Hub 5.2 release.

## Changes

- Add 6 Tekton pipeline files for `globalhub-5-2` Konflux builds
  - Operator: pull-request and push pipelines
  - Manager: pull-request and push pipelines  
  - Agent: pull-request and push pipelines

## Pattern

Following the same pattern as PR #2747 (5.1 release):
- **PR pipelines**: Trigger on `main` OR `release-5.2` branches (via CEL)
- **Push pipelines**: Trigger only on `release-5.2` branch
- **Build args**: Pass `RELEASE_CPE=5.2::el9` and `RELEASE_VERSION=release-5.2`
- **Fast-forward compatible**: Enables clean `main → release-5.2` ffwd without Containerfile conflicts

## Testing

- Files follow the same structure as existing `globalhub-5-0` and `globalhub-5-1` pipelines
- CEL expressions ensure pipelines trigger only on appropriate branches

Related: [ACM-42643](https://redhat.atlassian.net/browse/ACM-42643)

[ACM-42643]: https://redhat.atlassian.net/browse/ACM-42643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated pull-request and push build pipelines for the Global Hub agent, manager, and operator components in the 5.2 release stream.
  * Builds now support multiple architectures with hermetic dependency handling and release-specific metadata.
  * Pull-request pipelines run only when relevant source or build files change.
  * Push pipelines include build notifications and configured image publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->