### PR TITLE
Security: Backport Go 1.26.7 [multicluster-globalhub-1.7]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/multicluster-global-hub
 
-go 1.26.4
+go 1.26.7
 
 tool (
 	github.com/daixiang0/gci


### PR DESCRIPTION
## Summary

Backport [#2854](https://github.com/stolostron/multicluster-global-hub/pull/2854): bump Go from `1.26.4` to `1.26.7`.

Fixes:
- [ACM-41300](https://redhat.atlassian.net/browse/ACM-41300) — CVE-2026-33818
- [ACM-41280](https://redhat.atlassian.net/browse/ACM-41280) — CVE-2026-56862
- [ACM-41255](https://redhat.atlassian.net/browse/ACM-41255) — CVE-2026-56858
- [ACM-41232](https://redhat.atlassian.net/browse/ACM-41232) — CVE-2026-56853
- [ACM-41204](https://redhat.atlassian.net/browse/ACM-41204) — CVE-2026-56859
- [ACM-41185](https://redhat.atlassian.net/browse/ACM-41185) — CVE-2026-56860

[ACM-41300]: https://redhat.atlassian.net/browse/ACM-41300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-41280]: https://redhat.atlassian.net/browse/ACM-41280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-41255]: https://redhat.atlassian.net/browse/ACM-41255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-41232]: https://redhat.atlassian.net/browse/ACM-41232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-41204]: https://redhat.atlassian.net/browse/ACM-41204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-41185]: https://redhat.atlassian.net/browse/ACM-41185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ