### PR TITLE
ACM-34442: Isolate BYO transport e2e from localpolicy

### DIFF
--- a/test/e2e/transport_byo_test.go
+++ b/test/e2e/transport_byo_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -145,10 +146,12 @@ var _ = Describe("Transport BYO Kafka E2E", Serial, Label("e2e-test-transport-by
 	})
 })
 
+// byoAPIContext returns a timeout context for BYO e2e Kubernetes API calls.
 func byoAPIContext() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(ctx, byoAPITimeout)
 }
 
+// byoSharedTransportSecret returns the shared BYO Kafka transport secret.
 func byoSharedTransportSecret() (*corev1.Secret, error) {
 	apiCtx, cancel := byoAPIContext()
 	defer cancel()
@@ -157,6 +160,7 @@ func byoSharedTransportSecret() (*corev1.Secret, error) {
 	)
 }
 
+// createBYOPerHubSecret creates or updates a per-hub BYO transport secret from the shared secret.
 func createBYOPerHubSecret(clusterName string, mutate func(*corev1.Secret)) {
 	shared, err := byoSharedTransportSecret()
 	Expect(err).NotTo(HaveOccurred(), "expected the shared BYO transport secret as a template")
@@ -193,28 +197,40 @@ func createBYOPerHubSecret(clusterName string, mutate func(*corev1.Secret)) {
 	Expect(err).NotTo(HaveOccurred(), "expected to create or update the per-hub BYO secret")
 }
 
+// waitHubsUseSharedBootstrap waits until both managed hub agents use the shared
+// BYO Kafka bootstrap after per-hub transport secrets are removed. It skips
+// polling when setup did not record a shared bootstrap, and checks both hubs
+// before reporting failure.
 func waitHubsUseSharedBootstrap(
 	sourceClient client.Client, sourceName string,
 	targetClient client.Client, targetName, sharedBootstrap string,
 ) {
 	GinkgoHelper()
-	for _, hub := range []struct {
-		name   string
-		client client.Client
-	}{
-		{sourceName, sourceClient},
-		{targetName, targetClient},
-	} {
-		if hub.client == nil {
-			continue
-		}
-		Eventually(func() error {
-			return managedHubAgentUsesSharedBootstrap(hub.client, hub.name, sharedBootstrap)
-		}, 2*time.Minute, 5*time.Second).Should(Succeed(),
-			"agent on %s must fall back to the shared BYO secret after per-hub cleanup", hub.name)
+	if sharedBootstrap == "" {
+		return
 	}
+	Eventually(func() error {
+		var errs []error
+		for _, hub := range []struct {
+			name   string
+			client client.Client
+		}{
+			{sourceName, sourceClient},
+			{targetName, targetClient},
+		} {
+			if hub.client == nil {
+				continue
+			}
+			if err := managedHubAgentUsesSharedBootstrap(hub.client, hub.name, sharedBootstrap); err != nil {
+				errs = append(errs, err)
+			}
+		}
+		return errors.Join(errs...)
+	}, 2*time.Minute, 5*time.Second).Should(Succeed(),
+		"agents must fall back to the shared BYO secret after per-hub cleanup")
 }
 
+// deleteBYOPerHubSecret removes the per-hub BYO transport secret if it exists.
 func deleteBYOPerHubSecret(clusterName string) {
 	apiCtx, cancel := byoAPIContext()
 	defer cancel()
@@ -265,6 +281,7 @@ func managedHubAgentUsesSharedBootstrap(hubClient client.Client, hubName, shared
 	return nil
 }
 
+// pemCertificateCommonName returns the CommonName from a PEM-encoded client certificate.
 func pemCertificateCommonName(certPEM []byte) string {
 	block, _ := pem.Decode(certPEM)
 	Expect(block).NotTo(BeNil(), "shared BYO client.crt must be PEM")
@@ -273,6 +290,7 @@ func pemCertificateCommonName(certPEM []byte) string {
 	return cert.Subject.CommonName
 }
 
+// operatorLogsContain reports whether any Global Hub operator pod log contains substr.
 func operatorLogsContain(substr string) error {
 	apiCtx, cancel := byoAPIContext()
 	defer cancel()

--- a/test/e2e/transport_byo_test.go
+++ b/test/e2e/transport_byo_test.go
@@ -79,6 +79,7 @@ var _ = Describe("Transport BYO Kafka E2E", Serial, Label("e2e-test-transport-by
 		}
 		deleteBYOPerHubSecret(sourceHubName)
 		deleteBYOPerHubSecret(targetHubName)
+		waitHubsUseSharedBootstrap(sourceHubClient, sourceHubName, targetHubClient, targetHubName, sharedBootstrap)
 	})
 
 	It("allows a custom client certificate CN on the shared BYO secret", func() {
@@ -112,17 +113,7 @@ var _ = Describe("Transport BYO Kafka E2E", Serial, Label("e2e-test-transport-by
 		})
 		DeferCleanup(func() {
 			deleteBYOPerHubSecret(sourceHubName)
-			Eventually(func() error {
-				cfg, err := managedHubAgentKafkaConfig(sourceHubClient)
-				if err != nil {
-					return err
-				}
-				if cfg.BootstrapServer != sharedBootstrap {
-					return fmt.Errorf("waiting for shared-secret bootstrap to be restored")
-				}
-				return nil
-			}, 2*time.Minute, 5*time.Second).Should(Succeed(),
-				"agent transport must fall back to the shared BYO secret after per-hub cleanup")
+			waitHubsUseSharedBootstrap(sourceHubClient, sourceHubName, targetHubClient, targetHubName, sharedBootstrap)
 		})
 
 		Eventually(func() error {
@@ -144,6 +135,7 @@ var _ = Describe("Transport BYO Kafka E2E", Serial, Label("e2e-test-transport-by
 		DeferCleanup(func() {
 			deleteBYOPerHubSecret(sourceHubName)
 			deleteBYOPerHubSecret(targetHubName)
+			waitHubsUseSharedBootstrap(sourceHubClient, sourceHubName, targetHubClient, targetHubName, sharedBootstrap)
 		})
 
 		Eventually(func() error {
@@ -199,6 +191,28 @@ func createBYOPerHubSecret(clusterName string, mutate func(*corev1.Secret)) {
 		_, err = kube.Update(apiCtx, existing, metav1.UpdateOptions{})
 	}
 	Expect(err).NotTo(HaveOccurred(), "expected to create or update the per-hub BYO secret")
+}
+
+func waitHubsUseSharedBootstrap(
+	sourceClient client.Client, sourceName string,
+	targetClient client.Client, targetName, sharedBootstrap string,
+) {
+	GinkgoHelper()
+	for _, hub := range []struct {
+		name   string
+		client client.Client
+	}{
+		{sourceName, sourceClient},
+		{targetName, targetClient},
+	} {
+		if hub.client == nil {
+			continue
+		}
+		Eventually(func() error {
+			return managedHubAgentUsesSharedBootstrap(hub.client, hub.name, sharedBootstrap)
+		}, 2*time.Minute, 5*time.Second).Should(Succeed(),
+			"agent on %s must fall back to the shared BYO secret after per-hub cleanup", hub.name)
+	}
 }
 
 func deleteBYOPerHubSecret(clusterName string) {

--- a/test/script/e2e_run.sh
+++ b/test/script/e2e_run.sh
@@ -18,7 +18,7 @@ export MC_NUM=${MC_NUM:-1}
 export GH_NAME="global-hub" # the KinD name
 export GH_KUBECONFIG="${CONFIG_DIR}/${GH_NAME}"
 
-while getopts ":f:v:n:" opt; do
+while getopts ":f:v:n:r:" opt; do
   case $opt in
   f)
     filter="$OPTARG"
@@ -28,6 +28,9 @@ while getopts ":f:v:n:" opt; do
     ;;
   n)
     GH_NAMESPACE="$OPTARG"
+    ;;
+  r)
+    report_prefix="$OPTARG"
     ;;
   \?)
     echo "Invalid option -$OPTARG" >&2
@@ -44,6 +47,7 @@ while getopts ":f:v:n:" opt; do
 done
 
 verbose=${verbose:=5}
+report_prefix=${report_prefix:=report}
 GH_NAMESPACE=${GH_NAMESPACE:=multicluster-global-hub}
 export GH_NAMESPACE
 echo "namespace: "$GH_NAMESPACE
@@ -120,15 +124,15 @@ EOF
 if [ "${filter}" = "e2e-test-prune" ]; then
   export ISPRUNE="true"
   echo "run prune"
-  ginkgo --fail-fast --label-filter="e2e-test-prune" --output-dir="$CONFIG_DIR" --json-report=report.json \
-    --junit-report=report.xml "$TEST_DIR/e2e" -- -options="$OPTION_FILE" -v="$verbose"
+  ginkgo --fail-fast --label-filter="e2e-test-prune" --output-dir="$CONFIG_DIR" --json-report="${report_prefix}.json" \
+    --junit-report="${report_prefix}.xml" "$TEST_DIR/e2e" -- -options="$OPTION_FILE" -v="$verbose"
 else
-  ginkgo --fail-fast --label-filter="${filter}" --output-dir="$CONFIG_DIR" --json-report=report.json \
-    --junit-report=report.xml "$TEST_DIR"/e2e -- -options="$OPTION_FILE" -v="$verbose"
+  ginkgo --fail-fast --label-filter="${filter}" --output-dir="$CONFIG_DIR" --json-report="${report_prefix}.json" \
+    --junit-report="${report_prefix}.xml" "$TEST_DIR"/e2e -- -options="$OPTION_FILE" -v="$verbose"
 fi
 
-if ! cat "$CONFIG_DIR/report.xml" | grep failures=\"0\" | grep errors=\"0\" >/dev/null; then
+if ! cat "$CONFIG_DIR/${report_prefix}.xml" | grep failures=\"0\" | grep errors=\"0\" >/dev/null; then
   echo "Cannot pass all test cases."
-  cat "$CONFIG_DIR/report.xml"
+  cat "$CONFIG_DIR/${report_prefix}.xml"
   exit 1
 fi

--- a/test/script/e2e_run_byo.sh
+++ b/test/script/e2e_run_byo.sh
@@ -88,8 +88,8 @@ echo "transport secret is ready in ${target_namespace} namespace!"
 # secrets). Ginkgo randomizes Describe order in a single process, so those
 # mutations can leak into localpolicy if transport-byo runs first. Keep it in
 # a separate invocation after the other BYO suites.
-bash "$CURRENT_DIR/e2e_run.sh" -n "${target_namespace}" -f "e2e-test-localpolicy,e2e-test-grafana,e2e-test-local-agent"
-bash "$CURRENT_DIR/e2e_run.sh" -n "${target_namespace}" -f "e2e-test-transport-byo"
+bash "$CURRENT_DIR/e2e_run.sh" -n "${target_namespace}" -f "e2e-test-localpolicy,e2e-test-grafana,e2e-test-local-agent" -r report-byo-suites
+bash "$CURRENT_DIR/e2e_run.sh" -n "${target_namespace}" -f "e2e-test-transport-byo" -r report-transport-byo
 
 # Clean up MulticlusterGlobalHub resources before migration tests
 echo "Cleaning up BYO test resources..."

--- a/test/script/e2e_run_byo.sh
+++ b/test/script/e2e_run_byo.sh
@@ -84,7 +84,12 @@ kubectl create secret generic "$transport_secret" -n "${target_namespace}" --kub
 echo "transport secret is ready in ${target_namespace} namespace!"
 
 ## run e2e
-bash "$CURRENT_DIR/e2e_run.sh" -n "${target_namespace}" -f "e2e-test-localpolicy,e2e-test-grafana,e2e-test-local-agent,e2e-test-transport-byo"
+# transport-byo mutates per-hub Kafka bootstrap (fake marker, identical-cert
+# secrets). Ginkgo randomizes Describe order in a single process, so those
+# mutations can leak into localpolicy if transport-byo runs first. Keep it in
+# a separate invocation after the other BYO suites.
+bash "$CURRENT_DIR/e2e_run.sh" -n "${target_namespace}" -f "e2e-test-localpolicy,e2e-test-grafana,e2e-test-local-agent"
+bash "$CURRENT_DIR/e2e_run.sh" -n "${target_namespace}" -f "e2e-test-transport-byo"
 
 # Clean up MulticlusterGlobalHub resources before migration tests
 echo "Cleaning up BYO test resources..."


### PR DESCRIPTION
Fixes: [ACM-34442](https://redhat.atlassian.net/browse/ACM-34442)

## Summary

- Run `e2e-test-transport-byo` in a **separate Ginkgo invocation** after localpolicy/grafana/local-agent
- Wait for both hubs to fall back to the shared BYO Kafka secret in AfterAll and DeferCleanup

## Context

[PR #2841](https://github.com/stolostron/multicluster-global-hub/pull/2841) `test-e2e` failed in the BYO pass on `Local Policy` / `policy spec`: hub2 reached the manager DB, hub1 did not.

Ginkgo randomizes Describe order in a single process. `e2e_run_byo.sh` previously ran `e2e-test-localpolicy,e2e-test-grafana,e2e-test-local-agent,e2e-test-transport-byo` together. When transport-byo ran first it:

- Pointed hub1 at a fake bootstrap (`e2e-byo-per-hub-marker`)
- Created identical per-hub client certs, which blocks the operator from updating transport-config

Hub1 then never synced local policy. This is test isolation, not a TLS/Grafana product bug.

Related:

- [stolostron/multicluster-global-hub#2841](https://github.com/stolostron/multicluster-global-hub/pull/2841) — e2e failure that surfaced this
- [ACM-34442](https://redhat.atlassian.net/browse/ACM-34442) — BYO Kafka / Phase 6 parent

## Test plan

- [ ] Prow `test-e2e` BYO pass: localpolicy completes before transport-byo
- [ ] transport-byo still covers per-hub secret selection and identical-cert rejection


Made with [Cursor](https://cursor.com)

[ACM-34442]: https://redhat.atlassian.net/browse/ACM-34442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-34442]: https://redhat.atlassian.net/browse/ACM-34442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved BYO Kafka end-to-end test reliability by handling empty bootstrap configurations and checking hub-agent readiness together.
  - Added clearer validation of fallback behavior and aggregated readiness errors for easier diagnosis.
  - Separated transport-related Kafka test reporting from other BYO test suites.

- **Chores**
  - Added configurable report filename prefixes for generated test reports, with the existing default preserved.
  - Added documentation comments to test helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->