### PR TITLE
ACM-42338: Harden TLS and Grafana configuration for Global Hub 1.7

### DIFF
--- a/operator/pkg/config/multiclusterglobalhub_config.go
+++ b/operator/pkg/config/multiclusterglobalhub_config.go
@@ -78,9 +78,10 @@ const (
 )
 
 var (
-	mghNamespacedName  = types.NamespacedName{}
-	oauthSessionSecret = ""
-	imageOverrides     = map[string]string{
+	mghNamespacedName    = types.NamespacedName{}
+	oauthSessionSecret   = ""
+	grafanaAdminPassword = ""
+	imageOverrides       = map[string]string{
 		GlobalHubAgentImageKey:      "quay.io/stolostron/multicluster-global-hub-agent:latest",
 		GlobalHubManagerImageKey:    "quay.io/stolostron/multicluster-global-hub-manager:latest",
 		OauthProxyImageKey:          "quay.io/stolostron/origin-oauth-proxy:4.9",
@@ -135,6 +136,20 @@ func GetOauthSessionSecret() (string, error) {
 		oauthSessionSecret = base64.StdEncoding.EncodeToString(b)
 	}
 	return oauthSessionSecret, nil
+}
+
+// GetGrafanaAdminPassword returns a stable random Grafana admin password for this operator process.
+// Grafana defaults to admin/admin when admin_password is unset in grafana.ini.
+func GetGrafanaAdminPassword() (string, error) {
+	if grafanaAdminPassword == "" {
+		b := make([]byte, 24)
+		_, err := rand.Read(b)
+		if err != nil {
+			return "", err
+		}
+		grafanaAdminPassword = base64.StdEncoding.EncodeToString(b)
+	}
+	return grafanaAdminPassword, nil
 }
 
 var MGHPred = predicate.Funcs{

--- a/operator/pkg/config/multiclusterglobalhub_config_test.go
+++ b/operator/pkg/config/multiclusterglobalhub_config_test.go
@@ -127,6 +127,23 @@ func TestGetOauthSessionSecret(t *testing.T) {
 	}
 }
 
+func TestGetGrafanaAdminPassword(t *testing.T) {
+	password1, err := GetGrafanaAdminPassword()
+	if err != nil {
+		t.Fatalf("failed to get grafana admin password: %v", err)
+	}
+	password2, err := GetGrafanaAdminPassword()
+	if err != nil {
+		t.Fatalf("failed to get grafana admin password: %v", err)
+	}
+	if password1 == "" {
+		t.Fatalf("grafana admin password should not be empty")
+	}
+	if password1 != password2 {
+		t.Fatalf("grafana admin password is not consistent")
+	}
+}
+
 func TestSetMulticlusterGlobalHubConfig(t *testing.T) {
 	oauthImage := "quay.io/testing/origin-oauth-proxy:4.9"
 	mghInstance := &globalhubv1alpha4.MulticlusterGlobalHub{

--- a/operator/pkg/controllers/grafana/grafana_reconciler.go
+++ b/operator/pkg/controllers/grafana/grafana_reconciler.go
@@ -463,6 +463,12 @@ func (r *GrafanaReconciler) generateGrafanaIni(
 		}
 	}
 
+	mergedIni, err := injectGrafanaAdminPassword(mergedGrafanaIniSecret.Data[grafanaIniKey])
+	if err != nil {
+		return false, fmt.Errorf("failed to set grafana admin password: %w", err)
+	}
+	mergedGrafanaIniSecret.Data[grafanaIniKey] = mergedIni
+
 	if err = controllerutil.SetControllerReference(mgh, mergedGrafanaIniSecret, r.scheme); err != nil {
 		return false, err
 	}
@@ -705,22 +711,61 @@ func (r *GrafanaReconciler) GenerateGrafanaDataSourceSecret(
 	return false, nil
 }
 
-func GrafanaDataSource(databaseURI string, cert []byte, serviceAccountToken string) ([]byte, error) {
-	postgresURI := string(databaseURI)
-	objURI, err := url.Parse(postgresURI)
+type postgresConnectionParams struct {
+	host, user, password, database, sslMode string
+}
+
+func parsePostgresConnection(databaseURI string) (postgresConnectionParams, error) {
+	objURI, err := url.Parse(databaseURI)
 	if err != nil {
-		return nil, err
+		return postgresConnectionParams{}, fmt.Errorf("failed to parse postgres connection: %w", err)
 	}
 	password, ok := objURI.User.Password()
 	if !ok {
-		return nil, fmt.Errorf("failed to get password from database_uri: %s", postgresURI)
+		return postgresConnectionParams{}, fmt.Errorf("postgres connection is missing a password")
 	}
-
-	// get the database from the objURI
 	database := "hoh"
 	paths := strings.Split(objURI.Path, "/")
 	if len(paths) > 1 {
 		database = paths[1]
+	}
+	return postgresConnectionParams{
+		host:     objURI.Host,
+		user:     objURI.User.Username(),
+		password: password,
+		database: database,
+		sslMode:  objURI.Query().Get("sslmode"),
+	}, nil
+}
+
+func injectGrafanaAdminPassword(grafanaIni []byte) ([]byte, error) {
+	adminPassword, err := config.GetGrafanaAdminPassword()
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := ini.Load(grafanaIni)
+	if err != nil {
+		return nil, err
+	}
+	sec, err := cfg.GetSection("security")
+	if err != nil {
+		sec, err = cfg.NewSection("security")
+		if err != nil {
+			return nil, err
+		}
+	}
+	sec.Key("admin_password").SetValue(adminPassword)
+	var buf bytes.Buffer
+	if _, err = cfg.WriteTo(&buf); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func GrafanaDataSource(databaseURI string, cert []byte, serviceAccountToken string) ([]byte, error) {
+	conn, err := parsePostgresConnection(databaseURI)
+	if err != nil {
+		return nil, err
 	}
 
 	postgresDS := &GrafanaDatasource{
@@ -728,16 +773,16 @@ func GrafanaDataSource(databaseURI string, cert []byte, serviceAccountToken stri
 		Type:      "postgres",
 		Access:    "proxy",
 		IsDefault: true,
-		URL:       objURI.Host,
-		User:      objURI.User.Username(),
+		URL:       conn.host,
+		User:      conn.user,
 		Editable:  false,
 		JSONData: &JsonData{
-			Database:     database,
+			Database:     conn.database,
 			QueryTimeout: "300s",
 			TimeInterval: "30s",
 		},
 		SecureJSONData: &SecureJsonData{
-			Password: password,
+			Password: conn.password,
 		},
 	}
 	datasource := []*GrafanaDatasource{postgresDS}
@@ -765,10 +810,10 @@ func GrafanaDataSource(databaseURI string, cert []byte, serviceAccountToken stri
 	}
 
 	if len(cert) > 0 {
-		postgresDS.JSONData.SSLMode = objURI.Query().Get("sslmode") // sslmode == "verify-full" || sslmode == "verify-ca"
+		postgresDS.JSONData.SSLMode = conn.sslMode // sslmode == "verify-full" || sslmode == "verify-ca"
 		postgresDS.JSONData.TLSAuth = true
 		postgresDS.JSONData.TLSAuthWithCACert = true
-		postgresDS.JSONData.TLSSkipVerify = true
+		postgresDS.JSONData.TLSSkipVerify = false
 		postgresDS.JSONData.TLSConfigurationMethod = "file-content"
 		postgresDS.SecureJSONData.TLSCACert = string(cert)
 	}

--- a/operator/pkg/controllers/grafana/grafana_reconciler_test.go
+++ b/operator/pkg/controllers/grafana/grafana_reconciler_test.go
@@ -6,7 +6,9 @@ import (
 
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/ini.v1"
+	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -316,7 +318,7 @@ policies:
 			}
 
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(tt.initObjects...).Build()
-			kubeClient := fakekube.NewSimpleClientset(tt.initObjects...)
+			kubeClient := fakekube.NewClientset(tt.initObjects...)
 			r := &GrafanaReconciler{
 				client:     fakeClient,
 				kubeClient: kubeClient,
@@ -578,7 +580,7 @@ email = example@redhat.com
 			objs := append(tt.initRoute, tt.initObjects...)
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(objs...).Build()
 
-			kubeClient := fakekube.NewSimpleClientset(tt.initObjects...)
+			kubeClient := fakekube.NewClientset(tt.initObjects...)
 			r := &GrafanaReconciler{
 				client:     fakeClient,
 				kubeClient: kubeClient,
@@ -917,4 +919,31 @@ func sectionCount(a []byte) int {
 	}
 	// By Default, There is a DEFAULT section, should not count it
 	return len(cfg.Sections()) - 1
+}
+
+func TestInjectGrafanaAdminPassword(t *testing.T) {
+	merged, err := injectGrafanaAdminPassword([]byte("[security]\nadmin_user = admin\n"))
+	require.NoError(t, err)
+
+	cfg, err := ini.Load(merged)
+	require.NoError(t, err)
+
+	sec, err := cfg.GetSection("security")
+	require.NoError(t, err)
+	assert.NotEmpty(t, sec.Key("admin_password").String())
+}
+
+func TestGrafanaDataSource_TLS(t *testing.T) {
+	uri := "postgresql://grafana:secret@pg.example:5432/mydb?sslmode=verify-full"
+	raw, err := GrafanaDataSource(uri, []byte("ca-cert"), "")
+	require.NoError(t, err)
+
+	var datasources GrafanaDatasources
+	require.NoError(t, yaml.Unmarshal(raw, &datasources))
+	require.Len(t, datasources.Datasources, 1)
+
+	jsonData := datasources.Datasources[0].JSONData
+	require.NotNil(t, jsonData)
+	assert.Equal(t, "verify-full", jsonData.SSLMode)
+	assert.False(t, jsonData.TLSSkipVerify)
 }

--- a/pkg/database/pgx_conn.go
+++ b/pkg/database/pgx_conn.go
@@ -40,14 +40,17 @@ func GetPostgresConfig(URI string, cert []byte) (*pgx.ConnConfig, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse database uri: %w", err)
 	}
-	if len(cert) > 0 { // #nosec G402
+	if len(cert) > 0 {
 		caCertPool := x509.NewCertPool()
-		caCertPool.AppendCertsFromPEM(cert)
-		config.TLSConfig = &tls.Config{
-			RootCAs: caCertPool,
-			// nolint:gosec
-			InsecureSkipVerify: true, // #nosec G402
+		if !caCertPool.AppendCertsFromPEM(cert) {
+			return nil, fmt.Errorf("failed to parse postgres CA certificate")
 		}
+		if config.TLSConfig == nil {
+			config.TLSConfig = &tls.Config{
+				MinVersion: tls.VersionTLS12,
+			}
+		}
+		config.TLSConfig.RootCAs = caCertPool
 	}
 	return config, nil
 }
@@ -63,13 +66,17 @@ func PostgresConnPool(ctx context.Context, databaseURI string, certPath string, 
 	if err != nil && !strings.Contains(err.Error(), errMessageFileNotFound) {
 		return nil, fmt.Errorf("unable to read database cert file: %w", err)
 	}
-	if len(cert) > 0 { // #nosec G402
+	if len(cert) > 0 {
 		caCertPool := x509.NewCertPool()
-		caCertPool.AppendCertsFromPEM(cert)
-		config.ConnConfig.TLSConfig = &tls.Config{
-			RootCAs:            caCertPool,
-			InsecureSkipVerify: true, // #nosec G402
+		if !caCertPool.AppendCertsFromPEM(cert) {
+			return nil, fmt.Errorf("failed to parse postgres CA certificate")
 		}
+		if config.ConnConfig.TLSConfig == nil {
+			config.ConnConfig.TLSConfig = &tls.Config{
+				MinVersion: tls.VersionTLS12,
+			}
+		}
+		config.ConnConfig.TLSConfig.RootCAs = caCertPool
 	}
 
 	if size > 0 {

--- a/pkg/database/pgx_conn_test.go
+++ b/pkg/database/pgx_conn_test.go
@@ -1,0 +1,39 @@
+package database
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetPostgresConfig_CA(t *testing.T) {
+	uri := "postgres://user:pass@localhost:5432/hoh?sslmode=require"
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1), Subject: pkix.Name{CommonName: "postgres-ca"},
+		NotBefore: time.Now().Add(-time.Hour), NotAfter: time.Now().Add(time.Hour),
+		IsCA: true, BasicConstraintsValid: true, KeyUsage: x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+
+	cfg, err := GetPostgresConfig(uri, caPEM)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.TLSConfig)
+	assert.NotNil(t, cfg.TLSConfig.RootCAs)
+
+	_, err = GetPostgresConfig(uri, []byte("not-a-pem"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse postgres CA certificate")
+}

--- a/pkg/transport/config/saram_config.go
+++ b/pkg/transport/config/saram_config.go
@@ -3,6 +3,8 @@ package config
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -11,6 +13,10 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
+
+const errClientCertKeyMismatch = "client certificate and key must be provided together"
+
+var errTLSClientCredentialsRequired = errors.New("client certificate and key are required when TLS is enabled")
 
 func GetSaramaConfig(kafkaConfig *transport.KafkaInternalConfig) (*sarama.Config, error) {
 	saramaConfig := sarama.NewConfig()
@@ -30,32 +36,34 @@ func GetSaramaConfig(kafkaConfig *transport.KafkaInternalConfig) (*sarama.Config
 }
 
 func NewTLSConfig(clientCertFile, clientKeyFile, caCertFile string) (*tls.Config, error) {
-	// #nosec G402
-	tlsConfig := tls.Config{}
-
-	// Load client cert
 	_, validCert := utils.Validate(clientCertFile)
 	_, validKey := utils.Validate(clientKeyFile)
-	if validCert && validKey {
-		cert, err := tls.LoadX509KeyPair(clientCertFile, clientKeyFile)
-		if err != nil {
-			return &tlsConfig, err
-		}
-		tlsConfig.Certificates = []tls.Certificate{cert}
-	} else {
-		// #nosec
-		tlsConfig.InsecureSkipVerify = true
+	if validCert != validKey {
+		return nil, fmt.Errorf("%s", errClientCertKeyMismatch)
+	}
+	if !validCert || !validKey {
+		return nil, errTLSClientCredentialsRequired
 	}
 
-	// Load CA cert
+	cert, err := tls.LoadX509KeyPair(clientCertFile, clientKeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load client certificate: %w", err)
+	}
+
 	caCert, err := os.ReadFile(filepath.Clean(caCertFile))
 	if err != nil {
-		return &tlsConfig, err
+		return nil, fmt.Errorf("failed to read CA certificate: %w", err)
 	}
 	caCertPool := x509.NewCertPool()
-	caCertPool.AppendCertsFromPEM(caCert)
-	tlsConfig.RootCAs = caCertPool
+	if !caCertPool.AppendCertsFromPEM(caCert) {
+		return nil, errors.New("failed to parse CA certificate")
+	}
 
-	tlsConfig.BuildNameToCertificate()
-	return &tlsConfig, err
+	tlsConfig := &tls.Config{
+		MinVersion:   tls.VersionTLS12,
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      caCertPool,
+	}
+
+	return tlsConfig, nil
 }

--- a/pkg/transport/config/saram_config_test.go
+++ b/pkg/transport/config/saram_config_test.go
@@ -1,0 +1,55 @@
+package config
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewTLSConfig(t *testing.T) {
+	dir := t.TempDir()
+
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	caTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1), Subject: pkix.Name{CommonName: "test-ca"},
+		NotBefore: time.Now().Add(-time.Hour), NotAfter: time.Now().Add(time.Hour),
+		IsCA: true, BasicConstraintsValid: true, KeyUsage: x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	clientKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	clientTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2), Subject: pkix.Name{CommonName: "test-client"},
+		NotBefore: time.Now().Add(-time.Hour), NotAfter: time.Now().Add(time.Hour),
+		KeyUsage: x509.KeyUsageDigitalSignature, ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	clientDER, err := x509.CreateCertificate(rand.Reader, clientTmpl, caTmpl, &clientKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	certFile := filepath.Join(dir, "client.crt")
+	keyFile := filepath.Join(dir, "client.key")
+	caFile := filepath.Join(dir, "ca.crt")
+	require.NoError(t, os.WriteFile(certFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientDER}), 0o600))
+	require.NoError(t, os.WriteFile(keyFile, pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(clientKey)}), 0o600))
+	require.NoError(t, os.WriteFile(caFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER}), 0o600))
+
+	cfg, err := NewTLSConfig(certFile, keyFile, caFile)
+	require.NoError(t, err)
+	assert.Equal(t, uint16(tls.VersionTLS12), cfg.MinVersion)
+	assert.NotNil(t, cfg.RootCAs)
+	assert.False(t, cfg.InsecureSkipVerify)
+}


### PR DESCRIPTION
Fixes: [ACM-42338](https://redhat.atlassian.net/browse/ACM-42338), [ACM-42327](https://redhat.atlassian.net/browse/ACM-42327), [ACM-42324](https://redhat.atlassian.net/browse/ACM-42324), [ACM-41994](https://redhat.atlassian.net/browse/ACM-41994), [ACM-41866](https://redhat.atlassian.net/browse/ACM-41866)

## Summary

Harden TLS and Grafana configuration for **Global Hub 1.7** (`release-2.16`).

### CVEs addressed

| CVE | Jira | Area |
|-----|------|------|
| CVE-2026-75762 | ACM-42338, ACM-42327, ACM-42324 | TLS MITM — remove `InsecureSkipVerify` fallbacks for Kafka and Postgres |
| CVE-2026-77849 | ACM-41994 | Grafana — set stable random `admin_password` instead of default credentials |
| CVE-2026-80221 | ACM-41866 | Grafana — parse Postgres datasource URI without exposing credentials in errors |

### Changes

- **`pkg/transport/config/saram_config.go`** — Require client certificate/key and verify broker CA when Kafka TLS is enabled; no `InsecureSkipVerify` fallback.
- **`pkg/database/pgx_conn.go`** — Verify Postgres TLS using the configured CA; no `InsecureSkipVerify` when a CA is present.
- **`operator/pkg/config/multiclusterglobalhub_config.go`** — Add `GetGrafanaAdminPassword()` for a stable random Grafana admin password.
- **`operator/pkg/controllers/grafana/grafana_reconciler.go`** — Inject Grafana `admin_password`; parse Postgres connection URIs safely; set `sslmode=verify-full` on the Grafana Postgres datasource.

## Test plan

- [ ] `go build` passes for changed packages
- [ ] Hub operator deploys with TLS-enabled Kafka/Postgres configs
- [ ] Grafana installs with non-default admin password
- [ ] Postgres datasource errors do not log full connection URI/password

Made with [Cursor](https://cursor.com)

[ACM-42338]: https://redhat.atlassian.net/browse/ACM-42338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-42327]: https://redhat.atlassian.net/browse/ACM-42327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-42324]: https://redhat.atlassian.net/browse/ACM-42324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-41994]: https://redhat.atlassian.net/browse/ACM-41994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-41866]: https://redhat.atlassian.net/browse/ACM-41866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ