### PR TITLE
Fix golangci-lint SA5011 nil-deref findings in tests

### DIFF
--- a/agent/pkg/status/syncers/hubha/hubha_controller_test.go
+++ b/agent/pkg/status/syncers/hubha/hubha_controller_test.go
@@ -309,6 +309,7 @@ func TestWithNoOpStartResourceSyncerFn(t *testing.T) {
 
 	if c.startResourceSyncerFn == nil {
 		t.Fatal("expected startResourceSyncerFn to be non-nil after applying option")
+		return
 	}
 	gvks, err := c.startResourceSyncerFn(nil)
 	if err != nil {

--- a/operator/pkg/controllers/transporter/protocol/strimzi_kafka_controller_test.go
+++ b/operator/pkg/controllers/transporter/protocol/strimzi_kafka_controller_test.go
@@ -535,6 +535,7 @@ func TestGetManagerTransportConn(t *testing.T) {
 	}
 	if conn == nil {
 		t.Fatal("getManagerTransportConn() returned nil connection")
+		return
 	}
 	if conn.SpecTopic != "spec1" {
 		t.Fatalf("SpecTopic = %q, want spec1", conn.SpecTopic)

--- a/pkg/transport/consumer/generic_consumer_test.go
+++ b/pkg/transport/consumer/generic_consumer_test.go
@@ -19,10 +19,11 @@ import (
 func TestGenerateConsumer(t *testing.T) {
 	consumer, err := NewGenericConsumer(true, false)
 	if err != nil {
-		t.Errorf("failed to generate consumer - %v", err)
+		t.Fatalf("failed to generate consumer - %v", err)
 	}
 	if consumer == nil {
 		t.Fatal("consumer should not be nil")
+		return
 	}
 	if consumer.eventChan == nil {
 		t.Fatal("eventChan should be initialized")

--- a/pkg/transport/requester/inventory_client_test.go
+++ b/pkg/transport/requester/inventory_client_test.go
@@ -31,6 +31,7 @@ func TestRefreshClientSetsTLS12MinVersion(t *testing.T) {
 	}
 	if client.tlsConfig == nil {
 		t.Fatal("expected tls config to be set before client init failure")
+		return
 	}
 	if client.tlsConfig.MinVersion != tls.VersionTLS12 {
 		t.Fatalf("expected MinVersion TLS 1.2, got %d", client.tlsConfig.MinVersion)


### PR DESCRIPTION
## Summary

- Fix golangci-lint SA5011 (`staticcheck`) failures that broke the `format` job on push to `main` ([run 33536975518](https://github.com/stolostron/multicluster-global-hub/actions/runs/33536975518/job/99966472651))
- Add `return` after `t.Fatal` on nil pointer checks so staticcheck sees the control flow
- Also cover the same pattern in `inventory_client_test.go` and `hubha_controller_test.go`

## Test plan

- [ ] `format` job (`golangci-lint`) passes

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test error handling by stopping execution after fatal setup failures.
  * Prevented follow-up assertions from accessing unavailable or nil values.
  * Made failures clearer and reduced misleading test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->