### PR TITLE
Security: Backport Go 1.26.7 [multicluster-globalhub-1.4]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/multicluster-global-hub
 
-go 1.26.4
+go 1.26.7
 
 tool (
 	github.com/daixiang0/gci


### PR DESCRIPTION
## Summary

Backport [#2854](https://github.com/stolostron/multicluster-global-hub/pull/2854): bump Go from `1.26.4` to `1.26.7`.

Fixes:
- [ACM-41297](https://redhat.atlassian.net/browse/ACM-41297) — CVE-2026-33818
- [ACM-41277](https://redhat.atlassian.net/browse/ACM-41277) — CVE-2026-56862
- [ACM-41252](https://redhat.atlassian.net/browse/ACM-41252) — CVE-2026-56858
- [ACM-41229](https://redhat.atlassian.net/browse/ACM-41229) — CVE-2026-56853
- [ACM-41201](https://redhat.atlassian.net/browse/ACM-41201) — CVE-2026-56859
- [ACM-41182](https://redhat.atlassian.net/browse/ACM-41182) — CVE-2026-56860

[ACM-41297]: https://redhat.atlassian.net/browse/ACM-41297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-41277]: https://redhat.atlassian.net/browse/ACM-41277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-41252]: https://redhat.atlassian.net/browse/ACM-41252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-41229]: https://redhat.atlassian.net/browse/ACM-41229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-41201]: https://redhat.atlassian.net/browse/ACM-41201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-41182]: https://redhat.atlassian.net/browse/ACM-41182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ