### PR TITLE
ACM-34442: Document Kafka simple authorization for BYO ACLs

### DIFF
--- a/doc/byo.md
+++ b/doc/byo.md
@@ -48,7 +48,7 @@ kubectl create secret generic multicluster-global-hub-transport-hub1 -n multiclu
 
 - Unless you configured your Kafka to automatically create topics, you must manually create the transport topics `gh-spec`, `gh-migration`, and `gh-status`. By default, all managed hubs publish status to the shared topic `gh-status`. If you set a different `statusTopic` in `spec.dataLayer.kafka.topics`, create that topic instead. See [Kafka topics and ACLs](#kafka-topics-and-acls) below.
 - Enable simple ACL authorization on the Kafka cluster so those ACLs take effect (Strimzi: `spec.kafka.authorization.type: simple`).
-- Kafka 3.3 or later is tested.
+- Kafka 3.3 and later is supported. Versions before 3.3 are unsupported. End-to-end tests use Kafka 4.0.0.
 - Persistent volume is recommended for Kafka.
 
 ### Kafka topics and ACLs
@@ -62,7 +62,7 @@ spec:
       type: simple
 ```
 
-Without a broker authorizer, KafkaUser (or equivalent) ACLs are ignored and authenticated clients can still read and write all topics.
+Without a broker authorizer, Kafka cannot enforce manually configured ACLs, so authenticated clients can still read and write all topics. A Strimzi `KafkaUser` that defines ACL rules while authorization is disabled is marked `NotReady` with an authorization-disabled error; those ACLs are not silently ignored.
 
 Global Hub uses three Kafka topics for transport:
 

--- a/doc/byo.md
+++ b/doc/byo.md
@@ -87,7 +87,9 @@ Notes:
 - Grant **Write** on `gh-migration` to the source managed hub only for the duration of an active migration, then revoke it. With built-in Strimzi Kafka, the operator applies and removes that ACL automatically; with BYO Kafka, you must update ACLs yourself or through your Kafka administration tooling.
 - For more information about cluster migration, see [Managed Cluster Migration](./migration/global_hub_cluster_migration.md).
 - Built-in Strimzi Kafka uses per-hub status topics such as `gh-status.<cluster-name>` with a prefix ACL on `gh-status`. BYO Kafka always uses one shared status topic (`gh-status` by default, or the configured `statusTopic`) for every managed hub.
-- Kafka consumers also need **Group Read** (FindCoordinator). Topic-only ACLs fail with `Group authorization failed` and the consumer group is never created. A shared BYO principal (single `multicluster-global-hub-transport` secret / `global-hub-byo-user`) must use Group `*` Read. Per-hub KafkaUsers should use the literal group id: `consumerGroupPrefix` + cluster name with hyphens replaced by underscores (for example `custom_qe_global_hub`).
+- Kafka consumers also need **Group Read** (FindCoordinator). Topic-only ACLs fail with `Group authorization failed` and the consumer group is never created.
+- Per-hub KafkaUsers (`{hub}-kafka-user`) must use the **literal** group id: `consumerGroupPrefix` + cluster name with hyphens replaced by underscores. With prefix `custom-qe-`, the manager group is `custom_qe_global_hub` and hub `hub1` is `custom_qe_hub1`. Do not grant Group `*` to per-hub users.
+- A shared BYO principal (single `multicluster-global-hub-transport` secret / `global-hub-byo-user`) joins both the manager group and every hub group, so that user needs Group `*` Read. See the labeled shared-BYO example below.
 
 Example Strimzi `KafkaUser` ACL entries for the global hub manager transport user (BYO defaults shown):
 
@@ -110,16 +112,15 @@ Example Strimzi `KafkaUser` ACL entries for the global hub manager transport use
     type: topic
     name: gh-status
     patternType: literal
-# consumer group — FindCoordinator / group join
-# Shared BYO user: "*". Per-hub user: literal "{prefix}{cluster}" (hyphens → underscores)
+# consumer group — manager id is {prefix}global_hub (hyphens → underscores)
 - operations: [Read]
   resource:
     type: group
-    name: "*"
+    name: custom_qe_global_hub
     patternType: literal
 ```
 
-Example managed-hub `KafkaUser` ACL entries:
+Example managed-hub `KafkaUser` ACL entries (hub `hub1` with prefix `custom-qe-`):
 
 ```yaml
 # gh-spec — consume spec/policy only
@@ -140,8 +141,18 @@ Example managed-hub `KafkaUser` ACL entries:
     type: topic
     name: gh-status
     patternType: literal
-# consumer group — FindCoordinator / group join
-# Shared BYO user: "*". Per-hub user: literal "{prefix}{cluster}" (hyphens → underscores)
+# consumer group — {prefix}{hub} with hyphens replaced by underscores
+- operations: [Read]
+  resource:
+    type: group
+    name: custom_qe_hub1
+    patternType: literal
+```
+
+Example Group ACL for a **shared BYO principal** only (`global-hub-byo-user` / single transport secret). Do not use `*` on per-hub `{hub}-kafka-user` resources:
+
+```yaml
+# consumer group — shared BYO user joins manager + every hub group
 - operations: [Read]
   resource:
     type: group

--- a/doc/byo.md
+++ b/doc/byo.md
@@ -87,6 +87,7 @@ Notes:
 - Grant **Write** on `gh-migration` to the source managed hub only for the duration of an active migration, then revoke it. With built-in Strimzi Kafka, the operator applies and removes that ACL automatically; with BYO Kafka, you must update ACLs yourself or through your Kafka administration tooling.
 - For more information about cluster migration, see [Managed Cluster Migration](./migration/global_hub_cluster_migration.md).
 - Built-in Strimzi Kafka uses per-hub status topics such as `gh-status.<cluster-name>` with a prefix ACL on `gh-status`. BYO Kafka always uses one shared status topic (`gh-status` by default, or the configured `statusTopic`) for every managed hub.
+- Kafka consumers also need **Group Read** (FindCoordinator). Topic-only ACLs fail with `Group authorization failed` and the consumer group is never created. A shared BYO principal (single `multicluster-global-hub-transport` secret / `global-hub-byo-user`) must use Group `*` Read. Per-hub KafkaUsers should use the literal group id: `consumerGroupPrefix` + cluster name with hyphens replaced by underscores (for example `custom_qe_global_hub`).
 
 Example Strimzi `KafkaUser` ACL entries for the global hub manager transport user (BYO defaults shown):
 
@@ -108,6 +109,13 @@ Example Strimzi `KafkaUser` ACL entries for the global hub manager transport use
   resource:
     type: topic
     name: gh-status
+    patternType: literal
+# consumer group — FindCoordinator / group join
+# Shared BYO user: "*". Per-hub user: literal "{prefix}{cluster}" (hyphens → underscores)
+- operations: [Read]
+  resource:
+    type: group
+    name: "*"
     patternType: literal
 ```
 
@@ -131,6 +139,13 @@ Example managed-hub `KafkaUser` ACL entries:
   resource:
     type: topic
     name: gh-status
+    patternType: literal
+# consumer group — FindCoordinator / group join
+# Shared BYO user: "*". Per-hub user: literal "{prefix}{cluster}" (hyphens → underscores)
+- operations: [Read]
+  resource:
+    type: group
+    name: "*"
     patternType: literal
 ```
 

--- a/doc/byo.md
+++ b/doc/byo.md
@@ -47,10 +47,22 @@ kubectl create secret generic multicluster-global-hub-transport-hub1 -n multiclu
 *Prerequisite:*
 
 - Unless you configured your Kafka to automatically create topics, you must manually create the transport topics `gh-spec`, `gh-migration`, and `gh-status`. By default, all managed hubs publish status to the shared topic `gh-status`. If you set a different `statusTopic` in `spec.dataLayer.kafka.topics`, create that topic instead. See [Kafka topics and ACLs](#kafka-topics-and-acls) below.
+- Enable simple ACL authorization on the Kafka cluster so those ACLs take effect (Strimzi: `spec.kafka.authorization.type: simple`).
 - Kafka 3.3 or later is tested.
 - Persistent volume is recommended for Kafka.
 
 ### Kafka topics and ACLs
+
+Enable simple ACL authorization on the Kafka cluster before granting the ACLs below. With Strimzi or AMQ Streams, set:
+
+```yaml
+spec:
+  kafka:
+    authorization:
+      type: simple
+```
+
+Without a broker authorizer, KafkaUser (or equivalent) ACLs are ignored and authenticated clients can still read and write all topics.
 
 Global Hub uses three Kafka topics for transport:
 

--- a/tools/generate-kafka-config.sh
+++ b/tools/generate-kafka-config.sh
@@ -19,12 +19,20 @@ Available options:
   global_hub_namespace       The namespace of the Global Hub operator. Default is 'multicluster-global-hub'.
   kafka_cluster_name         The Kafka cluster name. Default is 'kafka'.
 
+Environment:
+
+  CONSUMER_GROUP_PREFIX      Optional. Same as spec.dataLayer.kafka.consumerGroupPrefix.
+                             Prepended to cluster_name for the KafkaUser Group ACL.
+                             The resulting id has hyphens replaced with underscores.
+
 EOF
   exit
 }
 
 # create a KafkaUser CR
 createKafkaUser() {
+  # Literal group id matches GetConsumerGroupID(prefix, clusterName).
+  group_id=$(printf '%s%s' "${CONSUMER_GROUP_PREFIX:-}" "$1" | tr '-' '_')
   cat <<EOF | kubectl apply -f -
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaUser
@@ -42,7 +50,7 @@ spec:
       operations:
       - Read
       resource:
-        name: '*'
+        name: ${group_id}
         patternType: literal
         type: group
     - host: '*'


### PR DESCRIPTION
Fixes: [ACM-34442](https://redhat.atlassian.net/browse/ACM-34442)

Related: [stolostron/multicluster-global-hub#2807](https://github.com/stolostron/multicluster-global-hub/pull/2807), [stolostron/acmqe-hoh-e2e#605](https://github.com/stolostron/acmqe-hoh-e2e/pull/605), [stolostron/acmqe-hoh-e2e#611](https://github.com/stolostron/acmqe-hoh-e2e/pull/611)

## Summary

- Document that BYO Kafka must enable simple ACL authorization so the KafkaUser ACLs in `doc/byo.md` take effect
- Document **Group Read** on the consumer group (FindCoordinator). Topic-only ACLs fail with `Group authorization failed` after simple authorization is enabled, so a custom `consumerGroupPrefix` never appears on the broker
- Shared BYO principal (`global-hub-byo-user`) uses Group `*`; per-hub KafkaUsers use the literal group id (`consumerGroupPrefix` + cluster name, hyphens → underscores)

## Context

- Follow-up to [#2807](https://github.com/stolostron/multicluster-global-hub/pull/2807). Without `spec.kafka.authorization.type: simple`, broker ACLs are not enforced
- Same Kafka CR change as [acmqe-hoh-e2e#605](https://github.com/stolostron/acmqe-hoh-e2e/pull/605). That PR also copied the topic-only YAML example, which is why RHACM4K-59007 / 58986 fail until [acmqe-hoh-e2e#611](https://github.com/stolostron/acmqe-hoh-e2e/pull/611)

Related:

- [#2807](https://github.com/stolostron/multicluster-global-hub/pull/2807) — phase 6 on `main`
- [ACM-34442](https://redhat.atlassian.net/browse/ACM-34442) — parent

## Test plan

- [ ] Review the Kafka topics and ACLs section in `doc/byo.md` (simple authorization + Group Read examples)
- [ ] QE [acmqe-hoh-e2e#611](https://github.com/stolostron/acmqe-hoh-e2e/pull/611) KafkaUser includes Group `*` Read
- [ ] RHACM4K-59007 / 58986: prefixed consumer group is listed on the broker


[ACM-34442]: https://redhat.atlassian.net/browse/ACM-34442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-34442]: https://redhat.atlassian.net/browse/ACM-34442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Kafka consumer access controls now support configurable consumer-group prefixes.
  - Consumer-group permissions are restricted to the specific derived group used by each cluster.

- **Documentation**
  - Added guidance for configuring broker ACL authorization.
  - Documented Kafka 3.3+ support and clarified that earlier versions are not supported.
  - Added ACL examples for manager, managed-hub, and shared BYO Kafka configurations.
  - Documented Kafka 4.0.0 end-to-end test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->