### PR TITLE
ACM-34442: Assert BYO per-hub secret does not replace other hubs' shared secret

### DIFF
--- a/operator/pkg/controllers/transporter/protocol/byo_transporter_test.go
+++ b/operator/pkg/controllers/transporter/protocol/byo_transporter_test.go
@@ -188,6 +188,8 @@ func TestGetConnCredentialFallsBackToSharedSecret(t *testing.T) {
 	}
 }
 
+// TestGetConnCredentialPerHubLeavesOtherHubsOnSharedSecret checks that a per-hub
+// BYO secret for one hub does not change credentials for other hubs or the manager.
 func TestGetConnCredentialPerHubLeavesOtherHubsOnSharedSecret(t *testing.T) {
 	ns := utils.GetDefaultNamespace()
 	shared := byoSecret(constants.GHTransportSecretName, ns, "shared-cert")

--- a/operator/pkg/controllers/transporter/protocol/byo_transporter_test.go
+++ b/operator/pkg/controllers/transporter/protocol/byo_transporter_test.go
@@ -188,6 +188,49 @@ func TestGetConnCredentialFallsBackToSharedSecret(t *testing.T) {
 	}
 }
 
+func TestGetConnCredentialPerHubLeavesOtherHubsOnSharedSecret(t *testing.T) {
+	ns := utils.GetDefaultNamespace()
+	shared := byoSecret(constants.GHTransportSecretName, ns, "shared-cert")
+	hub1 := byoSecret(constants.GHTransportSecretNameForCluster("hub1"), ns, "hub1-cert")
+	trans := newBYOTransporter(t, byoMGH(ns), shared, hub1)
+
+	hub1Conn, err := trans.GetConnCredential("hub1")
+	if err != nil {
+		t.Fatalf("GetConnCredential(hub1) error = %v", err)
+	}
+	hub1Cert, err := base64.StdEncoding.DecodeString(hub1Conn.ClientCert)
+	if err != nil {
+		t.Fatalf("decode hub1 client cert: %v", err)
+	}
+	if string(hub1Cert) != "hub1-cert" {
+		t.Fatalf("hub1 client cert = %q, want hub1-cert", hub1Cert)
+	}
+
+	hub2Conn, err := trans.GetConnCredential("hub2")
+	if err != nil {
+		t.Fatalf("GetConnCredential(hub2) error = %v", err)
+	}
+	hub2Cert, err := base64.StdEncoding.DecodeString(hub2Conn.ClientCert)
+	if err != nil {
+		t.Fatalf("decode hub2 client cert: %v", err)
+	}
+	if string(hub2Cert) != "shared-cert" {
+		t.Fatalf("hub2 client cert = %q, want shared-cert", hub2Cert)
+	}
+
+	mgrConn, err := trans.GetConnCredential(constants.CloudEventGlobalHubClusterName)
+	if err != nil {
+		t.Fatalf("GetConnCredential(global-hub) error = %v", err)
+	}
+	mgrCert, err := base64.StdEncoding.DecodeString(mgrConn.ClientCert)
+	if err != nil {
+		t.Fatalf("decode manager client cert: %v", err)
+	}
+	if string(mgrCert) != "shared-cert" {
+		t.Fatalf("manager client cert = %q, want shared-cert", mgrCert)
+	}
+}
+
 func TestEnsureUserRejectsIdenticalPerHubCerts(t *testing.T) {
 	ns := utils.GetDefaultNamespace()
 	same := "duplicate-cert"

--- a/test/e2e/transport_byo_test.go
+++ b/test/e2e/transport_byo_test.go
@@ -48,6 +48,7 @@ var _ = Describe("Transport BYO Kafka E2E", Serial, Label("e2e-test-transport-by
 		sourceHubName   string
 		targetHubName   string
 		sourceHubClient client.Client
+		targetHubClient client.Client
 		sharedBootstrap string
 	)
 
@@ -63,6 +64,8 @@ var _ = Describe("Transport BYO Kafka E2E", Serial, Label("e2e-test-transport-by
 		var err error
 		sourceHubClient, err = testClients.RuntimeClient(sourceHubName, agentScheme)
 		Expect(err).NotTo(HaveOccurred(), "expected a kube client for the source managed hub")
+		targetHubClient, err = testClients.RuntimeClient(targetHubName, agentScheme)
+		Expect(err).NotTo(HaveOccurred(), "expected a kube client for the target managed hub")
 
 		shared, err := byoSharedTransportSecret()
 		Expect(err).NotTo(HaveOccurred(), "expected the shared BYO transport secret")
@@ -89,10 +92,18 @@ var _ = Describe("Transport BYO Kafka E2E", Serial, Label("e2e-test-transport-by
 	})
 
 	It("starts the managed hub agent with shared-secret fallback", func() {
-		Eventually(func() error {
-			return managedHubAgentKafkaReady(sourceHubClient, sourceHubName)
-		}, 2*time.Minute, 5*time.Second).Should(Succeed(),
-			"managed hub agent must start with the shared BYO transport secret")
+		for _, hub := range []struct {
+			name   string
+			client client.Client
+		}{
+			{sourceHubName, sourceHubClient},
+			{targetHubName, targetHubClient},
+		} {
+			Eventually(func() error {
+				return managedHubAgentKafkaReady(hub.client, hub.name)
+			}, 2*time.Minute, 5*time.Second).Should(Succeed(),
+				"managed hub %s agent must start with the shared BYO transport secret", hub.name)
+		}
 	})
 
 	It("selects a per-hub transport secret over the shared secret", func() {
@@ -115,16 +126,24 @@ var _ = Describe("Transport BYO Kafka E2E", Serial, Label("e2e-test-transport-by
 		})
 
 		Eventually(func() error {
-			cfg, err := managedHubAgentKafkaConfig(sourceHubClient)
+			src, err := managedHubAgentKafkaConfig(sourceHubClient)
 			if err != nil {
 				return err
 			}
-			if cfg.BootstrapServer != byoPerHubBootstrapMarker {
-				return fmt.Errorf("agent transport still uses shared bootstrap")
+			if src.BootstrapServer != byoPerHubBootstrapMarker {
+				return fmt.Errorf("agent on %s still uses shared bootstrap", sourceHubName)
 			}
-			return nil
+			dst, err := managedHubAgentKafkaConfig(targetHubClient)
+			if err != nil {
+				return err
+			}
+			if dst.BootstrapServer != sharedBootstrap {
+				return fmt.Errorf("agent on %s left the shared BYO secret (bootstrap %q)",
+					targetHubName, dst.BootstrapServer)
+			}
+			return managedHubAgentKafkaReady(targetHubClient, targetHubName)
 		}, 2*time.Minute, 5*time.Second).Should(Succeed(),
-			"agent transport credentials must come from the per-hub BYO secret")
+			"per-hub secret must apply only to that hub; other hubs stay on the shared secret")
 	})
 
 	It("rejects identical client certificates on two per-hub secrets", func() {

--- a/test/e2e/transport_byo_test.go
+++ b/test/e2e/transport_byo_test.go
@@ -231,7 +231,9 @@ func managedHubAgentKafkaConfig(hubClient client.Client) (*transport.KafkaConfig
 }
 
 // managedHubAgentUsesSharedBootstrap reports whether the spoke agent still uses the
-// shared BYO transport secret. The bootstrap endpoint is not included in the error.
+// shared BYO transport secret. Bootstrap, client cert, and deployment readiness
+// are checked from one transport-config read. The bootstrap endpoint is not
+// included in the error.
 func managedHubAgentUsesSharedBootstrap(hubClient client.Client, hubName, sharedBootstrap string) error {
 	cfg, err := managedHubAgentKafkaConfig(hubClient)
 	if err != nil {
@@ -239,15 +241,6 @@ func managedHubAgentUsesSharedBootstrap(hubClient client.Client, hubName, shared
 	}
 	if cfg.BootstrapServer != sharedBootstrap {
 		return fmt.Errorf("agent on %s did not use the shared BYO secret", hubName)
-	}
-	return managedHubAgentKafkaReady(hubClient, hubName)
-}
-
-// managedHubAgentKafkaReady reports whether the spoke agent has a client cert and a Ready deployment.
-func managedHubAgentKafkaReady(hubClient client.Client, hubName string) error {
-	cfg, err := managedHubAgentKafkaConfig(hubClient)
-	if err != nil {
-		return err
 	}
 	if cfg.ClientCert == "" {
 		return fmt.Errorf("agent transport-config is missing a client certificate")

--- a/test/e2e/transport_byo_test.go
+++ b/test/e2e/transport_byo_test.go
@@ -100,7 +100,7 @@ var _ = Describe("Transport BYO Kafka E2E", Serial, Label("e2e-test-transport-by
 			{targetHubName, targetHubClient},
 		} {
 			Eventually(func() error {
-				return managedHubAgentKafkaReady(hub.client, hub.name)
+				return managedHubAgentUsesSharedBootstrap(hub.client, hub.name, sharedBootstrap)
 			}, 2*time.Minute, 5*time.Second).Should(Succeed(),
 				"managed hub %s agent must start with the shared BYO transport secret", hub.name)
 		}
@@ -133,15 +133,7 @@ var _ = Describe("Transport BYO Kafka E2E", Serial, Label("e2e-test-transport-by
 			if src.BootstrapServer != byoPerHubBootstrapMarker {
 				return fmt.Errorf("agent on %s still uses shared bootstrap", sourceHubName)
 			}
-			dst, err := managedHubAgentKafkaConfig(targetHubClient)
-			if err != nil {
-				return err
-			}
-			if dst.BootstrapServer != sharedBootstrap {
-				return fmt.Errorf("agent on %s left the shared BYO secret (bootstrap %q)",
-					targetHubName, dst.BootstrapServer)
-			}
-			return managedHubAgentKafkaReady(targetHubClient, targetHubName)
+			return managedHubAgentUsesSharedBootstrap(targetHubClient, targetHubName, sharedBootstrap)
 		}, 2*time.Minute, 5*time.Second).Should(Succeed(),
 			"per-hub secret must apply only to that hub; other hubs stay on the shared secret")
 	})
@@ -220,6 +212,7 @@ func deleteBYOPerHubSecret(clusterName string) {
 	}
 }
 
+// managedHubAgentKafkaConfig reads the spoke agent transport-config secret.
 func managedHubAgentKafkaConfig(hubClient client.Client) (*transport.KafkaConfig, error) {
 	apiCtx, cancel := byoAPIContext()
 	defer cancel()
@@ -237,6 +230,20 @@ func managedHubAgentKafkaConfig(hubClient client.Client) (*transport.KafkaConfig
 	return cfg, nil
 }
 
+// managedHubAgentUsesSharedBootstrap reports whether the spoke agent still uses the
+// shared BYO transport secret. The bootstrap endpoint is not included in the error.
+func managedHubAgentUsesSharedBootstrap(hubClient client.Client, hubName, sharedBootstrap string) error {
+	cfg, err := managedHubAgentKafkaConfig(hubClient)
+	if err != nil {
+		return err
+	}
+	if cfg.BootstrapServer != sharedBootstrap {
+		return fmt.Errorf("agent on %s did not use the shared BYO secret", hubName)
+	}
+	return managedHubAgentKafkaReady(hubClient, hubName)
+}
+
+// managedHubAgentKafkaReady reports whether the spoke agent has a client cert and a Ready deployment.
 func managedHubAgentKafkaReady(hubClient client.Client, hubName string) error {
 	cfg, err := managedHubAgentKafkaConfig(hubClient)
 	if err != nil {


### PR DESCRIPTION
Fixes: [ACM-34442](https://redhat.atlassian.net/browse/ACM-34442)

## Summary

- KinD BYO e2e (`e2e-test-transport-byo`) now fails if hub2 leaves the shared `multicluster-global-hub-transport` secret while hub1 uses a per-hub secret
- Both managed hubs must start on the shared secret before the per-hub swap
- Unit test: `GetConnCredential(hub2)` still returns the shared cert when only hub1 has a per-hub secret

Jenkins BYO has one regional hub, so it cannot cover this. Prow `ci/prow/test-e2e` runs `e2e_run_byo.sh` with `MH_NUM=2`.

Not in this PR (Jenkins already covers them):

- Per-hub consume/produce (HoH TODO-4 / [#628](https://github.com/stolostron/acmqe-hoh-e2e/pull/628) heartbeat)
- Wrong `{other-hub}-kafka-user` CN (TODO-6)
- Single-secret upgrade (TODO-7 / `TEST_TAGS=post-upgrade`)

## Test plan

- [ ] `go test ./operator/pkg/controllers/transporter/protocol/ -run TestGetConnCredentialPerHubLeavesOtherHubsOnSharedSecret`
- [ ] `ci/prow/test-e2e` BYO label `e2e-test-transport-byo` (two KinD hubs)


Made with [Cursor](https://cursor.com)

[ACM-34442]: https://redhat.atlassian.net/browse/ACM-34442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming that configured hubs use dedicated credentials while unconfigured hubs and global connections continue using shared credentials.
  * Expanded end-to-end transport validation across target hubs, including bootstrap settings, client certificates, agent startup, and readiness.
  * Improved shared-secret authentication checks across managed hubs to help ensure consistent connectivity and configuration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->