### PR TITLE
Fix bundle channel annotations for release-5.2

### DIFF
--- a/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/multicluster-global-hub-operator.clusterserviceversion.yaml
@@ -71,7 +71,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: multicluster-global-hub-operator.v5.0.0-dev
+  name: multicluster-global-hub-operator.v5.2.0-dev
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1499,8 +1499,8 @@ spec:
   maintainers:
   - email: acm-contact@redhat.com
     name: acm-contact
-  maturity: release-5.0
+  maturity: release-5.2
   provider:
     name: Red Hat, Inc
     url: https://github.com/stolostron/multicluster-global-hub
-  version: 5.0.0-dev
+  version: 5.2.0-dev

--- a/operator/bundle/metadata/annotations.yaml
+++ b/operator/bundle/metadata/annotations.yaml
@@ -4,8 +4,8 @@ annotations:
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: multicluster-global-hub-operator
-  operators.operatorframework.io.bundle.channels.v1: release-5.0
-  operators.operatorframework.io.bundle.channel.default.v1: release-5.0
+  operators.operatorframework.io.bundle.channels.v1: release-5.2
+  operators.operatorframework.io.bundle.channel.default.v1: release-5.2
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.34.1
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4


### PR DESCRIPTION
## Summary

Fixes the postsubmit CI failure on release-5.2 branch where bundle metadata was hardcoded to release-5.0.

## Changes

- Update `operators.operatorframework.io.bundle.channels.v1`: release-5.0 → release-5.2
- Update `operators.operatorframework.io.bundle.channel.default.v1`: release-5.0 → release-5.2  
- Update CSV name: `multicluster-global-hub-operator.v5.0.0-dev` → `v5.2.0-dev`
- Update version: `5.0.0-dev` → `5.2.0-dev`
- Update maturity: `release-5.0` → `release-5.2`

## Problem

The CI workflow runs `make bundle RELEASE_LINE=5.2` on release-5.2 branch, which regenerates the bundle with correct values. However, the committed bundle had hardcoded 5.0 values, causing `git diff --exit-code` to fail.

See failed CI run: https://github.com/stolostron/multicluster-global-hub/actions/runs/33513045182/job/99874758794

## Testing

After this fix, `make bundle RELEASE_LINE=5.2` will produce no diff.

Related branches: release-5.1 (separate PR), release-5.2