### PR TITLE
Harden TLS, Grafana credentials, and database error handling

### DIFF
--- a/operator/pkg/config/multiclusterglobalhub_config.go
+++ b/operator/pkg/config/multiclusterglobalhub_config.go
@@ -78,9 +78,10 @@ const (
 )
 
 var (
-	mghNamespacedName  = types.NamespacedName{}
-	oauthSessionSecret = ""
-	imageOverrides     = map[string]string{
+	mghNamespacedName    = types.NamespacedName{}
+	oauthSessionSecret   = ""
+	grafanaAdminPassword = ""
+	imageOverrides       = map[string]string{
 		GlobalHubAgentImageKey:      "quay.io/stolostron/multicluster-global-hub-agent:latest",
 		GlobalHubManagerImageKey:    "quay.io/stolostron/multicluster-global-hub-manager:latest",
 		OauthProxyImageKey:          "quay.io/stolostron/origin-oauth-proxy:4.9",
@@ -135,6 +136,28 @@ func GetOauthSessionSecret() (string, error) {
 		oauthSessionSecret = base64.StdEncoding.EncodeToString(b)
 	}
 	return oauthSessionSecret, nil
+}
+
+// GetGrafanaAdminPassword returns a stable random Grafana admin password for this operator process.
+// Grafana defaults to admin/admin when admin_password is unset in grafana.ini.
+func GetGrafanaAdminPassword() (string, error) {
+	if grafanaAdminPassword == "" {
+		b := make([]byte, 24)
+		_, err := rand.Read(b)
+		if err != nil {
+			return "", fmt.Errorf("failed to generate grafana admin password: %w", err)
+		}
+		grafanaAdminPassword = base64.StdEncoding.EncodeToString(b)
+	}
+	return grafanaAdminPassword, nil
+}
+
+// SeedGrafanaAdminPassword restores a previously persisted Grafana admin password, for example
+// from the merged grafana.ini secret after an operator restart.
+func SeedGrafanaAdminPassword(password string) {
+	if password != "" {
+		grafanaAdminPassword = password
+	}
 }
 
 var MGHPred = predicate.Funcs{

--- a/operator/pkg/config/multiclusterglobalhub_config_test.go
+++ b/operator/pkg/config/multiclusterglobalhub_config_test.go
@@ -127,6 +127,45 @@ func TestGetOauthSessionSecret(t *testing.T) {
 	}
 }
 
+// TestGetGrafanaAdminPassword verifies a stable generated Grafana admin password.
+func TestGetGrafanaAdminPassword(t *testing.T) {
+	previous := grafanaAdminPassword
+	grafanaAdminPassword = ""
+	t.Cleanup(func() {
+		grafanaAdminPassword = previous
+	})
+	password1, err := GetGrafanaAdminPassword()
+	if err != nil {
+		t.Fatalf("failed to get grafana admin password: %v", err)
+	}
+	password2, err := GetGrafanaAdminPassword()
+	if err != nil {
+		t.Fatalf("failed to get grafana admin password: %v", err)
+	}
+	if password1 == "" {
+		t.Fatalf("grafana admin password should not be empty")
+	}
+	if password1 != password2 {
+		t.Fatalf("grafana admin password is not consistent")
+	}
+}
+
+// TestSeedGrafanaAdminPassword verifies persisted Grafana admin passwords are reused.
+func TestSeedGrafanaAdminPassword(t *testing.T) {
+	previous := grafanaAdminPassword
+	t.Cleanup(func() {
+		grafanaAdminPassword = previous
+	})
+	SeedGrafanaAdminPassword("persisted-password")
+	password, err := GetGrafanaAdminPassword()
+	if err != nil {
+		t.Fatalf("failed to get grafana admin password: %v", err)
+	}
+	if password != "persisted-password" {
+		t.Fatal("seeded Grafana admin password should be reused")
+	}
+}
+
 func TestSetMulticlusterGlobalHubConfig(t *testing.T) {
 	oauthImage := "quay.io/testing/origin-oauth-proxy:4.9"
 	mghInstance := &globalhubv1alpha4.MulticlusterGlobalHub{

--- a/operator/pkg/controllers/grafana/grafana_reconciler.go
+++ b/operator/pkg/controllers/grafana/grafana_reconciler.go
@@ -114,6 +114,7 @@ type GrafanaReconciler struct {
 	scheme     *runtime.Scheme
 }
 
+// NewGrafanaReconciler constructs a GrafanaReconciler bound to the controller-runtime manager.
 func NewGrafanaReconciler(mgr ctrl.Manager, kubeClient kubernetes.Interface) *GrafanaReconciler {
 	return &GrafanaReconciler{
 		Manager:    mgr,
@@ -125,10 +126,12 @@ func NewGrafanaReconciler(mgr ctrl.Manager, kubeClient kubernetes.Interface) *Gr
 
 var grafanaController *GrafanaReconciler
 
+// IsResourceRemoved reports whether Grafana resources were cleaned up.
 func (r *GrafanaReconciler) IsResourceRemoved() bool {
 	return true
 }
 
+// StartController registers the Grafana controller when ACM and storage are ready.
 func StartController(initOption config.ControllerOption) (config.ControllerInterface, error) {
 	if grafanaController != nil {
 		return grafanaController, nil
@@ -387,6 +390,7 @@ func (r *GrafanaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	return ctrl.Result{}, nil
 }
 
+// logGrafanaIngressTLSProfile records the IngressController TLS profile used by the Grafana route.
 func (r *GrafanaReconciler) logGrafanaIngressTLSProfile(ctx context.Context) {
 	ingressCtx, ingressCancel := context.WithTimeout(ctx, 10*time.Second)
 	defer ingressCancel()
@@ -498,6 +502,32 @@ func (r *GrafanaReconciler) generateGrafanaIni(
 		}
 	}
 
+	existingMerged := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      mergedGrafanaIniName,
+			Namespace: configNamespace,
+		},
+	}
+	if err := r.client.Get(ctx, client.ObjectKeyFromObject(existingMerged), existingMerged); err != nil {
+		if !errors.IsNotFound(err) {
+			return false, fmt.Errorf("failed to get merged grafana.ini secret: %w", err)
+		}
+	} else {
+		pwd, pwdErr := adminPasswordFromGrafanaIni(existingMerged.Data[grafanaIniKey])
+		if pwdErr != nil {
+			return false, fmt.Errorf("failed to parse persisted grafana.ini: %w", pwdErr)
+		}
+		if pwd != "" {
+			config.SeedGrafanaAdminPassword(pwd)
+		}
+	}
+
+	mergedIni, err := injectGrafanaAdminPassword(mergedGrafanaIniSecret.Data[grafanaIniKey])
+	if err != nil {
+		return false, fmt.Errorf("failed to set grafana admin password: %w", err)
+	}
+	mergedGrafanaIniSecret.Data[grafanaIniKey] = mergedIni
+
 	if err = controllerutil.SetControllerReference(mgh, mergedGrafanaIniSecret, r.scheme); err != nil {
 		return false, err
 	}
@@ -569,11 +599,11 @@ func mergeGrafanaIni(defaultIni, customIni []byte) ([]byte, error) {
 	if len(customIni) == 0 {
 		return defaultIni, nil
 	}
-	defaultCfg, err := ini.Load(defaultIni)
+	defaultCfg, err := loadGrafanaIni(defaultIni)
 	if err != nil {
 		return nil, err
 	}
-	customCfg, err := ini.Load(customIni)
+	customCfg, err := loadGrafanaIni(customIni)
 	if err != nil {
 		return nil, err
 	}
@@ -740,22 +770,91 @@ func (r *GrafanaReconciler) GenerateGrafanaDataSourceSecret(
 	return false, nil
 }
 
-func GrafanaDataSource(databaseURI string, cert []byte, serviceAccountToken string) ([]byte, error) {
-	postgresURI := string(databaseURI)
-	objURI, err := url.Parse(postgresURI)
+type postgresConnectionParams struct {
+	host, user, password, database, sslMode string
+}
+
+// parsePostgresConnection extracts Grafana datasource fields from a PostgreSQL URI.
+// Parse errors use a fixed message so credentials in the URI cannot leak.
+func parsePostgresConnection(databaseURI string) (postgresConnectionParams, error) {
+	objURI, err := url.Parse(databaseURI)
 	if err != nil {
-		return nil, err
+		return postgresConnectionParams{}, fmt.Errorf("failed to parse postgres connection")
 	}
 	password, ok := objURI.User.Password()
 	if !ok {
-		return nil, fmt.Errorf("failed to get password from database_uri: %s", postgresURI)
+		return postgresConnectionParams{}, fmt.Errorf("postgres connection is missing a password")
 	}
-
-	// get the database from the objURI
 	database := "hoh"
 	paths := strings.Split(objURI.Path, "/")
-	if len(paths) > 1 {
+	if len(paths) > 1 && paths[1] != "" {
 		database = paths[1]
+	}
+	return postgresConnectionParams{
+		host:     objURI.Host,
+		user:     objURI.User.Username(),
+		password: password,
+		database: database,
+		sslMode:  objURI.Query().Get("sslmode"),
+	}, nil
+}
+
+// injectGrafanaAdminPassword writes a stable admin_password into grafana.ini.
+func injectGrafanaAdminPassword(grafanaIni []byte) ([]byte, error) {
+	adminPassword, err := config.GetGrafanaAdminPassword()
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := loadGrafanaIni(grafanaIni)
+	if err != nil {
+		return nil, err
+	}
+	sec, err := cfg.GetSection("security")
+	if err != nil {
+		sec, err = cfg.NewSection("security")
+		if err != nil {
+			return nil, fmt.Errorf("failed to create grafana security section: %w", err)
+		}
+	}
+	sec.Key("admin_password").SetValue(adminPassword)
+	var buf bytes.Buffer
+	if _, err = cfg.WriteTo(&buf); err != nil {
+		return nil, fmt.Errorf("failed to serialize grafana.ini: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// adminPasswordFromGrafanaIni reads a previously persisted Grafana admin_password.
+func adminPasswordFromGrafanaIni(grafanaIni []byte) (string, error) {
+	if len(grafanaIni) == 0 {
+		return "", nil
+	}
+	cfg, err := loadGrafanaIni(grafanaIni)
+	if err != nil {
+		return "", err
+	}
+	sec, err := cfg.GetSection("security")
+	if err != nil {
+		return "", nil
+	}
+	return sec.Key("admin_password").String(), nil
+}
+
+// loadGrafanaIni parses grafana.ini without wrapping parser errors, which can
+// include file contents such as admin_password.
+func loadGrafanaIni(data []byte) (*ini.File, error) {
+	cfg, err := ini.Load(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load grafana.ini")
+	}
+	return cfg, nil
+}
+
+// GrafanaDataSource builds the Grafana datasource secret payload for PostgreSQL and optional Prometheus.
+func GrafanaDataSource(databaseURI string, cert []byte, serviceAccountToken string) ([]byte, error) {
+	conn, err := parsePostgresConnection(databaseURI)
+	if err != nil {
+		return nil, err
 	}
 
 	postgresDS := &GrafanaDatasource{
@@ -763,16 +862,16 @@ func GrafanaDataSource(databaseURI string, cert []byte, serviceAccountToken stri
 		Type:      "postgres",
 		Access:    "proxy",
 		IsDefault: true,
-		URL:       objURI.Host,
-		User:      objURI.User.Username(),
+		URL:       conn.host,
+		User:      conn.user,
 		Editable:  false,
 		JSONData: &JsonData{
-			Database:     database,
+			Database:     conn.database,
 			QueryTimeout: "300s",
 			TimeInterval: "30s",
 		},
 		SecureJSONData: &SecureJsonData{
-			Password: password,
+			Password: conn.password,
 		},
 	}
 	datasource := []*GrafanaDatasource{postgresDS}
@@ -800,10 +899,17 @@ func GrafanaDataSource(databaseURI string, cert []byte, serviceAccountToken stri
 	}
 
 	if len(cert) > 0 {
-		postgresDS.JSONData.SSLMode = objURI.Query().Get("sslmode") // sslmode == "verify-full" || sslmode == "verify-ca"
+		switch conn.sslMode {
+		case "verify-ca", "verify-full":
+		default:
+			return nil, fmt.Errorf(
+				"postgres sslmode must be verify-ca or verify-full when CA certificate is configured",
+			)
+		}
+		postgresDS.JSONData.SSLMode = conn.sslMode // sslmode == "verify-full" || sslmode == "verify-ca"
 		postgresDS.JSONData.TLSAuth = true
 		postgresDS.JSONData.TLSAuthWithCACert = true
-		postgresDS.JSONData.TLSSkipVerify = true
+		postgresDS.JSONData.TLSSkipVerify = false
 		postgresDS.JSONData.TLSConfigurationMethod = "file-content"
 		postgresDS.SecureJSONData.TLSCACert = string(cert)
 	}

--- a/operator/pkg/controllers/grafana/grafana_reconciler_test.go
+++ b/operator/pkg/controllers/grafana/grafana_reconciler_test.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 	"gopkg.in/ini.v1"
+	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -620,8 +621,120 @@ email = example@redhat.com
 			if sectionCount(tt.wantSecret.Data[grafanaIniKey]) == -1 || (sectionCount(mergedGrafanaIniSecret.Data[grafanaIniKey]) != sectionCount(tt.wantSecret.Data[grafanaIniKey])) {
 				t.Errorf("mergeGrafanaIni() = %v, want %v", sectionCount(mergedGrafanaIniSecret.Data[grafanaIniKey]), sectionCount(tt.wantSecret.Data[grafanaIniKey]))
 			}
+
+			// F003: generateGrafanaIni must inject a random admin password into grafana.ini.
+			iniCfg, err := ini.Load(mergedGrafanaIniSecret.Data[grafanaIniKey])
+			require.NoError(t, err, "merged grafana.ini must remain valid INI after reconciliation")
+			sec, err := iniCfg.GetSection("security")
+			require.NoError(t, err, "merged grafana.ini must retain a security section")
+			assert.NotEmpty(t, sec.Key("admin_password").String(),
+				"Grafana admin_password must be injected instead of default admin/admin")
 		})
 	}
+}
+
+func defaultGrafanaIniSecretForTest(namespace string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      defaultGrafanaIniName,
+			Labels: map[string]string{
+				"name": "multicluster-global-hub-grafana",
+			},
+		},
+		Data: map[string][]byte{
+			grafanaIniKey: []byte("[security]\nadmin_user = admin\n[server]\nhttp_port = 3001\n"),
+		},
+	}
+}
+
+// TestGenerateGrafanaIniPersistedSecretErrors verifies secret lookup failures do not mint a new password.
+func TestGenerateGrafanaIniPersistedSecretErrors(t *testing.T) {
+	configNamespace := utils.GetDefaultNamespace()
+	mgh := &v1alpha4.MulticlusterGlobalHub{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: configNamespace,
+		},
+		Spec: v1alpha4.MulticlusterGlobalHubSpec{},
+	}
+
+	t.Run("merged secret lookup failure", func(t *testing.T) {
+		require.NoError(t, v1alpha4.AddToScheme(scheme.Scheme),
+			"operator scheme registration must succeed before fake client setup")
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme.Scheme).
+			WithRuntimeObjects(defaultGrafanaIniSecretForTest(configNamespace)).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Get: func(
+					ctx context.Context,
+					c client.WithWatch,
+					key client.ObjectKey,
+					obj client.Object,
+					opts ...client.GetOption,
+				) error {
+					if key.Name == mergedGrafanaIniName {
+						return fmt.Errorf("simulated merged grafana.ini lookup failure")
+					}
+					return c.Get(ctx, key, obj, opts...)
+				},
+			}).
+			Build()
+
+		r := &GrafanaReconciler{
+			client: fakeClient,
+			scheme: scheme.Scheme,
+		}
+
+		_, err := r.generateGrafanaIni(context.Background(), mgh)
+		require.Error(t, err, "merged grafana.ini lookup failures must abort reconciliation")
+		assert.Contains(t, err.Error(), "failed to get merged grafana.ini secret",
+			"lookup failures must identify the persisted Grafana secret")
+	})
+
+	t.Run("invalid persisted grafana.ini", func(t *testing.T) {
+		require.NoError(t, v1alpha4.AddToScheme(scheme.Scheme),
+			"operator scheme registration must succeed before fake client setup")
+		existingMerged := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: configNamespace,
+				Name:      mergedGrafanaIniName,
+			},
+			Data: map[string][]byte{
+				grafanaIniKey: []byte("[security]\nadmin_password = leaked-secret\n[[[broken"),
+			},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme.Scheme).
+			WithRuntimeObjects(
+				defaultGrafanaIniSecretForTest(configNamespace),
+				existingMerged,
+			).
+			Build()
+
+		r := &GrafanaReconciler{
+			client: fakeClient,
+			scheme: scheme.Scheme,
+		}
+
+		_, err := r.generateGrafanaIni(context.Background(), mgh)
+		require.Error(t, err, "invalid persisted grafana.ini must abort reconciliation")
+		assert.Contains(t, err.Error(), "failed to parse persisted grafana.ini",
+			"persisted INI parse failures must not rotate the Grafana admin password")
+		assert.NotContains(t, err.Error(), "leaked-secret",
+			"INI parse errors must not include grafana.ini contents")
+		assert.NotContains(t, err.Error(), "[[[broken",
+			"INI parse errors must not include parser details from grafana.ini")
+
+		unchanged := &corev1.Secret{}
+		require.NoError(t, fakeClient.Get(
+			context.Background(),
+			client.ObjectKeyFromObject(existingMerged),
+			unchanged,
+		), "failed reconciliation must still leave the persisted grafana.ini secret readable")
+		assert.Equal(t, existingMerged.Data[grafanaIniKey], unchanged.Data[grafanaIniKey],
+			"failed reconciliation must not overwrite the persisted grafana.ini secret")
+	})
 }
 
 func TestMergeGrafanaIni(t *testing.T) {
@@ -1037,4 +1150,190 @@ func sectionCount(a []byte) int {
 	}
 	// By Default, There is a DEFAULT section, should not count it
 	return len(cfg.Sections()) - 1
+}
+
+// TestAdminPasswordFromGrafanaIni verifies persisted password restore and INI error redaction.
+func TestAdminPasswordFromGrafanaIni(t *testing.T) {
+	t.Run("reads persisted password", func(t *testing.T) {
+		password, err := adminPasswordFromGrafanaIni([]byte("[security]\nadmin_password = cached\n"))
+		require.NoError(t, err, "valid persisted grafana.ini must parse")
+		assert.Equal(t, "cached", password, "persisted Grafana admin password must be restored")
+	})
+
+	t.Run("invalid ini", func(t *testing.T) {
+		_, err := adminPasswordFromGrafanaIni([]byte("[security]\nadmin_password = leaked-secret\n[[[broken"))
+		require.Error(t, err, "invalid persisted grafana.ini must be rejected")
+		assert.Equal(t, "failed to load grafana.ini", err.Error(),
+			"INI parse failures must use a fixed message without parser details")
+		assert.NotContains(t, err.Error(), "leaked-secret",
+			"INI parse errors must not include grafana.ini contents")
+	})
+}
+
+// TestInjectGrafanaAdminPassword verifies admin_password injection and INI error redaction.
+func TestInjectGrafanaAdminPassword(t *testing.T) {
+	t.Run("sets password in existing security section", func(t *testing.T) {
+		merged, err := injectGrafanaAdminPassword([]byte("[security]\nadmin_user = admin\n"))
+		require.NoError(t, err, "valid grafana.ini must accept admin password injection")
+
+		cfg, err := ini.Load(merged)
+		require.NoError(t, err, "injected grafana.ini must remain valid INI")
+
+		sec, err := cfg.GetSection("security")
+		require.NoError(t, err, "injected grafana.ini must keep a security section")
+		assert.NotEmpty(t, sec.Key("admin_password").String(),
+			"Grafana admin_password must be injected into an existing security section")
+	})
+
+	t.Run("creates security section when missing", func(t *testing.T) {
+		merged, err := injectGrafanaAdminPassword([]byte("[server]\nhttp_port = 3001\n"))
+		require.NoError(t, err, "grafana.ini without security must accept admin password injection")
+
+		cfg, err := ini.Load(merged)
+		require.NoError(t, err, "injected grafana.ini must remain valid INI")
+
+		sec, err := cfg.GetSection("security")
+		require.NoError(t, err, "injection must create a security section")
+		assert.NotEmpty(t, sec.Key("admin_password").String(),
+			"Grafana admin_password must be injected when the security section is missing")
+	})
+
+	t.Run("invalid ini does not leak contents", func(t *testing.T) {
+		_, err := injectGrafanaAdminPassword([]byte("[security]\nadmin_password = leaked-secret\n[[[broken"))
+		require.Error(t, err, "invalid grafana.ini must be rejected before password injection")
+		assert.Equal(t, "failed to load grafana.ini", err.Error(),
+			"INI parse failures must use a fixed message without parser details")
+		assert.NotContains(t, err.Error(), "leaked-secret",
+			"INI parse errors must not include grafana.ini contents")
+	})
+}
+
+// F004: postgres connection parsing must not echo credentials in errors.
+func TestParsePostgresConnection(t *testing.T) {
+	tests := []struct {
+		name    string
+		uri     string
+		want    postgresConnectionParams
+		wantErr bool
+	}{
+		{
+			name: "valid uri",
+			uri:  "postgresql://grafana:secret@pg.example:5432/mydb?sslmode=verify-full",
+			want: postgresConnectionParams{
+				host: "pg.example:5432", user: "grafana", password: "secret",
+				database: "mydb", sslMode: "verify-full",
+			},
+		},
+		{
+			name: "default database",
+			uri:  "postgresql://grafana:secret@pg.example:5432",
+			want: postgresConnectionParams{
+				host: "pg.example:5432", user: "grafana", password: "secret", database: "hoh",
+			},
+		},
+		{
+			name: "trailing slash keeps default database",
+			uri:  "postgresql://grafana:secret@pg.example:5432/",
+			want: postgresConnectionParams{
+				host: "pg.example:5432", user: "grafana", password: "secret", database: "hoh",
+			},
+		},
+		{
+			name:    "missing password",
+			uri:     "postgresql://grafana@pg.example:5432/mydb",
+			wantErr: true,
+		},
+		{
+			name:    "invalid uri",
+			uri:     "://bad-uri",
+			wantErr: true,
+		},
+		{
+			name:    "malformed uri with password",
+			uri:     "postgresql://grafana:secret-password%zz@db.example:5432/hoh",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parsePostgresConnection(tt.uri)
+			if tt.wantErr {
+				require.Error(t, err, "invalid postgres URI %q must be rejected", tt.name)
+				assert.NotContains(t, err.Error(), "postgresql://",
+					"parse errors must not expose the raw PostgreSQL URI")
+				assert.NotContains(t, err.Error(), "secret-password",
+					"parse errors must not expose the PostgreSQL password")
+				return
+			}
+			require.NoError(t, err, "valid postgres URI %q must parse", tt.name)
+			assert.Equal(t, tt.want, got, "parsed postgres connection fields must match")
+		})
+	}
+}
+
+// F002: Grafana Postgres datasource must verify TLS when a CA cert is configured.
+func TestGrafanaDataSource(t *testing.T) {
+	uri := "postgresql://grafana:secret@pg.example:5432/mydb?sslmode=verify-full"
+
+	t.Run("without cert", func(t *testing.T) {
+		raw, err := GrafanaDataSource(uri, nil, "")
+		require.NoError(t, err, "datasource generation without CA must succeed")
+
+		var datasources GrafanaDatasources
+		require.NoError(t, yaml.Unmarshal(raw, &datasources), "datasource YAML must unmarshal")
+		require.Len(t, datasources.Datasources, 1, "postgres datasource must be present")
+		assert.Equal(t, "Global-Hub-DataSource", datasources.Datasources[0].Name,
+			"postgres datasource name must match")
+		require.NotNil(t, datasources.Datasources[0].JSONData, "postgres JSONData must be set")
+		assert.Equal(t, "mydb", datasources.Datasources[0].JSONData.Database,
+			"postgres database name must come from the URI")
+	})
+
+	t.Run("with cert", func(t *testing.T) {
+		raw, err := GrafanaDataSource(uri, []byte("ca-cert"), "")
+		require.NoError(t, err, "datasource generation with CA must succeed")
+
+		var datasources GrafanaDatasources
+		require.NoError(t, yaml.Unmarshal(raw, &datasources), "datasource YAML must unmarshal")
+		require.Len(t, datasources.Datasources, 1, "postgres datasource must be present")
+
+		ds := datasources.Datasources[0]
+		require.NotNil(t, ds.JSONData, "postgres JSONData must be set")
+		assert.Equal(t, "verify-full", ds.JSONData.SSLMode,
+			"CA-backed datasource must keep a verifying sslmode")
+		assert.True(t, ds.JSONData.TLSAuth, "CA-backed datasource must enable TLS auth")
+		assert.True(t, ds.JSONData.TLSAuthWithCACert, "CA-backed datasource must attach the CA cert")
+		assert.False(t, ds.JSONData.TLSSkipVerify, "CA-backed datasource must not skip TLS verify")
+		assert.NotEmpty(t, ds.SecureJSONData.TLSCACert, "CA-backed datasource must store the CA cert")
+	})
+
+	t.Run("with cert rejects require sslmode", func(t *testing.T) {
+		uriRequire := "postgresql://grafana:secret@pg.example:5432/mydb?sslmode=require"
+		_, err := GrafanaDataSource(uriRequire, []byte("ca-cert"), "")
+		require.Error(t, err, "sslmode=require must be rejected when a CA certificate is configured")
+		assert.Contains(t, err.Error(), "verify-ca or verify-full",
+			"the error must require a certificate-verifying sslmode")
+	})
+
+	t.Run("with cert rejects disable sslmode", func(t *testing.T) {
+		uriDisable := "postgresql://grafana:secret@pg.example:5432/mydb?sslmode=disable"
+		_, err := GrafanaDataSource(uriDisable, []byte("ca-cert"), "")
+		require.Error(t, err, "sslmode=disable must be rejected when a CA certificate is configured")
+		assert.Contains(t, err.Error(), "verify-ca or verify-full",
+			"the error must require a certificate-verifying sslmode")
+	})
+
+	t.Run("with service account token", func(t *testing.T) {
+		raw, err := GrafanaDataSource(uri, nil, "token")
+		require.NoError(t, err, "datasource generation with a service account token must succeed")
+
+		var datasources GrafanaDatasources
+		require.NoError(t, yaml.Unmarshal(raw, &datasources), "datasource YAML must unmarshal")
+		require.Len(t, datasources.Datasources, 2, "prometheus datasource must be appended")
+		assert.Equal(t, "Prometheus", datasources.Datasources[1].Name,
+			"second datasource must be Prometheus")
+		assert.Equal(t, "Bearer token", datasources.Datasources[1].SecureJSONData.HttpHeaderValue1,
+			"prometheus datasource must use the bearer token header")
+	})
 }

--- a/operator/pkg/controllers/inventory/inventory_reconciler.go
+++ b/operator/pkg/controllers/inventory/inventory_reconciler.go
@@ -199,14 +199,14 @@ func (r *InventoryReconciler) Reconcile(ctx context.Context,
 		return ctrl.Result{}, reconcileErr
 	}
 
-	postgresURI, err := url.Parse(string(storageConn.SuperuserDatabaseURI))
+	postgresURI, err := parsePostgresURI(string(storageConn.SuperuserDatabaseURI))
 	if err != nil {
 		reconcileErr = err
 		return ctrl.Result{}, reconcileErr
 	}
-	postgresPassword, ok := postgresURI.User.Password()
-	if !ok {
-		reconcileErr = fmt.Errorf("failed to get password from database_uri: %s", postgresURI)
+	postgresPassword, err := postgresPasswordFromURI(postgresURI)
+	if err != nil {
+		reconcileErr = fmt.Errorf("failed to extract postgres password: %w", err)
 		return ctrl.Result{}, reconcileErr
 	}
 
@@ -361,4 +361,23 @@ func createUpdateInventoryRoute(ctx context.Context, c client.Client,
 	}
 
 	return nil
+}
+
+// parsePostgresURI parses a PostgreSQL URI without returning parser details that can include the password.
+func parsePostgresURI(raw string) (*url.URL, error) {
+	postgresURI, err := url.Parse(raw)
+	if err != nil {
+		// url.Parse errors include the raw URI, which can contain the password.
+		return nil, fmt.Errorf("failed to parse postgres connection")
+	}
+	return postgresURI, nil
+}
+
+// postgresPasswordFromURI returns the URI password without echoing the connection string on error.
+func postgresPasswordFromURI(postgresURI *url.URL) (string, error) {
+	password, ok := postgresURI.User.Password()
+	if !ok {
+		return "", fmt.Errorf("postgres connection is missing a password")
+	}
+	return password, nil
 }

--- a/operator/pkg/controllers/inventory/inventory_reconciler_test.go
+++ b/operator/pkg/controllers/inventory/inventory_reconciler_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inventory
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// F004: database credentials must not appear in error messages.
+func TestPostgresPasswordFromURI(t *testing.T) {
+	t.Run("valid uri", func(t *testing.T) {
+		uri, err := url.Parse("postgresql://inventory:secret@postgres.example:5432/hoh")
+		require.NoError(t, err, "test URI must parse for password extraction coverage")
+
+		password, err := postgresPasswordFromURI(uri)
+		require.NoError(t, err, "valid inventory URI must yield a postgres password")
+		assert.Equal(t, "secret", password, "postgres password must match the URI credential")
+	})
+
+	t.Run("missing password does not leak connection string", func(t *testing.T) {
+		uri, err := url.Parse("postgresql://inventory@postgres.example:5432/hoh")
+		require.NoError(t, err, "test URI must parse for missing-password coverage")
+
+		_, err = postgresPasswordFromURI(uri)
+		require.Error(t, err, "inventory URI without a password must be rejected")
+		assert.Equal(t, "postgres connection is missing a password", err.Error(),
+			"missing-password errors must use a stable message")
+		assert.NotContains(t, err.Error(), "postgresql://",
+			"postgres errors must not echo the raw connection URI")
+		assert.NotContains(t, err.Error(), "inventory@",
+			"postgres errors must not echo the database username")
+	})
+}
+
+// TestParsePostgresURI verifies URI parse failures do not leak credentials.
+func TestParsePostgresURI(t *testing.T) {
+	t.Run("valid uri", func(t *testing.T) {
+		uri, err := parsePostgresURI("postgresql://inventory:secret@postgres.example:5432/hoh")
+		require.NoError(t, err, "valid inventory URI must parse")
+		require.NotNil(t, uri, "parsed inventory URI must be returned")
+		assert.Equal(t, "postgres.example:5432", uri.Host,
+			"parsed inventory URI host must match")
+	})
+
+	t.Run("malformed uri with percent-escaped password does not leak credentials", func(t *testing.T) {
+		const sentinel = "secret-password"
+		raw := "postgresql://inventory:" + sentinel + "%zz@postgres.example:5432/hoh"
+
+		_, err := parsePostgresURI(raw)
+		require.Error(t, err, "malformed inventory URI must be rejected")
+		assert.Equal(t, "failed to parse postgres connection", err.Error(),
+			"parse errors must use a fixed message")
+		assert.NotContains(t, err.Error(), raw,
+			"parse errors must not echo the raw connection URI")
+		assert.NotContains(t, err.Error(), "postgresql://",
+			"parse errors must not echo the URI scheme")
+		assert.NotContains(t, err.Error(), sentinel,
+			"parse errors must not echo the postgres password")
+	})
+}
+
+// TestSpiceDBPostgresConfig verifies SpiceDB URI parse failures do not leak credentials.
+func TestSpiceDBPostgresConfig(t *testing.T) {
+	t.Run("valid uri", func(t *testing.T) {
+		cfg, err := spiceDBPostgresConfig("postgresql://inventory:secret@postgres.example:5432/hoh")
+		require.NoError(t, err, "valid spiceDB storage URI must parse")
+		require.NotNil(t, cfg, "parsed spiceDB postgres config must be returned")
+		assert.Equal(t, "inventory", cfg.User, "spiceDB postgres user must match the URI")
+		assert.Equal(t, "secret", cfg.Password, "spiceDB postgres password must match the URI")
+	})
+
+	t.Run("malformed uri with percent-escaped password does not leak credentials", func(t *testing.T) {
+		const sentinel = "secret-password"
+		raw := "postgresql://inventory:" + sentinel + "%zz@postgres.example:5432/hoh"
+
+		_, err := spiceDBPostgresConfig(raw)
+		require.Error(t, err, "malformed spiceDB storage URI must be rejected")
+		assert.Equal(t, "failed to parse database uri", err.Error(),
+			"parse errors must use a fixed message")
+		assert.NotContains(t, err.Error(), raw,
+			"parse errors must not echo the raw connection URI")
+		assert.NotContains(t, err.Error(), "postgresql://",
+			"parse errors must not echo the URI scheme")
+		assert.NotContains(t, err.Error(), sentinel,
+			"parse errors must not echo the postgres password")
+	})
+}

--- a/operator/pkg/controllers/inventory/spicedb_controller.go
+++ b/operator/pkg/controllers/inventory/spicedb_controller.go
@@ -182,15 +182,12 @@ func (r *spiceDBClusterReconciler) reconcileStorageSecret(ctx context.Context,
 	pgConn *config.PostgresConnection,
 	mgh *v1alpha4.MulticlusterGlobalHub,
 ) error {
-	pgConfig, err := pgx.ParseConfig(pgConn.SuperuserDatabaseURI)
+	pgConfig, err := spiceDBPostgresConfig(pgConn.SuperuserDatabaseURI)
 	if err != nil {
-		return fmt.Errorf("failed to parse database uri: %w", err)
+		return fmt.Errorf("failed to parse spicedb database uri: %w", err)
 	}
 
-	// Refer https://github.com/authzed/spicedb-operator/blob/main/examples/cockroachdb-tls-ingress/spicedb/spicedb.yaml
-	// TODO: Currently using the 'disable' method to establish the connection.
-	// Other methods have not been validated. GH itself uses `required-ca`,
-	// so we might need to update both to support `verify-full`.
+	// See authzed/spicedb-operator cockroachdb-tls-ingress example for datastore URI shape.
 	pgURI := fmt.Sprintf(
 		"postgres://%s:%s@%s:%d/%s?sslmode=%s",
 		url.QueryEscape(pgConfig.User),
@@ -234,6 +231,15 @@ func (r *spiceDBClusterReconciler) reconcileStorageSecret(ctx context.Context,
 		}
 	}
 	return nil
+}
+
+// spiceDBPostgresConfig parses the storage URI without exposing credentials in parse errors.
+func spiceDBPostgresConfig(databaseURI string) (*pgx.ConnConfig, error) {
+	pgConfig, err := pgx.ParseConfig(databaseURI)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse database uri")
+	}
+	return pgConfig, nil
 }
 
 func (r *spiceDBClusterReconciler) reconcileSpiceDBCluster(ctx context.Context,

--- a/operator/pkg/controllers/storage/storage_reconciler.go
+++ b/operator/pkg/controllers/storage/storage_reconciler.go
@@ -41,12 +41,14 @@ import (
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;delete;patch
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups="apps",resources=deployments,verbs=get;list;watch;create;update;delete
-// +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors;prometheusrules,verbs=get;create;delete;update;list;watch
+// +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;create;delete;update;list;watch
+// +kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules,verbs=get;create;delete;update;list;watch
 // +kubebuilder:rbac:groups="apps",resources=statefulsets,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;create;update;delete;patch
 // +kubebuilder:rbac:groups=postgres-operator.crunchydata.com,resources=postgresclusters,verbs=get;create;list;watch
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;delete
-// +kubebuilder:rbac:groups=olm.operatorframework.io,resources=clusterextensions,verbs=get;create;list;watch;patch;delete
+// +kubebuilder:rbac:groups=olm.operatorframework.io,resources=clusterextensions,verbs=get;list;watch
+// +kubebuilder:rbac:groups=olm.operatorframework.io,resources=clusterextensions,verbs=create;patch;delete
 // +kubebuilder:rbac:groups=olm.operatorframework.io,resources=clustercatalogs,verbs=get;list;watch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=get;create;delete
 
@@ -400,20 +402,19 @@ func (r *StorageReconciler) applyGlobalHubInitSQL(ctx context.Context, conn *pgx
 		}
 	}
 
-	objURI, err := url.Parse(readonlyUserURI)
+	readonlyUsername, err := readonlyUsernameFromURI(readonlyUserURI)
 	if err != nil {
-		log.Error(err, "failed to parse database_uri_with_readonlyuser")
+		return fmt.Errorf("failed to extract readonly username: %w", err)
 	}
-	readonlyUsername := objURI.User.Username()
 
 	if err = applySQL(ctx, conn, databaseFS, "database", readonlyUsername); err != nil {
-		return fmt.Errorf("failed to apply the database sql: %v", err)
+		return fmt.Errorf("failed to apply the database sql: %w", err)
 	}
 
 	if !r.upgrade {
 		err = applySQL(ctx, conn, upgradeFS, "upgrade", readonlyUsername)
 		if err != nil {
-			return fmt.Errorf("failed to apply the upgrade sql: %v", err)
+			return fmt.Errorf("failed to apply the upgrade sql: %w", err)
 		}
 		r.upgrade = true
 	}
@@ -505,4 +506,19 @@ func getDatabaseComponentStatus(ctx context.Context, c client.Client,
 type AnnotationPGUser struct {
 	Name      string   `json:"name"`
 	Databases []string `json:"databases"`
+}
+
+const errParseReadonlyUserURI = "failed to parse database_uri_with_readonlyuser"
+
+// readonlyUsernameFromURI extracts the username from a PostgreSQL URI when present.
+// Parser errors use a fixed message so the URI cannot leak credentials.
+func readonlyUsernameFromURI(readonlyUserURI string) (string, error) {
+	objURI, err := url.Parse(readonlyUserURI)
+	if err != nil {
+		return "", fmt.Errorf("%s", errParseReadonlyUserURI)
+	}
+	if objURI.User == nil {
+		return "", nil
+	}
+	return objURI.User.Username(), nil
 }

--- a/operator/pkg/controllers/storage/storage_reconciler_test.go
+++ b/operator/pkg/controllers/storage/storage_reconciler_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -357,4 +358,41 @@ func TestGeneratePassword(t *testing.T) {
 func TestIsResourceRemoved(t *testing.T) {
 	reconciler := &StorageReconciler{}
 	assert.True(t, reconciler.IsResourceRemoved())
+}
+
+// TestReadonlyUsernameFromURI verifies readonly URI parse failures do not leak credentials.
+func TestReadonlyUsernameFromURI(t *testing.T) {
+	t.Run("valid uri", func(t *testing.T) {
+		username, err := readonlyUsernameFromURI("postgresql://readonly:secret@postgres.example:5432/hoh")
+		require.NoError(t, err, "valid readonly URI must parse")
+		assert.Equal(t, "readonly", username, "readonly username must match the URI")
+	})
+
+	t.Run("malformed uri with percent-escaped password does not leak credentials", func(t *testing.T) {
+		const sentinel = "secret-password"
+		raw := "postgresql://readonly:" + sentinel + "%zz@postgres.example:5432/hoh"
+
+		_, err := readonlyUsernameFromURI(raw)
+		require.Error(t, err, "malformed readonly URI must be rejected")
+		assert.Equal(t, errParseReadonlyUserURI, err.Error(),
+			"parse errors must use a fixed message")
+		assert.NotContains(t, err.Error(), raw,
+			"parse errors must not echo the raw connection URI")
+		assert.NotContains(t, err.Error(), "postgresql://",
+			"parse errors must not echo the URI scheme")
+		assert.NotContains(t, err.Error(), sentinel,
+			"parse errors must not echo the postgres password")
+	})
+
+	t.Run("uri without userinfo returns empty username", func(t *testing.T) {
+		username, err := readonlyUsernameFromURI("postgresql://postgres.example:5432/hoh")
+		require.NoError(t, err, "readonly URI without userinfo must not fail database init")
+		assert.Empty(t, username, "missing userinfo should skip privileges.sql username substitution")
+	})
+
+	t.Run("uri with empty username returns empty username", func(t *testing.T) {
+		username, err := readonlyUsernameFromURI("postgresql://:secret@postgres.example:5432/hoh")
+		require.NoError(t, err, "readonly URI with empty username must not fail database init")
+		assert.Empty(t, username, "empty username should skip privileges.sql username substitution")
+	})
 }

--- a/pkg/database/gorm_conn.go
+++ b/pkg/database/gorm_conn.go
@@ -165,10 +165,12 @@ func CloseGorm(sqlConn *sql.DB) {
 	}
 }
 
+// completePostgres parses a PostgreSQL URI and attaches sslrootcert when sslmode is verify-ca.
+// Parser errors use a fixed message so the URI cannot leak credentials.
 func completePostgres(postgresUri string, caCertPath string) (*url.URL, error) {
 	urlObj, err := url.Parse(postgresUri)
 	if err != nil {
-		return nil, err
+		return nil, errParseDatabaseURI
 	}
 	// only support verify-ca or disable(for test)
 	query := urlObj.Query()

--- a/pkg/database/gorm_uri_test.go
+++ b/pkg/database/gorm_uri_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCompletePostgres verifies GORM URI parse failures do not leak credentials.
+func TestCompletePostgres(t *testing.T) {
+	t.Run("valid uri", func(t *testing.T) {
+		got, err := completePostgres("postgres://user:secret@localhost:5432/hoh?sslmode=disable", "")
+		require.NoError(t, err, "valid postgres URI must parse")
+		require.NotNil(t, got, "parsed postgres URI must be returned")
+		assert.Equal(t, "localhost:5432", got.Host, "parsed postgres host must match")
+	})
+
+	t.Run("malformed uri with percent-escaped password does not leak credentials", func(t *testing.T) {
+		const sentinel = "secret-password"
+		raw := "postgres://user:" + sentinel + "%zz@localhost:5432/hoh"
+
+		_, err := completePostgres(raw, "")
+		require.Error(t, err, "malformed postgres URI must be rejected")
+		assert.ErrorIs(t, err, errParseDatabaseURI,
+			"parse errors must use a fixed message")
+		assert.NotContains(t, err.Error(), raw,
+			"parse errors must not echo the raw connection URI")
+		assert.NotContains(t, err.Error(), "postgres://",
+			"parse errors must not echo the URI scheme")
+		assert.NotContains(t, err.Error(), sentinel,
+			"parse errors must not echo the postgres password")
+	})
+}

--- a/pkg/database/pgx_conn.go
+++ b/pkg/database/pgx_conn.go
@@ -4,20 +4,27 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
+	"net/url"
 	"os"
-	"strings"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-const errMessageFileNotFound = "no such file or directory"
+var (
+	errParseDatabaseURI           = errors.New("failed to parse database uri")
+	errPostgresCARequiresVerify   = errors.New("postgres CA requires sslmode verify-ca or verify-full")
+	errParsePostgresCACertificate = errors.New("failed to parse postgres CA certificate")
+)
 
+// PostgresConnection opens a PostgreSQL connection using the given URI and optional CA certificate.
 func PostgresConnection(ctx context.Context, URI string, cert []byte) (*pgx.Conn, error) {
 	return PostgresDBConn(ctx, URI, cert, "")
 }
 
+// PostgresDBConn opens a PostgreSQL connection, optionally overriding the database name.
 func PostgresDBConn(ctx context.Context, URI string, cert []byte, db string) (*pgx.Conn, error) {
 	config, err := GetPostgresConfig(URI, cert)
 	if err != nil {
@@ -35,56 +42,56 @@ func PostgresDBConn(ctx context.Context, URI string, cert []byte, db string) (*p
 	return conn, nil
 }
 
+// GetPostgresConfig parses a PostgreSQL URI and installs a CA pool when cert is provided.
+// Parser errors use a fixed message so the URI cannot leak credentials.
 func GetPostgresConfig(URI string, cert []byte) (*pgx.ConnConfig, error) {
 	config, err := pgx.ParseConfig(URI)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse database uri: %w", err)
+		return nil, errParseDatabaseURI
 	}
 	if len(cert) > 0 {
-		caCertPool := x509.NewCertPool()
-		if !caCertPool.AppendCertsFromPEM(cert) {
-			return nil, fmt.Errorf("failed to parse database CA certificate PEM")
+		if err := requireVerifyingPostgresSSLMode(postgresSSLModeFromURI(URI)); err != nil {
+			return nil, fmt.Errorf("failed to validate postgres sslmode: %w", err)
 		}
-		// Preserve existing TLSConfig settings from ParseConfig (ServerName, etc.)
-		// and only update RootCAs
-		if config.TLSConfig == nil {
-			config.TLSConfig = &tls.Config{
-				MinVersion: tls.VersionTLS12,
-			}
+		if err := applyPostgresCA(config, cert); err != nil {
+			return nil, fmt.Errorf("failed to apply postgres CA certificate: %w", err)
 		}
-		config.TLSConfig.RootCAs = caCertPool
 	}
 	return config, nil
 }
 
-// PostgresConnPool returns a new postgres connection pool. size < 0 means deafult size.
-func PostgresConnPool(ctx context.Context, databaseURI string, certPath string, size int32) (*pgxpool.Pool, error) {
+// postgresPoolConfig parses pool settings and CA material without opening a connection.
+func postgresPoolConfig(databaseURI string, certPath string, size int32) (*pgxpool.Config, error) {
 	config, err := pgxpool.ParseConfig(databaseURI)
 	if err != nil {
-		return nil, fmt.Errorf("unable to get postgres pool config: %w", err)
+		return nil, errParseDatabaseURI
 	}
 
-	cert, err := os.ReadFile(certPath) // #nosec G304
-	if err != nil && !strings.Contains(err.Error(), errMessageFileNotFound) {
-		return nil, fmt.Errorf("unable to read database cert file: %w", err)
-	}
-	if len(cert) > 0 {
-		caCertPool := x509.NewCertPool()
-		if !caCertPool.AppendCertsFromPEM(cert) {
-			return nil, fmt.Errorf("failed to parse database CA certificate PEM")
+	if certPath != "" {
+		cert, err := os.ReadFile(certPath) // #nosec G304
+		if err != nil {
+			return nil, fmt.Errorf("unable to read database cert file: %w", err)
 		}
-		// Preserve existing TLSConfig settings from ParseConfig (ServerName, etc.)
-		// and only update RootCAs
-		if config.ConnConfig.TLSConfig == nil {
-			config.ConnConfig.TLSConfig = &tls.Config{
-				MinVersion: tls.VersionTLS12,
-			}
+		if err := requireVerifyingPostgresSSLMode(postgresSSLModeFromURI(databaseURI)); err != nil {
+			return nil, fmt.Errorf("failed to validate postgres sslmode: %w", err)
 		}
-		config.ConnConfig.TLSConfig.RootCAs = caCertPool
+		if err := applyPostgresCA(config.ConnConfig, cert); err != nil {
+			return nil, fmt.Errorf("failed to apply postgres CA certificate: %w", err)
+		}
 	}
 
 	if size > 0 {
 		config.MaxConns = size
+	}
+
+	return config, nil
+}
+
+// PostgresConnPool returns a new postgres connection pool. size < 0 means default size.
+func PostgresConnPool(ctx context.Context, databaseURI string, certPath string, size int32) (*pgxpool.Pool, error) {
+	config, err := postgresPoolConfig(databaseURI, certPath, size)
+	if err != nil {
+		return nil, fmt.Errorf("failed to configure postgres connection pool: %w", err)
 	}
 
 	dbConnectionPool, err := pgxpool.NewWithConfig(ctx, config)
@@ -93,4 +100,60 @@ func PostgresConnPool(ctx context.Context, databaseURI string, certPath string, 
 	}
 
 	return dbConnectionPool, nil
+}
+
+// postgresSSLModeFromURI returns the URI sslmode, defaulting to prefer when unset.
+func postgresSSLModeFromURI(databaseURI string) string {
+	parsed, err := url.Parse(databaseURI)
+	if err != nil {
+		return "prefer"
+	}
+	if mode := parsed.Query().Get("sslmode"); mode != "" {
+		return mode
+	}
+	return "prefer"
+}
+
+// requireVerifyingPostgresSSLMode rejects CA-backed connections that can skip verify or fall back to plaintext.
+func requireVerifyingPostgresSSLMode(sslmode string) error {
+	switch sslmode {
+	case "verify-ca", "verify-full":
+		return nil
+	default:
+		return errPostgresCARequiresVerify
+	}
+}
+
+// applyPostgresCA installs the CA on the primary TLS config and every pgx fallback.
+func applyPostgresCA(config *pgx.ConnConfig, cert []byte) error {
+	updated, err := postgresTLSConfigWithCA(config.TLSConfig, cert)
+	if err != nil {
+		return fmt.Errorf("failed to apply postgres CA to connection config: %w", err)
+	}
+	config.TLSConfig = updated
+	for _, fallback := range config.Fallbacks {
+		if fallback == nil {
+			continue
+		}
+		fallback.TLSConfig, err = postgresTLSConfigWithCA(fallback.TLSConfig, cert)
+		if err != nil {
+			return fmt.Errorf("failed to apply postgres CA to fallback connection config: %w", err)
+		}
+	}
+	return nil
+}
+
+// postgresTLSConfigWithCA installs RootCAs on the parsed TLS config, preserving ServerName and related settings.
+func postgresTLSConfigWithCA(existing *tls.Config, cert []byte) (*tls.Config, error) {
+	caCertPool := x509.NewCertPool()
+	if !caCertPool.AppendCertsFromPEM(cert) {
+		return nil, errParsePostgresCACertificate
+	}
+	if existing == nil {
+		existing = &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		}
+	}
+	existing.RootCAs = caCertPool
+	return existing, nil
 }

--- a/pkg/database/pgx_conn_test.go
+++ b/pkg/database/pgx_conn_test.go
@@ -3,137 +3,185 @@ package database
 import (
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"math/big"
-	"strings"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-const testPostgresURI = "postgres://user:pass@localhost:5432/db"
-
-const testPostgresURIRequireSSL = "postgres://user:pass@localhost:5432/db?sslmode=require"
-
-func TestGetPostgresConfigWithoutCert(t *testing.T) {
-	cfg, err := GetPostgresConfig(testPostgresURI, nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if cfg.TLSConfig != nil && cfg.TLSConfig.RootCAs != nil {
-		t.Fatal("expected no custom RootCAs without cert")
-	}
-}
-
-func TestGetPostgresConfigWithValidCA(t *testing.T) {
-	caPEM := generateTestCAPEM(t)
-
-	cfg, err := GetPostgresConfig(testPostgresURI, caPEM)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if cfg.TLSConfig == nil {
-		t.Fatal("expected TLSConfig to be set")
-	}
-	if cfg.TLSConfig.RootCAs == nil {
-		t.Fatal("expected RootCAs to be set")
-	}
-}
-
-func TestGetPostgresConfigSetsMinVersionWhenTLSUnset(t *testing.T) {
-	caPEM := generateTestCAPEM(t)
-
-	parsed, err := pgx.ParseConfig(testPostgresURI)
-	if err != nil {
-		t.Fatalf("failed to parse uri: %v", err)
-	}
-	if parsed.TLSConfig != nil {
-		t.Skip("pgx sets TLSConfig for this URI; MinVersion branch requires nil TLSConfig")
-	}
-
-	cfg, err := GetPostgresConfig(testPostgresURI, caPEM)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if cfg.TLSConfig == nil {
-		t.Fatal("expected TLSConfig to be set when CA is provided")
-	}
-	if cfg.TLSConfig.MinVersion != tls.VersionTLS12 {
-		t.Fatalf("expected MinVersion TLS 1.2, got %d", cfg.TLSConfig.MinVersion)
-	}
-}
-
-func TestGetPostgresConfigWithInvalidCA(t *testing.T) {
-	_, err := GetPostgresConfig(testPostgresURI, []byte("not-a-pem-cert"))
-	if err == nil {
-		t.Fatal("expected error for invalid CA PEM")
-	}
-	if !strings.Contains(err.Error(), "failed to parse database CA certificate PEM") {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func TestGetPostgresConfigPreservesExistingTLSConfig(t *testing.T) {
-	caPEM := generateTestCAPEM(t)
-
-	baseline, err := pgx.ParseConfig(testPostgresURIRequireSSL)
-	if err != nil {
-		t.Fatalf("failed to parse uri: %v", err)
-	}
-	if baseline.TLSConfig == nil {
-		t.Fatal("expected pgx to set TLSConfig for sslmode=require")
-	}
-	expectedServerName := baseline.TLSConfig.ServerName
-	expectedMinVersion := baseline.TLSConfig.MinVersion
-
-	cfg, err := GetPostgresConfig(testPostgresURIRequireSSL, caPEM)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if cfg.TLSConfig == nil || cfg.TLSConfig.RootCAs == nil {
-		t.Fatal("expected TLSConfig with RootCAs")
-	}
-	if cfg.TLSConfig.ServerName != expectedServerName {
-		t.Fatalf("expected ServerName %q, got %q", expectedServerName, cfg.TLSConfig.ServerName)
-	}
-	if cfg.TLSConfig.MinVersion != expectedMinVersion {
-		t.Fatalf("expected MinVersion %d, got %d", expectedMinVersion, cfg.TLSConfig.MinVersion)
-	}
-}
-
-func TestGetPostgresConfigInvalidURI(t *testing.T) {
-	_, err := GetPostgresConfig("not-a-valid-uri", nil)
-	if err == nil {
-		t.Fatal("expected error for invalid URI")
-	}
-	if !strings.Contains(err.Error(), "failed to parse database uri") {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func generateTestCAPEM(t *testing.T) []byte {
+// testCAPEM returns a self-signed CA PEM used by PostgreSQL TLS unit tests.
+func testCAPEM(t *testing.T) []byte {
 	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err, "test CA key generation must succeed")
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1), Subject: pkix.Name{CommonName: "postgres-ca"},
+		NotBefore: time.Now().Add(-time.Hour), NotAfter: time.Now().Add(time.Hour),
+		IsCA: true, BasicConstraintsValid: true, KeyUsage: x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err, "test CA certificate creation must succeed")
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
 
-	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		t.Fatalf("failed to generate CA key: %v", err)
-	}
-	caTemplate := &x509.Certificate{
-		SerialNumber:          big.NewInt(1),
-		Subject:               pkix.Name{CommonName: "test-ca"},
-		NotBefore:             time.Now().Add(-time.Hour),
-		NotAfter:              time.Now().Add(time.Hour),
-		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
-		BasicConstraintsValid: true,
-		IsCA:                  true,
-	}
-	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
-	if err != nil {
-		t.Fatalf("failed to create CA cert: %v", err)
-	}
-	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+// TestGetPostgresConfig verifies URI parsing, CA installation, and sslmode enforcement.
+func TestGetPostgresConfig(t *testing.T) {
+	uri := "postgres://user:pass@localhost:5432/hoh?sslmode=verify-full"
+	caPEM := testCAPEM(t)
+
+	t.Run("without cert leaves pgx defaults unchanged", func(t *testing.T) {
+		cfg, err := GetPostgresConfig("postgres://user:pass@localhost:5432/hoh?sslmode=require", nil)
+		require.NoError(t, err, "postgres config without a CA must parse")
+		if cfg.TLSConfig != nil {
+			assert.Nil(t, cfg.TLSConfig.RootCAs)
+		}
+	})
+
+	t.Run("with valid CA", func(t *testing.T) {
+		cfg, err := GetPostgresConfig(uri, caPEM)
+		require.NoError(t, err, "valid CA PEM must produce a postgres config")
+		require.NotNil(t, cfg.TLSConfig, "CA-backed postgres config must set TLSConfig")
+		assert.NotNil(t, cfg.TLSConfig.RootCAs, "CA-backed postgres config must install RootCAs")
+	})
+
+	t.Run("CA is installed on multi-host fallbacks", func(t *testing.T) {
+		multi := "postgres://user:pass@primary:5432,standby:5432/hoh?sslmode=verify-full"
+		cfg, err := GetPostgresConfig(multi, caPEM)
+		require.NoError(t, err, "multi-host URI with CA must parse")
+		require.NotNil(t, cfg.TLSConfig, "primary TLS config must be set")
+		assert.NotNil(t, cfg.TLSConfig.RootCAs, "primary TLS config must install RootCAs")
+		require.NotEmpty(t, cfg.Fallbacks, "multi-host URI must produce fallbacks")
+		for i, fb := range cfg.Fallbacks {
+			require.NotNil(t, fb, "fallback %d must not be nil", i)
+			require.NotNil(t, fb.TLSConfig, "fallback %d must have TLSConfig", i)
+			assert.NotNil(t, fb.TLSConfig.RootCAs, "fallback %d must install RootCAs", i)
+		}
+	})
+
+	t.Run("invalid CA PEM", func(t *testing.T) {
+		_, err := GetPostgresConfig(uri, []byte("not-a-pem"))
+		require.Error(t, err, "invalid CA PEM must be rejected")
+		assert.ErrorIs(t, err, errParsePostgresCACertificate,
+			"error should identify CA parsing failure")
+	})
+
+	t.Run("sslmode require with CA is rejected", func(t *testing.T) {
+		_, err := GetPostgresConfig("postgres://user:pass@localhost:5432/hoh?sslmode=require", caPEM)
+		require.Error(t, err, "CA-backed sslmode=require must be rejected")
+		assert.ErrorIs(t, err, errPostgresCARequiresVerify,
+			"CA-backed connections must require verify-ca or verify-full")
+	})
+
+	t.Run("sslmode prefer with CA is rejected", func(t *testing.T) {
+		_, err := GetPostgresConfig("postgres://user:pass@localhost:5432/hoh?sslmode=prefer", caPEM)
+		require.Error(t, err, "CA-backed sslmode=prefer must be rejected")
+		assert.ErrorIs(t, err, errPostgresCARequiresVerify,
+			"CA-backed connections must require verify-ca or verify-full")
+	})
+
+	t.Run("invalid URI", func(t *testing.T) {
+		_, err := GetPostgresConfig("://bad-uri", caPEM)
+		require.Error(t, err, "invalid postgres URI must be rejected")
+		assert.ErrorIs(t, err, errParseDatabaseURI,
+			"URI parse errors must use a fixed message")
+	})
+
+	t.Run("invalid URI does not leak password", func(t *testing.T) {
+		const sentinel = "secret-password"
+		_, err := GetPostgresConfig("postgres://user:"+sentinel+"%zz@localhost:5432/hoh", nil)
+		require.Error(t, err, "malformed postgres URI must be rejected")
+		assert.ErrorIs(t, err, errParseDatabaseURI,
+			"URI parse errors must use a fixed message")
+		assert.NotContains(t, err.Error(), sentinel,
+			"URI parse errors must not expose the postgres password")
+		assert.NotContains(t, err.Error(), "postgres://",
+			"URI parse errors must not expose the connection string")
+	})
+}
+
+// TestPostgresPoolConfig_CA verifies CA file handling and sslmode checks without opening a pool.
+func TestPostgresPoolConfig_CA(t *testing.T) {
+	uri := "postgres://user:pass@localhost:5432/hoh?sslmode=verify-full"
+	dir := t.TempDir()
+	caPath := filepath.Join(dir, "ca.crt")
+	require.NoError(t, os.WriteFile(caPath, testCAPEM(t), 0o600), "test CA file must be written")
+
+	t.Run("with valid CA file", func(t *testing.T) {
+		cfg, err := postgresPoolConfig(uri, caPath, 1)
+		require.NoError(t, err, "valid CA file must produce a pool config")
+		require.NotNil(t, cfg.ConnConfig.TLSConfig, "CA-backed pool config must set TLSConfig")
+		assert.NotNil(t, cfg.ConnConfig.TLSConfig.RootCAs, "CA-backed pool config must install RootCAs")
+		assert.Equal(t, int32(1), cfg.MaxConns, "requested pool size must be applied")
+	})
+
+	t.Run("CA is installed on multi-host fallbacks", func(t *testing.T) {
+		multi := "postgres://user:pass@primary:5432,standby:5432/hoh?sslmode=verify-full"
+		cfg, err := postgresPoolConfig(multi, caPath, 1)
+		require.NoError(t, err, "multi-host URI with CA must produce a pool config")
+		require.NotNil(t, cfg.ConnConfig.TLSConfig, "primary TLS config must be set")
+		assert.NotNil(t, cfg.ConnConfig.TLSConfig.RootCAs, "primary TLS config must install RootCAs")
+		require.NotEmpty(t, cfg.ConnConfig.Fallbacks, "multi-host URI must produce fallbacks")
+		for i, fb := range cfg.ConnConfig.Fallbacks {
+			require.NotNil(t, fb, "fallback %d must not be nil", i)
+			require.NotNil(t, fb.TLSConfig, "fallback %d must have TLSConfig", i)
+			assert.NotNil(t, fb.TLSConfig.RootCAs, "fallback %d must install RootCAs", i)
+		}
+	})
+
+	t.Run("invalid CA PEM", func(t *testing.T) {
+		badPath := filepath.Join(dir, "bad-ca.crt")
+		require.NoError(t, os.WriteFile(badPath, []byte("not-a-pem"), 0o600),
+			"invalid CA file must be written for coverage")
+		_, err := postgresPoolConfig(uri, badPath, 1)
+		require.Error(t, err, "invalid CA PEM must be rejected")
+		assert.ErrorIs(t, err, errParsePostgresCACertificate,
+			"error should identify CA parsing failure")
+	})
+
+	t.Run("missing configured cert file is rejected", func(t *testing.T) {
+		_, err := postgresPoolConfig(uri, filepath.Join(dir, "missing.crt"), 1)
+		require.Error(t, err, "a configured CA path that does not exist must fail closed")
+		assert.Contains(t, err.Error(), "unable to read database cert file",
+			"missing CA path errors must identify the cert-file read")
+	})
+
+	t.Run("empty cert path skips CA", func(t *testing.T) {
+		cfg, err := postgresPoolConfig(uri, "", 1)
+		require.NoError(t, err, "empty CA path should skip cert loading")
+		if cfg.ConnConfig.TLSConfig != nil {
+			assert.Nil(t, cfg.ConnConfig.TLSConfig.RootCAs,
+				"empty CA path must not install RootCAs")
+		}
+	})
+
+	t.Run("sslmode require with CA is rejected", func(t *testing.T) {
+		_, err := postgresPoolConfig("postgres://user:pass@localhost:5432/hoh?sslmode=require", caPath, 1)
+		require.Error(t, err, "CA-backed sslmode=require must be rejected")
+		assert.ErrorIs(t, err, errPostgresCARequiresVerify,
+			"CA-backed connections must require verify-ca or verify-full")
+	})
+
+	t.Run("sslmode prefer with CA is rejected", func(t *testing.T) {
+		_, err := postgresPoolConfig("postgres://user:pass@localhost:5432/hoh?sslmode=prefer", caPath, 1)
+		require.Error(t, err, "CA-backed sslmode=prefer must be rejected")
+		assert.ErrorIs(t, err, errPostgresCARequiresVerify,
+			"CA-backed connections must require verify-ca or verify-full")
+	})
+
+	t.Run("invalid URI does not leak password", func(t *testing.T) {
+		const sentinel = "secret-password"
+		_, err := postgresPoolConfig("postgres://user:"+sentinel+"%zz@localhost:5432/hoh", "", 1)
+		require.Error(t, err, "malformed postgres URI must be rejected")
+		assert.ErrorIs(t, err, errParseDatabaseURI,
+			"URI parse errors must use a fixed message")
+		assert.NotContains(t, err.Error(), sentinel,
+			"URI parse errors must not expose the postgres password")
+	})
 }

--- a/pkg/transport/config/saram_config.go
+++ b/pkg/transport/config/saram_config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -15,12 +16,14 @@ import (
 
 const errClientCertKeyMismatch = "client certificate and key must be provided together"
 
+var errTLSClientCredentialsRequired = errors.New("client certificate and key are required when TLS is enabled")
+
+// GetSaramaConfig builds a Sarama client config, requiring mTLS materials when TLS is enabled.
 func GetSaramaConfig(kafkaConfig *transport.KafkaInternalConfig) (*sarama.Config, error) {
 	saramaConfig := sarama.NewConfig()
 	saramaConfig.Version = sarama.V2_0_0_0
 
-	_, validCa := utils.Validate(kafkaConfig.CaCertPath)
-	if kafkaConfig.EnableTLS && validCa {
+	if kafkaConfig.EnableTLS {
 		var err error
 		saramaConfig.Net.TLS.Enable = true
 		saramaConfig.Net.TLS.Config, err = NewTLSConfig(kafkaConfig.ClientCertPath, kafkaConfig.ClientKeyPath,
@@ -32,36 +35,36 @@ func GetSaramaConfig(kafkaConfig *transport.KafkaInternalConfig) (*sarama.Config
 	return saramaConfig, nil
 }
 
+// NewTLSConfig loads client certificate, key, and CA materials for Kafka TLS.
 func NewTLSConfig(clientCertFile, clientKeyFile, caCertFile string) (*tls.Config, error) {
-	tlsConfig := tls.Config{
-		MinVersion: tls.VersionTLS12,
-	}
-
-	// Load client cert for mutual TLS (optional)
 	_, validCert := utils.Validate(clientCertFile)
 	_, validKey := utils.Validate(clientKeyFile)
 	if validCert != validKey {
-		return &tlsConfig, fmt.Errorf("%s", errClientCertKeyMismatch)
+		return nil, fmt.Errorf("%s", errClientCertKeyMismatch)
 	}
-	if validCert && validKey {
-		cert, err := tls.LoadX509KeyPair(clientCertFile, clientKeyFile)
-		if err != nil {
-			return &tlsConfig, fmt.Errorf("failed to load client certificate: %w", err)
-		}
-		tlsConfig.Certificates = []tls.Certificate{cert}
+	if !validCert || !validKey {
+		return nil, errTLSClientCredentialsRequired
 	}
 
-	// Load CA cert - this is required to verify the server
+	cert, err := tls.LoadX509KeyPair(clientCertFile, clientKeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load client certificate: %w", err)
+	}
+
 	caCert, err := os.ReadFile(filepath.Clean(caCertFile))
 	if err != nil {
-		return &tlsConfig, fmt.Errorf("failed to read CA certificate: %w", err)
+		return nil, fmt.Errorf("failed to read CA certificate: %w", err)
 	}
 	caCertPool := x509.NewCertPool()
 	if !caCertPool.AppendCertsFromPEM(caCert) {
-		return &tlsConfig, fmt.Errorf("failed to parse CA certificate")
+		return nil, errors.New("failed to parse CA certificate")
 	}
-	tlsConfig.RootCAs = caCertPool
 
-	tlsConfig.BuildNameToCertificate()
-	return &tlsConfig, nil
+	tlsConfig := &tls.Config{
+		MinVersion:   tls.VersionTLS12,
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      caCertPool,
+	}
+
+	return tlsConfig, nil
 }

--- a/pkg/transport/config/saram_config_test.go
+++ b/pkg/transport/config/saram_config_test.go
@@ -10,172 +10,169 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/stolostron/multicluster-global-hub/pkg/transport"
 )
 
-func TestNewTLSConfigMismatchedClientCertAndKey(t *testing.T) {
+type tlsTestMaterials struct {
+	certFile string
+	keyFile  string
+	caFile   string
+}
+
+// writeTLSTestMaterials writes temporary client and CA certificates for TLS tests.
+func writeTLSTestMaterials(t *testing.T) tlsTestMaterials {
+	t.Helper()
 	dir := t.TempDir()
-	certFile := filepath.Join(dir, "tls.crt")
-	keyFile := filepath.Join(dir, "tls.key")
+
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err, "test CA key generation must succeed")
+	caTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1), Subject: pkix.Name{CommonName: "test-ca"},
+		NotBefore: time.Now().Add(-time.Hour), NotAfter: time.Now().Add(time.Hour),
+		IsCA: true, BasicConstraintsValid: true, KeyUsage: x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	require.NoError(t, err, "test CA certificate creation must succeed")
+
+	clientKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err, "test client key generation must succeed")
+	clientTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2), Subject: pkix.Name{CommonName: "test-client"},
+		NotBefore: time.Now().Add(-time.Hour), NotAfter: time.Now().Add(time.Hour),
+		KeyUsage: x509.KeyUsageDigitalSignature, ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	clientDER, err := x509.CreateCertificate(rand.Reader, clientTmpl, caTmpl, &clientKey.PublicKey, caKey)
+	require.NoError(t, err, "test client certificate creation must succeed")
+
+	certFile := filepath.Join(dir, "client.crt")
+	keyFile := filepath.Join(dir, "client.key")
 	caFile := filepath.Join(dir, "ca.crt")
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientDER})
+	keyPEM := pem.EncodeToMemory(&pem.Block{
+		Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(clientKey),
+	})
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+	require.NoError(t, os.WriteFile(certFile, certPEM, 0o600), "client cert file must be written for mTLS test")
+	require.NoError(t, os.WriteFile(keyFile, keyPEM, 0o600), "client key file must be written for mTLS test")
+	require.NoError(t, os.WriteFile(caFile, caPEM, 0o600), "CA file must be written for broker verification test")
 
-	if err := os.WriteFile(certFile, []byte("cert"), 0o600); err != nil {
-		t.Fatalf("failed to write cert file: %v", err)
-	}
-	caPEM := []byte("-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----")
-	if err := os.WriteFile(caFile, caPEM, 0o600); err != nil {
-		t.Fatalf("failed to write ca file: %v", err)
+	return tlsTestMaterials{certFile: certFile, keyFile: keyFile, caFile: caFile}
+}
+
+// F002: Kafka TLS must verify server certificates and require client credentials.
+// TestNewTLSConfig verifies Kafka TLS requires matching client credentials and a valid CA.
+func TestNewTLSConfig(t *testing.T) {
+	materials := writeTLSTestMaterials(t)
+
+	tests := []struct {
+		name        string
+		certFile    string
+		keyFile     string
+		caFile      string
+		wantErr     bool
+		errContains string
+		errIs       error
+	}{
+		{
+			name:     "valid mTLS config",
+			certFile: materials.certFile,
+			keyFile:  materials.keyFile,
+			caFile:   materials.caFile,
+		},
+		{
+			name:    "missing client credentials",
+			caFile:  materials.caFile,
+			wantErr: true,
+			errIs:   errTLSClientCredentialsRequired,
+		},
+		{
+			name:        "cert without key",
+			certFile:    materials.certFile,
+			caFile:      materials.caFile,
+			wantErr:     true,
+			errContains: errClientCertKeyMismatch,
+		},
+		{
+			name:        "missing CA file",
+			certFile:    materials.certFile,
+			keyFile:     materials.keyFile,
+			caFile:      filepath.Join(t.TempDir(), "missing-ca.crt"),
+			wantErr:     true,
+			errContains: "failed to read CA certificate",
+		},
+		{
+			name:        "invalid CA PEM",
+			certFile:    materials.certFile,
+			keyFile:     materials.keyFile,
+			caFile:      filepath.Join(t.TempDir(), "bad-ca.pem"),
+			wantErr:     true,
+			errContains: "failed to parse CA certificate",
+		},
 	}
 
-	_, err := NewTLSConfig(certFile, keyFile, caFile)
-	if err == nil {
-		t.Fatal("expected error when only client certificate is provided")
-	}
-	if !strings.Contains(err.Error(), errClientCertKeyMismatch) {
-		t.Fatalf("expected error %q, got %v", errClientCertKeyMismatch, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.caFile != "" && tt.errContains == "failed to parse CA certificate" {
+				require.NoError(t, os.WriteFile(tt.caFile, []byte("not-a-pem"), 0o600),
+					"invalid CA fixture must be written for parse-failure test")
+			}
+			cfg, err := NewTLSConfig(tt.certFile, tt.keyFile, tt.caFile)
+			if tt.wantErr {
+				require.Error(t, err, "TLS config must fail for invalid credentials or CA material")
+				if tt.errIs != nil {
+					assert.ErrorIs(t, err, tt.errIs, "error should match expected TLS credential failure")
+				}
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains,
+						"error should describe the TLS validation failure")
+				}
+				return
+			}
+			require.NoError(t, err, "valid mTLS materials must produce a TLS config")
+			assert.Equal(t, uint16(tls.VersionTLS12), cfg.MinVersion,
+				"Kafka TLS must enforce TLS 1.2 minimum")
+			assert.NotNil(t, cfg.RootCAs, "broker CA pool must be configured for verification")
+			assert.Len(t, cfg.Certificates, 1, "client certificate must be loaded for mTLS")
+			assert.False(t, cfg.InsecureSkipVerify,
+				"InsecureSkipVerify must remain disabled for Kafka connections")
+		})
 	}
 }
 
-func TestNewTLSConfigMismatchedKeyOnly(t *testing.T) {
-	dir := t.TempDir()
-	keyFile := filepath.Join(dir, "tls.key")
-	caFile := filepath.Join(dir, "ca.crt")
-
-	if err := os.WriteFile(keyFile, []byte("key"), 0o600); err != nil {
-		t.Fatalf("failed to write key file: %v", err)
-	}
-	caPEM := []byte("-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----")
-	if err := os.WriteFile(caFile, caPEM, 0o600); err != nil {
-		t.Fatalf("failed to write ca file: %v", err)
-	}
-
-	_, err := NewTLSConfig("", keyFile, caFile)
-	if err == nil {
-		t.Fatal("expected error when only client key is provided")
-	}
-	if !strings.Contains(err.Error(), errClientCertKeyMismatch) {
-		t.Fatalf("expected error %q, got %v", errClientCertKeyMismatch, err)
-	}
-}
-
-func TestNewTLSConfigWithClientCertAndCA(t *testing.T) {
-	dir := t.TempDir()
-	certPEM, keyPEM, caPEM := generateTestCertKeyAndCA(t)
-
-	certFile := filepath.Join(dir, "tls.crt")
-	keyFile := filepath.Join(dir, "tls.key")
-	caFile := filepath.Join(dir, "ca.crt")
-	writeFile(t, certFile, certPEM)
-	writeFile(t, keyFile, keyPEM)
-	writeFile(t, caFile, caPEM)
-
-	cfg, err := NewTLSConfig(certFile, keyFile, caFile)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(cfg.Certificates) != 1 {
-		t.Fatalf("expected one client certificate, got %d", len(cfg.Certificates))
-	}
-	if cfg.RootCAs == nil {
-		t.Fatal("expected RootCAs to be set")
-	}
-}
-
-func TestGetSaramaConfigWithoutTLS(t *testing.T) {
-	cfg, err := GetSaramaConfig(&transport.KafkaInternalConfig{EnableTLS: false})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if cfg.Net.TLS.Enable {
-		t.Fatal("expected TLS to be disabled")
-	}
-}
-
-func TestGetSaramaConfigWithTLS(t *testing.T) {
-	dir := t.TempDir()
-	certPEM, keyPEM, caPEM := generateTestCertKeyAndCA(t)
-
-	certFile := filepath.Join(dir, "tls.crt")
-	keyFile := filepath.Join(dir, "tls.key")
-	caFile := filepath.Join(dir, "ca.crt")
-	writeFile(t, certFile, certPEM)
-	writeFile(t, keyFile, keyPEM)
-	writeFile(t, caFile, caPEM)
+// TestGetSaramaConfig_TLS verifies Sarama TLS is enabled when valid credentials are provided.
+func TestGetSaramaConfig_TLS(t *testing.T) {
+	materials := writeTLSTestMaterials(t)
 
 	cfg, err := GetSaramaConfig(&transport.KafkaInternalConfig{
 		EnableTLS:      true,
-		CaCertPath:     caFile,
-		ClientCertPath: certFile,
-		ClientKeyPath:  keyFile,
+		ClientCertPath: materials.certFile,
+		ClientKeyPath:  materials.keyFile,
+		CaCertPath:     materials.caFile,
 	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !cfg.Net.TLS.Enable {
-		t.Fatal("expected TLS to be enabled")
-	}
-	if cfg.Net.TLS.Config == nil {
-		t.Fatal("expected TLS config to be set")
-	}
-	if cfg.Net.TLS.Config.MinVersion != tls.VersionTLS12 {
-		t.Fatalf("expected MinVersion TLS 1.2, got %d", cfg.Net.TLS.Config.MinVersion)
-	}
+	require.NoError(t, err, "Sarama TLS config must be created from valid mTLS materials")
+	require.True(t, cfg.Net.TLS.Enable, "TLS must be enabled when Kafka TLS is requested")
+	require.NotNil(t, cfg.Net.TLS.Config, "TLS config must be attached to Sarama client settings")
+	assert.False(t, cfg.Net.TLS.Config.InsecureSkipVerify,
+		"Sarama client must verify broker certificates")
 }
 
-func generateTestCertKeyAndCA(t *testing.T) (certPEM, keyPEM, caPEM []byte) {
-	t.Helper()
+// TestGetSaramaConfig_TLSRequiresValidCA verifies TLS configuration fails closed without a CA.
+func TestGetSaramaConfig_TLSRequiresValidCA(t *testing.T) {
+	materials := writeTLSTestMaterials(t)
 
-	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		t.Fatalf("failed to generate CA key: %v", err)
-	}
-	caTemplate := &x509.Certificate{
-		SerialNumber:          big.NewInt(1),
-		Subject:               pkix.Name{CommonName: "test-ca"},
-		NotBefore:             time.Now().Add(-time.Hour),
-		NotAfter:              time.Now().Add(time.Hour),
-		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
-		BasicConstraintsValid: true,
-		IsCA:                  true,
-	}
-	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
-	if err != nil {
-		t.Fatalf("failed to create CA cert: %v", err)
-	}
-	caPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
-
-	clientKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		t.Fatalf("failed to generate client key: %v", err)
-	}
-	clientTemplate := &x509.Certificate{
-		SerialNumber: big.NewInt(2),
-		Subject:      pkix.Name{CommonName: "test-client"},
-		NotBefore:    time.Now().Add(-time.Hour),
-		NotAfter:     time.Now().Add(time.Hour),
-		KeyUsage:     x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
-	}
-	clientDER, err := x509.CreateCertificate(rand.Reader, clientTemplate, caTemplate, &clientKey.PublicKey, caKey)
-	if err != nil {
-		t.Fatalf("failed to create client cert: %v", err)
-	}
-	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientDER})
-	keyDER, err := x509.MarshalPKCS8PrivateKey(clientKey)
-	if err != nil {
-		t.Fatalf("failed to marshal client key: %v", err)
-	}
-	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
-	return certPEM, keyPEM, caPEM
-}
-
-func writeFile(t *testing.T, path string, data []byte) {
-	t.Helper()
-	if err := os.WriteFile(path, data, 0o600); err != nil {
-		t.Fatalf("failed to write %s: %v", path, err)
-	}
+	_, err := GetSaramaConfig(&transport.KafkaInternalConfig{
+		EnableTLS:      true,
+		ClientCertPath: materials.certFile,
+		ClientKeyPath:  materials.keyFile,
+		CaCertPath:     filepath.Join(t.TempDir(), "missing-ca.crt"),
+	})
+	require.Error(t, err, "Kafka TLS must fail closed when the CA certificate is missing")
+	assert.Contains(t, err.Error(), "failed to read CA certificate",
+		"missing CA errors must describe the broker verification failure")
 }

--- a/test/e2e/transport_byo_test.go
+++ b/test/e2e/transport_byo_test.go
@@ -79,6 +79,7 @@ var _ = Describe("Transport BYO Kafka E2E", Serial, Label("e2e-test-transport-by
 		}
 		deleteBYOPerHubSecret(sourceHubName)
 		deleteBYOPerHubSecret(targetHubName)
+		waitHubsUseSharedBootstrap(sourceHubClient, sourceHubName, targetHubClient, targetHubName, sharedBootstrap)
 	})
 
 	It("allows a custom client certificate CN on the shared BYO secret", func() {
@@ -112,17 +113,7 @@ var _ = Describe("Transport BYO Kafka E2E", Serial, Label("e2e-test-transport-by
 		})
 		DeferCleanup(func() {
 			deleteBYOPerHubSecret(sourceHubName)
-			Eventually(func() error {
-				cfg, err := managedHubAgentKafkaConfig(sourceHubClient)
-				if err != nil {
-					return err
-				}
-				if cfg.BootstrapServer != sharedBootstrap {
-					return fmt.Errorf("waiting for shared-secret bootstrap to be restored")
-				}
-				return nil
-			}, 2*time.Minute, 5*time.Second).Should(Succeed(),
-				"agent transport must fall back to the shared BYO secret after per-hub cleanup")
+			waitHubsUseSharedBootstrap(sourceHubClient, sourceHubName, targetHubClient, targetHubName, sharedBootstrap)
 		})
 
 		Eventually(func() error {
@@ -144,6 +135,7 @@ var _ = Describe("Transport BYO Kafka E2E", Serial, Label("e2e-test-transport-by
 		DeferCleanup(func() {
 			deleteBYOPerHubSecret(sourceHubName)
 			deleteBYOPerHubSecret(targetHubName)
+			waitHubsUseSharedBootstrap(sourceHubClient, sourceHubName, targetHubClient, targetHubName, sharedBootstrap)
 		})
 
 		Eventually(func() error {
@@ -199,6 +191,28 @@ func createBYOPerHubSecret(clusterName string, mutate func(*corev1.Secret)) {
 		_, err = kube.Update(apiCtx, existing, metav1.UpdateOptions{})
 	}
 	Expect(err).NotTo(HaveOccurred(), "expected to create or update the per-hub BYO secret")
+}
+
+func waitHubsUseSharedBootstrap(
+	sourceClient client.Client, sourceName string,
+	targetClient client.Client, targetName, sharedBootstrap string,
+) {
+	GinkgoHelper()
+	for _, hub := range []struct {
+		name   string
+		client client.Client
+	}{
+		{sourceName, sourceClient},
+		{targetName, targetClient},
+	} {
+		if hub.client == nil {
+			continue
+		}
+		Eventually(func() error {
+			return managedHubAgentUsesSharedBootstrap(hub.client, hub.name, sharedBootstrap)
+		}, 2*time.Minute, 5*time.Second).Should(Succeed(),
+			"agent on %s must fall back to the shared BYO secret after per-hub cleanup", hub.name)
+	}
 }
 
 func deleteBYOPerHubSecret(clusterName string) {

--- a/test/integration/operator/controllers/grafana_test.go
+++ b/test/integration/operator/controllers/grafana_test.go
@@ -6,6 +6,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"gopkg.in/ini.v1"
+	"gopkg.in/yaml.v2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -42,38 +44,37 @@ var _ = Describe("grafana", Ordered, func() {
 				EnableMetrics: true,
 			},
 		}
-		Expect(runtimeClient.Create(ctx, mgh)).To(Succeed())
-		Expect(runtimeClient.Get(ctx, client.ObjectKeyFromObject(mgh), mgh)).To(Succeed())
+		Expect(runtimeClient.Create(ctx, mgh)).To(Succeed(), "test MulticlusterGlobalHub must be created")
+		Expect(runtimeClient.Get(ctx, client.ObjectKeyFromObject(mgh), mgh)).To(Succeed(),
+			"created MulticlusterGlobalHub must be readable")
+		previousConn := config.GetStorageConnection()
+		previousReady := config.GetDatabaseReady()
+		DeferCleanup(func() {
+			_ = config.SetStorageConnection(previousConn)
+			config.SetDatabaseReady(previousReady)
+		})
+		Expect(config.SetStorageConnection(&config.PostgresConnection{
+			SuperuserDatabaseURI:    "postgresql://testuser:testpassword@localhost:5432/testdb?sslmode=verify-full",
+			ReadonlyUserDatabaseURI: "postgresql://testuser:testpassword@localhost:5432/testdb?sslmode=verify-full",
+			CACert:                  []byte("test-crt"),
+		})).To(BeTrue(), "set storage configuration for Grafana TLS validation")
+		config.SetDatabaseReady(true)
+		Expect(grafana.NewGrafanaReconciler(runtimeManager, kubeClient).SetupWithManager(runtimeManager)).
+			To(Succeed(), "Grafana reconciler must register with the test manager")
 	})
 
 	It("should generate the grafana resources", func() {
-		// storage
-		_ = config.SetStorageConnection(&config.PostgresConnection{
-			SuperuserDatabaseURI:    "postgresql://testuser:testpassword@localhost:5432/testdb?sslmode=disable",
-			ReadonlyUserDatabaseURI: "postgresql://testuser:testpassword@localhost:5432/testdb?sslmode=disable",
-			CACert:                  []byte("test-crt"),
-		})
-		config.SetDatabaseReady(true)
-
-		grafanaReconciler := grafana.NewGrafanaReconciler(runtimeManager, kubeClient)
-
-		err := grafanaReconciler.SetupWithManager(runtimeManager)
-		Expect(err).To(Succeed())
-
-		// deployment
 		Eventually(func() error {
 			deployment := &appsv1.Deployment{}
-			err = runtimeClient.Get(ctx, types.NamespacedName{
+			if err := runtimeClient.Get(ctx, types.NamespacedName{
 				Name:      "multicluster-global-hub-grafana",
 				Namespace: mgh.Namespace,
-			}, deployment)
-			if err != nil {
+			}, deployment); err != nil {
 				return err
 			}
 			return nil
 		}, 10*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
 
-		// NetworkPolicy is rendered alongside other grafana manifests; verify it is created
 		Eventually(func() error {
 			np := &networkingv1.NetworkPolicy{}
 			return runtimeClient.Get(ctx, types.NamespacedName{
@@ -81,6 +82,60 @@ var _ = Describe("grafana", Ordered, func() {
 				Namespace: mgh.Namespace,
 			}, np)
 		}, 10*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
+	})
+
+	It("should configure postgres datasource TLS verification", func() {
+		Eventually(func() error {
+			dsSecret := &corev1.Secret{}
+			if err := runtimeClient.Get(ctx, types.NamespacedName{
+				Name:      "multicluster-global-hub-grafana-datasources",
+				Namespace: mgh.Namespace,
+			}, dsSecret); err != nil {
+				return err
+			}
+			var datasources grafana.GrafanaDatasources
+			if err := yaml.Unmarshal(dsSecret.Data["datasources.yaml"], &datasources); err != nil {
+				return err
+			}
+			if len(datasources.Datasources) == 0 || datasources.Datasources[0].JSONData == nil {
+				return fmt.Errorf("grafana datasource not ready")
+			}
+			ds := datasources.Datasources[0]
+			if ds.JSONData.TLSSkipVerify {
+				return fmt.Errorf("expected postgres datasource TLS verification enabled")
+			}
+			if ds.JSONData.SSLMode != "verify-full" {
+				return fmt.Errorf("expected sslmode verify-full, got %q", ds.JSONData.SSLMode)
+			}
+			if !ds.JSONData.TLSAuth || !ds.JSONData.TLSAuthWithCACert {
+				return fmt.Errorf("expected TLS auth flags enabled on postgres datasource")
+			}
+			return nil
+		}, 10*time.Second, 100*time.Millisecond).Should(Succeed())
+	})
+
+	It("should inject a grafana admin password", func() {
+		Eventually(func() error {
+			iniSecret := &corev1.Secret{}
+			if err := runtimeClient.Get(ctx, types.NamespacedName{
+				Name:      "multicluster-global-hub-grafana-config",
+				Namespace: mgh.Namespace,
+			}, iniSecret); err != nil {
+				return err
+			}
+			cfg, err := ini.Load(iniSecret.Data["grafana.ini"])
+			if err != nil {
+				return err
+			}
+			sec, err := cfg.GetSection("security")
+			if err != nil {
+				return err
+			}
+			if sec.Key("admin_password").String() == "" {
+				return fmt.Errorf("grafana admin_password not set")
+			}
+			return nil
+		}, 10*time.Second, 100*time.Millisecond).Should(Succeed())
 	})
 
 	AfterAll(func() {
@@ -94,6 +149,7 @@ var _ = Describe("grafana", Ordered, func() {
 	})
 })
 
+// deleteNamespace removes the test namespace created for Grafana integration coverage.
 func deleteNamespace(name string) error {
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/script/e2e_run_byo.sh
+++ b/test/script/e2e_run_byo.sh
@@ -84,7 +84,12 @@ kubectl create secret generic "$transport_secret" -n "${target_namespace}" --kub
 echo "transport secret is ready in ${target_namespace} namespace!"
 
 ## run e2e
-bash "$CURRENT_DIR/e2e_run.sh" -n "${target_namespace}" -f "e2e-test-localpolicy,e2e-test-grafana,e2e-test-local-agent,e2e-test-transport-byo"
+# transport-byo mutates per-hub Kafka bootstrap (fake marker, identical-cert
+# secrets). Ginkgo randomizes Describe order in a single process, so those
+# mutations can leak into localpolicy if transport-byo runs first. Keep it in
+# a separate invocation after the other BYO suites.
+bash "$CURRENT_DIR/e2e_run.sh" -n "${target_namespace}" -f "e2e-test-localpolicy,e2e-test-grafana,e2e-test-local-agent"
+bash "$CURRENT_DIR/e2e_run.sh" -n "${target_namespace}" -f "e2e-test-transport-byo"
 
 # Clean up MulticlusterGlobalHub resources before migration tests
 echo "Cleaning up BYO test resources..."


### PR DESCRIPTION
## Summary

- **Kafka TLS (F002):** Require client certificate/key when TLS is enabled; verify broker CA; TLS 1.2 minimum; no `InsecureSkipVerify`.
- **Postgres TLS (F002):** Validate CA PEM and configure `RootCAs` for connection pool and direct connections.
- **Grafana credentials (F003):** Generate a stable random `admin_password` and inject it into merged `grafana.ini` (avoids default `admin/admin`).
- **Grafana datasource TLS (F002):** Set `tlsSkipVerify: false` when a CA cert is configured.
- **Credential-safe errors (F004):** Parse Postgres URIs without echoing connection strings in Grafana/inventory error messages.

## Out of scope (follow-up)

- F001 cluster-wide Secrets RBAC
- Manager metrics scrape `InsecureSkipVerify` (ACM-30175)
- `postgres_exporter` pprof (separate repo)

## Test plan

- [x] Unit tests: `pkg/transport/config`, `pkg/database`, `operator/pkg/controllers/grafana`, `operator/pkg/controllers/inventory`
- [x] Unit test: `operator/pkg/config` (`TestGetGrafanaAdminPassword`)
- [ ] CI: `verify`, `unit-tests`, `integration-test/operator` (grafana suite)
- [ ] CodeRabbit review


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Grafana now receives a stable, secure administrator password that persists across reconciliations.
  * PostgreSQL connections with CA certificates enforce TLS certificate verification.
  * TLS-enabled messaging connections require both a client certificate and private key.

* **Bug Fixes**
  * Improved error handling prevents credentials and connection details from appearing in errors.
  * Missing database certificate files now produce clear errors instead of being ignored.
  * PostgreSQL connection settings now support a default database when omitted.

* **Tests**
  * Expanded coverage for Grafana, TLS, certificate verification, and credential-safe errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->