### PR TITLE
Security: Backport Go 1.26.7 [multicluster-globalhub-1.5]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/multicluster-global-hub
 
-go 1.26.4
+go 1.26.7
 
 tool (
 	github.com/daixiang0/gci


### PR DESCRIPTION
## Summary

Backport [#2854](https://github.com/stolostron/multicluster-global-hub/pull/2854): bump Go from `1.26.4` to `1.26.7`.

Fixes:
- [ACM-41298](https://redhat.atlassian.net/browse/ACM-41298) — CVE-2026-33818
- [ACM-41278](https://redhat.atlassian.net/browse/ACM-41278) — CVE-2026-56862
- [ACM-41253](https://redhat.atlassian.net/browse/ACM-41253) — CVE-2026-56858
- [ACM-41230](https://redhat.atlassian.net/browse/ACM-41230) — CVE-2026-56853
- [ACM-41202](https://redhat.atlassian.net/browse/ACM-41202) — CVE-2026-56859
- [ACM-41184](https://redhat.atlassian.net/browse/ACM-41184) — CVE-2026-56860

[ACM-41298]: https://redhat.atlassian.net/browse/ACM-41298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-41278]: https://redhat.atlassian.net/browse/ACM-41278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-41253]: https://redhat.atlassian.net/browse/ACM-41253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-41230]: https://redhat.atlassian.net/browse/ACM-41230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-41202]: https://redhat.atlassian.net/browse/ACM-41202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-41184]: https://redhat.atlassian.net/browse/ACM-41184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ