### PR TITLE
Security: Bump Go to 1.26.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/multicluster-global-hub
 
-go 1.26.4
+go 1.26.7
 
 require (
 	github.com/IBM/sarama v1.46.3


### PR DESCRIPTION
## Summary

Bump Go from `1.26.4` to `1.26.7`.

Fixes:
- CVE-2026-33818
- CVE-2026-56853
- CVE-2026-56858
- CVE-2026-56859
- CVE-2026-56860
- CVE-2026-56862

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s Go runtime compatibility version to Go 1.26.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->