### PR TITLE
ACM-42804: prevent regional hub addon recreation on hub-role label addition

### DIFF
--- a/agent/pkg/spec/hubha/hubha_config_annotator.go
+++ b/agent/pkg/spec/hubha/hubha_config_annotator.go
@@ -138,6 +138,9 @@ func hasHAKlusterletConfigAnnotation(obj client.Object) bool {
 }
 
 func isGlobalHubManagedHub(obj client.Object) bool {
+	if obj.GetAnnotations()[constants.AnnotationONMulticlusterHub] == "true" {
+		return true
+	}
 	labels := obj.GetLabels()
 	if labels == nil {
 		return false

--- a/agent/pkg/spec/hubha/hubha_config_annotator_test.go
+++ b/agent/pkg/spec/hubha/hubha_config_annotator_test.go
@@ -114,15 +114,14 @@ func TestHAConfigAnnotator_NoOpWhenNotActiveHub(t *testing.T) {
 		"standby/global hub must not annotate ManagedClusters when ha-standby config is synced")
 }
 
-func TestHAConfigAnnotator_SkipsImportedRegionalHub(t *testing.T) {
+func TestHAConfigAnnotator_SkipsImportedRegionalHubBeforeGlobalHubLabels(t *testing.T) {
 	setAnnotatorHubRole(t, constants.GHHubRoleActive)
 	scheme := newAnnotatorTestScheme(t)
 	regionalHub := &clusterv1.ManagedCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "regional-hub",
-			Labels: map[string]string{
-				constants.GHDeployModeLabelKey: constants.GHDeployModeHosted,
-				constants.GHHubRoleLabelKey:    constants.GHHubRoleActive,
+			Annotations: map[string]string{
+				constants.AnnotationONMulticlusterHub: "true",
 			},
 		},
 	}
@@ -142,7 +141,7 @@ func TestHAConfigAnnotator_SkipsImportedRegionalHub(t *testing.T) {
 	err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "regional-hub"}, mc)
 	require.NoError(t, err, "should retrieve imported regional hub ManagedCluster")
 	assert.Empty(t, mc.GetAnnotations()[klusterletConfigAnnotation],
-		"ManagedCluster for a regional hub imported into Global Hub must not get "+
+		"ManagedCluster for a regional hub must not get "+
 			"klusterlet-config annotation")
 }
 
@@ -377,6 +376,15 @@ func TestIsLocalManagedCluster(t *testing.T) {
 }
 
 func TestIsGlobalHubManagedHub(t *testing.T) {
+	assert.True(t, isGlobalHubManagedHub(&clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "regional-hub",
+			Annotations: map[string]string{
+				constants.AnnotationONMulticlusterHub: "true",
+			},
+		},
+	}), "multicluster-hub annotation identifies an imported hub before Global Hub labels are added")
+
 	assert.True(t, isGlobalHubManagedHub(&clusterv1.ManagedCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "regional-hub",

--- a/operator/pkg/controllers/agent/addon/default_agent_controller.go
+++ b/operator/pkg/controllers/agent/addon/default_agent_controller.go
@@ -461,8 +461,11 @@ func expectedManagedClusterAddon(cluster *clusterv1.ManagedCluster, cma *addonv1
 		expectedAddonAnnotations[imageregistryv1alpha1.ClusterImageRegistriesAnnotation] = val
 	}
 
-	// Hub HA: store hub role in addon annotations to trigger re-rendering when role changes
-	if hubRole, ok := cluster.Labels[constants.GHHubRoleLabelKey]; ok {
+	// Hub HA: store hub role in addon annotations to trigger re-rendering when role changes.
+	// Skip for imported regional hubs (identified by the multicluster-hub annotation) to prevent
+	// addon recreation when the hub-role label is added (ACM-42804).
+	isRegionalHub := cluster.Annotations[constants.AnnotationONMulticlusterHub] == "true"
+	if hubRole, ok := cluster.Labels[constants.GHHubRoleLabelKey]; ok && !isRegionalHub {
 		expectedAddonAnnotations[constants.GHHubRoleLabelKey] = hubRole
 	}
 

--- a/operator/pkg/controllers/agent/addon/default_agent_controller_test.go
+++ b/operator/pkg/controllers/agent/addon/default_agent_controller_test.go
@@ -311,6 +311,98 @@ func TestConfirmDeployLabelAbsent(t *testing.T) {
 	}
 }
 
+// TestExpectedManagedClusterAddon_RegionalHubSkipsHubRoleAnnotation verifies ACM-42804 fix: when a
+// regional hub (identified by addon.open-cluster-management.io/on-multicluster-hub=true) has the
+// hub-role label, expectedManagedClusterAddon must NOT copy it to the addon annotations to prevent
+// triggering addon recreation.
+//
+//	go test -run ^TestExpectedManagedClusterAddon_RegionalHubSkipsHubRoleAnnotation$ \
+//	  github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/agent/addon
+func TestExpectedManagedClusterAddon_RegionalHubSkipsHubRoleAnnotation(t *testing.T) {
+	tests := []struct {
+		name                      string
+		cluster                   *v1.ManagedCluster
+		expectHubRoleInAnnotation bool
+	}{
+		{
+			name: "regular managed cluster with hub-role label -> annotation added",
+			cluster: &v1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "regular-cluster",
+					Labels: map[string]string{
+						constants.GHHubRoleLabelKey: constants.GHHubRoleActive,
+					},
+				},
+			},
+			expectHubRoleInAnnotation: true,
+		},
+		{
+			name: "regional hub with hub-role label -> annotation skipped (ACM-42804)",
+			cluster: &v1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "regional-hub",
+					Labels: map[string]string{
+						constants.GHHubRoleLabelKey: constants.GHHubRoleActive,
+					},
+					Annotations: map[string]string{
+						constants.AnnotationONMulticlusterHub: "true",
+					},
+				},
+			},
+			expectHubRoleInAnnotation: false,
+		},
+		{
+			name: "regional hub without hub-role label -> no annotation",
+			cluster: &v1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "regional-hub-no-role",
+					Annotations: map[string]string{
+						constants.AnnotationONMulticlusterHub: "true",
+					},
+				},
+			},
+			expectHubRoleInAnnotation: false,
+		},
+		{
+			name: "cluster without hub-role label -> no annotation",
+			cluster: &v1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "regular-cluster-no-role",
+				},
+			},
+			expectHubRoleInAnnotation: false,
+		},
+	}
+
+	cma := fakeClusterManagementAddon()
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			addon, err := expectedManagedClusterAddon(tc.cluster, cma)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			annotations := addon.GetAnnotations()
+			_, hasHubRole := annotations[constants.GHHubRoleLabelKey]
+
+			if hasHubRole != tc.expectHubRoleInAnnotation {
+				t.Errorf("hub-role in addon annotations = %v, want %v (annotations: %v)",
+					hasHubRole, tc.expectHubRoleInAnnotation, annotations)
+			}
+
+			// If hub-role annotation is expected, verify it matches the label value
+			if tc.expectHubRoleInAnnotation {
+				expectedRole := tc.cluster.Labels[constants.GHHubRoleLabelKey]
+				actualRole := annotations[constants.GHHubRoleLabelKey]
+				if actualRole != expectedRole {
+					t.Errorf("hub-role annotation value = %q, want %q", actualRole, expectedRole)
+				}
+			}
+		})
+	}
+}
+
 // TestReconcileStaleCacheKeepsManagedHub is the ACM-40204 Reconcile regression: when the controller
 // cache transiently lacks BOTH the deploy-mode label and the ManagedClusterAddOn during an operator
 // restart/upgrade, but the API server still reports the labeled cluster, Reconcile must NOT take the


### PR DESCRIPTION
## Summary

- Skip copying hub-role label to ManagedClusterAddOn annotations for imported regional hubs
- Prevents addon framework from triggering manifest re-rendering that causes ACM addon recreation
- Preserves Hub HA functionality by flowing hub-role via ManagedCluster label to agent
- Adds comprehensive test coverage for regional hub vs. regular cluster scenarios

## Problem

When the `global-hub.open-cluster-management.io/hub-role=active` label is added to an imported regional hub ManagedCluster on the global hub:

1. The operator copies it to the ManagedClusterAddOn annotations
2. Addon framework detects annotation change and re-renders ALL addon manifests for that cluster
3. ACM addons (cluster-proxy, work-manager, managed-serviceaccount) on the regional hub get recreated
4. New pods try to mount klusterlet-config secrets (e.g., `work-manager-hub-kubeconfig`) that don't exist
5. Pods stuck in ContainerCreating state with mount failures

## Root Cause

The operator's `default_agent_controller.go` was unconditionally copying the hub-role label to addon annotations for ALL clusters, including regional hubs. Regional hubs should be treated specially because:
- They already have the `addon.open-cluster-management.io/on-multicluster-hub=true` annotation
- They don't need addon annotation updates to trigger re-rendering
- The hub-role flows correctly via the ManagedCluster label (not the addon annotation)

## Solution

Check for the `addon.open-cluster-management.io/on-multicluster-hub=true` annotation before copying hub-role to addon annotations:

```go
isRegionalHub := cluster.Annotations[constants.AnnotationONMulticlusterHub] == "true"
if hubRole, ok := cluster.Labels[constants.GHHubRoleLabelKey]; ok && !isRegionalHub {
    expectedAddonAnnotations[constants.GHHubRoleLabelKey] = hubRole
}
```

This prevents the trigger that causes addon recreation while preserving:
- Hub HA functionality (hub-role flows via ManagedCluster label in `addon_agent.go`)
- Normal behavior for regular managed clusters (hub-role still copied to addon annotations)

## Testing

**Unit Tests Added:**
- Regular managed cluster WITH hub-role: annotation added (existing behavior preserved)
- Regional hub WITH hub-role: annotation skipped (fix for ACM-42804)
- Regional hub WITHOUT hub-role: no annotation
- Regular cluster WITHOUT hub-role: no annotation

All existing tests pass with no regressions.

**Manual Testing:**
After applying this fix, adding the hub-role label to a regional hub ManagedCluster should NOT trigger addon recreation. The Global Hub agent will still receive the hub-role configuration via the ManagedCluster label.

## Relationship to PR #2833

This completes the ACM-42804 fix:
- **PR #2833** (merged): Agent-side fix preventing klusterlet-config annotations on ManagedClusters
- **This PR**: Operator-side fix preventing addon annotation updates that trigger recreation

Both are needed for a complete solution.

## Jira

https://redhat.atlassian.net/browse/ACM-42804

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recognition of managed hubs identified by the multicluster-hub annotation.
  - Prevented regional hubs from incorrectly receiving hub-role metadata in managed cluster add-ons.
  - Reduced unnecessary add-on recreation when regional hub labels change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->