### PR TITLE
ACM-30974: suppress observability resources on standby hub

### DIFF
--- a/agent/pkg/spec/hubha/hubha_standby_syncer.go
+++ b/agent/pkg/spec/hubha/hubha_standby_syncer.go
@@ -8,6 +8,7 @@ import (
 	stderrors "errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -33,6 +34,8 @@ type HubHAStandbySyncer struct {
 	// pendingResyncSessions accumulates live object metadata per GVK until cleanup after
 	// Complete succeeds. Partial ResyncMetadata frames must not trigger stale cleanup.
 	pendingResyncSessions map[string]*resyncInventorySession
+
+	suppressedCleanupDone atomic.Bool
 }
 
 // resyncInventorySession tracks one per-GVK inventory across size-split frames.
@@ -72,6 +75,12 @@ func (s *HubHAStandbySyncer) Sync(ctx context.Context, evt *cloudevents.Event) e
 
 	sourceHub := source
 	var syncErrs []error
+
+	// Filter suppressed metrics resources from all bundle slices before dispatching.
+	bundle.Create = filterSuppressedObjects(bundle.Create, sourceHub)
+	bundle.Update = filterSuppressedObjects(bundle.Update, sourceHub)
+	bundle.Resync = filterSuppressedObjects(bundle.Resync, sourceHub)
+	bundle.Delete = filterSuppressedMetadata(bundle.Delete, sourceHub)
 
 	// Apply created resources
 	for _, obj := range bundle.Create {
@@ -117,6 +126,17 @@ func (s *HubHAStandbySyncer) Sync(ctx context.Context, evt *cloudevents.Event) e
 		}
 	}
 
+	// One-time cleanup of observability resources replicated before suppression was added.
+	// Uses atomic.Bool instead of sync.Once so transient failures are retried on the next Sync.
+	if !s.suppressedCleanupDone.Load() {
+		if err := s.cleanupPreExistingSuppressedResources(ctx); err != nil {
+			log.Errorw("failed to clean up pre-existing suppressed metrics resources", "error", err)
+			syncErrs = append(syncErrs, err)
+		} else {
+			s.suppressedCleanupDone.Store(true)
+		}
+	}
+
 	log.Infof("standby hub processed Hub HA bundle from %s: created=%d, updated=%d, "+
 		"resynced=%d, deleted=%d, resync_metadata=%d",
 		sourceHub, len(bundle.Create), len(bundle.Update), len(bundle.Resync), len(bundle.Delete),
@@ -138,10 +158,10 @@ func (s *HubHAStandbySyncer) createResource(ctx context.Context, obj *unstructur
 		return nil
 	}
 
+	gvk := obj.GroupVersionKind()
+
 	log.Infof("creating resource from active hub %s: %s/%s (%s)",
 		sourceHub, obj.GetNamespace(), obj.GetName(), obj.GetKind())
-
-	gvk := obj.GroupVersionKind()
 
 	// The active hub's own local-cluster (and hubs imported into Global Hub) must not be
 	// applied onto the standby: they collide with the standby's own local-cluster. Mirror
@@ -195,10 +215,10 @@ func (s *HubHAStandbySyncer) updateResource(ctx context.Context, obj *unstructur
 		return nil
 	}
 
+	gvk := obj.GroupVersionKind()
+
 	log.Debugf("updating resource from active hub %s: %s/%s (%s)",
 		sourceHub, obj.GetNamespace(), obj.GetName(), obj.GetKind())
-
-	gvk := obj.GroupVersionKind()
 
 	// The active hub's own local-cluster (and hubs imported into Global Hub) must not be
 	// applied onto the standby: they collide with the standby's own local-cluster. Mirror
@@ -535,4 +555,89 @@ func shouldSkipHubHAResourceApply(obj *unstructured.Unstructured) bool {
 		return utils.IsLocalManagedCluster(obj)
 	}
 	return false
+}
+
+// suppressedMetricsGVKs is the single source of truth for observability GVKs that must
+// not exist on the standby hub. Both shouldSuppressMetricsResource and the one-time
+// cleanup use this list.
+var suppressedMetricsGVKs = []schema.GroupVersionKind{
+	{Group: groupObservabilityOCM, Version: "v1beta2", Kind: "MultiClusterObservability"},
+	{Group: groupObservabilityOCM, Version: "v1beta1", Kind: "ObservabilityAddon"},
+	{Group: groupObservatorium, Version: "v1alpha1", Kind: "Observatorium"},
+}
+
+// shouldSuppressMetricsResource returns true for observability resources that must not be
+// applied to the standby hub. Suppressing these prevents the standby hub from reporting
+// metrics to Thanos object storage, which would produce duplicate data.
+func shouldSuppressMetricsResource(gvk schema.GroupVersionKind) bool {
+	for _, suppressed := range suppressedMetricsGVKs {
+		if gvk.Group == suppressed.Group && gvk.Kind == suppressed.Kind {
+			return true
+		}
+	}
+	return false
+}
+
+// filterSuppressedObjects removes suppressed metrics resources from a slice of objects.
+func filterSuppressedObjects(objects []*unstructured.Unstructured, sourceHub string) []*unstructured.Unstructured {
+	filtered := objects[:0]
+	for _, obj := range objects {
+		gvk := obj.GroupVersionKind()
+		if shouldSuppressMetricsResource(gvk) {
+			log.Infow("suppressing metrics resource on standby hub",
+				"namespace", obj.GetNamespace(), "name", obj.GetName(), "kind", gvk.Kind, "sourceHub", sourceHub)
+			continue
+		}
+		filtered = append(filtered, obj)
+	}
+	return filtered
+}
+
+// filterSuppressedMetadata removes suppressed metrics resources from a slice of metadata.
+func filterSuppressedMetadata(metadata []generic.ObjectMetadata, sourceHub string) []generic.ObjectMetadata {
+	filtered := metadata[:0]
+	for _, m := range metadata {
+		gvk := schema.GroupVersionKind{Group: m.Group, Version: m.Version, Kind: m.Kind}
+		if shouldSuppressMetricsResource(gvk) {
+			log.Infow("suppressing delete of metrics resource on standby hub",
+				"namespace", m.Namespace, "name", m.Name, "kind", gvk.Kind, "sourceHub", sourceHub)
+			continue
+		}
+		filtered = append(filtered, m)
+	}
+	return filtered
+}
+
+// cleanupPreExistingSuppressedResources removes observability resources that were
+// replicated to the standby hub before suppression was introduced.
+func (s *HubHAStandbySyncer) cleanupPreExistingSuppressedResources(ctx context.Context) error {
+	var errs []error
+	for _, gvk := range suppressedMetricsGVKs {
+		list := &unstructured.UnstructuredList{}
+		list.SetGroupVersionKind(schema.GroupVersionKind{
+			Group: gvk.Group, Version: gvk.Version, Kind: gvk.Kind + "List",
+		})
+		if err := s.client.List(ctx, list); err != nil {
+			if meta.IsNoMatchError(err) {
+				continue
+			}
+			errs = append(errs, fmt.Errorf("failed to list pre-existing %s: %w", gvk, err))
+			continue
+		}
+		for i := range list.Items {
+			obj := &list.Items[i]
+			log.Infow("removing pre-existing suppressed metrics resource from standby hub",
+				"namespace", obj.GetNamespace(), "name", obj.GetName(), "kind", gvk.Kind)
+			if err := s.client.Delete(ctx, obj); err != nil {
+				if !errors.IsNotFound(err) {
+					errs = append(errs, fmt.Errorf("failed to delete pre-existing %s %s/%s: %w",
+						gvk.Kind, obj.GetNamespace(), obj.GetName(), err))
+				}
+			}
+		}
+	}
+	if len(errs) > 0 {
+		return stderrors.Join(errs...)
+	}
+	return nil
 }

--- a/agent/pkg/spec/hubha/hubha_standby_syncer_test.go
+++ b/agent/pkg/spec/hubha/hubha_standby_syncer_test.go
@@ -6,6 +6,7 @@ package hubha
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -14,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -1283,6 +1285,440 @@ func TestHubHAStandbySyncer_SkipsLocalClusterManagedClusterApply(t *testing.T) {
 		t.Fatal("local cluster ManagedCluster should not be created on standby hub")
 	} else if !errors.IsNotFound(err) {
 		t.Fatalf("expected NotFound, got: %v", err)
+	}
+}
+
+func TestShouldSuppressMetricsResource(t *testing.T) {
+	tests := []struct {
+		name     string
+		group    string
+		version  string
+		kind     string
+		suppress bool
+	}{
+		{
+			name:     "ObservabilityAddon is suppressed",
+			group:    "observability.open-cluster-management.io",
+			version:  "v1beta1",
+			kind:     "ObservabilityAddon",
+			suppress: true,
+		},
+		{
+			name:     "MultiClusterObservability is suppressed",
+			group:    "observability.open-cluster-management.io",
+			version:  "v1beta2",
+			kind:     "MultiClusterObservability",
+			suppress: true,
+		},
+		{
+			name:     "Observatorium is suppressed",
+			group:    "core.observatorium.io",
+			version:  "v1alpha1",
+			kind:     "Observatorium",
+			suppress: true,
+		},
+		{
+			name:     "ConfigMap is not suppressed",
+			group:    "",
+			version:  "v1",
+			kind:     "ConfigMap",
+			suppress: false,
+		},
+		{
+			name:     "ManagedCluster is not suppressed",
+			group:    "cluster.open-cluster-management.io",
+			version:  "v1",
+			kind:     "ManagedCluster",
+			suppress: false,
+		},
+		{
+			name:     "Policy is not suppressed",
+			group:    "policy.open-cluster-management.io",
+			version:  "v1",
+			kind:     "Policy",
+			suppress: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gvk := schema.GroupVersionKind{Group: tt.group, Version: tt.version, Kind: tt.kind}
+			if got := shouldSuppressMetricsResource(gvk); got != tt.suppress {
+				t.Errorf("shouldSuppressMetricsResource(%v) = %v, want %v", gvk, got, tt.suppress)
+			}
+		})
+	}
+}
+
+func TestFilterSuppressedObjects(t *testing.T) {
+	cases := []struct {
+		name       string
+		apiVersion string
+		kind       string
+		objName    string
+		namespace  string
+		kept       bool
+	}{
+		{
+			"ObservabilityAddon filtered", "observability.open-cluster-management.io/v1beta1",
+			"ObservabilityAddon", "obs-addon", "spoke", false,
+		},
+		{"MCO filtered", "observability.open-cluster-management.io/v1beta2", "MultiClusterObservability", "mco", "", false},
+		{"Observatorium filtered", "core.observatorium.io/v1alpha1", "Observatorium", "obs", "obs-ns", false},
+		{"ConfigMap kept", "v1", "ConfigMap", "my-cm", "default", true},
+		{"Policy kept", "policy.open-cluster-management.io/v1", "Policy", "my-policy", "default", true},
+	}
+
+	objects := make([]*unstructured.Unstructured, 0, len(cases))
+	for _, tc := range cases {
+		objects = append(objects, &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": tc.apiVersion,
+				"kind":       tc.kind,
+				"metadata":   map[string]interface{}{"name": tc.objName, "namespace": tc.namespace},
+			},
+		})
+	}
+
+	filtered := filterSuppressedObjects(objects, "hub1")
+	keptNames := make(map[string]bool)
+	for _, obj := range filtered {
+		keptNames[obj.GetName()] = true
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if keptNames[tc.objName] != tc.kept {
+				t.Errorf("object %s: kept=%v, want %v", tc.objName, keptNames[tc.objName], tc.kept)
+			}
+		})
+	}
+}
+
+func TestFilterSuppressedMetadata(t *testing.T) {
+	metadata := []generic.ObjectMetadata{
+		{
+			Group: "observability.open-cluster-management.io", Version: "v1beta1",
+			Kind: "ObservabilityAddon", Name: "addon", Namespace: "spoke",
+		},
+		{Group: "", Version: "v1", Kind: "ConfigMap", Name: "cm", Namespace: "default"},
+		{Group: "core.observatorium.io", Version: "v1alpha1", Kind: "Observatorium", Name: "obs", Namespace: "obs-ns"},
+	}
+
+	filtered := filterSuppressedMetadata(metadata, "hub1")
+	if len(filtered) != 1 || filtered[0].Name != "cm" {
+		t.Fatalf("expected only ConfigMap kept, got %d items", len(filtered))
+	}
+}
+
+func TestHubHAStandbySyncer_Sync_SuppressesObservabilityInBundle(t *testing.T) {
+	scheme := runtime.NewScheme()
+
+	existingCM := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name":      "delete-me",
+				"namespace": "default",
+			},
+			"data": map[string]interface{}{"key": "value"},
+		},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existingCM).Build()
+	syncer := NewHubHAStandbySyncer(cl)
+
+	bundle := generic.NewGenericBundle[*unstructured.Unstructured]()
+	bundle.Create = []*unstructured.Unstructured{
+		{Object: map[string]interface{}{
+			"apiVersion": "v1", "kind": "ConfigMap",
+			"metadata": map[string]interface{}{"name": "allowed-cm", "namespace": "default"},
+			"data":     map[string]interface{}{"key": "value"},
+		}},
+		{Object: map[string]interface{}{
+			"apiVersion": "observability.open-cluster-management.io/v1beta1", "kind": "ObservabilityAddon",
+			"metadata": map[string]interface{}{"name": "obs-addon", "namespace": "spoke-cluster"},
+		}},
+	}
+	bundle.Update = []*unstructured.Unstructured{
+		{Object: map[string]interface{}{
+			"apiVersion": "observability.open-cluster-management.io/v1beta2", "kind": "MultiClusterObservability",
+			"metadata": map[string]interface{}{"name": "observability"},
+		}},
+	}
+	bundle.Delete = []generic.ObjectMetadata{
+		{Name: "delete-me", Namespace: "default", Group: "", Version: "v1", Kind: "ConfigMap"},
+		{
+			Name: "obs-addon", Namespace: "spoke-cluster",
+			Group: "observability.open-cluster-management.io", Version: "v1beta1", Kind: "ObservabilityAddon",
+		},
+	}
+
+	evt := cloudevents.NewEvent()
+	evt.SetType(constants.HubHAResourcesMsgKey)
+	evt.SetSource("hub1")
+	if err := evt.SetData(cloudevents.ApplicationJSON, bundle); err != nil {
+		t.Fatalf("SetData() error = %v", err)
+	}
+
+	if err := syncer.Sync(context.Background(), &evt); err != nil {
+		t.Fatalf("Sync() error = %v", err)
+	}
+
+	ctx := context.Background()
+
+	cm := &unstructured.Unstructured{}
+	cm.SetAPIVersion("v1")
+	cm.SetKind("ConfigMap")
+	if err := cl.Get(ctx, types.NamespacedName{Name: "allowed-cm", Namespace: "default"}, cm); err != nil {
+		t.Fatalf("expected allowed-cm to be created: %v", err)
+	}
+
+	addon := &unstructured.Unstructured{}
+	addon.SetAPIVersion("observability.open-cluster-management.io/v1beta1")
+	addon.SetKind("ObservabilityAddon")
+	if err := cl.Get(ctx, types.NamespacedName{Name: "obs-addon", Namespace: "spoke-cluster"}, addon); err == nil {
+		t.Fatal("ObservabilityAddon should not be created on standby hub")
+	}
+
+	mco := &unstructured.Unstructured{}
+	mco.SetAPIVersion("observability.open-cluster-management.io/v1beta2")
+	mco.SetKind("MultiClusterObservability")
+	if err := cl.Get(ctx, types.NamespacedName{Name: "observability"}, mco); err == nil {
+		t.Fatal("MultiClusterObservability should not be created on standby hub")
+	}
+
+	deletedCM := &unstructured.Unstructured{}
+	deletedCM.SetAPIVersion("v1")
+	deletedCM.SetKind("ConfigMap")
+	err := cl.Get(ctx, types.NamespacedName{Name: "delete-me", Namespace: "default"}, deletedCM)
+	if err == nil {
+		t.Fatal("expected delete-me ConfigMap to be deleted")
+	}
+	if !errors.IsNotFound(err) {
+		t.Fatalf("expected NotFound for delete-me, got: %v", err)
+	}
+}
+
+func TestHubHAStandbySyncer_CleanupPreExisting_ListFailureContinues(t *testing.T) {
+	scheme := runtime.NewScheme()
+
+	preExistingAddon := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "observability.open-cluster-management.io/v1beta1",
+			"kind":       "ObservabilityAddon",
+			"metadata": map[string]interface{}{
+				"name":      "obs-addon",
+				"namespace": "spoke-cluster",
+			},
+		},
+	}
+
+	base := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(preExistingAddon).
+		Build()
+
+	cl := interceptor.NewClient(base, interceptor.Funcs{
+		List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+			gvk := list.GetObjectKind().GroupVersionKind()
+			if gvk.Kind == "MultiClusterObservabilityList" {
+				return fmt.Errorf("simulated list failure for MCO")
+			}
+			return c.List(ctx, list, opts...)
+		},
+	})
+	syncer := NewHubHAStandbySyncer(cl)
+
+	ctx := context.Background()
+	err := syncer.cleanupPreExistingSuppressedResources(ctx)
+	if err == nil {
+		t.Fatal("expected error from list failure")
+	}
+	if !strings.Contains(err.Error(), "simulated list failure for MCO") {
+		t.Fatalf("expected list failure in error, got: %v", err)
+	}
+
+	// ObservabilityAddon should still be cleaned up despite MCO list failure
+	addonResult := &unstructured.Unstructured{}
+	addonResult.SetGroupVersionKind(preExistingAddon.GroupVersionKind())
+	getErr := cl.Get(ctx, types.NamespacedName{Name: "obs-addon", Namespace: "spoke-cluster"}, addonResult)
+	if getErr == nil {
+		t.Fatal("ObservabilityAddon should have been deleted even though MCO list failed")
+	}
+	if !errors.IsNotFound(getErr) {
+		t.Fatalf("expected NotFound for ObservabilityAddon, got: %v", getErr)
+	}
+}
+
+func TestHubHAStandbySyncer_CleanupPreExisting_DeleteFailureReported(t *testing.T) {
+	scheme := runtime.NewScheme()
+
+	preExistingAddon := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "observability.open-cluster-management.io/v1beta1",
+			"kind":       "ObservabilityAddon",
+			"metadata": map[string]interface{}{
+				"name":      "obs-addon",
+				"namespace": "spoke-cluster",
+			},
+		},
+	}
+
+	base := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(preExistingAddon).
+		Build()
+
+	cl := interceptor.NewClient(base, interceptor.Funcs{
+		Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+			if obj.GetName() == "obs-addon" {
+				return fmt.Errorf("simulated delete failure")
+			}
+			return c.Delete(ctx, obj, opts...)
+		},
+	})
+	syncer := NewHubHAStandbySyncer(cl)
+
+	ctx := context.Background()
+	err := syncer.cleanupPreExistingSuppressedResources(ctx)
+	if err == nil {
+		t.Fatal("expected error from delete failure")
+	}
+	if !strings.Contains(err.Error(), "simulated delete failure") {
+		t.Fatalf("expected delete failure in error, got: %v", err)
+	}
+}
+
+func TestHubHAStandbySyncer_CleanupPreExisting_PartialFailure(t *testing.T) {
+	scheme := runtime.NewScheme()
+
+	preExistingAddon := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "observability.open-cluster-management.io/v1beta1",
+			"kind":       "ObservabilityAddon",
+			"metadata": map[string]interface{}{
+				"name":      "obs-addon",
+				"namespace": "spoke-cluster",
+			},
+		},
+	}
+	preExistingMCO := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "observability.open-cluster-management.io/v1beta2",
+			"kind":       "MultiClusterObservability",
+			"metadata": map[string]interface{}{
+				"name": "observability",
+			},
+		},
+	}
+
+	base := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(preExistingAddon, preExistingMCO).
+		Build()
+
+	cl := interceptor.NewClient(base, interceptor.Funcs{
+		Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+			if obj.GetName() == "obs-addon" {
+				return fmt.Errorf("addon delete failure")
+			}
+			return c.Delete(ctx, obj, opts...)
+		},
+	})
+	syncer := NewHubHAStandbySyncer(cl)
+
+	ctx := context.Background()
+	err := syncer.cleanupPreExistingSuppressedResources(ctx)
+	if err == nil {
+		t.Fatal("expected error from partial failure")
+	}
+	if !strings.Contains(err.Error(), "addon delete failure") {
+		t.Fatalf("expected addon delete failure in error, got: %v", err)
+	}
+
+	// MCO should be successfully deleted despite addon failure
+	mcoResult := &unstructured.Unstructured{}
+	mcoResult.SetGroupVersionKind(preExistingMCO.GroupVersionKind())
+	getErr := cl.Get(ctx, types.NamespacedName{Name: "observability"}, mcoResult)
+	if getErr == nil {
+		t.Fatal("MCO should have been deleted even though addon delete failed")
+	}
+	if !errors.IsNotFound(getErr) {
+		t.Fatalf("expected NotFound for MCO, got: %v", getErr)
+	}
+}
+
+func TestHubHAStandbySyncer_CleanupPreExistingSuppressedResources(t *testing.T) {
+	scheme := runtime.NewScheme()
+
+	preExistingAddon := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "observability.open-cluster-management.io/v1beta1",
+			"kind":       "ObservabilityAddon",
+			"metadata": map[string]interface{}{
+				"name":      "obs-addon",
+				"namespace": "spoke-cluster",
+			},
+		},
+	}
+	preExistingMCO := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "observability.open-cluster-management.io/v1beta2",
+			"kind":       "MultiClusterObservability",
+			"metadata": map[string]interface{}{
+				"name": "observability",
+			},
+		},
+	}
+	allowedCM := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name":      "allowed-cm",
+				"namespace": "default",
+			},
+			"data": map[string]interface{}{"key": "value"},
+		},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(preExistingAddon, preExistingMCO, allowedCM).
+		Build()
+	syncer := NewHubHAStandbySyncer(cl)
+
+	ctx := context.Background()
+	if err := syncer.cleanupPreExistingSuppressedResources(ctx); err != nil {
+		t.Fatalf("cleanupPreExistingSuppressedResources() error = %v", err)
+	}
+
+	addonResult := &unstructured.Unstructured{}
+	addonResult.SetGroupVersionKind(preExistingAddon.GroupVersionKind())
+	err := cl.Get(ctx, types.NamespacedName{Name: "obs-addon", Namespace: "spoke-cluster"}, addonResult)
+	if err == nil {
+		t.Fatal("pre-existing ObservabilityAddon should have been deleted")
+	}
+	if !errors.IsNotFound(err) {
+		t.Fatalf("expected NotFound for ObservabilityAddon, got: %v", err)
+	}
+
+	mcoResult := &unstructured.Unstructured{}
+	mcoResult.SetGroupVersionKind(preExistingMCO.GroupVersionKind())
+	err = cl.Get(ctx, types.NamespacedName{Name: "observability"}, mcoResult)
+	if err == nil {
+		t.Fatal("pre-existing MultiClusterObservability should have been deleted")
+	}
+	if !errors.IsNotFound(err) {
+		t.Fatalf("expected NotFound for MultiClusterObservability, got: %v", err)
+	}
+
+	cmResult := &unstructured.Unstructured{}
+	cmResult.SetAPIVersion("v1")
+	cmResult.SetKind("ConfigMap")
+	if err := cl.Get(ctx, types.NamespacedName{Name: "allowed-cm", Namespace: "default"}, cmResult); err != nil {
+		t.Fatalf("allowed ConfigMap should NOT have been deleted: %v", err)
 	}
 }
 

--- a/test/integration/agent/hubha/hubha_syncer_test.go
+++ b/test/integration/agent/hubha/hubha_syncer_test.go
@@ -1240,4 +1240,78 @@ var _ = Describe("Hub HA Standby Syncer Integration", func() {
 		Expect(accepts).To(BeTrue(),
 			"standby local-cluster hubAcceptsClient must not be overwritten to false")
 	})
+
+	It("should suppress observability resources while applying regular resources (ACM-30974)", func() {
+		ctx := context.Background()
+
+		bundle := generic.NewGenericBundle[*unstructured.Unstructured]()
+		bundle.Create = []*unstructured.Unstructured{
+			{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]interface{}{
+						"name":      "allowed-cm-integ",
+						"namespace": "default",
+					},
+					"data": map[string]interface{}{"key": "value"},
+				},
+			},
+			{
+				Object: map[string]interface{}{
+					"apiVersion": "observability.open-cluster-management.io/v1beta1",
+					"kind":       "ObservabilityAddon",
+					"metadata": map[string]interface{}{
+						"name":      "obs-addon-integ",
+						"namespace": "default",
+					},
+				},
+			},
+		}
+		bundle.Update = []*unstructured.Unstructured{
+			{
+				Object: map[string]interface{}{
+					"apiVersion": "observability.open-cluster-management.io/v1beta2",
+					"kind":       "MultiClusterObservability",
+					"metadata": map[string]interface{}{
+						"name": "observability-integ",
+					},
+				},
+			},
+		}
+
+		evt := cloudevents.NewEvent()
+		evt.SetType(constants.HubHAResourcesMsgKey)
+		evt.SetSource("hub1")
+		err := evt.SetData(cloudevents.ApplicationJSON, bundle)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = syncer.Sync(ctx, &evt)
+		Expect(err).NotTo(HaveOccurred())
+
+		cm := &corev1.ConfigMap{}
+		Eventually(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{
+				Name: "allowed-cm-integ", Namespace: "default",
+			}, cm)
+		}, 5*time.Second, 100*time.Millisecond).Should(Succeed(),
+			"regular ConfigMap should be created on standby hub")
+		Expect(k8sClient.Delete(ctx, cm)).To(Succeed())
+
+		addon := &unstructured.Unstructured{}
+		addon.SetAPIVersion("observability.open-cluster-management.io/v1beta1")
+		addon.SetKind("ObservabilityAddon")
+		err = k8sClient.Get(ctx, types.NamespacedName{
+			Name: "obs-addon-integ", Namespace: "default",
+		}, addon)
+		Expect(err).To(HaveOccurred(),
+			"ObservabilityAddon should NOT be created on standby hub")
+
+		mco := &unstructured.Unstructured{}
+		mco.SetAPIVersion("observability.open-cluster-management.io/v1beta2")
+		mco.SetKind("MultiClusterObservability")
+		err = k8sClient.Get(ctx, types.NamespacedName{Name: "observability-integ"}, mco)
+		Expect(err).To(HaveOccurred(),
+			"MultiClusterObservability should NOT be created on standby hub")
+	})
 })


### PR DESCRIPTION
## Summary
- Prevent `ObservabilityAddon`, `MultiClusterObservability`, and `Observatorium` resources from being synced to the standby hub during Hub HA replication
- This avoids the standby hub reporting duplicate metrics to Thanos object storage while the active hub is healthy
- Suppression is applied at `createResource`, `updateResource`, and `cleanupStaleResources` in the standby syncer

## Changes
- Added `shouldSuppressMetricsResource()` function that gates on the observability API groups
- Inserted suppression checks early in `createResource()` and `updateResource()` (after existing `shouldSkipHubHAResourceApply` check)
- Added suppression in `cleanupStaleResources()` to skip stale-object cleanup for suppressed GVKs
- Added unit tests: `TestShouldSuppressMetricsResource`, create/update suppression tests for ObservabilityAddon and MultiClusterObservability, and a full `Sync()` bundle test verifying non-observability resources still apply while observability resources are dropped

## Test plan
- [x] `TestShouldSuppressMetricsResource` — table-driven test covering all three suppressed kinds plus non-suppressed kinds (ConfigMap, ManagedCluster, Policy)
- [x] `TestHubHAStandbySyncer_CreateResource_SuppressesObservabilityAddon` — verifies addon is not created on standby
- [x] `TestHubHAStandbySyncer_UpdateResource_SuppressesObservabilityAddon` — verifies addon is not updated on standby
- [x] `TestHubHAStandbySyncer_CreateResource_SuppressesMultiClusterObservability` — verifies MCO is not created on standby
- [x] `TestHubHAStandbySyncer_Sync_SuppressesObservabilityInBundle` — full bundle sync: ConfigMap applied, ObservabilityAddon and MCO dropped
- [x] All existing hubha tests pass (`go test ./agent/pkg/spec/hubha/...`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Standby hubs now skip observability and metrics resources during creation, updates, resynchronization, and deletion.
  - Previously synchronized suppressed resources are cleaned up from standby hubs.
  - Cleanup continues for remaining resources when individual listing or deletion operations fail.
  - Other resource types continue to synchronize normally.

- **Tests**
  - Expanded coverage for resource filtering, cleanup failures, partial failures, and mixed resource bundles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->