### PR TITLE
Security: Backport Go 1.26.7 [multicluster-globalhub-1.8]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/multicluster-global-hub
 
-go 1.26.4
+go 1.26.7
 
 tool (
 	github.com/daixiang0/gci


### PR DESCRIPTION
## Summary

Backport [#2854](https://github.com/stolostron/multicluster-global-hub/pull/2854): bump Go from `1.26.4` to `1.26.7`.

Fixes:
- [ACM-41301](https://redhat.atlassian.net/browse/ACM-41301) — CVE-2026-33818
- [ACM-41281](https://redhat.atlassian.net/browse/ACM-41281) — CVE-2026-56862
- [ACM-41256](https://redhat.atlassian.net/browse/ACM-41256) — CVE-2026-56858
- [ACM-41233](https://redhat.atlassian.net/browse/ACM-41233) — CVE-2026-56853
- [ACM-41205](https://redhat.atlassian.net/browse/ACM-41205) — CVE-2026-56859
- [ACM-41186](https://redhat.atlassian.net/browse/ACM-41186) — CVE-2026-56860

[ACM-41301]: https://redhat.atlassian.net/browse/ACM-41301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-41281]: https://redhat.atlassian.net/browse/ACM-41281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-41256]: https://redhat.atlassian.net/browse/ACM-41256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-41233]: https://redhat.atlassian.net/browse/ACM-41233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-41205]: https://redhat.atlassian.net/browse/ACM-41205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-41186]: https://redhat.atlassian.net/browse/ACM-41186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ