### PR TITLE
Fixes: ACM-42316,ACM-42317, ACM-42318, ACM-42325, ACM-41991, ACM-41853 Harden TLS, Grafana credentials, and database error handling for GH 1.4 (#2841)

### DIFF
--- a/manager/pkg/restapis/apis.go
+++ b/manager/pkg/restapis/apis.go
@@ -45,15 +45,14 @@ type restApiServer struct {
 }
 
 func readCertificateAuthority(nonK8sAPIServerConfig *RestApiServerConfig) ([]byte, error) {
-	var clusterAPICABundle []byte
+	if nonK8sAPIServerConfig.ClusterAPICABundlePath == "" {
+		return nil, nil
+	}
 
-	if nonK8sAPIServerConfig.ClusterAPICABundlePath != "" {
-		clusterAPICABundle, err := os.ReadFile(nonK8sAPIServerConfig.ClusterAPICABundlePath)
-		if err != nil {
-			return clusterAPICABundle,
-				fmt.Errorf("%w: %s", errFailedToLoadCertificate,
-					nonK8sAPIServerConfig.ClusterAPICABundlePath)
-		}
+	clusterAPICABundle, err := os.ReadFile(nonK8sAPIServerConfig.ClusterAPICABundlePath)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s", errFailedToLoadCertificate,
+			nonK8sAPIServerConfig.ClusterAPICABundlePath)
 	}
 
 	return clusterAPICABundle, nil

--- a/manager/pkg/restapis/authentication/authentication.go
+++ b/manager/pkg/restapis/authentication/authentication.go
@@ -25,7 +25,10 @@ const (
 	GroupsKey = "groups"
 )
 
-var errUnableToAppendCABundle = errors.New("unable to append CA Bundle")
+var (
+	errUnableToAppendCABundle     = errors.New("unable to append CA Bundle")
+	errClusterAPICABundleRequired = errors.New("cluster API CA bundle is required")
+)
 
 // Authentication middleware.
 func Authentication(clusterAPIURL string, clusterAPICABundle []byte) gin.HandlerFunc {
@@ -47,22 +50,19 @@ func Authentication(clusterAPIURL string, clusterAPICABundle []byte) gin.Handler
 }
 
 func createClient(clusterAPICABundle []byte) (*http.Client, error) {
-	tlsConfig := &tls.Config{ // #nosec G402
-		// nolint:gosec
-		InsecureSkipVerify: true, // #nosec G402
+	if len(clusterAPICABundle) == 0 {
+		return nil, errClusterAPICABundleRequired
 	}
 
-	if clusterAPICABundle != nil {
-		rootCAs := x509.NewCertPool()
-		if ok := rootCAs.AppendCertsFromPEM(clusterAPICABundle); !ok {
-			fmt.Fprintf(gin.DefaultWriter, "unable to append cluster API CA Bundle")
-			return nil, fmt.Errorf("unable to append cluster API CA Bundle %w", errUnableToAppendCABundle)
-		}
+	rootCAs := x509.NewCertPool()
+	if ok := rootCAs.AppendCertsFromPEM(clusterAPICABundle); !ok {
+		fmt.Fprintf(gin.DefaultWriter, "unable to append cluster API CA Bundle")
+		return nil, fmt.Errorf("unable to append cluster API CA Bundle %w", errUnableToAppendCABundle)
+	}
 
-		tlsConfig = &tls.Config{
-			MinVersion: tls.VersionTLS12,
-			RootCAs:    rootCAs,
-		}
+	tlsConfig := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		RootCAs:    rootCAs,
 	}
 
 	tr := &http.Transport{TLSClientConfig: tlsConfig}
@@ -76,6 +76,7 @@ func setAuthenticatedUser(ginCtx *gin.Context, authorizationHeader string, clust
 	client, err := createClient(clusterAPICABundle)
 	if err != nil {
 		fmt.Fprintf(gin.DefaultWriter, "unable to create client: %v\n", err)
+		return false
 	}
 
 	authURL := fmt.Sprintf("%s/apis/user.openshift.io/v1/users/~", clusterAPIURL)

--- a/operator/pkg/config/multiclusterglobalhub_config.go
+++ b/operator/pkg/config/multiclusterglobalhub_config.go
@@ -73,9 +73,10 @@ const (
 )
 
 var (
-	mghNamespacedName  = types.NamespacedName{}
-	oauthSessionSecret = ""
-	imageOverrides     = map[string]string{
+	mghNamespacedName    = types.NamespacedName{}
+	oauthSessionSecret   = ""
+	grafanaAdminPassword = ""
+	imageOverrides       = map[string]string{
 		GlobalHubAgentImageKey:   "quay.io/stolostron/multicluster-global-hub-agent:latest",
 		GlobalHubManagerImageKey: "quay.io/stolostron/multicluster-global-hub-manager:latest",
 		OauthProxyImageKey:       "quay.io/stolostron/origin-oauth-proxy:4.9",
@@ -119,6 +120,28 @@ func GetOauthSessionSecret() (string, error) {
 		oauthSessionSecret = base64.StdEncoding.EncodeToString(b)
 	}
 	return oauthSessionSecret, nil
+}
+
+// GetGrafanaAdminPassword returns a stable random Grafana admin password for this operator process.
+// Grafana defaults to admin/admin when admin_password is unset in grafana.ini.
+func GetGrafanaAdminPassword() (string, error) {
+	if grafanaAdminPassword == "" {
+		b := make([]byte, 24)
+		_, err := rand.Read(b)
+		if err != nil {
+			return "", fmt.Errorf("failed to generate grafana admin password: %w", err)
+		}
+		grafanaAdminPassword = base64.StdEncoding.EncodeToString(b)
+	}
+	return grafanaAdminPassword, nil
+}
+
+// SeedGrafanaAdminPassword restores a previously persisted Grafana admin password, for example
+// from the merged grafana.ini secret after an operator restart.
+func SeedGrafanaAdminPassword(password string) {
+	if password != "" {
+		grafanaAdminPassword = password
+	}
 }
 
 var MGHPred = predicate.Funcs{

--- a/operator/pkg/config/multiclusterglobalhub_config_test.go
+++ b/operator/pkg/config/multiclusterglobalhub_config_test.go
@@ -127,6 +127,45 @@ func TestGetOauthSessionSecret(t *testing.T) {
 	}
 }
 
+// TestGetGrafanaAdminPassword verifies a stable generated Grafana admin password.
+func TestGetGrafanaAdminPassword(t *testing.T) {
+	previous := grafanaAdminPassword
+	grafanaAdminPassword = ""
+	t.Cleanup(func() {
+		grafanaAdminPassword = previous
+	})
+	password1, err := GetGrafanaAdminPassword()
+	if err != nil {
+		t.Fatalf("failed to get grafana admin password: %v", err)
+	}
+	password2, err := GetGrafanaAdminPassword()
+	if err != nil {
+		t.Fatalf("failed to get grafana admin password: %v", err)
+	}
+	if password1 == "" {
+		t.Fatalf("grafana admin password should not be empty")
+	}
+	if password1 != password2 {
+		t.Fatalf("grafana admin password is not consistent")
+	}
+}
+
+// TestSeedGrafanaAdminPassword verifies persisted Grafana admin passwords are reused.
+func TestSeedGrafanaAdminPassword(t *testing.T) {
+	previous := grafanaAdminPassword
+	t.Cleanup(func() {
+		grafanaAdminPassword = previous
+	})
+	SeedGrafanaAdminPassword("persisted-password")
+	password, err := GetGrafanaAdminPassword()
+	if err != nil {
+		t.Fatalf("failed to get grafana admin password: %v", err)
+	}
+	if password != "persisted-password" {
+		t.Fatal("seeded Grafana admin password should be reused")
+	}
+}
+
 func TestSetMulticlusterGlobalHubConfig(t *testing.T) {
 	oauthImage := "quay.io/testing/origin-oauth-proxy:4.9"
 	mghInstance := &globalhubv1alpha4.MulticlusterGlobalHub{

--- a/operator/pkg/controllers/grafana/grafana_reconciler.go
+++ b/operator/pkg/controllers/grafana/grafana_reconciler.go
@@ -111,6 +111,7 @@ type GrafanaReconciler struct {
 	scheme     *runtime.Scheme
 }
 
+// NewGrafanaReconciler constructs a GrafanaReconciler bound to the controller-runtime manager.
 func NewGrafanaReconciler(mgr ctrl.Manager, kubeClient kubernetes.Interface) *GrafanaReconciler {
 	return &GrafanaReconciler{
 		Manager:    mgr,
@@ -122,10 +123,12 @@ func NewGrafanaReconciler(mgr ctrl.Manager, kubeClient kubernetes.Interface) *Gr
 
 var grafanaController *GrafanaReconciler
 
+// IsResourceRemoved reports whether Grafana resources were cleaned up.
 func (r *GrafanaReconciler) IsResourceRemoved() bool {
 	return true
 }
 
+// StartController registers the Grafana controller when ACM and storage are ready.
 func StartController(initOption config.ControllerOption) (config.ControllerInterface, error) {
 	if grafanaController != nil {
 		return grafanaController, nil
@@ -462,6 +465,32 @@ func (r *GrafanaReconciler) generateGrafanaIni(
 		}
 	}
 
+	existingMerged := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      mergedGrafanaIniName,
+			Namespace: configNamespace,
+		},
+	}
+	if err := r.client.Get(ctx, client.ObjectKeyFromObject(existingMerged), existingMerged); err != nil {
+		if !errors.IsNotFound(err) {
+			return false, fmt.Errorf("failed to get merged grafana.ini secret: %w", err)
+		}
+	} else {
+		pwd, pwdErr := adminPasswordFromGrafanaIni(existingMerged.Data[grafanaIniKey])
+		if pwdErr != nil {
+			return false, fmt.Errorf("failed to parse persisted grafana.ini: %w", pwdErr)
+		}
+		if pwd != "" {
+			config.SeedGrafanaAdminPassword(pwd)
+		}
+	}
+
+	mergedIni, err := injectGrafanaAdminPassword(mergedGrafanaIniSecret.Data[grafanaIniKey])
+	if err != nil {
+		return false, fmt.Errorf("failed to set grafana admin password: %w", err)
+	}
+	mergedGrafanaIniSecret.Data[grafanaIniKey] = mergedIni
+
 	if err = controllerutil.SetControllerReference(mgh, mergedGrafanaIniSecret, r.scheme); err != nil {
 		return false, err
 	}
@@ -533,11 +562,11 @@ func mergeGrafanaIni(defaultIni, customIni []byte) ([]byte, error) {
 	if len(customIni) == 0 {
 		return defaultIni, nil
 	}
-	defaultCfg, err := ini.Load(defaultIni)
+	defaultCfg, err := loadGrafanaIni(defaultIni)
 	if err != nil {
 		return nil, err
 	}
-	customCfg, err := ini.Load(customIni)
+	customCfg, err := loadGrafanaIni(customIni)
 	if err != nil {
 		return nil, err
 	}
@@ -703,22 +732,91 @@ func (r *GrafanaReconciler) GenerateGrafanaDataSourceSecret(
 	return false, nil
 }
 
-func GrafanaDataSource(databaseURI string, cert []byte, serviceAccountToken string) ([]byte, error) {
-	postgresURI := string(databaseURI)
-	objURI, err := url.Parse(postgresURI)
+type postgresConnectionParams struct {
+	host, user, password, database, sslMode string
+}
+
+// parsePostgresConnection extracts Grafana datasource fields from a PostgreSQL URI.
+// Parse errors use a fixed message so credentials in the URI cannot leak.
+func parsePostgresConnection(databaseURI string) (postgresConnectionParams, error) {
+	objURI, err := url.Parse(databaseURI)
 	if err != nil {
-		return nil, err
+		return postgresConnectionParams{}, fmt.Errorf("failed to parse postgres connection")
 	}
 	password, ok := objURI.User.Password()
 	if !ok {
-		return nil, fmt.Errorf("failed to get password from database_uri: %s", postgresURI)
+		return postgresConnectionParams{}, fmt.Errorf("postgres connection is missing a password")
 	}
-
-	// get the database from the objURI
 	database := "hoh"
 	paths := strings.Split(objURI.Path, "/")
-	if len(paths) > 1 {
+	if len(paths) > 1 && paths[1] != "" {
 		database = paths[1]
+	}
+	return postgresConnectionParams{
+		host:     objURI.Host,
+		user:     objURI.User.Username(),
+		password: password,
+		database: database,
+		sslMode:  objURI.Query().Get("sslmode"),
+	}, nil
+}
+
+// injectGrafanaAdminPassword writes a stable admin_password into grafana.ini.
+func injectGrafanaAdminPassword(grafanaIni []byte) ([]byte, error) {
+	adminPassword, err := config.GetGrafanaAdminPassword()
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := loadGrafanaIni(grafanaIni)
+	if err != nil {
+		return nil, err
+	}
+	sec, err := cfg.GetSection("security")
+	if err != nil {
+		sec, err = cfg.NewSection("security")
+		if err != nil {
+			return nil, fmt.Errorf("failed to create grafana security section: %w", err)
+		}
+	}
+	sec.Key("admin_password").SetValue(adminPassword)
+	var buf bytes.Buffer
+	if _, err = cfg.WriteTo(&buf); err != nil {
+		return nil, fmt.Errorf("failed to serialize grafana.ini: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// adminPasswordFromGrafanaIni reads a previously persisted Grafana admin_password.
+func adminPasswordFromGrafanaIni(grafanaIni []byte) (string, error) {
+	if len(grafanaIni) == 0 {
+		return "", nil
+	}
+	cfg, err := loadGrafanaIni(grafanaIni)
+	if err != nil {
+		return "", err
+	}
+	sec, err := cfg.GetSection("security")
+	if err != nil {
+		return "", nil
+	}
+	return sec.Key("admin_password").String(), nil
+}
+
+// loadGrafanaIni parses grafana.ini without wrapping parser errors, which can
+// include file contents such as admin_password.
+func loadGrafanaIni(data []byte) (*ini.File, error) {
+	cfg, err := ini.Load(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load grafana.ini")
+	}
+	return cfg, nil
+}
+
+// GrafanaDataSource builds the Grafana datasource secret payload for PostgreSQL and optional Prometheus.
+func GrafanaDataSource(databaseURI string, cert []byte, serviceAccountToken string) ([]byte, error) {
+	conn, err := parsePostgresConnection(databaseURI)
+	if err != nil {
+		return nil, err
 	}
 
 	postgresDS := &GrafanaDatasource{
@@ -726,16 +824,16 @@ func GrafanaDataSource(databaseURI string, cert []byte, serviceAccountToken stri
 		Type:      "postgres",
 		Access:    "proxy",
 		IsDefault: true,
-		URL:       objURI.Host,
-		User:      objURI.User.Username(),
-		Database:  database,
+		URL:       conn.host,
+		User:      conn.user,
+		Database:  conn.database,
 		Editable:  false,
 		JSONData: &JsonData{
 			QueryTimeout: "300s",
 			TimeInterval: "30s",
 		},
 		SecureJSONData: &SecureJsonData{
-			Password: password,
+			Password: conn.password,
 		},
 	}
 	datasource := []*GrafanaDatasource{postgresDS}
@@ -763,10 +861,17 @@ func GrafanaDataSource(databaseURI string, cert []byte, serviceAccountToken stri
 	}
 
 	if len(cert) > 0 {
-		postgresDS.JSONData.SSLMode = objURI.Query().Get("sslmode") // sslmode == "verify-full" || sslmode == "verify-ca"
+		switch conn.sslMode {
+		case "verify-ca", "verify-full":
+		default:
+			return nil, fmt.Errorf(
+				"postgres sslmode must be verify-ca or verify-full when CA certificate is configured",
+			)
+		}
+		postgresDS.JSONData.SSLMode = conn.sslMode // sslmode == "verify-full" || sslmode == "verify-ca"
 		postgresDS.JSONData.TLSAuth = true
 		postgresDS.JSONData.TLSAuthWithCACert = true
-		postgresDS.JSONData.TLSSkipVerify = true
+		postgresDS.JSONData.TLSSkipVerify = false
 		postgresDS.JSONData.TLSConfigurationMethod = "file-content"
 		postgresDS.SecureJSONData.TLSCACert = string(cert)
 	}

--- a/operator/pkg/controllers/grafana/grafana_reconciler_test.go
+++ b/operator/pkg/controllers/grafana/grafana_reconciler_test.go
@@ -2,11 +2,14 @@ package grafana
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/ini.v1"
+	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -16,6 +19,7 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
 	operatorutils "github.com/stolostron/multicluster-global-hub/operator/pkg/utils"
@@ -609,8 +613,120 @@ email = example@redhat.com
 			if sectionCount(tt.wantSecret.Data[grafanaIniKey]) == -1 || (sectionCount(mergedGrafanaIniSecret.Data[grafanaIniKey]) != sectionCount(tt.wantSecret.Data[grafanaIniKey])) {
 				t.Errorf("mergeGrafanaIni() = %v, want %v", sectionCount(mergedGrafanaIniSecret.Data[grafanaIniKey]), sectionCount(tt.wantSecret.Data[grafanaIniKey]))
 			}
+
+			// F003: generateGrafanaIni must inject a random admin password into grafana.ini.
+			iniCfg, err := ini.Load(mergedGrafanaIniSecret.Data[grafanaIniKey])
+			require.NoError(t, err, "merged grafana.ini must remain valid INI after reconciliation")
+			sec, err := iniCfg.GetSection("security")
+			require.NoError(t, err, "merged grafana.ini must retain a security section")
+			assert.NotEmpty(t, sec.Key("admin_password").String(),
+				"Grafana admin_password must be injected instead of default admin/admin")
 		})
 	}
+}
+
+func defaultGrafanaIniSecretForTest(namespace string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      defaultGrafanaIniName,
+			Labels: map[string]string{
+				"name": "multicluster-global-hub-grafana",
+			},
+		},
+		Data: map[string][]byte{
+			grafanaIniKey: []byte("[security]\nadmin_user = admin\n[server]\nhttp_port = 3001\n"),
+		},
+	}
+}
+
+// TestGenerateGrafanaIniPersistedSecretErrors verifies secret lookup failures do not mint a new password.
+func TestGenerateGrafanaIniPersistedSecretErrors(t *testing.T) {
+	configNamespace := utils.GetDefaultNamespace()
+	mgh := &v1alpha4.MulticlusterGlobalHub{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: configNamespace,
+		},
+		Spec: v1alpha4.MulticlusterGlobalHubSpec{},
+	}
+
+	t.Run("merged secret lookup failure", func(t *testing.T) {
+		require.NoError(t, v1alpha4.AddToScheme(scheme.Scheme),
+			"operator scheme registration must succeed before fake client setup")
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme.Scheme).
+			WithRuntimeObjects(defaultGrafanaIniSecretForTest(configNamespace)).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Get: func(
+					ctx context.Context,
+					c client.WithWatch,
+					key client.ObjectKey,
+					obj client.Object,
+					opts ...client.GetOption,
+				) error {
+					if key.Name == mergedGrafanaIniName {
+						return fmt.Errorf("simulated merged grafana.ini lookup failure")
+					}
+					return c.Get(ctx, key, obj, opts...)
+				},
+			}).
+			Build()
+
+		r := &GrafanaReconciler{
+			client: fakeClient,
+			scheme: scheme.Scheme,
+		}
+
+		_, err := r.generateGrafanaIni(context.Background(), mgh)
+		require.Error(t, err, "merged grafana.ini lookup failures must abort reconciliation")
+		assert.Contains(t, err.Error(), "failed to get merged grafana.ini secret",
+			"lookup failures must identify the persisted Grafana secret")
+	})
+
+	t.Run("invalid persisted grafana.ini", func(t *testing.T) {
+		require.NoError(t, v1alpha4.AddToScheme(scheme.Scheme),
+			"operator scheme registration must succeed before fake client setup")
+		existingMerged := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: configNamespace,
+				Name:      mergedGrafanaIniName,
+			},
+			Data: map[string][]byte{
+				grafanaIniKey: []byte("[security]\nadmin_password = leaked-secret\n[[[broken"),
+			},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme.Scheme).
+			WithRuntimeObjects(
+				defaultGrafanaIniSecretForTest(configNamespace),
+				existingMerged,
+			).
+			Build()
+
+		r := &GrafanaReconciler{
+			client: fakeClient,
+			scheme: scheme.Scheme,
+		}
+
+		_, err := r.generateGrafanaIni(context.Background(), mgh)
+		require.Error(t, err, "invalid persisted grafana.ini must abort reconciliation")
+		assert.Contains(t, err.Error(), "failed to parse persisted grafana.ini",
+			"persisted INI parse failures must not rotate the Grafana admin password")
+		assert.NotContains(t, err.Error(), "leaked-secret",
+			"INI parse errors must not include grafana.ini contents")
+		assert.NotContains(t, err.Error(), "[[[broken",
+			"INI parse errors must not include parser details from grafana.ini")
+
+		unchanged := &corev1.Secret{}
+		require.NoError(t, fakeClient.Get(
+			context.Background(),
+			client.ObjectKeyFromObject(existingMerged),
+			unchanged,
+		), "failed reconciliation must still leave the persisted grafana.ini secret readable")
+		assert.Equal(t, existingMerged.Data[grafanaIniKey], unchanged.Data[grafanaIniKey],
+			"failed reconciliation must not overwrite the persisted grafana.ini secret")
+	})
 }
 
 func TestMergeGrafanaIni(t *testing.T) {
@@ -917,4 +1033,190 @@ func sectionCount(a []byte) int {
 	}
 	// By Default, There is a DEFAULT section, should not count it
 	return len(cfg.Sections()) - 1
+}
+
+// TestAdminPasswordFromGrafanaIni verifies persisted password restore and INI error redaction.
+func TestAdminPasswordFromGrafanaIni(t *testing.T) {
+	t.Run("reads persisted password", func(t *testing.T) {
+		password, err := adminPasswordFromGrafanaIni([]byte("[security]\nadmin_password = cached\n"))
+		require.NoError(t, err, "valid persisted grafana.ini must parse")
+		assert.Equal(t, "cached", password, "persisted Grafana admin password must be restored")
+	})
+
+	t.Run("invalid ini", func(t *testing.T) {
+		_, err := adminPasswordFromGrafanaIni([]byte("[security]\nadmin_password = leaked-secret\n[[[broken"))
+		require.Error(t, err, "invalid persisted grafana.ini must be rejected")
+		assert.Equal(t, "failed to load grafana.ini", err.Error(),
+			"INI parse failures must use a fixed message without parser details")
+		assert.NotContains(t, err.Error(), "leaked-secret",
+			"INI parse errors must not include grafana.ini contents")
+	})
+}
+
+// TestInjectGrafanaAdminPassword verifies admin_password injection and INI error redaction.
+func TestInjectGrafanaAdminPassword(t *testing.T) {
+	t.Run("sets password in existing security section", func(t *testing.T) {
+		merged, err := injectGrafanaAdminPassword([]byte("[security]\nadmin_user = admin\n"))
+		require.NoError(t, err, "valid grafana.ini must accept admin password injection")
+
+		cfg, err := ini.Load(merged)
+		require.NoError(t, err, "injected grafana.ini must remain valid INI")
+
+		sec, err := cfg.GetSection("security")
+		require.NoError(t, err, "injected grafana.ini must keep a security section")
+		assert.NotEmpty(t, sec.Key("admin_password").String(),
+			"Grafana admin_password must be injected into an existing security section")
+	})
+
+	t.Run("creates security section when missing", func(t *testing.T) {
+		merged, err := injectGrafanaAdminPassword([]byte("[server]\nhttp_port = 3001\n"))
+		require.NoError(t, err, "grafana.ini without security must accept admin password injection")
+
+		cfg, err := ini.Load(merged)
+		require.NoError(t, err, "injected grafana.ini must remain valid INI")
+
+		sec, err := cfg.GetSection("security")
+		require.NoError(t, err, "injection must create a security section")
+		assert.NotEmpty(t, sec.Key("admin_password").String(),
+			"Grafana admin_password must be injected when the security section is missing")
+	})
+
+	t.Run("invalid ini does not leak contents", func(t *testing.T) {
+		_, err := injectGrafanaAdminPassword([]byte("[security]\nadmin_password = leaked-secret\n[[[broken"))
+		require.Error(t, err, "invalid grafana.ini must be rejected before password injection")
+		assert.Equal(t, "failed to load grafana.ini", err.Error(),
+			"INI parse failures must use a fixed message without parser details")
+		assert.NotContains(t, err.Error(), "leaked-secret",
+			"INI parse errors must not include grafana.ini contents")
+	})
+}
+
+// F004: postgres connection parsing must not echo credentials in errors.
+func TestParsePostgresConnection(t *testing.T) {
+	tests := []struct {
+		name    string
+		uri     string
+		want    postgresConnectionParams
+		wantErr bool
+	}{
+		{
+			name: "valid uri",
+			uri:  "postgresql://grafana:secret@pg.example:5432/mydb?sslmode=verify-full",
+			want: postgresConnectionParams{
+				host: "pg.example:5432", user: "grafana", password: "secret",
+				database: "mydb", sslMode: "verify-full",
+			},
+		},
+		{
+			name: "default database",
+			uri:  "postgresql://grafana:secret@pg.example:5432",
+			want: postgresConnectionParams{
+				host: "pg.example:5432", user: "grafana", password: "secret", database: "hoh",
+			},
+		},
+		{
+			name: "trailing slash keeps default database",
+			uri:  "postgresql://grafana:secret@pg.example:5432/",
+			want: postgresConnectionParams{
+				host: "pg.example:5432", user: "grafana", password: "secret", database: "hoh",
+			},
+		},
+		{
+			name:    "missing password",
+			uri:     "postgresql://grafana@pg.example:5432/mydb",
+			wantErr: true,
+		},
+		{
+			name:    "invalid uri",
+			uri:     "://bad-uri",
+			wantErr: true,
+		},
+		{
+			name:    "malformed uri with password",
+			uri:     "postgresql://grafana:secret-password%zz@db.example:5432/hoh",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parsePostgresConnection(tt.uri)
+			if tt.wantErr {
+				require.Error(t, err, "invalid postgres URI %q must be rejected", tt.name)
+				assert.NotContains(t, err.Error(), "postgresql://",
+					"parse errors must not expose the raw PostgreSQL URI")
+				assert.NotContains(t, err.Error(), "secret-password",
+					"parse errors must not expose the PostgreSQL password")
+				return
+			}
+			require.NoError(t, err, "valid postgres URI %q must parse", tt.name)
+			assert.Equal(t, tt.want, got, "parsed postgres connection fields must match")
+		})
+	}
+}
+
+// F002: Grafana Postgres datasource must verify TLS when a CA cert is configured.
+func TestGrafanaDataSource(t *testing.T) {
+	uri := "postgresql://grafana:secret@pg.example:5432/mydb?sslmode=verify-full"
+
+	t.Run("without cert", func(t *testing.T) {
+		raw, err := GrafanaDataSource(uri, nil, "")
+		require.NoError(t, err, "datasource generation without CA must succeed")
+
+		var datasources GrafanaDatasources
+		require.NoError(t, yaml.Unmarshal(raw, &datasources), "datasource YAML must unmarshal")
+		require.Len(t, datasources.Datasources, 1, "postgres datasource must be present")
+		assert.Equal(t, "Global-Hub-DataSource", datasources.Datasources[0].Name,
+			"postgres datasource name must match")
+		require.NotNil(t, datasources.Datasources[0].JSONData, "postgres JSONData must be set")
+		assert.Equal(t, "mydb", datasources.Datasources[0].Database,
+			"postgres database name must come from the URI")
+	})
+
+	t.Run("with cert", func(t *testing.T) {
+		raw, err := GrafanaDataSource(uri, []byte("ca-cert"), "")
+		require.NoError(t, err, "datasource generation with CA must succeed")
+
+		var datasources GrafanaDatasources
+		require.NoError(t, yaml.Unmarshal(raw, &datasources), "datasource YAML must unmarshal")
+		require.Len(t, datasources.Datasources, 1, "postgres datasource must be present")
+
+		ds := datasources.Datasources[0]
+		require.NotNil(t, ds.JSONData, "postgres JSONData must be set")
+		assert.Equal(t, "verify-full", ds.JSONData.SSLMode,
+			"CA-backed datasource must keep a verifying sslmode")
+		assert.True(t, ds.JSONData.TLSAuth, "CA-backed datasource must enable TLS auth")
+		assert.True(t, ds.JSONData.TLSAuthWithCACert, "CA-backed datasource must attach the CA cert")
+		assert.False(t, ds.JSONData.TLSSkipVerify, "CA-backed datasource must not skip TLS verify")
+		assert.NotEmpty(t, ds.SecureJSONData.TLSCACert, "CA-backed datasource must store the CA cert")
+	})
+
+	t.Run("with cert rejects require sslmode", func(t *testing.T) {
+		uriRequire := "postgresql://grafana:secret@pg.example:5432/mydb?sslmode=require"
+		_, err := GrafanaDataSource(uriRequire, []byte("ca-cert"), "")
+		require.Error(t, err, "sslmode=require must be rejected when a CA certificate is configured")
+		assert.Contains(t, err.Error(), "verify-ca or verify-full",
+			"the error must require a certificate-verifying sslmode")
+	})
+
+	t.Run("with cert rejects disable sslmode", func(t *testing.T) {
+		uriDisable := "postgresql://grafana:secret@pg.example:5432/mydb?sslmode=disable"
+		_, err := GrafanaDataSource(uriDisable, []byte("ca-cert"), "")
+		require.Error(t, err, "sslmode=disable must be rejected when a CA certificate is configured")
+		assert.Contains(t, err.Error(), "verify-ca or verify-full",
+			"the error must require a certificate-verifying sslmode")
+	})
+
+	t.Run("with service account token", func(t *testing.T) {
+		raw, err := GrafanaDataSource(uri, nil, "token")
+		require.NoError(t, err, "datasource generation with a service account token must succeed")
+
+		var datasources GrafanaDatasources
+		require.NoError(t, yaml.Unmarshal(raw, &datasources), "datasource YAML must unmarshal")
+		require.Len(t, datasources.Datasources, 2, "prometheus datasource must be appended")
+		assert.Equal(t, "Prometheus", datasources.Datasources[1].Name,
+			"second datasource must be Prometheus")
+		assert.Equal(t, "Bearer token", datasources.Datasources[1].SecureJSONData.HttpHeaderValue1,
+			"prometheus datasource must use the bearer token header")
+	})
 }

--- a/operator/pkg/controllers/inventory/inventory_reconciler.go
+++ b/operator/pkg/controllers/inventory/inventory_reconciler.go
@@ -204,14 +204,14 @@ func (r *InventoryReconciler) Reconcile(ctx context.Context,
 		return ctrl.Result{}, reconcileErr
 	}
 
-	postgresURI, err := url.Parse(string(storageConn.SuperuserDatabaseURI))
+	postgresURI, err := parsePostgresURI(string(storageConn.SuperuserDatabaseURI))
 	if err != nil {
 		reconcileErr = err
 		return ctrl.Result{}, reconcileErr
 	}
-	postgresPassword, ok := postgresURI.User.Password()
-	if !ok {
-		reconcileErr = fmt.Errorf("failed to get password from database_uri: %s", postgresURI)
+	postgresPassword, err := postgresPasswordFromURI(postgresURI)
+	if err != nil {
+		reconcileErr = fmt.Errorf("failed to extract postgres password: %w", err)
 		return ctrl.Result{}, reconcileErr
 	}
 
@@ -347,4 +347,23 @@ func createUpdateInventoryRoute(ctx context.Context, c client.Client,
 	}
 
 	return nil
+}
+
+// parsePostgresURI parses a PostgreSQL URI without returning parser details that can include the password.
+func parsePostgresURI(raw string) (*url.URL, error) {
+	postgresURI, err := url.Parse(raw)
+	if err != nil {
+		// url.Parse errors include the raw URI, which can contain the password.
+		return nil, fmt.Errorf("failed to parse postgres connection")
+	}
+	return postgresURI, nil
+}
+
+// postgresPasswordFromURI returns the URI password without echoing the connection string on error.
+func postgresPasswordFromURI(postgresURI *url.URL) (string, error) {
+	password, ok := postgresURI.User.Password()
+	if !ok {
+		return "", fmt.Errorf("postgres connection is missing a password")
+	}
+	return password, nil
 }

--- a/operator/pkg/controllers/inventory/inventory_reconciler_test.go
+++ b/operator/pkg/controllers/inventory/inventory_reconciler_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inventory
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// F004: database credentials must not appear in error messages.
+func TestPostgresPasswordFromURI(t *testing.T) {
+	t.Run("valid uri", func(t *testing.T) {
+		uri, err := url.Parse("postgresql://inventory:secret@postgres.example:5432/hoh")
+		require.NoError(t, err, "test URI must parse for password extraction coverage")
+
+		password, err := postgresPasswordFromURI(uri)
+		require.NoError(t, err, "valid inventory URI must yield a postgres password")
+		assert.Equal(t, "secret", password, "postgres password must match the URI credential")
+	})
+
+	t.Run("missing password does not leak connection string", func(t *testing.T) {
+		uri, err := url.Parse("postgresql://inventory@postgres.example:5432/hoh")
+		require.NoError(t, err, "test URI must parse for missing-password coverage")
+
+		_, err = postgresPasswordFromURI(uri)
+		require.Error(t, err, "inventory URI without a password must be rejected")
+		assert.Equal(t, "postgres connection is missing a password", err.Error(),
+			"missing-password errors must use a stable message")
+		assert.NotContains(t, err.Error(), "postgresql://",
+			"postgres errors must not echo the raw connection URI")
+		assert.NotContains(t, err.Error(), "inventory@",
+			"postgres errors must not echo the database username")
+	})
+}
+
+// TestParsePostgresURI verifies URI parse failures do not leak credentials.
+func TestParsePostgresURI(t *testing.T) {
+	t.Run("valid uri", func(t *testing.T) {
+		uri, err := parsePostgresURI("postgresql://inventory:secret@postgres.example:5432/hoh")
+		require.NoError(t, err, "valid inventory URI must parse")
+		require.NotNil(t, uri, "parsed inventory URI must be returned")
+		assert.Equal(t, "postgres.example:5432", uri.Host,
+			"parsed inventory URI host must match")
+	})
+
+	t.Run("malformed uri with percent-escaped password does not leak credentials", func(t *testing.T) {
+		const sentinel = "secret-password"
+		raw := "postgresql://inventory:" + sentinel + "%zz@postgres.example:5432/hoh"
+
+		_, err := parsePostgresURI(raw)
+		require.Error(t, err, "malformed inventory URI must be rejected")
+		assert.Equal(t, "failed to parse postgres connection", err.Error(),
+			"parse errors must use a fixed message")
+		assert.NotContains(t, err.Error(), raw,
+			"parse errors must not echo the raw connection URI")
+		assert.NotContains(t, err.Error(), "postgresql://",
+			"parse errors must not echo the URI scheme")
+		assert.NotContains(t, err.Error(), sentinel,
+			"parse errors must not echo the postgres password")
+	})
+}

--- a/operator/pkg/controllers/storage/storage_reconciler.go
+++ b/operator/pkg/controllers/storage/storage_reconciler.go
@@ -40,7 +40,8 @@ import (
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;delete;patch
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups="apps",resources=deployments,verbs=get;list;watch;create;update;delete
-// +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors;prometheusrules,verbs=get;create;delete;update;list;watch
+// +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;create;delete;update;list;watch
+// +kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules,verbs=get;create;delete;update;list;watch
 // +kubebuilder:rbac:groups="apps",resources=statefulsets,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;create;update;delete;patch
 // +kubebuilder:rbac:groups=postgres-operator.crunchydata.com,resources=postgresclusters,verbs=get;create;list;watch
@@ -353,14 +354,13 @@ func (r *StorageReconciler) applyGlobalHubInitSQL(ctx context.Context, conn *pgx
 		}
 	}
 
-	objURI, err := url.Parse(readonlyUserURI)
+	readonlyUsername, err := readonlyUsernameFromURI(readonlyUserURI)
 	if err != nil {
-		log.Error(err, "failed to parse database_uri_with_readonlyuser")
+		return fmt.Errorf("failed to extract readonly username: %w", err)
 	}
-	readonlyUsername := objURI.User.Username()
 
 	if err = applySQL(ctx, conn, databaseFS, "database", readonlyUsername); err != nil {
-		return fmt.Errorf("failed to apply the database sql: %v", err)
+		return fmt.Errorf("failed to apply the database sql: %w", err)
 	}
 
 	if r.enableGlobalResource {
@@ -372,7 +372,7 @@ func (r *StorageReconciler) applyGlobalHubInitSQL(ctx context.Context, conn *pgx
 	if !r.upgrade {
 		err = applySQL(ctx, conn, upgradeFS, "upgrade", readonlyUsername)
 		if err != nil {
-			return fmt.Errorf("failed to apply the upgrade sql: %v", err)
+			return fmt.Errorf("failed to apply the upgrade sql: %w", err)
 		}
 		r.upgrade = true
 	}
@@ -464,4 +464,19 @@ func getDatabaseComponentStatus(ctx context.Context, c client.Client,
 type AnnotationPGUser struct {
 	Name      string   `json:"name"`
 	Databases []string `json:"databases"`
+}
+
+const errParseReadonlyUserURI = "failed to parse database_uri_with_readonlyuser"
+
+// readonlyUsernameFromURI extracts the username from a PostgreSQL URI when present.
+// Parser errors use a fixed message so the URI cannot leak credentials.
+func readonlyUsernameFromURI(readonlyUserURI string) (string, error) {
+	objURI, err := url.Parse(readonlyUserURI)
+	if err != nil {
+		return "", fmt.Errorf("%s", errParseReadonlyUserURI)
+	}
+	if objURI.User == nil {
+		return "", nil
+	}
+	return objURI.User.Username(), nil
 }

--- a/operator/pkg/controllers/storage/storage_reconciler_test.go
+++ b/operator/pkg/controllers/storage/storage_reconciler_test.go
@@ -1,0 +1,377 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/stolostron/multicluster-global-hub/operator/api/operator/v1alpha4"
+	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
+	"github.com/stolostron/multicluster-global-hub/pkg/constants"
+	commonutils "github.com/stolostron/multicluster-global-hub/pkg/utils"
+)
+
+// Predicate Tests - These test critical watch logic that determines which resources trigger reconciliation
+
+// assertPredicateAllEvents asserts Create, Update, and Delete predicate results for the same expected value.
+func assertPredicateAllEvents(t *testing.T, pred predicate.Funcs, obj client.Object, want bool) {
+	t.Helper()
+	assert.Equal(t, want, pred.Create(event.CreateEvent{Object: obj}),
+		"predicate Create should return %v for watched resource events", want)
+	assert.Equal(t, want, pred.Update(event.UpdateEvent{ObjectNew: obj}),
+		"predicate Update should return %v for watched resource events", want)
+	assert.Equal(t, want, pred.Delete(event.DeleteEvent{Object: obj}),
+		"predicate Delete should return %v for watched resource events", want)
+}
+
+func TestConfigMapPredicate(t *testing.T) {
+	// configMapPredicate.CreateFunc only checks the watched-name set; owner label is only
+	// evaluated in UpdateFunc/DeleteFunc (operator-created resources don't need Create triggers).
+	tests := []struct {
+		name             string
+		obj              *corev1.ConfigMap
+		wantCreate       bool
+		wantUpdateDelete bool
+	}{
+		{
+			name: "watched configmap should match",
+			obj: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      BuiltinPostgresCAName,
+					Namespace: commonutils.GetDefaultNamespace(),
+				},
+			},
+			wantCreate:       true,
+			wantUpdateDelete: true,
+		},
+		{
+			name: "configmap with owner label should match on update/delete but not create",
+			obj: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "some-configmap",
+					Namespace: commonutils.GetDefaultNamespace(),
+					Labels: map[string]string{
+						constants.GlobalHubOwnerLabelKey: constants.GHOperatorOwnerLabelVal,
+					},
+				},
+			},
+			wantCreate:       false, // CreateFunc only checks name, not owner label
+			wantUpdateDelete: true,  // UpdateFunc/DeleteFunc also check owner label
+		},
+		{
+			name: "other configmap should not match",
+			obj: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "other-configmap",
+					Namespace: commonutils.GetDefaultNamespace(),
+				},
+			},
+			wantCreate:       false,
+			wantUpdateDelete: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantCreate, configMapPredicate.Create(event.CreateEvent{Object: tt.obj}),
+				"configMapPredicate Create should return %v for %q", tt.wantCreate, tt.name)
+			assert.Equal(t, tt.wantUpdateDelete, configMapPredicate.Update(event.UpdateEvent{ObjectNew: tt.obj}),
+				"configMapPredicate Update should return %v for %q", tt.wantUpdateDelete, tt.name)
+			assert.Equal(t, tt.wantUpdateDelete, configMapPredicate.Delete(event.DeleteEvent{Object: tt.obj}),
+				"configMapPredicate Delete should return %v for %q", tt.wantUpdateDelete, tt.name)
+		})
+	}
+}
+
+func TestStatefulSetPredicate(t *testing.T) {
+	namespace := commonutils.GetDefaultNamespace()
+
+	tests := []struct {
+		name     string
+		obj      *appsv1.StatefulSet
+		wantBool bool
+	}{
+		{
+			name: "builtin postgres statefulset should match",
+			obj: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      BuiltinPostgresName,
+					Namespace: namespace,
+				},
+			},
+			wantBool: true,
+		},
+		{
+			name: "other statefulset should not match",
+			obj: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "other-sts",
+					Namespace: namespace,
+				},
+			},
+			wantBool: false,
+		},
+		{
+			name: "wrong namespace should not match",
+			obj: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      BuiltinPostgresName,
+					Namespace: "wrong-namespace",
+				},
+			},
+			wantBool: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertPredicateAllEvents(t, statefulSetPred, tt.obj, tt.wantBool)
+		})
+	}
+}
+
+func TestSecretPredicate_Storage(t *testing.T) {
+	// secretPred.CreateFunc only checks the watched-name set; owner label is only evaluated in
+	// UpdateFunc/DeleteFunc (operator-created secrets don't need Create triggers).
+	tests := []struct {
+		name             string
+		obj              *corev1.Secret
+		wantCreate       bool
+		wantUpdateDelete bool
+	}{
+		{
+			name: "watched secret should match",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: constants.GHStorageSecretName,
+				},
+			},
+			wantCreate:       true,
+			wantUpdateDelete: true,
+		},
+		{
+			name: "secret with owner label should match on update/delete but not create",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "some-secret",
+					Labels: map[string]string{
+						constants.GlobalHubOwnerLabelKey: constants.GHOperatorOwnerLabelVal,
+					},
+				},
+			},
+			wantCreate:       false, // CreateFunc only checks name, not owner label
+			wantUpdateDelete: true,  // UpdateFunc/DeleteFunc also check owner label
+		},
+		{
+			name: "other secret should not match",
+			obj: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "other-secret",
+				},
+			},
+			wantCreate:       false,
+			wantUpdateDelete: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantCreate, secretPred.Create(event.CreateEvent{Object: tt.obj}),
+				"secretPred Create should return %v for %q", tt.wantCreate, tt.name)
+			assert.Equal(t, tt.wantUpdateDelete, secretPred.Update(event.UpdateEvent{ObjectNew: tt.obj}),
+				"secretPred Update should return %v for %q", tt.wantUpdateDelete, tt.name)
+			assert.Equal(t, tt.wantUpdateDelete, secretPred.Delete(event.DeleteEvent{Object: tt.obj}),
+				"secretPred Delete should return %v for %q", tt.wantUpdateDelete, tt.name)
+		})
+	}
+}
+
+// Utility Function Tests - These test pure functions with business logic
+
+func TestGetRetentionConditions(t *testing.T) {
+	tests := []struct {
+		name       string
+		mgh        *v1alpha4.MulticlusterGlobalHub
+		wantType   string
+		wantStatus string
+	}{
+		{
+			name: "valid retention",
+			mgh: &v1alpha4.MulticlusterGlobalHub{
+				Spec: v1alpha4.MulticlusterGlobalHubSpec{
+					DataLayerSpec: v1alpha4.DataLayerSpec{
+						Postgres: v1alpha4.PostgresSpec{
+							Retention: "6m",
+						},
+					},
+				},
+			},
+			wantType:   config.CONDITION_TYPE_DATABASE,
+			wantStatus: config.CONDITION_STATUS_TRUE,
+		},
+		{
+			name: "invalid retention",
+			mgh: &v1alpha4.MulticlusterGlobalHub{
+				Spec: v1alpha4.MulticlusterGlobalHubSpec{
+					DataLayerSpec: v1alpha4.DataLayerSpec{
+						Postgres: v1alpha4.PostgresSpec{
+							Retention: "invalid",
+						},
+					},
+				},
+			},
+			wantType:   config.CONDITION_TYPE_DATABASE,
+			wantStatus: config.CONDITION_STATUS_FALSE,
+		},
+		{
+			name: "empty retention is invalid",
+			mgh: &v1alpha4.MulticlusterGlobalHub{
+				Spec: v1alpha4.MulticlusterGlobalHubSpec{
+					DataLayerSpec: v1alpha4.DataLayerSpec{
+						Postgres: v1alpha4.PostgresSpec{
+							Retention: "",
+						},
+					},
+				},
+			},
+			wantType:   config.CONDITION_TYPE_DATABASE,
+			wantStatus: config.CONDITION_STATUS_FALSE,
+		},
+		{
+			name: "retention with year format",
+			mgh: &v1alpha4.MulticlusterGlobalHub{
+				Spec: v1alpha4.MulticlusterGlobalHubSpec{
+					DataLayerSpec: v1alpha4.DataLayerSpec{
+						Postgres: v1alpha4.PostgresSpec{
+							Retention: "1y",
+						},
+					},
+				},
+			},
+			wantType:   config.CONDITION_TYPE_DATABASE,
+			wantStatus: config.CONDITION_STATUS_TRUE,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			condition := getRetentionConditions(tt.mgh)
+			assert.Equal(t, tt.wantType, condition.Type,
+				"retention condition type should be %q for %q", tt.wantType, tt.name)
+			assert.Equal(t, tt.wantStatus, string(condition.Status),
+				"retention condition status should be %q for %q", tt.wantStatus, tt.name)
+		})
+	}
+}
+
+func TestGeneratePassword(t *testing.T) {
+	tests := []struct {
+		name   string
+		length int
+	}{
+		{
+			name:   "generate 8 char password",
+			length: 8,
+		},
+		{
+			name:   "generate 16 char password",
+			length: 16,
+		},
+		{
+			name:   "generate 32 char password",
+			length: 32,
+		},
+		{
+			name:   "generate 64 char password",
+			length: 64,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			password := generatePassword(tt.length)
+			assert.Equal(t, tt.length, len(password),
+				"generated password length must match requested length %d", tt.length)
+
+			// Verify all characters are alphanumeric
+			for _, char := range password {
+				assert.True(t, (char >= 'A' && char <= 'Z') ||
+					(char >= 'a' && char <= 'z') ||
+					(char >= '0' && char <= '9'),
+					"Password contains non-alphanumeric character: %c", char)
+			}
+
+			// Test that multiple calls generate different passwords (randomness check)
+			password2 := generatePassword(tt.length)
+			// It's extremely unlikely (but not impossible) that two random passwords are identical
+			// This is a heuristic check
+			if tt.length > 8 {
+				assert.NotEqual(t, password, password2, "Generated passwords should be random")
+			}
+		})
+	}
+}
+
+func TestIsResourceRemoved(t *testing.T) {
+	reconciler := &StorageReconciler{}
+	assert.True(t, reconciler.IsResourceRemoved(), "storage reconciler should report resources as removed")
+}
+
+// TestReadonlyUsernameFromURI verifies readonly URI parse failures do not leak credentials.
+func TestReadonlyUsernameFromURI(t *testing.T) {
+	t.Run("valid uri", func(t *testing.T) {
+		username, err := readonlyUsernameFromURI("postgresql://readonly:secret@postgres.example:5432/hoh")
+		require.NoError(t, err, "valid readonly URI must parse")
+		assert.Equal(t, "readonly", username, "readonly username must match the URI")
+	})
+
+	t.Run("malformed uri with percent-escaped password does not leak credentials", func(t *testing.T) {
+		const sentinel = "secret-password"
+		raw := "postgresql://readonly:" + sentinel + "%zz@postgres.example:5432/hoh"
+
+		_, err := readonlyUsernameFromURI(raw)
+		require.Error(t, err, "malformed readonly URI must be rejected")
+		assert.Equal(t, errParseReadonlyUserURI, err.Error(),
+			"parse errors must use a fixed message")
+		assert.NotContains(t, err.Error(), raw,
+			"parse errors must not echo the raw connection URI")
+		assert.NotContains(t, err.Error(), "postgresql://",
+			"parse errors must not echo the URI scheme")
+		assert.NotContains(t, err.Error(), sentinel,
+			"parse errors must not echo the postgres password")
+	})
+
+	t.Run("uri without userinfo returns empty username", func(t *testing.T) {
+		username, err := readonlyUsernameFromURI("postgresql://postgres.example:5432/hoh")
+		require.NoError(t, err, "readonly URI without userinfo must not fail database init")
+		assert.Empty(t, username, "missing userinfo should skip privileges.sql username substitution")
+	})
+
+	t.Run("uri with empty username returns empty username", func(t *testing.T) {
+		username, err := readonlyUsernameFromURI("postgresql://:secret@postgres.example:5432/hoh")
+		require.NoError(t, err, "readonly URI with empty username must not fail database init")
+		assert.Empty(t, username, "empty username should skip privileges.sql username substitution")
+	})
+}

--- a/pkg/database/gorm_conn.go
+++ b/pkg/database/gorm_conn.go
@@ -165,10 +165,12 @@ func CloseGorm(sqlConn *sql.DB) {
 	}
 }
 
+// completePostgres parses a PostgreSQL URI and attaches sslrootcert when sslmode is verify-ca.
+// Parser errors use a fixed message so the URI cannot leak credentials.
 func completePostgres(postgresUri string, caCertPath string) (*url.URL, error) {
 	urlObj, err := url.Parse(postgresUri)
 	if err != nil {
-		return nil, err
+		return nil, errParseDatabaseURI
 	}
 	// only support verify-ca or disable(for test)
 	query := urlObj.Query()

--- a/pkg/database/gorm_uri_test.go
+++ b/pkg/database/gorm_uri_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCompletePostgres verifies GORM URI parse failures do not leak credentials.
+func TestCompletePostgres(t *testing.T) {
+	t.Run("valid uri", func(t *testing.T) {
+		got, err := completePostgres("postgres://user:secret@localhost:5432/hoh?sslmode=disable", "")
+		require.NoError(t, err, "valid postgres URI must parse")
+		require.NotNil(t, got, "parsed postgres URI must be returned")
+		assert.Equal(t, "localhost:5432", got.Host, "parsed postgres host must match")
+	})
+
+	t.Run("malformed uri with percent-escaped password does not leak credentials", func(t *testing.T) {
+		const sentinel = "secret-password"
+		raw := "postgres://user:" + sentinel + "%zz@localhost:5432/hoh"
+
+		_, err := completePostgres(raw, "")
+		require.Error(t, err, "malformed postgres URI must be rejected")
+		assert.ErrorIs(t, err, errParseDatabaseURI,
+			"parse errors must use a fixed message")
+		assert.NotContains(t, err.Error(), raw,
+			"parse errors must not echo the raw connection URI")
+		assert.NotContains(t, err.Error(), "postgres://",
+			"parse errors must not echo the URI scheme")
+		assert.NotContains(t, err.Error(), sentinel,
+			"parse errors must not echo the postgres password")
+	})
+}

--- a/pkg/database/pgx_conn.go
+++ b/pkg/database/pgx_conn.go
@@ -4,20 +4,27 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
+	"net/url"
 	"os"
-	"strings"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-const errMessageFileNotFound = "no such file or directory"
+var (
+	errParseDatabaseURI           = errors.New("failed to parse database uri")
+	errPostgresCARequiresVerify   = errors.New("postgres CA requires sslmode verify-ca or verify-full")
+	errParsePostgresCACertificate = errors.New("failed to parse postgres CA certificate")
+)
 
+// PostgresConnection opens a PostgreSQL connection using the given URI and optional CA certificate.
 func PostgresConnection(ctx context.Context, URI string, cert []byte) (*pgx.Conn, error) {
 	return PostgresDBConn(ctx, URI, cert, "")
 }
 
+// PostgresDBConn opens a PostgreSQL connection, optionally overriding the database name.
 func PostgresDBConn(ctx context.Context, URI string, cert []byte, db string) (*pgx.Conn, error) {
 	config, err := GetPostgresConfig(URI, cert)
 	if err != nil {
@@ -35,45 +42,56 @@ func PostgresDBConn(ctx context.Context, URI string, cert []byte, db string) (*p
 	return conn, nil
 }
 
+// GetPostgresConfig parses a PostgreSQL URI and installs a CA pool when cert is provided.
+// Parser errors use a fixed message so the URI cannot leak credentials.
 func GetPostgresConfig(URI string, cert []byte) (*pgx.ConnConfig, error) {
 	config, err := pgx.ParseConfig(URI)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse database uri: %w", err)
+		return nil, errParseDatabaseURI
 	}
-	if len(cert) > 0 { // #nosec G402
-		caCertPool := x509.NewCertPool()
-		caCertPool.AppendCertsFromPEM(cert)
-		config.TLSConfig = &tls.Config{
-			RootCAs: caCertPool,
-			// nolint:gosec
-			InsecureSkipVerify: true, // #nosec G402
+	if len(cert) > 0 {
+		if err := requireVerifyingPostgresSSLMode(postgresSSLModeFromURI(URI)); err != nil {
+			return nil, fmt.Errorf("failed to validate postgres sslmode: %w", err)
+		}
+		if err := applyPostgresCA(config, cert); err != nil {
+			return nil, fmt.Errorf("failed to apply postgres CA certificate: %w", err)
 		}
 	}
 	return config, nil
 }
 
-// PostgresConnPool returns a new postgres connection pool. size < 0 means deafult size.
-func PostgresConnPool(ctx context.Context, databaseURI string, certPath string, size int32) (*pgxpool.Pool, error) {
+// postgresPoolConfig parses pool settings and CA material without opening a connection.
+func postgresPoolConfig(databaseURI string, certPath string, size int32) (*pgxpool.Config, error) {
 	config, err := pgxpool.ParseConfig(databaseURI)
 	if err != nil {
-		return nil, fmt.Errorf("unable to get postgres pool config: %w", err)
+		return nil, errParseDatabaseURI
 	}
 
-	cert, err := os.ReadFile(certPath) // #nosec G304
-	if err != nil && !strings.Contains(err.Error(), errMessageFileNotFound) {
-		return nil, fmt.Errorf("unable to read database cert file: %w", err)
-	}
-	if len(cert) > 0 { // #nosec G402
-		caCertPool := x509.NewCertPool()
-		caCertPool.AppendCertsFromPEM(cert)
-		config.ConnConfig.TLSConfig = &tls.Config{
-			RootCAs:            caCertPool,
-			InsecureSkipVerify: true, // #nosec G402
+	if certPath != "" {
+		cert, err := os.ReadFile(certPath) // #nosec G304
+		if err != nil {
+			return nil, fmt.Errorf("unable to read database cert file: %w", err)
+		}
+		if err := requireVerifyingPostgresSSLMode(postgresSSLModeFromURI(databaseURI)); err != nil {
+			return nil, fmt.Errorf("failed to validate postgres sslmode: %w", err)
+		}
+		if err := applyPostgresCA(config.ConnConfig, cert); err != nil {
+			return nil, fmt.Errorf("failed to apply postgres CA certificate: %w", err)
 		}
 	}
 
 	if size > 0 {
 		config.MaxConns = size
+	}
+
+	return config, nil
+}
+
+// PostgresConnPool returns a new postgres connection pool. size < 0 means default size.
+func PostgresConnPool(ctx context.Context, databaseURI string, certPath string, size int32) (*pgxpool.Pool, error) {
+	config, err := postgresPoolConfig(databaseURI, certPath, size)
+	if err != nil {
+		return nil, fmt.Errorf("failed to configure postgres connection pool: %w", err)
 	}
 
 	dbConnectionPool, err := pgxpool.NewWithConfig(ctx, config)
@@ -82,4 +100,60 @@ func PostgresConnPool(ctx context.Context, databaseURI string, certPath string, 
 	}
 
 	return dbConnectionPool, nil
+}
+
+// postgresSSLModeFromURI returns the URI sslmode, defaulting to prefer when unset.
+func postgresSSLModeFromURI(databaseURI string) string {
+	parsed, err := url.Parse(databaseURI)
+	if err != nil {
+		return "prefer"
+	}
+	if mode := parsed.Query().Get("sslmode"); mode != "" {
+		return mode
+	}
+	return "prefer"
+}
+
+// requireVerifyingPostgresSSLMode rejects CA-backed connections that can skip verify or fall back to plaintext.
+func requireVerifyingPostgresSSLMode(sslmode string) error {
+	switch sslmode {
+	case "verify-ca", "verify-full":
+		return nil
+	default:
+		return errPostgresCARequiresVerify
+	}
+}
+
+// applyPostgresCA installs the CA on the primary TLS config and every pgx fallback.
+func applyPostgresCA(config *pgx.ConnConfig, cert []byte) error {
+	updated, err := postgresTLSConfigWithCA(config.TLSConfig, cert)
+	if err != nil {
+		return fmt.Errorf("failed to apply postgres CA to connection config: %w", err)
+	}
+	config.TLSConfig = updated
+	for _, fallback := range config.Fallbacks {
+		if fallback == nil {
+			continue
+		}
+		fallback.TLSConfig, err = postgresTLSConfigWithCA(fallback.TLSConfig, cert)
+		if err != nil {
+			return fmt.Errorf("failed to apply postgres CA to fallback connection config: %w", err)
+		}
+	}
+	return nil
+}
+
+// postgresTLSConfigWithCA installs RootCAs on the parsed TLS config, preserving ServerName and related settings.
+func postgresTLSConfigWithCA(existing *tls.Config, cert []byte) (*tls.Config, error) {
+	caCertPool := x509.NewCertPool()
+	if !caCertPool.AppendCertsFromPEM(cert) {
+		return nil, errParsePostgresCACertificate
+	}
+	if existing == nil {
+		existing = &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		}
+	}
+	existing.RootCAs = caCertPool
+	return existing, nil
 }

--- a/pkg/database/pgx_conn_test.go
+++ b/pkg/database/pgx_conn_test.go
@@ -1,0 +1,202 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testCAPEM returns a self-signed CA PEM used by PostgreSQL TLS unit tests.
+func testCAPEM(t *testing.T) []byte {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err, "test CA key generation must succeed")
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1), Subject: pkix.Name{CommonName: "postgres-ca"},
+		NotBefore: time.Now().Add(-time.Hour), NotAfter: time.Now().Add(time.Hour),
+		IsCA: true, BasicConstraintsValid: true, KeyUsage: x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err, "test CA certificate creation must succeed")
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+// TestGetPostgresConfig verifies URI parsing, CA installation, and sslmode enforcement.
+func TestGetPostgresConfig(t *testing.T) {
+	uri := "postgres://user:pass@localhost:5432/hoh?sslmode=verify-full"
+	caPEM := testCAPEM(t)
+
+	t.Run("without cert leaves pgx defaults unchanged", func(t *testing.T) {
+		cfg, err := GetPostgresConfig("postgres://user:pass@localhost:5432/hoh?sslmode=require", nil)
+		require.NoError(t, err, "postgres config without a CA must parse")
+		if cfg.TLSConfig != nil {
+			assert.Nil(t, cfg.TLSConfig.RootCAs, "postgres config without CA must not install RootCAs")
+		}
+	})
+
+	t.Run("with valid CA", func(t *testing.T) {
+		cfg, err := GetPostgresConfig(uri, caPEM)
+		require.NoError(t, err, "valid CA PEM must produce a postgres config")
+		require.NotNil(t, cfg.TLSConfig, "CA-backed postgres config must set TLSConfig")
+		assert.NotNil(t, cfg.TLSConfig.RootCAs, "CA-backed postgres config must install RootCAs")
+	})
+
+	t.Run("CA is installed on multi-host fallbacks", func(t *testing.T) {
+		multi := "postgres://user:pass@primary:5432,standby:5432/hoh?sslmode=verify-full"
+		cfg, err := GetPostgresConfig(multi, caPEM)
+		require.NoError(t, err, "multi-host URI with CA must parse")
+		require.NotNil(t, cfg.TLSConfig, "primary TLS config must be set")
+		assert.NotNil(t, cfg.TLSConfig.RootCAs, "primary TLS config must install RootCAs")
+		require.NotEmpty(t, cfg.Fallbacks, "multi-host URI must produce fallbacks")
+		for i, fb := range cfg.Fallbacks {
+			require.NotNil(t, fb, "fallback %d must not be nil", i)
+			require.NotNil(t, fb.TLSConfig, "fallback %d must have TLSConfig", i)
+			assert.NotNil(t, fb.TLSConfig.RootCAs, "fallback %d must install RootCAs", i)
+		}
+	})
+
+	t.Run("invalid CA PEM", func(t *testing.T) {
+		_, err := GetPostgresConfig(uri, []byte("not-a-pem"))
+		require.Error(t, err, "invalid CA PEM must be rejected")
+		assert.ErrorIs(t, err, errParsePostgresCACertificate,
+			"error should identify CA parsing failure")
+	})
+
+	t.Run("sslmode require with CA is rejected", func(t *testing.T) {
+		_, err := GetPostgresConfig("postgres://user:pass@localhost:5432/hoh?sslmode=require", caPEM)
+		require.Error(t, err, "CA-backed sslmode=require must be rejected")
+		assert.ErrorIs(t, err, errPostgresCARequiresVerify,
+			"CA-backed connections must require verify-ca or verify-full")
+	})
+
+	t.Run("sslmode prefer with CA is rejected", func(t *testing.T) {
+		_, err := GetPostgresConfig("postgres://user:pass@localhost:5432/hoh?sslmode=prefer", caPEM)
+		require.Error(t, err, "CA-backed sslmode=prefer must be rejected")
+		assert.ErrorIs(t, err, errPostgresCARequiresVerify,
+			"CA-backed connections must require verify-ca or verify-full")
+	})
+
+	t.Run("invalid URI", func(t *testing.T) {
+		_, err := GetPostgresConfig("://bad-uri", caPEM)
+		require.Error(t, err, "invalid postgres URI must be rejected")
+		assert.ErrorIs(t, err, errParseDatabaseURI,
+			"URI parse errors must use a fixed message")
+	})
+
+	t.Run("invalid URI does not leak password", func(t *testing.T) {
+		const sentinel = "secret-password"
+		_, err := GetPostgresConfig("postgres://user:"+sentinel+"%zz@localhost:5432/hoh", nil)
+		require.Error(t, err, "malformed postgres URI must be rejected")
+		assert.ErrorIs(t, err, errParseDatabaseURI,
+			"URI parse errors must use a fixed message")
+		assert.NotContains(t, err.Error(), sentinel,
+			"URI parse errors must not expose the postgres password")
+		assert.NotContains(t, err.Error(), "postgres://",
+			"URI parse errors must not expose the connection string")
+	})
+}
+
+// TestPostgresPoolConfig_CA verifies CA file handling and sslmode checks without opening a pool.
+func TestPostgresPoolConfig_CA(t *testing.T) {
+	uri := "postgres://user:pass@localhost:5432/hoh?sslmode=verify-full"
+	dir := t.TempDir()
+	caPath := filepath.Join(dir, "ca.crt")
+	require.NoError(t, os.WriteFile(caPath, testCAPEM(t), 0o600), "test CA file must be written")
+
+	t.Run("with valid CA file", func(t *testing.T) {
+		cfg, err := postgresPoolConfig(uri, caPath, 1)
+		require.NoError(t, err, "valid CA file must produce a pool config")
+		require.NotNil(t, cfg.ConnConfig.TLSConfig, "CA-backed pool config must set TLSConfig")
+		assert.NotNil(t, cfg.ConnConfig.TLSConfig.RootCAs, "CA-backed pool config must install RootCAs")
+		assert.Equal(t, int32(1), cfg.MaxConns, "requested pool size must be applied")
+	})
+
+	t.Run("CA is installed on multi-host fallbacks", func(t *testing.T) {
+		multi := "postgres://user:pass@primary:5432,standby:5432/hoh?sslmode=verify-full"
+		cfg, err := postgresPoolConfig(multi, caPath, 1)
+		require.NoError(t, err, "multi-host URI with CA must produce a pool config")
+		require.NotNil(t, cfg.ConnConfig.TLSConfig, "primary TLS config must be set")
+		assert.NotNil(t, cfg.ConnConfig.TLSConfig.RootCAs, "primary TLS config must install RootCAs")
+		require.NotEmpty(t, cfg.ConnConfig.Fallbacks, "multi-host URI must produce fallbacks")
+		for i, fb := range cfg.ConnConfig.Fallbacks {
+			require.NotNil(t, fb, "fallback %d must not be nil", i)
+			require.NotNil(t, fb.TLSConfig, "fallback %d must have TLSConfig", i)
+			assert.NotNil(t, fb.TLSConfig.RootCAs, "fallback %d must install RootCAs", i)
+		}
+	})
+
+	t.Run("invalid CA PEM", func(t *testing.T) {
+		badPath := filepath.Join(dir, "bad-ca.crt")
+		require.NoError(t, os.WriteFile(badPath, []byte("not-a-pem"), 0o600),
+			"invalid CA file must be written for coverage")
+		_, err := postgresPoolConfig(uri, badPath, 1)
+		require.Error(t, err, "invalid CA PEM must be rejected")
+		assert.ErrorIs(t, err, errParsePostgresCACertificate,
+			"error should identify CA parsing failure")
+	})
+
+	t.Run("missing configured cert file is rejected", func(t *testing.T) {
+		_, err := postgresPoolConfig(uri, filepath.Join(dir, "missing.crt"), 1)
+		require.Error(t, err, "a configured CA path that does not exist must fail closed")
+		assert.Contains(t, err.Error(), "unable to read database cert file",
+			"missing CA path errors must identify the cert-file read")
+	})
+
+	t.Run("empty cert path skips CA", func(t *testing.T) {
+		cfg, err := postgresPoolConfig(uri, "", 1)
+		require.NoError(t, err, "empty CA path should skip cert loading")
+		if cfg.ConnConfig.TLSConfig != nil {
+			assert.Nil(t, cfg.ConnConfig.TLSConfig.RootCAs,
+				"empty CA path must not install RootCAs")
+		}
+	})
+
+	t.Run("sslmode require with CA is rejected", func(t *testing.T) {
+		_, err := postgresPoolConfig("postgres://user:pass@localhost:5432/hoh?sslmode=require", caPath, 1)
+		require.Error(t, err, "CA-backed sslmode=require must be rejected")
+		assert.ErrorIs(t, err, errPostgresCARequiresVerify,
+			"CA-backed connections must require verify-ca or verify-full")
+	})
+
+	t.Run("sslmode prefer with CA is rejected", func(t *testing.T) {
+		_, err := postgresPoolConfig("postgres://user:pass@localhost:5432/hoh?sslmode=prefer", caPath, 1)
+		require.Error(t, err, "CA-backed sslmode=prefer must be rejected")
+		assert.ErrorIs(t, err, errPostgresCARequiresVerify,
+			"CA-backed connections must require verify-ca or verify-full")
+	})
+
+	t.Run("invalid URI does not leak password", func(t *testing.T) {
+		const sentinel = "secret-password"
+		_, err := postgresPoolConfig("postgres://user:"+sentinel+"%zz@localhost:5432/hoh", "", 1)
+		require.Error(t, err, "malformed postgres URI must be rejected")
+		assert.ErrorIs(t, err, errParseDatabaseURI,
+			"URI parse errors must use a fixed message")
+		assert.NotContains(t, err.Error(), sentinel,
+			"URI parse errors must not expose the postgres password")
+	})
+}

--- a/pkg/transport/config/saram_config.go
+++ b/pkg/transport/config/saram_config.go
@@ -3,6 +3,8 @@ package config
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -12,50 +14,57 @@ import (
 	"github.com/stolostron/multicluster-global-hub/pkg/utils"
 )
 
+const errClientCertKeyMismatch = "client certificate and key must be provided together"
+
+var errTLSClientCredentialsRequired = errors.New("client certificate and key are required when TLS is enabled")
+
+// GetSaramaConfig builds a Sarama client config, requiring mTLS materials when TLS is enabled.
 func GetSaramaConfig(kafkaConfig *transport.KafkaInternalConfig) (*sarama.Config, error) {
 	saramaConfig := sarama.NewConfig()
 	saramaConfig.Version = sarama.V2_0_0_0
 
-	_, validCa := utils.Validate(kafkaConfig.CaCertPath)
-	if kafkaConfig.EnableTLS && validCa {
+	if kafkaConfig.EnableTLS {
 		var err error
 		saramaConfig.Net.TLS.Enable = true
 		saramaConfig.Net.TLS.Config, err = NewTLSConfig(kafkaConfig.ClientCertPath, kafkaConfig.ClientKeyPath,
 			kafkaConfig.CaCertPath)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("configure Kafka TLS: %w", err)
 		}
 	}
 	return saramaConfig, nil
 }
 
+// NewTLSConfig loads client certificate, key, and CA materials for Kafka TLS.
 func NewTLSConfig(clientCertFile, clientKeyFile, caCertFile string) (*tls.Config, error) {
-	// #nosec G402
-	tlsConfig := tls.Config{}
-
-	// Load client cert
 	_, validCert := utils.Validate(clientCertFile)
 	_, validKey := utils.Validate(clientKeyFile)
-	if validCert && validKey {
-		cert, err := tls.LoadX509KeyPair(clientCertFile, clientKeyFile)
-		if err != nil {
-			return &tlsConfig, err
-		}
-		tlsConfig.Certificates = []tls.Certificate{cert}
-	} else {
-		// #nosec
-		tlsConfig.InsecureSkipVerify = true
+	if validCert != validKey {
+		return nil, fmt.Errorf("%s", errClientCertKeyMismatch)
+	}
+	if !validCert || !validKey {
+		return nil, errTLSClientCredentialsRequired
 	}
 
-	// Load CA cert
+	cert, err := tls.LoadX509KeyPair(clientCertFile, clientKeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load client certificate: %w", err)
+	}
+
 	caCert, err := os.ReadFile(filepath.Clean(caCertFile))
 	if err != nil {
-		return &tlsConfig, err
+		return nil, fmt.Errorf("failed to read CA certificate: %w", err)
 	}
 	caCertPool := x509.NewCertPool()
-	caCertPool.AppendCertsFromPEM(caCert)
-	tlsConfig.RootCAs = caCertPool
+	if !caCertPool.AppendCertsFromPEM(caCert) {
+		return nil, errors.New("failed to parse CA certificate")
+	}
 
-	tlsConfig.BuildNameToCertificate()
-	return &tlsConfig, err
+	tlsConfig := &tls.Config{
+		MinVersion:   tls.VersionTLS12,
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      caCertPool,
+	}
+
+	return tlsConfig, nil
 }

--- a/pkg/transport/config/saram_config_test.go
+++ b/pkg/transport/config/saram_config_test.go
@@ -1,0 +1,178 @@
+package config
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stolostron/multicluster-global-hub/pkg/transport"
+)
+
+type tlsTestMaterials struct {
+	certFile string
+	keyFile  string
+	caFile   string
+}
+
+// writeTLSTestMaterials writes temporary client and CA certificates for TLS tests.
+func writeTLSTestMaterials(t *testing.T) tlsTestMaterials {
+	t.Helper()
+	dir := t.TempDir()
+
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err, "test CA key generation must succeed")
+	caTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1), Subject: pkix.Name{CommonName: "test-ca"},
+		NotBefore: time.Now().Add(-time.Hour), NotAfter: time.Now().Add(time.Hour),
+		IsCA: true, BasicConstraintsValid: true, KeyUsage: x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	require.NoError(t, err, "test CA certificate creation must succeed")
+
+	clientKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err, "test client key generation must succeed")
+	clientTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2), Subject: pkix.Name{CommonName: "test-client"},
+		NotBefore: time.Now().Add(-time.Hour), NotAfter: time.Now().Add(time.Hour),
+		KeyUsage: x509.KeyUsageDigitalSignature, ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	clientDER, err := x509.CreateCertificate(rand.Reader, clientTmpl, caTmpl, &clientKey.PublicKey, caKey)
+	require.NoError(t, err, "test client certificate creation must succeed")
+
+	certFile := filepath.Join(dir, "client.crt")
+	keyFile := filepath.Join(dir, "client.key")
+	caFile := filepath.Join(dir, "ca.crt")
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientDER})
+	keyPEM := pem.EncodeToMemory(&pem.Block{
+		Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(clientKey),
+	})
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+	require.NoError(t, os.WriteFile(certFile, certPEM, 0o600), "client cert file must be written for mTLS test")
+	require.NoError(t, os.WriteFile(keyFile, keyPEM, 0o600), "client key file must be written for mTLS test")
+	require.NoError(t, os.WriteFile(caFile, caPEM, 0o600), "CA file must be written for broker verification test")
+
+	return tlsTestMaterials{certFile: certFile, keyFile: keyFile, caFile: caFile}
+}
+
+// F002: Kafka TLS must verify server certificates and require client credentials.
+// TestNewTLSConfig verifies Kafka TLS requires matching client credentials and a valid CA.
+func TestNewTLSConfig(t *testing.T) {
+	materials := writeTLSTestMaterials(t)
+
+	tests := []struct {
+		name        string
+		certFile    string
+		keyFile     string
+		caFile      string
+		wantErr     bool
+		errContains string
+		errIs       error
+	}{
+		{
+			name:     "valid mTLS config",
+			certFile: materials.certFile,
+			keyFile:  materials.keyFile,
+			caFile:   materials.caFile,
+		},
+		{
+			name:    "missing client credentials",
+			caFile:  materials.caFile,
+			wantErr: true,
+			errIs:   errTLSClientCredentialsRequired,
+		},
+		{
+			name:        "cert without key",
+			certFile:    materials.certFile,
+			caFile:      materials.caFile,
+			wantErr:     true,
+			errContains: errClientCertKeyMismatch,
+		},
+		{
+			name:        "missing CA file",
+			certFile:    materials.certFile,
+			keyFile:     materials.keyFile,
+			caFile:      filepath.Join(t.TempDir(), "missing-ca.crt"),
+			wantErr:     true,
+			errContains: "failed to read CA certificate",
+		},
+		{
+			name:        "invalid CA PEM",
+			certFile:    materials.certFile,
+			keyFile:     materials.keyFile,
+			caFile:      filepath.Join(t.TempDir(), "bad-ca.pem"),
+			wantErr:     true,
+			errContains: "failed to parse CA certificate",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.caFile != "" && tt.errContains == "failed to parse CA certificate" {
+				require.NoError(t, os.WriteFile(tt.caFile, []byte("not-a-pem"), 0o600),
+					"invalid CA fixture must be written for parse-failure test")
+			}
+			cfg, err := NewTLSConfig(tt.certFile, tt.keyFile, tt.caFile)
+			if tt.wantErr {
+				require.Error(t, err, "TLS config must fail for invalid credentials or CA material")
+				if tt.errIs != nil {
+					assert.ErrorIs(t, err, tt.errIs, "error should match expected TLS credential failure")
+				}
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains,
+						"error should describe the TLS validation failure")
+				}
+				return
+			}
+			require.NoError(t, err, "valid mTLS materials must produce a TLS config")
+			assert.Equal(t, uint16(tls.VersionTLS12), cfg.MinVersion,
+				"Kafka TLS must enforce TLS 1.2 minimum")
+			assert.NotNil(t, cfg.RootCAs, "broker CA pool must be configured for verification")
+			assert.Len(t, cfg.Certificates, 1, "client certificate must be loaded for mTLS")
+			assert.False(t, cfg.InsecureSkipVerify,
+				"InsecureSkipVerify must remain disabled for Kafka connections")
+		})
+	}
+}
+
+// TestGetSaramaConfig_TLS verifies Sarama TLS is enabled when valid credentials are provided.
+func TestGetSaramaConfig_TLS(t *testing.T) {
+	materials := writeTLSTestMaterials(t)
+
+	cfg, err := GetSaramaConfig(&transport.KafkaInternalConfig{
+		EnableTLS:      true,
+		ClientCertPath: materials.certFile,
+		ClientKeyPath:  materials.keyFile,
+		CaCertPath:     materials.caFile,
+	})
+	require.NoError(t, err, "Sarama TLS config must be created from valid mTLS materials")
+	require.True(t, cfg.Net.TLS.Enable, "TLS must be enabled when Kafka TLS is requested")
+	require.NotNil(t, cfg.Net.TLS.Config, "TLS config must be attached to Sarama client settings")
+	assert.False(t, cfg.Net.TLS.Config.InsecureSkipVerify,
+		"Sarama client must verify broker certificates")
+}
+
+// TestGetSaramaConfig_TLSRequiresValidCA verifies TLS configuration fails closed without a CA.
+func TestGetSaramaConfig_TLSRequiresValidCA(t *testing.T) {
+	materials := writeTLSTestMaterials(t)
+
+	_, err := GetSaramaConfig(&transport.KafkaInternalConfig{
+		EnableTLS:      true,
+		ClientCertPath: materials.certFile,
+		ClientKeyPath:  materials.keyFile,
+		CaCertPath:     filepath.Join(t.TempDir(), "missing-ca.crt"),
+	})
+	require.Error(t, err, "Kafka TLS must fail closed when the CA certificate is missing")
+	assert.Contains(t, err.Error(), "failed to read CA certificate",
+		"missing CA errors must describe the broker verification failure")
+}

--- a/test/integration/manager/api/api_test.go
+++ b/test/integration/manager/api/api_test.go
@@ -66,8 +66,9 @@ var _ = Describe("Nonk8s API Server", Ordered, func() {
 
 		By("Set up nonk8s-api server router")
 		router, err = restapis.SetupRouter(&restapis.RestApiServerConfig{
-			ServerBasePath: "/global-hub-api/v1",
-			ClusterAPIURL:  testAuthServer.URL,
+			ServerBasePath:         "/global-hub-api/v1",
+			ClusterAPIURL:          testAuthServer.URL,
+			ClusterAPICABundlePath: testAuthServerCAPEMPath,
 		})
 		Expect(err).NotTo(HaveOccurred())
 	})
@@ -150,7 +151,8 @@ var _ = Describe("Nonk8s API Server", Ordered, func() {
 		Expect(err).ToNot(HaveOccurred())
 		err = db.Exec(
 			`INSERT INTO status.managed_clusters (cluster_id,leaf_hub_name,payload,error) VALUES (?, ?, ?, 'none');`,
-			mc2Id, hub1, mc2).Error
+			mc2Id, hub1, mc2,
+		).Error
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Check the managedcclusters can be listed without parameters")
@@ -170,7 +172,8 @@ var _ = Describe("Nonk8s API Server", Ordered, func() {
 		]
 }`
 		Expect(w1.Body.String()).Should(MatchJSON(
-			fmt.Sprintf(managedClusterListFormatStr, mc1, mc2)))
+			fmt.Sprintf(managedClusterListFormatStr, mc1, mc2),
+		))
 
 		By("Check the managedclusters can be list with continue")
 		w21 := httptest.NewRecorder()
@@ -178,12 +181,14 @@ var _ = Describe("Nonk8s API Server", Ordered, func() {
 		Expect(err).ToNot(HaveOccurred())
 		req21, err := http.NewRequest("GET", fmt.Sprintf(
 			"/global-hub-api/v1/managedclusters?continue=%s",
-			continueToken), nil)
+			continueToken,
+		), nil)
 		Expect(err).ToNot(HaveOccurred())
 		router.ServeHTTP(w21, req21)
 		Expect(w21.Code).To(Equal(200))
 		Expect(w21.Body.String()).Should(MatchJSON(
-			fmt.Sprintf(managedClusterListFormatStr, mc1, mc2)))
+			fmt.Sprintf(managedClusterListFormatStr, mc1, mc2),
+		))
 
 		By("Check the managedclusters can be listed with limit and labelSelector")
 		w2 := httptest.NewRecorder()
@@ -195,7 +200,8 @@ var _ = Describe("Nonk8s API Server", Ordered, func() {
 		router.ServeHTTP(w2, req2)
 		Expect(w2.Code).To(Equal(200))
 		Expect(w2.Body.String()).Should(MatchJSON(
-			fmt.Sprintf(managedClusterListFormatStr, mc1, mc2)))
+			fmt.Sprintf(managedClusterListFormatStr, mc1, mc2),
+		))
 
 		By("Check the managedcclusters can be listed as table")
 		// mclTable := `
@@ -667,7 +673,8 @@ var _ = Describe("Nonk8s API Server", Ordered, func() {
 		]
 }`
 		Expect(w1.Body.String()).Should(MatchJSON(
-			fmt.Sprintf(policyListFormatStr, expectedPolicy1)))
+			fmt.Sprintf(policyListFormatStr, expectedPolicy1),
+		))
 
 		By("Check the policies can be listed with limit and labelSelector")
 		w2 := httptest.NewRecorder()
@@ -679,7 +686,8 @@ var _ = Describe("Nonk8s API Server", Ordered, func() {
 		router.ServeHTTP(w2, req2)
 		Expect(w2.Code).To(Equal(200))
 		Expect(w2.Body.String()).Should(MatchJSON(
-			fmt.Sprintf(policyListFormatStr, expectedPolicy1)))
+			fmt.Sprintf(policyListFormatStr, expectedPolicy1),
+		))
 
 		By("Check the policies can be listed as table")
 		// 		plcTable := `
@@ -885,7 +893,8 @@ var _ = Describe("Nonk8s API Server", Ordered, func() {
 		By("Check the policy status can be retrieved with policy ID")
 		w1 := httptest.NewRecorder()
 		req1, err := http.NewRequest("GET", fmt.Sprintf(
-			"/global-hub-api/v1/policy/%s/status", plc1ID), nil)
+			"/global-hub-api/v1/policy/%s/status", plc1ID,
+		), nil)
 		Expect(err).ToNot(HaveOccurred())
 		router.ServeHTTP(w1, req1)
 		Expect(w1.Code).To(Equal(200))
@@ -968,7 +977,8 @@ var _ = Describe("Nonk8s API Server", Ordered, func() {
 		// `
 		w2 := httptest.NewRecorder()
 		req2, err := http.NewRequest("GET", fmt.Sprintf(
-			"/global-hub-api/v1/policy/%s/status", plc1ID), nil)
+			"/global-hub-api/v1/policy/%s/status", plc1ID,
+		), nil)
 		Expect(err).ToNot(HaveOccurred())
 		req2.Header.Set("Accept", "application/json;as=Table;g=meta.k8s.io;v=v1")
 		router.ServeHTTP(w2, req2)
@@ -1104,7 +1114,8 @@ var _ = Describe("Nonk8s API Server", Ordered, func() {
 		]
 }`
 		Expect(w1.Body.String()).Should(MatchJSON(
-			fmt.Sprintf(subscriptionListFormatStr, subscription1, subscription2)))
+			fmt.Sprintf(subscriptionListFormatStr, subscription1, subscription2),
+		))
 
 		By("Check the subscriptions can be listed with limit and labelSelector")
 		w2 := httptest.NewRecorder()
@@ -1125,7 +1136,8 @@ var _ = Describe("Nonk8s API Server", Ordered, func() {
 			]
 		}`
 		Expect(w2.Body.String()).Should(MatchJSON(
-			fmt.Sprintf(subscriptionListFormatStr, subscription2)))
+			fmt.Sprintf(subscriptionListFormatStr, subscription2),
+		))
 
 		By("Check the subscriptions can be listed as table")
 		// subscriptionTable := `{
@@ -1376,7 +1388,8 @@ var _ = Describe("Nonk8s API Server", Ordered, func() {
 		By("Check the subscriptionreport can be retrieved")
 		w1 := httptest.NewRecorder()
 		req1, err := http.NewRequest("GET", fmt.Sprintf(
-			"/global-hub-api/v1/subscriptionreport/%s", sub2ID), nil)
+			"/global-hub-api/v1/subscriptionreport/%s", sub2ID,
+		), nil)
 		Expect(err).ToNot(HaveOccurred())
 		router.ServeHTTP(w1, req1)
 		Expect(w1.Code).To(Equal(200))

--- a/test/integration/manager/api/suite_test.go
+++ b/test/integration/manager/api/suite_test.go
@@ -5,8 +5,10 @@ package nonk8sapi_test
 
 import (
 	"context"
+	"encoding/pem"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	_ "github.com/lib/pq"
@@ -19,10 +21,11 @@ import (
 )
 
 var (
-	ctx            context.Context
-	cancel         context.CancelFunc
-	testPostgres   *testpostgres.TestPostgres
-	testAuthServer *httptest.Server
+	ctx                     context.Context
+	cancel                  context.CancelFunc
+	testPostgres            *testpostgres.TestPostgres
+	testAuthServer          *httptest.Server
+	testAuthServerCAPEMPath string
 )
 
 func TestNonK8sAPI(t *testing.T) {
@@ -42,7 +45,7 @@ var _ = BeforeSuite(func() {
 	err = testpostgres.InitDatabase(testPostgres.URI)
 	Expect(err).NotTo(HaveOccurred())
 
-	testAuthServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	testAuthServer = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
 			"kind": "User",
@@ -57,11 +60,23 @@ var _ = BeforeSuite(func() {
 			]
 		  }`))
 	}))
+
+	certDER := testAuthServer.TLS.Certificates[0].Certificate[0]
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+
+	caFile, err := os.CreateTemp("", "cluster-api-ca-*.pem")
+	Expect(err).NotTo(HaveOccurred())
+	_, err = caFile.Write(certPEM)
+	Expect(err).NotTo(HaveOccurred())
+	err = caFile.Close()
+	Expect(err).NotTo(HaveOccurred())
+	testAuthServerCAPEMPath = caFile.Name()
 })
 
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	testAuthServer.Close()
+	Expect(os.Remove(testAuthServerCAPEMPath)).To(Succeed())
 	err := testPostgres.Stop()
 	Expect(err).NotTo(HaveOccurred())
 	cancel()

--- a/test/integration/operator/controllers/grafana_test.go
+++ b/test/integration/operator/controllers/grafana_test.go
@@ -6,6 +6,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"gopkg.in/ini.v1"
+	"gopkg.in/yaml.v2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,36 +43,90 @@ var _ = Describe("grafana", Ordered, func() {
 				EnableMetrics: true,
 			},
 		}
-		Expect(runtimeClient.Create(ctx, mgh)).To(Succeed())
-		Expect(runtimeClient.Get(ctx, client.ObjectKeyFromObject(mgh), mgh)).To(Succeed())
+		Expect(runtimeClient.Create(ctx, mgh)).To(Succeed(), "test MulticlusterGlobalHub must be created")
+		Expect(runtimeClient.Get(ctx, client.ObjectKeyFromObject(mgh), mgh)).To(Succeed(),
+			"created MulticlusterGlobalHub must be readable")
+		previousConn := config.GetStorageConnection()
+		previousReady := config.GetDatabaseReady()
+		DeferCleanup(func() {
+			_ = config.SetStorageConnection(previousConn)
+			config.SetDatabaseReady(previousReady)
+		})
+		Expect(config.SetStorageConnection(&config.PostgresConnection{
+			SuperuserDatabaseURI:    "postgresql://testuser:testpassword@localhost:5432/testdb?sslmode=verify-full",
+			ReadonlyUserDatabaseURI: "postgresql://testuser:testpassword@localhost:5432/testdb?sslmode=verify-full",
+			CACert:                  []byte("test-crt"),
+		})).To(BeTrue(), "set storage configuration for Grafana TLS validation")
+		config.SetDatabaseReady(true)
+		Expect(grafana.NewGrafanaReconciler(runtimeManager, kubeClient).SetupWithManager(runtimeManager)).
+			To(Succeed(), "Grafana reconciler must register with the test manager")
 	})
 
 	It("should generate the grafana resources", func() {
-		// storage
-		_ = config.SetStorageConnection(&config.PostgresConnection{
-			SuperuserDatabaseURI:    "postgresql://testuser:testpassword@localhost:5432/testdb?sslmode=disable",
-			ReadonlyUserDatabaseURI: "postgresql://testuser:testpassword@localhost:5432/testdb?sslmode=disable",
-			CACert:                  []byte("test-crt"),
-		})
-		config.SetDatabaseReady(true)
-
-		grafanaReconciler := grafana.NewGrafanaReconciler(runtimeManager, kubeClient)
-
-		err := grafanaReconciler.SetupWithManager(runtimeManager)
-		Expect(err).To(Succeed())
-
-		// deployment
 		Eventually(func() error {
 			deployment := &appsv1.Deployment{}
-			err = runtimeClient.Get(ctx, types.NamespacedName{
+			if err := runtimeClient.Get(ctx, types.NamespacedName{
 				Name:      "multicluster-global-hub-grafana",
 				Namespace: mgh.Namespace,
-			}, deployment)
-			if err != nil {
+			}, deployment); err != nil {
 				return err
 			}
 			return nil
 		}, 10*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
+	})
+
+	It("should configure postgres datasource TLS verification", func() {
+		Eventually(func() error {
+			dsSecret := &corev1.Secret{}
+			if err := runtimeClient.Get(ctx, types.NamespacedName{
+				Name:      "multicluster-global-hub-grafana-datasources",
+				Namespace: mgh.Namespace,
+			}, dsSecret); err != nil {
+				return err
+			}
+			var datasources grafana.GrafanaDatasources
+			if err := yaml.Unmarshal(dsSecret.Data["datasources.yaml"], &datasources); err != nil {
+				return err
+			}
+			if len(datasources.Datasources) == 0 || datasources.Datasources[0].JSONData == nil {
+				return fmt.Errorf("grafana datasource not ready")
+			}
+			ds := datasources.Datasources[0]
+			if ds.JSONData.TLSSkipVerify {
+				return fmt.Errorf("expected postgres datasource TLS verification enabled")
+			}
+			if ds.JSONData.SSLMode != "verify-full" {
+				return fmt.Errorf("expected sslmode verify-full, got %q", ds.JSONData.SSLMode)
+			}
+			if !ds.JSONData.TLSAuth || !ds.JSONData.TLSAuthWithCACert {
+				return fmt.Errorf("expected TLS auth flags enabled on postgres datasource")
+			}
+			return nil
+		}, 10*time.Second, 100*time.Millisecond).Should(Succeed())
+	})
+
+	It("should inject a grafana admin password", func() {
+		Eventually(func() error {
+			iniSecret := &corev1.Secret{}
+			if err := runtimeClient.Get(ctx, types.NamespacedName{
+				Name:      "multicluster-global-hub-grafana-config",
+				Namespace: mgh.Namespace,
+			}, iniSecret); err != nil {
+				return err
+			}
+			cfg, err := ini.Load(iniSecret.Data["grafana.ini"])
+			if err != nil {
+				return err
+			}
+			sec, err := cfg.GetSection("security")
+			if err != nil {
+				return err
+			}
+			if sec.Key("admin_password").String() == "" {
+				return fmt.Errorf("grafana admin_password not set")
+			}
+			return nil
+		}, 10*time.Second, 100*time.Millisecond).Should(Succeed())
 	})
 
 	AfterAll(func() {
@@ -84,6 +140,7 @@ var _ = Describe("grafana", Ordered, func() {
 	})
 })
 
+// deleteNamespace removes the test namespace created for Grafana integration coverage.
 func deleteNamespace(name string) error {
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/script/e2e_run_byo.sh
+++ b/test/script/e2e_run_byo.sh
@@ -85,4 +85,7 @@ kubectl create secret generic "$transport_secret" -n "$target_namespace" --kubec
 
 echo "transport secret is ready in $target_namespace namespace!"
 ## run e2e
-bash "$CURRENT_DIR/e2e_run.sh" -n "$target_namespace" -f "e2e-test-localpolicy,e2e-test-grafana,e2e-test-transport-byo"
+# transport-byo mutates per-hub Kafka bootstrap. Ginkgo randomizes labels in a
+# single process, so keep transport-byo in a separate invocation.
+bash "$CURRENT_DIR/e2e_run.sh" -n "$target_namespace" -f "e2e-test-localpolicy,e2e-test-grafana"
+bash "$CURRENT_DIR/e2e_run.sh" -n "$target_namespace" -f "e2e-test-transport-byo"


### PR DESCRIPTION
Fixes: [ACM-42316](https://redhat.atlassian.net/browse/ACM-42316), [ACM-42317](https://redhat.atlassian.net/browse/ACM-42317), [ACM-42318](https://redhat.atlassian.net/browse/ACM-42318), [ACM-42325](https://redhat.atlassian.net/browse/ACM-42325), [ACM-41991](https://redhat.atlassian.net/browse/ACM-41991), [ACM-41853](https://redhat.atlassian.net/browse/ACM-41853)

## Summary

Harden TLS and Grafana configuration for **Global Hub 1.4** (`release-2.13`).

### CVEs addressed

| CVE | Jira | Area |
|-----|------|------|
| CVE-2026-75762 | ACM-42317, ACM-42318, ACM-42325 | TLS MITM — remove `InsecureSkipVerify` fallbacks for Kafka, Postgres, and inventory API |
| CVE-2026-77849 | ACM-41991 | Grafana — set stable random `admin_password` instead of default credentials |
| CVE-2026-80221 | ACM-41853 | Grafana — parse Postgres datasource URI without exposing credentials in errors |


## Summary

- Backport [#2841](https://github.com/stolostron/multicluster-global-hub/pull/2841) to GH 1.4 (`release-2.13`)
- Cherry-pick `48511886` with release-line conflict resolution (no main-only networkpolicy / Ingress TLS logging helpers)
- **F002 TLS:** Kafka mTLS client cert/key + CA verification; Postgres `verify-ca`/`verify-full` when CA is configured
- **F003/F004:** Persist Grafana `admin_password`; datasource TLS validation; credential-safe Postgres URI errors

## Jira (GH 1.4 — hub repo)

| Finding | BZ | Tickets |
|---------|-----|---------|
| F002 TLS MITM | 2518375 | ACM-42322 (agent), ACM-42337 (operator), ACM-42333 (manager) |
| F003 Grafana creds | 2518332 | ACM-41995 |
| F004 DB DSN exposure | 2518333 | (via hub operator Grafana/inventory paths) |

**Out of scope (same as #2841):** F001 RBAC cluster-wide secrets (ACM-42308, ACM-42309, ACM-42312)

## Conflict notes

- Kept `release-2.13` image overrides and dropped SpiceDB controller/image keys (SpiceDB not on this branch)
- Kept `release-2.13` BYO e2e cleanup (`transport_byo_test.go` unchanged); split transport-byo in `e2e_run_byo.sh`
- Dropped `logGrafanaIngressTLSProfile` and NetworkPolicy RBAC/tests (main-only)
- Dropped `TestNetworkPolicyPredicate_Storage` and `TestSpiceDBPostgresConfig` (no SpiceDB on 2.13)
- On 2.13, Grafana `database` stays on `GrafanaDatasource`

## Test plan

- [ ] `make fmt` / `format` CI job
- [ ] Unit tests: `pkg/transport/config`, `pkg/database`, `operator/pkg/controllers/grafana`, `operator/pkg/controllers/inventory`, `operator/pkg/controllers/storage`
- [ ] Integration: grafana controller suite
- [ ] `test-e2e`


Made with [Cursor](https://cursor.com)

[ACM-42317]: https://redhat.atlassian.net/browse/ACM-42317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-42318]: https://redhat.atlassian.net/browse/ACM-42318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-42325]: https://redhat.atlassian.net/browse/ACM-42325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-41991]: https://redhat.atlassian.net/browse/ACM-41991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-41853]: https://redhat.atlassian.net/browse/ACM-41853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ACM-42316]: https://redhat.atlassian.net/browse/ACM-42316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ