### PR TITLE
ACM-34442: Reject identical BYO certs on all per-hub secrets (GH 1.6)

### DIFF
--- a/operator/pkg/controllers/transporter/protocol/byo_transporter.go
+++ b/operator/pkg/controllers/transporter/protocol/byo_transporter.go
@@ -28,7 +28,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/stolostron/multicluster-global-hub/operator/pkg/config"
@@ -197,24 +196,13 @@ func (s *BYOTransporter) getTransportSecret(clusterName string) (*corev1.Secret,
 }
 
 // validateDistinctClientCerts requires a non-empty client.crt on a per-hub
-// secret and rejects identical certificates across managed hubs. Secrets that
-// only share the transport-secret name prefix are ignored unless the suffix
-// is an existing ManagedCluster name.
+// secret and rejects identical certificates across per-hub transport secrets.
 func (s *BYOTransporter) validateDistinctClientCerts(clusterName string, clientCert []byte) error {
 	if isManagerCluster(clusterName) {
 		return nil
 	}
 	if len(clientCert) == 0 {
 		return fmt.Errorf("BYO Kafka per-hub transport secret is missing client.crt")
-	}
-
-	managedHubs := map[string]struct{}{}
-	mcList := &clusterv1.ManagedClusterList{}
-	if err := s.runtimeClient.List(s.ctx, mcList); err != nil {
-		return fmt.Errorf("failed to list managed clusters for BYO cert uniqueness: %w", err)
-	}
-	for i := range mcList.Items {
-		managedHubs[mcList.Items[i].Name] = struct{}{}
 	}
 
 	secretList := &corev1.SecretList{}
@@ -225,10 +213,7 @@ func (s *BYOTransporter) validateDistinctClientCerts(clusterName string, clientC
 	for i := range secretList.Items {
 		secret := &secretList.Items[i]
 		otherCluster := constants.ClusterNameFromGHTransportSecret(secret.Name)
-		if _, ok := managedHubs[otherCluster]; !ok {
-			continue
-		}
-		if otherCluster == clusterName || isManagerCluster(otherCluster) {
+		if otherCluster == "" || otherCluster == clusterName || isManagerCluster(otherCluster) {
 			continue
 		}
 		otherCert := secret.Data[transportSecretClientCertKey]

--- a/operator/pkg/controllers/transporter/protocol/byo_transporter_test.go
+++ b/operator/pkg/controllers/transporter/protocol/byo_transporter_test.go
@@ -324,16 +324,20 @@ func TestEnsureUserReportsMissingClientCert(t *testing.T) {
 	}
 }
 
-// TestEnsureUserIgnoresUnrelatedPrefixedSecret ignores a prefixed secret that is not a ManagedCluster.
-func TestEnsureUserIgnoresUnrelatedPrefixedSecret(t *testing.T) {
+// TestEnsureUserRejectsIdenticalUnrelatedPrefixedSecret rejects identical certs on any per-hub secret.
+func TestEnsureUserRejectsIdenticalUnrelatedPrefixedSecret(t *testing.T) {
 	ns := utils.GetDefaultNamespace()
 	same := "duplicate-cert"
 	hub1 := byoSecret(constants.GHTransportSecretNameForCluster("hub1"), ns, same)
 	unrelated := byoSecret(constants.GHTransportSecretName+"-not-a-managed-hub", ns, same)
-	trans := newBYOTransporter(t, byoMGH(ns), hub1, unrelated, byoManagedCluster("hub1"))
+	trans := newBYOTransporter(t, byoMGH(ns), hub1, unrelated)
 
-	if _, err := trans.EnsureUser("hub1"); err != nil {
-		t.Fatalf("EnsureUser(hub1) unrelated prefix error = %v", err)
+	_, err := trans.EnsureUser("hub1")
+	if err == nil {
+		t.Fatal("EnsureUser(hub1) expected identical-cert error")
+	}
+	if !strings.Contains(err.Error(), "identical") {
+		t.Fatalf("EnsureUser() error = %v, want identical cert message", err)
 	}
 }
 

--- a/test/e2e/transport_byo_test.go
+++ b/test/e2e/transport_byo_test.go
@@ -206,6 +206,28 @@ func createBYOPerHubSecret(clusterName string, mutate func(*corev1.Secret)) {
 	Expect(err).NotTo(HaveOccurred(), "expected to create or update the per-hub BYO secret")
 }
 
+func waitHubsUseSharedBootstrap(
+	sourceClient client.Client, sourceName string,
+	targetClient client.Client, targetName, sharedBootstrap string,
+) {
+	GinkgoHelper()
+	for _, hub := range []struct {
+		name   string
+		client client.Client
+	}{
+		{sourceName, sourceClient},
+		{targetName, targetClient},
+	} {
+		if hub.client == nil {
+			continue
+		}
+		Eventually(func() error {
+			return managedHubAgentUsesSharedBootstrap(hub.client, hub.name, sharedBootstrap)
+		}, 5*time.Minute, 5*time.Second).Should(Succeed(),
+			"agent on %s must fall back to the shared BYO secret after per-hub cleanup", hub.name)
+	}
+}
+
 func deleteBYOPerHubSecret(clusterName string) {
 	apiCtx, cancel := byoAPIContext()
 	defer cancel()

--- a/test/e2e/transport_byo_test.go
+++ b/test/e2e/transport_byo_test.go
@@ -80,6 +80,7 @@ var _ = Describe("Transport BYO Kafka E2E", Serial, Label("e2e-test-transport-by
 		}
 		deleteBYOPerHubSecret(sourceHubName)
 		deleteBYOPerHubSecret(targetHubName)
+		waitHubsUseSharedBootstrap(sourceHubClient, sourceHubName, targetHubClient, targetHubName, sharedBootstrap)
 	})
 
 	It("allows a custom client certificate CN on the shared BYO secret", func() {
@@ -113,17 +114,7 @@ var _ = Describe("Transport BYO Kafka E2E", Serial, Label("e2e-test-transport-by
 		})
 		DeferCleanup(func() {
 			deleteBYOPerHubSecret(sourceHubName)
-			Eventually(func() error {
-				cfg, err := managedHubAgentKafkaConfig(sourceHubClient)
-				if err != nil {
-					return err
-				}
-				if cfg.BootstrapServer != sharedBootstrap {
-					return fmt.Errorf("waiting for shared-secret bootstrap to be restored")
-				}
-				return nil
-			}, 2*time.Minute, 5*time.Second).Should(Succeed(),
-				"agent transport must fall back to the shared BYO secret after per-hub cleanup")
+			waitHubsUseSharedBootstrap(sourceHubClient, sourceHubName, targetHubClient, targetHubName, sharedBootstrap)
 		})
 
 		Eventually(func() error {
@@ -146,6 +137,7 @@ var _ = Describe("Transport BYO Kafka E2E", Serial, Label("e2e-test-transport-by
 		DeferCleanup(func() {
 			deleteBYOPerHubSecret(sourceHubName)
 			deleteBYOPerHubSecret(targetHubName)
+			waitHubsUseSharedBootstrap(sourceHubClient, sourceHubName, targetHubClient, targetHubName, sharedBootstrap)
 		})
 
 		Eventually(func() error {


### PR DESCRIPTION
## Summary
- Align `validateDistinctClientCerts` on `release-2.15` with GH 1.7+ / 5.0 behavior: compare **all** per-hub BYO transport secrets for duplicate `client.crt` values
- Remove the ManagedCluster-name filter that caused identical certs on non-MC suffixes (e.g. `acmqe-dummy-hub`) to be ignored
- Update unit test to expect rejection instead of ignoring unrelated prefixed secrets

Fixes acmqe-hoh-e2e BYO TODO-5 (`operator logs do not contain "must not be identical"`) on GH 1.6 z-stream QE.

Related: [ACM-34442](https://redhat.atlassian.net/browse/ACM-34442), [ACM-38863](https://redhat.atlassian.net/browse/ACM-38863)

## Test plan
- [ ] `go test ./operator/pkg/controllers/transporter/protocol/ -run TestEnsureUserRejectsIdentical`
- [ ] Re-run `globalhub-e2e` BYO suite on GH 1.6 (`release-2.15` operator image)


Made with [Cursor](https://cursor.com)

[ACM-34442]: https://redhat.atlassian.net/browse/ACM-34442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-38863]: https://redhat.atlassian.net/browse/ACM-38863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved BYO transport certificate validation to detect duplicate client certificates across all relevant transport configurations.
  - Prevented creation or use of a BYO transport setup when its certificate conflicts with another configured transport secret.
  - Improved cleanup reliability after per-hub transport configuration removal by confirming hubs restore shared transport settings and become ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->