### PR TITLE
🐛 ACM-40204: Backport KafkaUser prune guard to GH 1.6

### DIFF
--- a/operator/pkg/controllers/agent/addon/default_agent_controller.go
+++ b/operator/pkg/controllers/agent/addon/default_agent_controller.go
@@ -41,6 +41,11 @@ var (
 
 type DefaultAgentController struct {
 	client.Client
+	// apiReader performs uncached reads straight from the API server. It is used to confirm a
+	// ManagedCluster genuinely lacks the deploy-mode label before pruning its transport
+	// resources, so a stale cache during operator restarts/upgrades cannot trigger a destructive
+	// prune of a live managed hub's KafkaUser (ACM-40204).
+	apiReader client.Reader
 }
 
 // Assert whether a secret is associated with or affects the addon
@@ -54,9 +59,10 @@ func targetAddonSecret(obj client.Object) bool {
 	return false
 }
 
-func NewDefaultAgentController(c client.Client) *DefaultAgentController {
+func NewDefaultAgentController(c client.Client, apiReader client.Reader) *DefaultAgentController {
 	return &DefaultAgentController{
-		Client: c,
+		Client:    c,
+		apiReader: apiReader,
 	}
 }
 
@@ -73,7 +79,7 @@ func StartDefaultAgentController(initOption config.ControllerOption) (config.Con
 	if !ReadyToEnableAddonManager(initOption.MulticlusterGlobalHub) {
 		return nil, nil
 	}
-	defaultAgentController = NewDefaultAgentController(initOption.Manager.GetClient())
+	defaultAgentController = NewDefaultAgentController(initOption.Manager.GetClient(), initOption.Manager.GetAPIReader())
 
 	err := ctrl.NewControllerManagedBy(initOption.Manager).
 		Named("default-agent-ctrl").
@@ -263,6 +269,27 @@ func (r *DefaultAgentController) Reconcile(ctx context.Context, req ctrl.Request
 	isDetaching := !cluster.DeletionTimestamp.IsZero()
 
 	log.Infof("cluster(%s): isDetaching - %v, hasDeployLabel - %v", cluster.Name, isDetaching, hasDeployLabel)
+
+	// ACM-40204: removeResourcesAndAddon prunes the managed hub's KafkaUser, which revokes the
+	// agent's Kafka ACLs and takes the managed hub offline ("Topic/Group authorization failed").
+	// The prune runs regardless of whether the cached ManagedClusterAddOn still exists, so gating
+	// the confirmation on the cached addon is not safe: during an operator restart/upgrade the
+	// cached ManagedCluster can transiently miss the deploy-mode label (and the addon), which would
+	// otherwise cause a spurious prune of a live managed hub. Whenever a non-detaching cluster
+	// appears to lack the deploy-mode label, confirm its absence with an uncached read straight
+	// from the API server before proceeding to the destructive prune path.
+	if !isDetaching && !hasDeployLabel {
+		absent, err := r.confirmDeployLabelAbsent(ctx, cluster.Name)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if !absent {
+			log.Infow("deploy-mode label present per API server; skipping prune to avoid stale-cache delete",
+				"cluster", cluster.Name)
+			hasDeployLabel = true
+		}
+	}
+
 	if isDetaching || !hasDeployLabel {
 		log.Infow("deleting resources and addon", "cluster", cluster.Name)
 		if err := r.removeResourcesAndAddon(ctx, cluster); err != nil {
@@ -273,6 +300,30 @@ func (r *DefaultAgentController) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	return ctrl.Result{}, r.reconcileAddonAndResources(ctx, cluster, clusterManagementAddOn)
+}
+
+// confirmDeployLabelAbsent performs an uncached read of the ManagedCluster straight from the API
+// server and reports whether the deploy-mode label is genuinely absent. It guards the destructive
+// prune path against a stale controller cache during operator restarts/upgrades (ACM-40204):
+// pruning a live managed hub's KafkaUser revokes the agent's Kafka ACLs and takes it offline.
+func (r *DefaultAgentController) confirmDeployLabelAbsent(ctx context.Context, clusterName string) (bool, error) {
+	if r.apiReader == nil {
+		// No uncached reader available; fall back to the cached decision.
+		return true, nil
+	}
+	// Bound the direct API read so an unavailable API server cannot hold a reconcile worker
+	// until manager shutdown.
+	readCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	latest := &clusterv1.ManagedCluster{}
+	if err := r.apiReader.Get(readCtx, types.NamespacedName{Name: clusterName}, latest); err != nil {
+		if errors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, fmt.Errorf("failed to read managedcluster %q from API server: %w", clusterName, err)
+	}
+	_, hasDeployLabel := latest.GetLabels()[constants.GHDeployModeLabelKey]
+	return !hasDeployLabel, nil
 }
 
 func (r *DefaultAgentController) deleteClusterManagementAddon(ctx context.Context) error {

--- a/operator/pkg/controllers/agent/addon/default_agent_controller_test.go
+++ b/operator/pkg/controllers/agent/addon/default_agent_controller_test.go
@@ -242,3 +242,131 @@ func TestAddonInstaller(t *testing.T) {
 		})
 	}
 }
+
+// TestConfirmDeployLabelAbsent verifies the ACM-40204 guard: the destructive prune path must only
+// treat the deploy-mode label as absent when an uncached read of the API server confirms it, so a
+// stale controller cache during an operator restart/upgrade cannot delete a live managed hub's
+// KafkaUser.
+//
+//	go test -run ^TestConfirmDeployLabelAbsent$ \
+//	  github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/agent/addon
+func TestConfirmDeployLabelAbsent(t *testing.T) {
+	clusterName := "regionalhub1"
+
+	withLabel := &v1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   clusterName,
+			Labels: map[string]string{constants.GHDeployModeLabelKey: constants.GHDeployModeDefault},
+		},
+	}
+	withoutLabel := &v1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: clusterName},
+	}
+
+	tests := []struct {
+		name       string
+		apiObjects []client.Object
+		nilReader  bool
+		wantAbsent bool
+	}{
+		{
+			name:       "label present per API server -> not absent (must NOT prune)",
+			apiObjects: []client.Object{withLabel},
+			wantAbsent: false,
+		},
+		{
+			name:       "label absent per API server -> absent (prune allowed)",
+			apiObjects: []client.Object{withoutLabel},
+			wantAbsent: true,
+		},
+		{
+			name:       "cluster not found -> absent (prune allowed)",
+			apiObjects: []client.Object{},
+			wantAbsent: true,
+		},
+		{
+			name:       "no api reader -> fall back to absent",
+			nilReader:  true,
+			wantAbsent: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &DefaultAgentController{}
+			if !tc.nilReader {
+				r.apiReader = fake.NewClientBuilder().
+					WithScheme(config.GetRuntimeScheme()).
+					WithObjects(tc.apiObjects...).
+					Build()
+			}
+			absent, err := r.confirmDeployLabelAbsent(context.Background(), clusterName)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if absent != tc.wantAbsent {
+				t.Fatalf("confirmDeployLabelAbsent = %v, want %v", absent, tc.wantAbsent)
+			}
+		})
+	}
+}
+
+// TestReconcileStaleCacheKeepsManagedHub is the ACM-40204 Reconcile regression: when the controller
+// cache transiently lacks BOTH the deploy-mode label and the ManagedClusterAddOn during an operator
+// restart/upgrade, but the API server still reports the labeled cluster, Reconcile must NOT take the
+// destructive prune path. It must confirm the label with an uncached read and reconcile the addon
+// instead of pruning the managed hub's KafkaUser.
+//
+//	go test -run ^TestReconcileStaleCacheKeepsManagedHub$ \
+//	  github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/agent/addon
+func TestReconcileStaleCacheKeepsManagedHub(t *testing.T) {
+	namespace := "multicluster-global-hub"
+	name := "test"
+	clusterName := "regionalhub1"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	config.SetMGHNamespacedName(types.NamespacedName{Namespace: namespace, Name: name})
+
+	// Cached view during an operator upgrade: the cluster is missing the deploy-mode label and the
+	// ManagedClusterAddOn is absent from the cache.
+	cachedCluster := &v1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: clusterName},
+	}
+	cachedClient := fake.NewClientBuilder().
+		WithScheme(config.GetRuntimeScheme()).
+		WithObjects(fakeMGH(namespace, name), fakeClusterManagementAddon(), cachedCluster).
+		Build()
+
+	// API server truth: the cluster still carries the deploy-mode label.
+	apiReader := fake.NewClientBuilder().
+		WithScheme(config.GetRuntimeScheme()).
+		WithObjects(fakeCluster(clusterName, "", constants.GHDeployModeDefault)).
+		Build()
+
+	config.SetTransporter(operatortrans.NewBYOTransporter(ctx, types.NamespacedName{
+		Namespace: namespace,
+		Name:      constants.GHTransportSecretName,
+	}, cachedClient))
+
+	r := &DefaultAgentController{
+		Client:    cachedClient,
+		apiReader: apiReader,
+	}
+
+	if _, err := r.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: clusterName},
+	}); err != nil {
+		t.Fatalf("unexpected reconcile error: %v", err)
+	}
+
+	// The addon must be reconciled (created), proving the prune path was skipped despite the stale
+	// cache lacking both the label and the addon.
+	addon := &v1alpha1.ManagedClusterAddOn{}
+	if err := cachedClient.Get(ctx, types.NamespacedName{
+		Namespace: clusterName, Name: constants.GHManagedClusterAddonName,
+	}, addon); err != nil {
+		t.Fatalf("expected addon to be reconciled (prune path skipped), but got err: %v", err)
+	}
+}


### PR DESCRIPTION
## Description

Backport the ACM-40204 fix to the Global Hub 1.6 release branch. During operator restart/upgrade, a stale ManagedCluster cache could make the controller prune the managed hub KafkaUser and revoke the agent Kafka ACLs, causing Topic/Group authorization failures.

This backport adds an uncached API-reader confirmation before the destructive prune path.

## Testing

- `go test -v ./operator/pkg/controllers/agent/addon -run 'TestConfirmDeployLabelAbsent|TestReconcileStaleCacheKeepsManagedHub'`\n- `make strict-fmt`\n- Full `make unit-tests-operator` was attempted but could not download setup-envtest because proxy.golang.org was unreachable.