### PR TITLE
ACM-42804: skip hub-role annotation for regional hubs

### DIFF
--- a/operator/pkg/controllers/agent/addon/default_agent_controller.go
+++ b/operator/pkg/controllers/agent/addon/default_agent_controller.go
@@ -461,8 +461,13 @@ func expectedManagedClusterAddon(cluster *clusterv1.ManagedCluster, cma *addonv1
 		expectedAddonAnnotations[imageregistryv1alpha1.ClusterImageRegistriesAnnotation] = val
 	}
 
-	// Hub HA: store hub role in addon annotations to trigger re-rendering when role changes
-	if hubRole, ok := cluster.Labels[constants.GHHubRoleLabelKey]; ok {
+	// Hub HA: store hub role in addon annotations to trigger re-rendering when role changes.
+	// Skip for imported regional hubs (hosted mode with hosting-cluster) to prevent addon
+	// recreation when the hub-role label is added (ACM-42804).
+	// Regular Hub HA managed hubs (non-hosted) need the annotation to trigger manifest updates.
+	isImportedRegionalHub := cluster.Annotations[constants.AnnotationONMulticlusterHub] == "true" &&
+		cluster.Annotations[constants.AnnotationClusterHostingClusterName] != ""
+	if hubRole, ok := cluster.Labels[constants.GHHubRoleLabelKey]; ok && !isImportedRegionalHub {
 		expectedAddonAnnotations[constants.GHHubRoleLabelKey] = hubRole
 	}
 

--- a/operator/pkg/controllers/agent/addon/default_agent_controller_test.go
+++ b/operator/pkg/controllers/agent/addon/default_agent_controller_test.go
@@ -311,6 +311,116 @@ func TestConfirmDeployLabelAbsent(t *testing.T) {
 	}
 }
 
+// TestExpectedManagedClusterAddon_RegionalHubSkipsHubRoleAnnotation verifies ACM-42804 fix: when an
+// imported regional hub (hosted mode with hosting-cluster) has the hub-role label,
+// expectedManagedClusterAddon must NOT copy it to the addon annotations to prevent addon recreation.
+// Regular Hub HA managed hubs (non-hosted) should still get the annotation.
+//
+//	go test -run ^TestExpectedManagedClusterAddon_RegionalHubSkipsHubRoleAnnotation$ \
+//	  github.com/stolostron/multicluster-global-hub/operator/pkg/controllers/agent/addon
+func TestExpectedManagedClusterAddon_RegionalHubSkipsHubRoleAnnotation(t *testing.T) {
+	tests := []struct {
+		name                      string
+		cluster                   *v1.ManagedCluster
+		expectHubRoleInAnnotation bool
+	}{
+		{
+			name: "regular managed cluster with hub-role label -> annotation added",
+			cluster: &v1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "regular-cluster",
+					Labels: map[string]string{
+						constants.GHHubRoleLabelKey: constants.GHHubRoleActive,
+					},
+				},
+			},
+			expectHubRoleInAnnotation: true,
+		},
+		{
+			name: "imported regional hub (hosted) with hub-role -> annotation skipped (ACM-42804)",
+			cluster: &v1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "imported-regional-hub",
+					Labels: map[string]string{
+						constants.GHHubRoleLabelKey: constants.GHHubRoleActive,
+					},
+					Annotations: map[string]string{
+						constants.AnnotationONMulticlusterHub:         "true",
+						constants.AnnotationClusterHostingClusterName: "local-cluster",
+					},
+				},
+			},
+			expectHubRoleInAnnotation: false,
+		},
+		{
+			name: "Hub HA managed hub (non-hosted) with hub-role -> annotation added",
+			cluster: &v1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "hubha-managed-hub",
+					Labels: map[string]string{
+						constants.GHHubRoleLabelKey: constants.GHHubRoleActive,
+					},
+					Annotations: map[string]string{
+						constants.AnnotationONMulticlusterHub: "true",
+						// No hosting-cluster annotation = not imported/hosted
+					},
+				},
+			},
+			expectHubRoleInAnnotation: true,
+		},
+		{
+			name: "regional hub without hub-role label -> no annotation",
+			cluster: &v1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "regional-hub-no-role",
+					Annotations: map[string]string{
+						constants.AnnotationONMulticlusterHub:         "true",
+						constants.AnnotationClusterHostingClusterName: "local-cluster",
+					},
+				},
+			},
+			expectHubRoleInAnnotation: false,
+		},
+		{
+			name: "cluster without hub-role label -> no annotation",
+			cluster: &v1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "regular-cluster-no-role",
+				},
+			},
+			expectHubRoleInAnnotation: false,
+		},
+	}
+
+	cma := fakeClusterManagementAddon()
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			addon, err := expectedManagedClusterAddon(tc.cluster, cma)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			annotations := addon.GetAnnotations()
+			_, hasHubRole := annotations[constants.GHHubRoleLabelKey]
+
+			if hasHubRole != tc.expectHubRoleInAnnotation {
+				t.Errorf("hub-role in addon annotations = %v, want %v (annotations: %v)",
+					hasHubRole, tc.expectHubRoleInAnnotation, annotations)
+			}
+
+			// If hub-role annotation is expected, verify it matches the label value
+			if tc.expectHubRoleInAnnotation {
+				expectedRole := tc.cluster.Labels[constants.GHHubRoleLabelKey]
+				actualRole := annotations[constants.GHHubRoleLabelKey]
+				if actualRole != expectedRole {
+					t.Errorf("hub-role annotation value = %q, want %q", actualRole, expectedRole)
+				}
+			}
+		})
+	}
+}
+
 // TestReconcileStaleCacheKeepsManagedHub is the ACM-40204 Reconcile regression: when the controller
 // cache transiently lacks BOTH the deploy-mode label and the ManagedClusterAddOn during an operator
 // restart/upgrade, but the API server still reports the labeled cluster, Reconcile must NOT take the


### PR DESCRIPTION
Skip copying hub-role label to addon annotations for regional hubs to prevent addon recreation.

Regional hubs are identified by `addon.open-cluster-management.io/on-multicluster-hub=true` annotation.

Completes the fix from PR #2833.

Jira: https://redhat.atlassian.net/browse/ACM-42804

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Regional hubs imported into the multicluster environment no longer receive hub-role annotations on their managed add-ons.
  - Managed clusters continue to retain hub-role annotations when applicable.
  - Add-ons no longer receive an unnecessary hub-role annotation when no hub-role label is present.
  - Hub-role annotation behavior is now consistent across regular managed clusters, hosted regional hubs, and highly available managed hubs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->