### PR TITLE
Security: Backport Go 1.26.7 [multicluster-globalhub-1.6]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/multicluster-global-hub
 
-go 1.26.4
+go 1.26.7
 
 tool (
 	github.com/daixiang0/gci


### PR DESCRIPTION
## Summary

Backport [#2854](https://github.com/stolostron/multicluster-global-hub/pull/2854): bump Go from `1.26.4` to `1.26.7`.

Fixes:
- [ACM-41299](https://redhat.atlassian.net/browse/ACM-41299) — CVE-2026-33818
- [ACM-41279](https://redhat.atlassian.net/browse/ACM-41279) — CVE-2026-56862
- [ACM-41254](https://redhat.atlassian.net/browse/ACM-41254) — CVE-2026-56858
- [ACM-41231](https://redhat.atlassian.net/browse/ACM-41231) — CVE-2026-56853
- [ACM-41203](https://redhat.atlassian.net/browse/ACM-41203) — CVE-2026-56859
- [ACM-41183](https://redhat.atlassian.net/browse/ACM-41183) — CVE-2026-56860

[ACM-41299]: https://redhat.atlassian.net/browse/ACM-41299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-41279]: https://redhat.atlassian.net/browse/ACM-41279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-41254]: https://redhat.atlassian.net/browse/ACM-41254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-41231]: https://redhat.atlassian.net/browse/ACM-41231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-41203]: https://redhat.atlassian.net/browse/ACM-41203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-41183]: https://redhat.atlassian.net/browse/ACM-41183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ