### PR TITLE
ACM-42804: prevent regional hub addon recreation

### DIFF
--- a/agent/pkg/spec/hubha/hubha_config_annotator.go
+++ b/agent/pkg/spec/hubha/hubha_config_annotator.go
@@ -138,6 +138,9 @@ func hasHAKlusterletConfigAnnotation(obj client.Object) bool {
 }
 
 func isGlobalHubManagedHub(obj client.Object) bool {
+	if obj.GetAnnotations()[constants.AnnotationONMulticlusterHub] == "true" {
+		return true
+	}
 	labels := obj.GetLabels()
 	if labels == nil {
 		return false

--- a/agent/pkg/spec/hubha/hubha_config_annotator_test.go
+++ b/agent/pkg/spec/hubha/hubha_config_annotator_test.go
@@ -114,15 +114,14 @@ func TestHAConfigAnnotator_NoOpWhenNotActiveHub(t *testing.T) {
 		"standby/global hub must not annotate ManagedClusters when ha-standby config is synced")
 }
 
-func TestHAConfigAnnotator_SkipsImportedRegionalHub(t *testing.T) {
+func TestHAConfigAnnotator_SkipsImportedRegionalHubBeforeGlobalHubLabels(t *testing.T) {
 	setAnnotatorHubRole(t, constants.GHHubRoleActive)
 	scheme := newAnnotatorTestScheme(t)
 	regionalHub := &clusterv1.ManagedCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "regional-hub",
-			Labels: map[string]string{
-				constants.GHDeployModeLabelKey: constants.GHDeployModeHosted,
-				constants.GHHubRoleLabelKey:    constants.GHHubRoleActive,
+			Annotations: map[string]string{
+				constants.AnnotationONMulticlusterHub: "true",
 			},
 		},
 	}
@@ -142,7 +141,7 @@ func TestHAConfigAnnotator_SkipsImportedRegionalHub(t *testing.T) {
 	err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "regional-hub"}, mc)
 	require.NoError(t, err, "should retrieve imported regional hub ManagedCluster")
 	assert.Empty(t, mc.GetAnnotations()[klusterletConfigAnnotation],
-		"ManagedCluster for a regional hub imported into Global Hub must not get "+
+		"ManagedCluster for a regional hub must not get "+
 			"klusterlet-config annotation")
 }
 
@@ -377,6 +376,15 @@ func TestIsLocalManagedCluster(t *testing.T) {
 }
 
 func TestIsGlobalHubManagedHub(t *testing.T) {
+	assert.True(t, isGlobalHubManagedHub(&clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "regional-hub",
+			Annotations: map[string]string{
+				constants.AnnotationONMulticlusterHub: "true",
+			},
+		},
+	}), "multicluster-hub annotation identifies an imported hub before Global Hub labels are added")
+
 	assert.True(t, isGlobalHubManagedHub(&clusterv1.ManagedCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "regional-hub",


### PR DESCRIPTION
## Summary

- recognize imported regional hubs through the existing `addon.open-cluster-management.io/on-multicluster-hub=true` annotation before Global Hub labels are applied
- prevent the Hub HA annotator from temporarily applying a KlusterletConfig to regional hubs
- add regression coverage for the pre-label import state

## Testing

- `go test -mod=mod ./agent/pkg/spec/hubha -run 'TestHAConfigAnnotator|TestIsGlobalHubManagedHub' -count=1`\n\nJira: https://redhat.atlassian.net/browse/ACM-42804

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of imported hubs managed by the Global Hub before associated labels are applied.
  * Prevented incorrect high-availability configuration updates for these hubs.

* **Tests**
  * Added coverage for identifying imported hubs through their multicluster hub annotation.
  * Updated regional hub scenarios to reflect the revised detection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->