### PR TITLE
ACM-40739: keep verify-bundle on committed RELEASE_LINE for ffwd branches

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -69,25 +69,15 @@ jobs:
               ;;
           esac
 
+      # Committed operator/bundle on main (and ffwd copies on release-5.0/5.1/5.2)
+      # is the current product line (RELEASE_LINE default, today 5.0.0-dev). Do not
+      # pass RELEASE_LINE from the git branch name: that regenerates 5.1/5.2 CSV
+      # metadata on ffwd branches and fails git diff --exit-code.
+      # Per-line OLM/CPE metadata stays in Tekton build-args and the operator-bundle repo.
       - name: bundle
-        env:
-          TARGET: ${{ steps.bundle-branch.outputs.target }}
-        run: |
-          case "$TARGET" in
-            release-*)
-              if [[ ! "$TARGET" =~ ^release-[0-9]+\.[0-9]+$ ]]; then
-                echo "Unsupported release branch format: $TARGET" >&2
-                exit 1
-              fi
-              RELEASE_LINE="${TARGET#release-}"
-              cd operator && make bundle RELEASE_LINE="$RELEASE_LINE"
-              ;;
-            *)
-              cd operator && make bundle
-              ;;
-          esac
+        run: cd operator && make bundle
 
-      # main and release-* branches use dev bundle versions (e.g. 5.0.0-dev / 5.1.0-dev) while the
+      # main and release-* branches use the in-repo dev bundle (e.g. 5.0.0-dev) while the
       # matching release-* branches in multicluster-global-hub-operator-bundle
       # carry GA z-stream versions — skip external sync on those branches.
 

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -1,8 +1,9 @@
 # RELEASE_LINE selects the OLM channel/version family for `make bundle` (e.g. 5.0, 5.1).
 # Override at build time: make bundle RELEASE_LINE=5.1
-# Defaults stay on 5.0 so main→release-* ffwd stays clean; CI passes RELEASE_LINE=5.1
-# on release-5.1 (see .github/workflows/go.yml). Konflux operand images use
-# RELEASE_CPE / RELEASE_VERSION build args in Containerfile.* (see .tekton/*).
+# Defaults stay on 5.0 so main→release-* ffwd stays clean. verify-bundle CI must
+# use this default (do not derive RELEASE_LINE from the git branch name): ffwd
+# copies of main still commit 5.0.0-dev. 5.1/5.2 image metadata comes from
+# Tekton RELEASE_CPE / RELEASE_VERSION (see .tekton/*), not from operator/bundle.
 RELEASE_LINE ?= 5.0
 
 # VERSION defines the project version for the bundle.


### PR DESCRIPTION
Related: [ACM-40739](https://redhat.atlassian.net/browse/ACM-40739)

## Summary

- Stop `verify bundle` from passing `RELEASE_LINE` derived from the git branch name (`release-5.1` → `5.1`, `release-5.2` → `5.2`)
- Always run `make bundle` with the committed default (`RELEASE_LINE ?= 5.0`) so ffwd copies of `main` stay reproducible
- Same pattern as [#2747](https://github.com/stolostron/multicluster-global-hub/pull/2747): per-line CPE/version stays in Tekton build-args and [multicluster-global-hub-operator-bundle](https://github.com/stolostron/multicluster-global-hub-operator-bundle), not in committed `operator/bundle` on ffwd branches

## Context

After ffwd of `main` → `release-5.1` / `release-5.2`, push CI regenerated CSV/channel metadata (`5.0.0-dev` / `release-5.0` → `5.1.0-dev` / `5.2.0-dev`) and `git diff --exit-code` failed. Committing 5.1/5.2 bundle files on those branches would break ffwd.

Fixes the Go **verify bundle** failure on [48ad8c5](https://github.com/stolostron/multicluster-global-hub/commit/48ad8c515f43406d5674d92c64d7ef09c84f5797) for `release-5.1` and `release-5.2`.

## Test plan

- [ ] PR `verify bundle` on `main` still passes (`make bundle` default 5.0)
- [ ] After merge + ffwd, push `verify bundle` on `release-5.1` and `release-5.2` passes without changing committed CSV version/channel
- [ ] `release-5.0` verify-bundle unchanged
- [ ] `git merge --ff-only origin/main` on `release-5.1` / `release-5.2` still works


Made with [Cursor](https://cursor.com)

[ACM-40739]: https://redhat.atlassian.net/browse/ACM-40739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized bundle generation across all branches using the default release configuration.
  * Updated release metadata guidance and verification settings for upcoming release versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->