### PR TITLE
Fix golangci-lint SA5011 nil-deref in tests for GH 1.7 (#2858)

### DIFF
--- a/pkg/transport/consumer/generic_consumer_test.go
+++ b/pkg/transport/consumer/generic_consumer_test.go
@@ -19,10 +19,11 @@ import (
 func TestGenerateConsumer(t *testing.T) {
 	consumer, err := NewGenericConsumer(true, false)
 	if err != nil {
-		t.Errorf("failed to generate consumer - %v", err)
+		t.Fatalf("failed to generate consumer - %v", err)
 	}
 	if consumer == nil {
 		t.Fatal("consumer should not be nil")
+		return
 	}
 	if consumer.eventChan == nil {
 		t.Fatal("eventChan should be initialized")


### PR DESCRIPTION
## Summary

- Backport the SA5011 (`staticcheck`) test fix from [#2858](https://github.com/stolostron/multicluster-global-hub/pull/2858) to GH 1.7 (`release-2.16`)
- Add `return` after `t.Fatal` on the nil consumer check in `generic_consumer_test.go`, and change the error path from `t.Errorf` to `t.Fatalf`

## Context

- [#2858](https://github.com/stolostron/multicluster-global-hub/pull/2858) landed on `main` after golangci-lint SA5011 failed the `format` job
- On this release line only `pkg/transport/consumer/generic_consumer_test.go` has that pattern; the other three files from [#2858](https://github.com/stolostron/multicluster-global-hub/pull/2858) (`hubha_controller_test.go`, `inventory_client_test.go`, `strimzi_kafka_controller_test.go` `TestGetManagerTransportConn`) are not present here

Related:

- [#2858](https://github.com/stolostron/multicluster-global-hub/pull/2858) — parent fix on `main`

## Test plan

- [ ] `format` job (`golangci-lint`) passes
- [ ] `TestGenerateConsumer` unit test passes


Made with [Cursor](https://cursor.com)